### PR TITLE
Add `server info/list` (/s)

### DIFF
--- a/common/src/main/java/com/wynntils/commands/ServerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ServerCommand.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.commands;
+
+import com.google.common.collect.Lists;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.wynntils.core.commands.WynntilsCommandBase;
+import com.wynntils.core.webapi.WebManager;
+import com.wynntils.utils.StringUtils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TextComponent;
+
+public class ServerCommand extends WynntilsCommandBase {
+    private final List<String> serverTypes =
+            Lists.newArrayList("WC", "lobby", "GM", "DEV", "WAR", "HB");
+
+    @Override
+    public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(
+                Commands.literal("server")
+                        .then(Commands.literal("list").executes(this::serverList))
+                        .then(Commands.literal("ls").executes(this::serverList))
+                        .then(Commands.literal("l").executes(this::serverList))
+                        .then(
+                                Commands.literal("info")
+                                        .then(
+                                                Commands.argument(
+                                                                "server", StringArgumentType.word())
+                                                        .executes(this::serverInfo))
+                                        .executes(this::serverInfoHelp))
+                        .then(
+                                Commands.literal("i")
+                                        .then(
+                                                Commands.argument(
+                                                                "server", StringArgumentType.word())
+                                                        .executes(this::serverInfo))
+                                        .executes(this::serverInfoHelp))
+                        .executes(this::serverHelp));
+
+        dispatcher.register(
+                Commands.literal("s")
+                        .then(Commands.literal("list").executes(this::serverList))
+                        .then(Commands.literal("ls").executes(this::serverList))
+                        .then(Commands.literal("l").executes(this::serverList))
+                        .then(
+                                Commands.literal("info")
+                                        .then(
+                                                Commands.argument(
+                                                                "server", StringArgumentType.word())
+                                                        .executes(this::serverInfo))
+                                        .executes(this::serverInfoHelp))
+                        .then(
+                                Commands.literal("i")
+                                        .then(
+                                                Commands.argument(
+                                                                "server", StringArgumentType.word())
+                                                        .executes(this::serverInfo))
+                                        .executes(this::serverInfoHelp))
+                        .executes(this::serverHelp));
+    }
+
+    private int serverInfoHelp(CommandContext<CommandSourceStack> context) {
+        context.getSource()
+                .sendFailure(
+                        new TextComponent("Usage: /s i,info <server> | Example: \"/s i WC1\"")
+                                .withStyle(ChatFormatting.RED));
+        return 1;
+    }
+
+    private int serverHelp(CommandContext<CommandSourceStack> context) {
+        MutableComponent text =
+                new TextComponent(
+                                "/s <command> [options]\n\n"
+                                        + "commands:\n"
+                                        + "l,ls,list | list available servers\n"
+                                        + "i,info | get info about a server\n\n"
+                                        + "more detailed help:\n"
+                                        + "/s <command> help")
+                        .withStyle(ChatFormatting.RED);
+
+        context.getSource().sendSuccess(text, false);
+
+        return 1;
+    }
+
+    private int serverInfo(CommandContext<CommandSourceStack> context) {
+        Map<String, List<String>> onlinePlayers;
+        try {
+            onlinePlayers = WebManager.getOnlinePlayers();
+        } catch (IOException e) {
+            context.getSource()
+                    .sendFailure(
+                            new TextComponent("Failed to get server data from API.")
+                                    .withStyle(ChatFormatting.RED));
+            return 1;
+        }
+
+        String server = context.getArgument("server", String.class);
+
+        if (server.startsWith("wc")) server = server.toUpperCase(Locale.ROOT);
+
+        try {
+            int serverNum = Integer.parseInt(server);
+            server = "WC" + serverNum;
+        } catch (Exception ignored) {
+        }
+
+        if (!onlinePlayers.containsKey(server)) {
+            context.getSource()
+                    .sendFailure(
+                            new TextComponent(server + " not found.")
+                                    .withStyle(ChatFormatting.RED));
+            return 1;
+        }
+
+        List<String> players = onlinePlayers.get(server);
+        MutableComponent message =
+                new TextComponent("Online players on " + server + ": " + players.size() + "\n")
+                        .withStyle(ChatFormatting.DARK_AQUA);
+
+        if (players.size() == 0) {
+            message.append(new TextComponent("No players!").withStyle(ChatFormatting.AQUA));
+        } else {
+            message.append(
+                    new TextComponent(String.join(", ", players)).withStyle(ChatFormatting.AQUA));
+        }
+
+        context.getSource().sendSuccess(message, false);
+
+        return 1;
+    }
+
+    private int serverList(CommandContext<CommandSourceStack> context) {
+        HashMap<String, List<String>> onlinePlayers;
+        try {
+            onlinePlayers = WebManager.getOnlinePlayers();
+        } catch (IOException e) {
+            context.getSource()
+                    .sendFailure(
+                            new TextComponent("Failed to get server data from API.")
+                                    .withStyle(ChatFormatting.RED));
+            return 1;
+        }
+
+        MutableComponent message =
+                new TextComponent("Server list:").withStyle(ChatFormatting.DARK_AQUA);
+
+        for (String serverType : serverTypes) {
+            List<String> currentTypeServers =
+                    onlinePlayers.keySet().stream()
+                            .filter(server -> server.startsWith(serverType))
+                            .sorted(
+                                    (o1, o2) -> {
+                                        int number1 =
+                                                Integer.parseInt(o1.substring(serverType.length()));
+                                        int number2 =
+                                                Integer.parseInt(o2.substring(serverType.length()));
+
+                                        return number1 - number2;
+                                    })
+                            .toList();
+
+            if (currentTypeServers.isEmpty()) continue;
+
+            message.append("\n");
+
+            message.append(
+                    new TextComponent(
+                                    StringUtils.capitalizeFirst(serverType)
+                                            + " ("
+                                            + currentTypeServers.size()
+                                            + "):\n")
+                            .withStyle(ChatFormatting.GOLD));
+
+            message.append(
+                    new TextComponent(String.join(", ", currentTypeServers))
+                            .withStyle(ChatFormatting.AQUA));
+        }
+
+        context.getSource().sendSuccess(message, false);
+
+        return 1;
+    }
+}

--- a/common/src/main/java/com/wynntils/commands/ServerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ServerCommand.java
@@ -8,8 +8,8 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import com.wynntils.core.commands.WynntilsCommandBase;
 import com.wynntils.core.webapi.WebManager;
+import com.wynntils.mc.utils.commands.CommandBase;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.wc.utils.WynnUtils;
 import java.io.IOException;
@@ -23,7 +23,7 @@ import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
 
-public class ServerCommand extends WynntilsCommandBase {
+public class ServerCommand extends CommandBase {
     @Override
     public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         LiteralCommandNode<CommandSourceStack> listNode =

--- a/common/src/main/java/com/wynntils/commands/ServerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ServerCommand.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.commands;
 
-import com.google.common.collect.Lists;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.wynntils.core.commands.WynntilsCommandBase;
 import com.wynntils.core.webapi.WebManager;
 import com.wynntils.utils.StringUtils;
+import com.wynntils.wc.utils.WynnUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -23,9 +23,6 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
 
 public class ServerCommand extends WynntilsCommandBase {
-    private final List<String> serverTypes =
-            Lists.newArrayList("WC", "lobby", "GM", "DEV", "WAR", "HB");
-
     @Override
     public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(
@@ -157,7 +154,7 @@ public class ServerCommand extends WynntilsCommandBase {
         MutableComponent message =
                 new TextComponent("Server list:").withStyle(ChatFormatting.DARK_AQUA);
 
-        for (String serverType : serverTypes) {
+        for (String serverType : WynnUtils.getWynnServerTypes()) {
             List<String> currentTypeServers =
                     onlinePlayers.keySet().stream()
                             .filter(server -> server.startsWith(serverType))

--- a/common/src/main/java/com/wynntils/commands/ServerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ServerCommand.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.wynntils.core.commands.WynntilsCommandBase;
 import com.wynntils.core.webapi.WebManager;
 import com.wynntils.utils.StringUtils;
@@ -28,47 +29,27 @@ public class ServerCommand extends WynntilsCommandBase {
 
     @Override
     public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-        dispatcher.register(
-                Commands.literal("server")
-                        .then(Commands.literal("list").executes(this::serverList))
-                        .then(Commands.literal("ls").executes(this::serverList))
-                        .then(Commands.literal("l").executes(this::serverList))
-                        .then(
-                                Commands.literal("info")
-                                        .then(
-                                                Commands.argument(
-                                                                "server", StringArgumentType.word())
-                                                        .executes(this::serverInfo))
-                                        .executes(this::serverInfoHelp))
-                        .then(
-                                Commands.literal("i")
-                                        .then(
-                                                Commands.argument(
-                                                                "server", StringArgumentType.word())
-                                                        .executes(this::serverInfo))
-                                        .executes(this::serverInfoHelp))
-                        .executes(this::serverHelp));
+        LiteralCommandNode<CommandSourceStack> listNode =
+                Commands.literal("list").executes(this::serverList).build();
 
-        dispatcher.register(
-                Commands.literal("s")
-                        .then(Commands.literal("list").executes(this::serverList))
-                        .then(Commands.literal("ls").executes(this::serverList))
-                        .then(Commands.literal("l").executes(this::serverList))
+        LiteralCommandNode<CommandSourceStack> infoNode =
+                Commands.literal("info")
                         .then(
-                                Commands.literal("info")
-                                        .then(
-                                                Commands.argument(
-                                                                "server", StringArgumentType.word())
-                                                        .executes(this::serverInfo))
-                                        .executes(this::serverInfoHelp))
-                        .then(
-                                Commands.literal("i")
-                                        .then(
-                                                Commands.argument(
-                                                                "server", StringArgumentType.word())
-                                                        .executes(this::serverInfo))
-                                        .executes(this::serverInfoHelp))
-                        .executes(this::serverHelp));
+                                Commands.argument("server", StringArgumentType.word())
+                                        .executes(this::serverInfo))
+                        .executes(this::serverInfoHelp)
+                        .build();
+        LiteralCommandNode<CommandSourceStack> node =
+                dispatcher.register(
+                        Commands.literal("server")
+                                .then(listNode)
+                                .then(Commands.literal("ls").redirect(listNode))
+                                .then(Commands.literal("l").redirect(listNode))
+                                .then(infoNode)
+                                .then(Commands.literal("i").redirect(infoNode))
+                                .executes(this::serverHelp));
+
+        dispatcher.register(Commands.literal("s").redirect(node));
     }
 
     private int serverInfoHelp(CommandContext<CommandSourceStack> context) {
@@ -82,12 +63,15 @@ public class ServerCommand extends WynntilsCommandBase {
     private int serverHelp(CommandContext<CommandSourceStack> context) {
         MutableComponent text =
                 new TextComponent(
-                                "/s <command> [options]\n\n"
-                                        + "commands:\n"
-                                        + "l,ls,list | list available servers\n"
-                                        + "i,info | get info about a server\n\n"
-                                        + "more detailed help:\n"
-                                        + "/s <command> help")
+                                """
+                                /s <command> [options]
+
+                                commands:
+                                l,ls,list | list available servers
+                                i,info | get info about a server
+
+                                more detailed help:
+                                /s <command> help""")
                         .withStyle(ChatFormatting.RED);
 
         context.getSource().sendSuccess(text, false);

--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -57,7 +57,8 @@ public class WynntilsCommand extends CommandBase {
     }
 
     private int reload(CommandContext<CommandSourceStack> context) {
-        for (Feature feature : FeatureRegistry.getFeatures()) { // disable all active features before resetting web
+        for (Feature feature :
+                FeatureRegistry.getFeatures()) { // disable all active features before resetting web
             if (feature.isEnabled()) {
                 feature.disable();
             }
@@ -65,9 +66,10 @@ public class WynntilsCommand extends CommandBase {
 
         WebManager.reset();
 
-        WebManager.setupUserAccount(); //fail message is handled by method already
+        WebManager.setupUserAccount(); // fail message is handled by method already
 
-        for (Feature feature : FeatureRegistry.getFeatures()) { // re-enable all features which should be
+        for (Feature feature :
+                FeatureRegistry.getFeatures()) { // re-enable all features which should be
             if (feature.canEnable()) {
                 feature.enable();
 
@@ -84,7 +86,8 @@ public class WynntilsCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Finished reloading everything!").withStyle(ChatFormatting.GREEN),
+                        new TextComponent("Finished reloading everything!")
+                                .withStyle(ChatFormatting.GREEN),
                         false);
 
         return 1;

--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -78,6 +78,12 @@ public class WynntilsCommand extends WynntilsCommandBase {
             //            addCommandDescription(text, "-wynntils", " reloadapi", "This reloads all
             // API data.");
             //            text.append("\n");
+            addCommandDescription(
+                    text,
+                    "-",
+                    "server",
+                    "This lists all online worlds in Wynncraft and the details of each world.");
+            text.append("\n");
             addCommandDescription(text, "-wynntils", " donate", "This provides our Patreon link.");
             context.getSource().sendSuccess(text, false);
             return 1;

--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -7,7 +7,10 @@ package com.wynntils.commands;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import com.wynntils.core.Reference;
+import com.wynntils.core.features.Feature;
+import com.wynntils.core.features.FeatureRegistry;
 import com.wynntils.core.webapi.WebManager;
+import com.wynntils.mc.utils.McUtils;
 import com.wynntils.mc.utils.commands.CommandBase;
 import java.util.List;
 import net.minecraft.ChatFormatting;
@@ -23,7 +26,7 @@ public class WynntilsCommand extends CommandBase {
                         .then(Commands.literal("help").executes(this::help))
                         .then(Commands.literal("discord").executes(this::discordLink))
                         .then(Commands.literal("donate").executes(this::donateLink))
-                        .then(Commands.literal("reloadapi").executes(this::reloadApi))
+                        .then(Commands.literal("reload").executes(this::reload))
                         .then(Commands.literal("version").executes(this::version))
                         .executes(this::help));
     }
@@ -53,25 +56,36 @@ public class WynntilsCommand extends CommandBase {
         return 1;
     }
 
-    private int reloadApi(CommandContext<CommandSourceStack> context) {
+    private int reload(CommandContext<CommandSourceStack> context) {
+        for (Feature feature : FeatureRegistry.getFeatures()) { // disable all active features before resetting web
+            if (feature.isEnabled()) {
+                feature.disable();
+            }
+        }
+
         WebManager.reset();
 
-        boolean success = WebManager.setupUserAccount();
+        WebManager.setupUserAccount(); //fail message is handled by method already
 
-        success &= WebManager.reloadUsedRoutes();
+        for (Feature feature : FeatureRegistry.getFeatures()) { // re-enable all features which should be
+            if (feature.canEnable()) {
+                feature.enable();
 
-        if (success) {
-            context.getSource()
-                    .sendSuccess(
-                            new TextComponent("Successfully reloaded all used API routes.")
-                                    .withStyle(ChatFormatting.GREEN),
-                            false);
-        } else {
-            context.getSource()
-                    .sendFailure(
-                            new TextComponent("One or more API routes failed to reload")
-                                    .withStyle(ChatFormatting.RED));
+                if (!feature.isEnabled()) {
+                    McUtils.sendMessageToClient(
+                            new TextComponent("Failed to reload ")
+                                    .withStyle(ChatFormatting.GREEN)
+                                    .append(
+                                            new TextComponent(feature.getName())
+                                                    .withStyle(ChatFormatting.AQUA)));
+                }
+            }
         }
+
+        context.getSource()
+                .sendSuccess(
+                        new TextComponent("Finished reloading everything!").withStyle(ChatFormatting.GREEN),
+                        false);
 
         return 1;
     }
@@ -182,7 +196,7 @@ public class WynntilsCommand extends CommandBase {
                             .getStyle()
                             .withClickEvent(
                                     new ClickEvent(
-                                            ClickEvent.Action.SUGGEST_COMMAND,
+                                            ClickEvent.Action.RUN_COMMAND,
                                             "/" + prefix + " " + String.join(" ", suffix)))
                             .withHoverEvent(
                                     new HoverEvent(

--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -8,6 +8,7 @@ import com.wynntils.core.features.FeatureRegistry;
 import com.wynntils.core.webapi.WebManager;
 import com.wynntils.mc.utils.CrashReportManager;
 import com.wynntils.mc.utils.McUtils;
+import com.wynntils.mc.utils.commands.ClientCommandManager;
 import com.wynntils.mc.utils.keybinds.KeyManager;
 import com.wynntils.wc.ModelLoader;
 import java.io.File;
@@ -38,6 +39,8 @@ public class WynntilsMod {
         parseVersion(modVersion);
 
         WebManager.init();
+
+        ClientCommandManager.init();
         KeyManager.init();
 
         addCrashCallbacks();

--- a/common/src/main/java/com/wynntils/core/commands/ClientCommandsManager.java
+++ b/common/src/main/java/com/wynntils/core/commands/ClientCommandsManager.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.wynntils.commands.ServerCommand;
 import com.wynntils.commands.WynntilsCommand;
 import com.wynntils.mc.utils.McUtils;
 import net.minecraft.ChatFormatting;
@@ -35,6 +36,7 @@ public class ClientCommandsManager {
     public static void registerCommands() {
         clientDispatcher = new CommandDispatcher<>();
         new WynntilsCommand().register(clientDispatcher); // TODO event
+        new ServerCommand().register(clientDispatcher);
     }
 
     public static ClientCommandSourceStack getSource() {

--- a/common/src/main/java/com/wynntils/core/features/DebugFeature.java
+++ b/common/src/main/java/com/wynntils/core/features/DebugFeature.java
@@ -17,9 +17,6 @@ import com.wynntils.core.features.properties.Stability;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.MEDIUM)
 public abstract class DebugFeature extends Feature {
-    public DebugFeature(String name) {
-        super(name);
-    }
 
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {

--- a/common/src/main/java/com/wynntils/core/features/DebugFeature.java
+++ b/common/src/main/java/com/wynntils/core/features/DebugFeature.java
@@ -17,6 +17,10 @@ import com.wynntils.core.features.properties.Stability;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.MEDIUM)
 public abstract class DebugFeature extends Feature {
+    public DebugFeature(String name) {
+        super(name);
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {
         conditions.add(new DevelopmentCondition());

--- a/common/src/main/java/com/wynntils/core/features/Feature.java
+++ b/common/src/main/java/com/wynntils/core/features/Feature.java
@@ -18,8 +18,13 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
  */
 public abstract class Feature {
     private ImmutableList<Condition> conditions;
+    private final String name;
 
     protected boolean enabled = false;
+
+    protected Feature(String name) {
+        this.name = name;
+    }
 
     public final void init() {
         ImmutableList.Builder<Condition> conditions = new ImmutableList.Builder<>();
@@ -79,7 +84,7 @@ public abstract class Feature {
     }
 
     /** Whether a feature can be enabled */
-    private boolean canEnable() {
+    public boolean canEnable() {
         for (Condition condition : conditions) {
             if (!condition.isSatisfied()) return false;
         }
@@ -112,6 +117,10 @@ public abstract class Feature {
             setSatisfied(true);
             WynntilsMod.getEventBus().unregister(this);
         }
+    }
+
+    public String getName() {
+        return name;
     }
 
     public abstract class Condition {

--- a/common/src/main/java/com/wynntils/core/features/Feature.java
+++ b/common/src/main/java/com/wynntils/core/features/Feature.java
@@ -18,13 +18,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
  */
 public abstract class Feature {
     private ImmutableList<Condition> conditions;
-    private final String name;
 
     protected boolean enabled = false;
-
-    protected Feature(String name) {
-        this.name = name;
-    }
 
     public final void init() {
         ImmutableList.Builder<Condition> conditions = new ImmutableList.Builder<>();
@@ -119,9 +114,8 @@ public abstract class Feature {
         }
     }
 
-    public String getName() {
-        return name;
-    }
+    /** Gets the name of a feature */
+    public abstract String getName();
 
     public abstract class Condition {
         boolean satisfied = false;

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -36,10 +36,6 @@ public class FeatureRegistry {
         features.forEach(FeatureRegistry::registerFeature);
     }
 
-    public static void registerOverlay(Overlay overlay) {
-        OVERLAYS.add(overlay);
-    }
-
     public static List<Feature> getFeatures() {
         return FEATURES;
     }
@@ -113,7 +109,7 @@ public class FeatureRegistry {
                 });
     }
 
-    private static class OverlayListener {
+    private static class OverlayListener { //TODO create a enum map for overlays instead of this
         @SubscribeEvent
         public static void onTick(ClientTickEvent e) {
             if (e.getTickPhase() == ClientTickEvent.Phase.END) {

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -139,7 +139,7 @@ public class FeatureRegistry {
                     }
 
                     if (contained && overlay.visible) {
-                        McUtils.mc().getProfiler().push(overlay.displayName);
+                        McUtils.mc().getProfiler().push(overlay.getName());
                         overlay.render(e);
                         McUtils.mc().getProfiler().pop();
                     }
@@ -165,7 +165,7 @@ public class FeatureRegistry {
                     if (overlay.hookElements.length != 0) {
                         for (RenderEvent.ElementType type : overlay.hookElements) {
                             if (e.getType() == type) {
-                                McUtils.mc().getProfiler().push(overlay.displayName);
+                                McUtils.mc().getProfiler().push(overlay.getName());
                                 overlay.render(e);
                                 McUtils.mc().getProfiler().pop();
                                 break;

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -79,7 +79,7 @@ public class FeatureRegistry {
 
                         for (Feature feature : FEATURES) {
                             if (feature.isEnabled()) {
-                                result.append("\n\t\t").append(feature.getClass().getName());
+                                result.append("\n\t\t").append(feature.getName());
                             }
                         }
 
@@ -100,7 +100,7 @@ public class FeatureRegistry {
 
                         for (Overlay overlay : OVERLAYS) {
                             if (overlay.isEnabled()) {
-                                result.append("\n\t\t").append(overlay.getClass().getName());
+                                result.append("\n\t\t").append(overlay.getName());
                             }
                         }
 

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -109,7 +109,7 @@ public class FeatureRegistry {
                 });
     }
 
-    private static class OverlayListener { //TODO create a enum map for overlays instead of this
+    private static class OverlayListener { // TODO create a enum map for overlays instead of this
         @SubscribeEvent
         public static void onTick(ClientTickEvent e) {
             if (e.getTickPhase() == ClientTickEvent.Phase.END) {

--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -26,6 +26,7 @@ public abstract class Overlay
             OverlayGrowFrom growthX,
             OverlayGrowFrom growthY,
             RenderEvent.ElementType... hookElements) {
+        super(displayName);
         this.displayName = displayName;
         this.staticSize = new Point(sizeX, sizeY);
         this.visible = visible;

--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -31,11 +31,11 @@ public abstract class Overlay
         this.growthY = growthY;
     }
 
-    public void render(RenderEvent.Pre e) {}
+    public abstract void render(RenderEvent.Pre e);
 
-    public void render(RenderEvent.Post e) {}
+    public abstract void render(RenderEvent.Post e);
 
-    public void tick() {}
+    public abstract void tick();
 
     public enum OverlayGrowFrom {
         LEFT,

--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -11,7 +11,6 @@ import java.awt.*;
 public abstract class Overlay
         extends Feature { // extends ScreenRenderer implements SettingsHolder {
 
-    public transient String displayName;
     public transient Point staticSize;
     public transient boolean visible;
     public transient OverlayGrowFrom growthX;
@@ -19,15 +18,12 @@ public abstract class Overlay
     public transient RenderEvent.ElementType[] hookElements;
 
     public Overlay(
-            String displayName,
             int sizeX,
             int sizeY,
             boolean visible,
             OverlayGrowFrom growthX,
             OverlayGrowFrom growthY,
             RenderEvent.ElementType... hookElements) {
-        super(displayName);
-        this.displayName = displayName;
         this.staticSize = new Point(sizeX, sizeY);
         this.visible = visible;
         this.hookElements = hookElements;

--- a/common/src/main/java/com/wynntils/core/webapi/WebManager.java
+++ b/common/src/main/java/com/wynntils/core/webapi/WebManager.java
@@ -197,15 +197,7 @@ public class WebManager {
     public static HashMap<String, List<String>> getOnlinePlayers() throws IOException {
         if (apiUrls == null) return new HashMap<>();
 
-        URLConnection st = new URL(apiUrls.get("OnlinePlayers")).openConnection();
-        st.setRequestProperty(
-                "User-Agent",
-                "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316"
-                        + " Firefox/3.6.2");
-        // st.setRequestProperty("apikey", apiUrls.get("WynnApiKey")); API key rate limits
-        // constantly, perhaps we don't need it?
-        st.setConnectTimeout(REQUEST_TIMEOUT_MILLIS);
-        st.setReadTimeout(REQUEST_TIMEOUT_MILLIS);
+        URLConnection st = generateURLRequest(apiUrls.get("OnlinePlayers"));
 
         JsonObject main =
                 new JsonParser()
@@ -220,6 +212,19 @@ public class WebManager {
         } else {
             return new HashMap<>();
         }
+    }
+
+    private static URLConnection generateURLRequest(String url) throws IOException {
+        URLConnection st = new URL(url).openConnection();
+        st.setRequestProperty(
+                "User-Agent",
+                "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316"
+                        + " Firefox/3.6.2");
+        if (apiUrls != null) st.setRequestProperty("apikey", apiUrls.get("WynnApiKey"));
+        st.setConnectTimeout(REQUEST_TIMEOUT_MILLIS);
+        st.setReadTimeout(REQUEST_TIMEOUT_MILLIS);
+
+        return st;
     }
 
     public static @Nullable WebReader getApiUrls() {

--- a/common/src/main/java/com/wynntils/core/webapi/WebManager.java
+++ b/common/src/main/java/com/wynntils/core/webapi/WebManager.java
@@ -117,7 +117,6 @@ public class WebManager {
 
             McUtils.sendMessageToClient(failed);
         }
-
     }
 
     public static void updateTerritories(RequestHandler handler) {

--- a/common/src/main/java/com/wynntils/core/webapi/WebManager.java
+++ b/common/src/main/java/com/wynntils/core/webapi/WebManager.java
@@ -27,9 +27,8 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import org.apache.commons.io.IOUtils;
-import java.util.*;
 import java.util.function.Supplier;
+import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.Nullable;
 
 /** Provides and loads web content on demand */

--- a/common/src/main/java/com/wynntils/core/webapi/account/WynntilsAccount.java
+++ b/common/src/main/java/com/wynntils/core/webapi/account/WynntilsAccount.java
@@ -50,11 +50,8 @@ public class WynntilsAccount {
         encodedConfigs.remove(name);
     }
 
-    int connectionAttempts = 0;
-
     public boolean login() {
-        if (WebManager.getApiUrls() == null || connectionAttempts >= 4) return false;
-        connectionAttempts++;
+        if (WebManager.getApiUrls() == null) return false;
 
         RequestHandler handler = WebManager.getHandler();
 
@@ -75,7 +72,6 @@ public class WynntilsAccount {
                                                     json.get("publicKeyIn").getAsString());
                                     return true;
                                 })
-                        .onError(this::login)
                         .build();
 
         handler.addAndDispatch(getPublicKey);
@@ -120,7 +116,6 @@ public class WynntilsAccount {
                                     Reference.LOGGER.info("Successfully connected to Athena!");
                                     return true;
                                 })
-                        .onError(this::login)
                         .build();
 
         handler.addAndDispatch(responseEncryption);

--- a/common/src/main/java/com/wynntils/features/GammabrightFeature.java
+++ b/common/src/main/java/com/wynntils/features/GammabrightFeature.java
@@ -39,6 +39,10 @@ public class GammabrightFeature extends Feature {
                         McUtils.mc().options.gamma = lastGamma;
                     });
 
+    public GammabrightFeature() {
+        super("Gammabright Keybind Feature");
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {}
 

--- a/common/src/main/java/com/wynntils/features/GammabrightFeature.java
+++ b/common/src/main/java/com/wynntils/features/GammabrightFeature.java
@@ -39,8 +39,8 @@ public class GammabrightFeature extends Feature {
                         McUtils.mc().options.gamma = lastGamma;
                     });
 
-    public GammabrightFeature() {
-        super("Gammabright Keybind Feature");
+    public String getName() {
+        return "Gammabright Keybind Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/HealthPotionBlockerFeature.java
@@ -26,8 +26,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.MEDIUM)
 public class HealthPotionBlockerFeature extends Feature {
-    public HealthPotionBlockerFeature() {
-        super("Health Potion Blocker Feature");
+    public String getName() {
+        return "Health Potion Blocker Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/HealthPotionBlockerFeature.java
@@ -26,6 +26,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.MEDIUM)
 public class HealthPotionBlockerFeature extends Feature {
+    public HealthPotionBlockerFeature() {
+        super("Health Potion Blocker Feature");
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {}
 

--- a/common/src/main/java/com/wynntils/features/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemGuessFeature.java
@@ -39,6 +39,10 @@ public class ItemGuessFeature extends Feature {
 
     private static final boolean showGuessesPrice = true;
 
+    public ItemGuessFeature() {
+        super("Item Guess Feature");
+    }
+
     @Override
     public void onInit(ImmutableList.Builder<Condition> conditions) {
         conditions.add(new WebLoadedCondition());

--- a/common/src/main/java/com/wynntils/features/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemGuessFeature.java
@@ -39,8 +39,8 @@ public class ItemGuessFeature extends Feature {
 
     private static final boolean showGuessesPrice = true;
 
-    public ItemGuessFeature() {
-        super("Item Guess Feature");
+    public String getName() {
+        return "Item Guess Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
@@ -74,6 +74,10 @@ public class ItemStatInfoFeature extends Feature {
     private static final boolean reorderIdentifications = true;
     private static final boolean groupIdentifications = true;
 
+    public ItemStatInfoFeature() {
+        super("Item Statistics Info Feature");
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {
         conditions.add(new WebLoadedCondition());

--- a/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
@@ -74,8 +74,8 @@ public class ItemStatInfoFeature extends Feature {
     private static final boolean reorderIdentifications = true;
     private static final boolean groupIdentifications = true;
 
-    public ItemStatInfoFeature() {
-        super("Item Statistics Info Feature");
+    public String getName() {
+        return "Item Statistics Info Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/PlayerGhostTransparencyFeature.java
+++ b/common/src/main/java/com/wynntils/features/PlayerGhostTransparencyFeature.java
@@ -13,6 +13,10 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class PlayerGhostTransparencyFeature extends Feature {
+    public PlayerGhostTransparencyFeature() {
+        super("Transparent Player Ghost Feature");
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {}
 

--- a/common/src/main/java/com/wynntils/features/PlayerGhostTransparencyFeature.java
+++ b/common/src/main/java/com/wynntils/features/PlayerGhostTransparencyFeature.java
@@ -13,8 +13,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class PlayerGhostTransparencyFeature extends Feature {
-    public PlayerGhostTransparencyFeature() {
-        super("Transparent Player Ghost Feature");
+    public String getName() {
+        return "Transparent Player Ghost Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/SoulPointTimerFeature.java
+++ b/common/src/main/java/com/wynntils/features/SoulPointTimerFeature.java
@@ -28,6 +28,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.MEDIUM)
 public class SoulPointTimerFeature extends Feature {
+    public SoulPointTimerFeature() {
+        super("Soul Point Timer Feature");
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {}
 

--- a/common/src/main/java/com/wynntils/features/SoulPointTimerFeature.java
+++ b/common/src/main/java/com/wynntils/features/SoulPointTimerFeature.java
@@ -28,8 +28,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.MEDIUM)
 public class SoulPointTimerFeature extends Feature {
-    public SoulPointTimerFeature() {
-        super("Soul Point Timer Feature");
+    public String getName() {
+        return "Soul Point Timer Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/WynncraftButtonFeature.java
@@ -30,8 +30,8 @@ import org.jetbrains.annotations.NotNull;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.SMALL)
 public class WynncraftButtonFeature extends Feature {
-    public WynncraftButtonFeature() {
-        super("Wynncraft Button Feature");
+    public String getName() {
+        return "Wynncraft Button Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/WynncraftButtonFeature.java
@@ -30,6 +30,10 @@ import org.jetbrains.annotations.NotNull;
         gameplay = GameplayImpact.MEDIUM,
         performance = PerformanceImpact.SMALL)
 public class WynncraftButtonFeature extends Feature {
+    public WynncraftButtonFeature() {
+        super("Wynncraft Button Feature");
+    }
+
     @Override
     protected void onInit(ImmutableList.Builder<Condition> conditions) {}
 

--- a/common/src/main/java/com/wynntils/features/debug/ConnectionProgressFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ConnectionProgressFeature.java
@@ -13,6 +13,10 @@ import com.wynntils.wc.model.WorldState.State;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class ConnectionProgressFeature extends DebugFeature {
+    public ConnectionProgressFeature() {
+        super("Connection Progress Feature");
+    }
+
     @Override
     protected boolean onEnable() {
         WynntilsMod.getEventBus().register(this);

--- a/common/src/main/java/com/wynntils/features/debug/ConnectionProgressFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ConnectionProgressFeature.java
@@ -13,8 +13,8 @@ import com.wynntils.wc.model.WorldState.State;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class ConnectionProgressFeature extends DebugFeature {
-    public ConnectionProgressFeature() {
-        super("Connection Progress Feature");
+    public String getName() {
+        return "Connection Progress Feature";
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/debug/KeyBindTestFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/KeyBindTestFeature.java
@@ -20,6 +20,10 @@ import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.scores.Team;
 
 public class KeyBindTestFeature extends DebugFeature {
+    public KeyBindTestFeature() {
+        super("Keybind Test Feature");
+    }
+
     private final List<KeyHolder> keybinds = new ArrayList<>();
 
     @Override

--- a/common/src/main/java/com/wynntils/features/debug/KeyBindTestFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/KeyBindTestFeature.java
@@ -20,8 +20,8 @@ import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.scores.Team;
 
 public class KeyBindTestFeature extends DebugFeature {
-    public KeyBindTestFeature() {
-        super("Keybind Test Feature");
+    public String getName() {
+        return "Keybind Test Feature";
     }
 
     private final List<KeyHolder> keybinds = new ArrayList<>();

--- a/common/src/main/java/com/wynntils/features/debug/PacketDebuggerFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/PacketDebuggerFeature.java
@@ -18,8 +18,8 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class PacketDebuggerFeature extends DebugFeature {
-    public PacketDebuggerFeature() {
-        super("Packet Debugger Feature");
+    public String getName() {
+        return "Packet Debugger Feature";
     }
 
     public static final boolean DEBUG_PACKETS = false;

--- a/common/src/main/java/com/wynntils/features/debug/PacketDebuggerFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/PacketDebuggerFeature.java
@@ -18,6 +18,10 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class PacketDebuggerFeature extends DebugFeature {
+    public PacketDebuggerFeature() {
+        super("Packet Debugger Feature");
+    }
+
     public static final boolean DEBUG_PACKETS = false;
 
     /* These packets just spam the log; ignore them. */

--- a/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
@@ -8,7 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.wynntils.mc.utils.commands.ClientCommandsManager;
+import com.wynntils.mc.utils.commands.ClientCommandManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -47,7 +47,7 @@ public class CommandSuggestionsMixin {
         }
 
         CommandDispatcher<CommandSourceStack> clientDispatcher =
-                ClientCommandsManager.getClientDispatcher();
+                ClientCommandManager.getClientDispatcher();
 
         CompletableFuture<Suggestions> clientSuggestions =
                 clientDispatcher.getCompletionSuggestions(clientParse, cursor);
@@ -81,8 +81,8 @@ public class CommandSuggestionsMixin {
             StringReader command,
             Object source) {
         CommandDispatcher<CommandSourceStack> clientDispatcher =
-                ClientCommandsManager.getClientDispatcher();
-        clientParse = clientDispatcher.parse(command, ClientCommandsManager.getSource());
+                ClientCommandManager.getClientDispatcher();
+        clientParse = clientDispatcher.parse(command, ClientCommandManager.getSource());
 
         return serverDispatcher.parse(command, (SharedSuggestionProvider) source);
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
@@ -6,7 +6,7 @@ package com.wynntils.mc.mixin;
 
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.StringReader;
-import com.wynntils.mc.utils.commands.ClientCommandsManager;
+import com.wynntils.mc.utils.commands.ClientCommandManager;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
@@ -26,7 +26,7 @@ public class LocalPlayerMixin extends AbstractClientPlayer {
         if (message.startsWith("/")) {
             StringReader reader = new StringReader(message);
             reader.skip();
-            if (ClientCommandsManager.executeCommand(reader, message)) {
+            if (ClientCommandManager.executeCommand(reader, message)) {
                 ci.cancel();
             }
         }

--- a/common/src/main/java/com/wynntils/mc/utils/commands/ClientCommandManager.java
+++ b/common/src/main/java/com/wynntils/mc/utils/commands/ClientCommandManager.java
@@ -23,11 +23,7 @@ import net.minecraft.network.chat.*;
 // Parts of this code originates from https://github.com/Earthcomputer/clientcommands, and other
 // parts originate
 // from https://github.com/MinecraftForge/MinecraftForge
-public class ClientCommandsManager {
-
-    static {
-        ClientCommandsManager.registerCommands();
-    }
+public class ClientCommandManager {
 
     private static CommandDispatcher<CommandSourceStack> clientDispatcher;
 
@@ -35,7 +31,7 @@ public class ClientCommandsManager {
         return clientDispatcher;
     }
 
-    public static void registerCommands() {
+    public static void init() {
         clientDispatcher = new CommandDispatcher<>();
         new WynntilsCommand().register(clientDispatcher); // TODO event
         new ServerCommand().register(clientDispatcher);
@@ -91,13 +87,13 @@ public class ClientCommandsManager {
                 text.append(
                         new TranslatableComponent("command.context.here")
                                 .withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
-                ClientCommandsManager.sendError(text);
+                ClientCommandManager.sendError(text);
             }
         } catch (Exception e) {
             TextComponent error =
                     new TextComponent(
                             e.getMessage() == null ? e.getClass().getName() : e.getMessage());
-            ClientCommandsManager.sendError(
+            ClientCommandManager.sendError(
                     new TranslatableComponent("command.failed")
                             .withStyle(
                                     Style.EMPTY.withHoverEvent(

--- a/common/src/main/java/com/wynntils/wc/utils/WynnUtils.java
+++ b/common/src/main/java/com/wynntils/wc/utils/WynnUtils.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.wc.utils;
 
+import com.google.common.collect.Lists;
 import com.wynntils.wc.ModelLoader;
+import java.util.List;
 
 public class WynnUtils {
     /**
@@ -30,5 +32,9 @@ public class WynnUtils {
 
     public static boolean onWorld() {
         return ModelLoader.getWorldState().onWorld();
+    }
+
+    public static List<String> getWynnServerTypes() {
+        return Lists.newArrayList("WC", "lobby", "GM", "DEV", "WAR", "HB");
     }
 }


### PR DESCRIPTION
The ported version of this feature functions slightly differently than the 1.12.2 implementation, but does everything without unnecessary options (like group and sort).

Screenshots of the feature:

`/s i` (or `/server i` or `/server info`)
![image](https://user-images.githubusercontent.com/49001742/156021719-9d53e7bf-6a04-497c-933a-ac0b4e152495.png)

`/s i 1` (or `/server i WC1` or `/server info 1`)
![image](https://user-images.githubusercontent.com/49001742/156021767-3eedfd48-05f9-4188-b7ac-817460c54cce.png)

`/s l` (or `/server list`)
![image](https://user-images.githubusercontent.com/49001742/156021860-93b0bea9-a358-4567-be59-1d3eca84ac46.png)
