### PR TITLE
Force correct locale in ItemStatInfoFeature

### DIFF
--- a/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
@@ -18,6 +18,7 @@ import com.wynntils.mc.utils.ComponentUtils;
 import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.utils.MathUtils;
+import com.wynntils.utils.Utils;
 import com.wynntils.utils.objects.Formatter;
 import com.wynntils.wc.objects.ClassType;
 import com.wynntils.wc.objects.SpellType;
@@ -405,7 +406,7 @@ public class ItemStatInfoFeature extends Feature {
                     "chance_perfect",
                     new TextComponent(
                                     String.format(
-                                            Locale.ROOT,
+                                            Utils.getGameLocale(),
                                             "\u2605%.2f%%",
                                             idContainer.getPerfectChance() * 100))
                             .withStyle(ChatFormatting.AQUA));
@@ -413,13 +414,17 @@ public class ItemStatInfoFeature extends Feature {
                     "chance_increase",
                     new TextComponent(
                                     String.format(
-                                            Locale.ROOT, "\u21E7%.1f%%", chances.increase() * 100))
+                                            Utils.getGameLocale(),
+                                            "\u21E7%.1f%%",
+                                            chances.increase() * 100))
                             .withStyle(ChatFormatting.GREEN));
             infoVariables.put(
                     "chance_decrease",
                     new TextComponent(
                                     String.format(
-                                            Locale.ROOT, "\u21E9%.1f%%", chances.decrease() * 100))
+                                            Utils.getGameLocale(),
+                                            "\u21E9%.1f%%",
+                                            chances.decrease() * 100))
                             .withStyle(ChatFormatting.RED));
 
             infoVariables.put(
@@ -501,7 +506,7 @@ public class ItemStatInfoFeature extends Feature {
                                         ? getPercentageColor(percentage)
                                         : getFlatPercentageColor(percentage))
                         .withItalic(false);
-        return new TextComponent(String.format(Locale.ROOT, "[%.1f%%]", percentage))
+        return new TextComponent(String.format(Utils.getGameLocale(), "[%.1f%%]", percentage))
                 .withStyle(color);
     }
 

--- a/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemStatInfoFeature.java
@@ -405,15 +405,21 @@ public class ItemStatInfoFeature extends Feature {
                     "chance_perfect",
                     new TextComponent(
                                     String.format(
-                                            "\u2605%.2f%%", idContainer.getPerfectChance() * 100))
+                                            Locale.ROOT,
+                                            "\u2605%.2f%%",
+                                            idContainer.getPerfectChance() * 100))
                             .withStyle(ChatFormatting.AQUA));
             infoVariables.put(
                     "chance_increase",
-                    new TextComponent(String.format("\u21E7%.1f%%", chances.increase() * 100))
+                    new TextComponent(
+                                    String.format(
+                                            Locale.ROOT, "\u21E7%.1f%%", chances.increase() * 100))
                             .withStyle(ChatFormatting.GREEN));
             infoVariables.put(
                     "chance_decrease",
-                    new TextComponent(String.format("\u21E9%.1f%%", chances.decrease() * 100))
+                    new TextComponent(
+                                    String.format(
+                                            Locale.ROOT, "\u21E9%.1f%%", chances.decrease() * 100))
                             .withStyle(ChatFormatting.RED));
 
             infoVariables.put(
@@ -495,7 +501,8 @@ public class ItemStatInfoFeature extends Feature {
                                         ? getPercentageColor(percentage)
                                         : getFlatPercentageColor(percentage))
                         .withItalic(false);
-        return new TextComponent(String.format("[%.1f%%]", percentage)).withStyle(color);
+        return new TextComponent(String.format(Locale.ROOT, "[%.1f%%]", percentage))
+                .withStyle(color);
     }
 
     private static final TreeMap<Float, TextColor> colorMap =

--- a/common/src/main/java/com/wynntils/utils/Utils.java
+++ b/common/src/main/java/com/wynntils/utils/Utils.java
@@ -4,8 +4,20 @@
  */
 package com.wynntils.utils;
 
+import java.util.Locale;
+
 /**
  * This is a "high-quality misc" class. Helper methods that are commonly used throughout the project
  * without an aspect on minecraft can be put here. Keep the names short, but distinct.
  */
-public class Utils {}
+public class Utils {
+    private static Locale gameLocale = Locale.ROOT;
+
+    public static Locale getGameLocale() {
+        return gameLocale;
+    }
+
+    public static void setGameLocale(Locale gameLocale) {
+        Utils.gameLocale = gameLocale;
+    }
+}


### PR DESCRIPTION
Without this change, it used to look like this: 
![image](https://user-images.githubusercontent.com/49001742/158080831-93817755-8c31-4e57-8730-bfc88d42e27c.png)
("," decimal separator)

This PR makes it so it works the way it is intended. (like this)
![image](https://user-images.githubusercontent.com/49001742/158080859-714c6977-2f7e-495c-a9ba-4535f74bbc83.png)
