### PR TITLE
Use slf4j logger

### DIFF
--- a/common/src/main/java/com/wynntils/core/Reference.java
+++ b/common/src/main/java/com/wynntils/core/Reference.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.core;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** TODO */
 public class Reference {
-    public static final Logger LOGGER = LogManager.getFormatterLogger(WynntilsMod.MOD_ID);
+    public static final Logger LOGGER = LoggerFactory.getLogger(WynntilsMod.MOD_ID);
     public static String VERSION = "";
     public static int BUILD_NUMBER = -1;
 }


### PR DESCRIPTION
Newer loom versions recommend `slf4j` and even require it later on. The transition seems to be seemless.

https://github.com/FabricMC/fabric-loom/releases/tag/0.11

> - Add an option to remove log4j from the compile classpath.
>   - Mods should move over to using SLF4j