### PR TITLE
Item screenshot feature

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -48,6 +48,8 @@ public class WynntilsMod {
         ModelLoader.init();
         FeatureRegistry.init();
 
+        // MC will sometimes think it's running headless and refuse to set clipboard contents
+        // making sure this is set to false will fix that
         System.setProperty("java.awt.headless", "false");
     }
 

--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -47,6 +47,8 @@ public class WynntilsMod {
 
         ModelLoader.init();
         FeatureRegistry.init();
+
+        System.setProperty("java.awt.headless", "false");
     }
 
     public static void parseVersion(String versionString) {

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -57,6 +57,7 @@ public class FeatureRegistry {
         registerFeature(new HealthPotionBlockerFeature());
         registerFeature(new PlayerGhostTransparencyFeature());
         registerFeature(new ItemStatInfoFeature());
+        registerFeature(new ItemScreenshotFeature());
 
         FEATURES.forEach(Feature::init);
 

--- a/common/src/main/java/com/wynntils/features/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemScreenshotFeature.java
@@ -5,20 +5,41 @@
 package com.wynntils.features;
 
 import com.google.common.collect.ImmutableList;
-import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.pipeline.MainTarget;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import com.mojang.math.Matrix4f;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.features.Feature;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.GameplayImpact;
 import com.wynntils.core.features.properties.PerformanceImpact;
 import com.wynntils.core.features.properties.Stability;
-import com.wynntils.mc.event.InventoryRenderEvent;
+import com.wynntils.mc.event.InventoryKeyPressEvent;
+import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.mc.utils.keybinds.KeyHolder;
 import com.wynntils.mc.utils.keybinds.KeyManager;
 import com.wynntils.wc.utils.WynnUtils;
+import java.awt.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TranslatableComponent;
@@ -28,27 +49,51 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.lwjgl.glfw.GLFW;
 
-import javax.xml.crypto.Data;
-import java.awt.*;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-@FeatureInfo(stability = Stability.INVARIABLE, gameplay = GameplayImpact.LARGE, performance = PerformanceImpact.MEDIUM)
+@FeatureInfo(stability = Stability.INVARIABLE, gameplay = GameplayImpact.MEDIUM, performance = PerformanceImpact.SMALL)
 public class ItemScreenshotFeature extends Feature {
 
     private static Pattern ITEM_PATTERN = Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
-    Slot hoveredSlot = null;
+    private Slot screenshotSlot = null;
 
-    private final KeyHolder itemScreenshotKeybind = new KeyHolder("Screenshot Item", GLFW.GLFW_KEY_F4, "Wynntils", true, this::takeScreenshot);
+    private final KeyHolder itemScreenshotKeybind =
+            new KeyHolder("Screenshot Item", GLFW.GLFW_KEY_F4, "Wynntils", true, () -> {});
 
-    private void takeScreenshot() {
+    @Override
+    protected void onInit(ImmutableList.Builder<Condition> conditions) {}
+
+    @Override
+    protected boolean onEnable() {
+        WynntilsMod.getEventBus().register(this);
+        KeyManager.registerKeybind(itemScreenshotKeybind);
+        return true;
+    }
+
+    @Override
+    protected void onDisable() {
+        WynntilsMod.getEventBus().unregister(this);
+        KeyManager.unregisterKeybind(itemScreenshotKeybind);
+    }
+
+    @Override
+    public MutableComponent getNameComponent() {
+        return new TranslatableComponent("feature.wynntils.itemScreenshot.name");
+    }
+
+    @SubscribeEvent
+    public void onKeyPress(InventoryKeyPressEvent e) {
+        if (itemScreenshotKeybind.getKeybind().matches(e.getKeyCode(), e.getScanCode()))
+            screenshotSlot = e.getHoveredSlot();
+    }
+
+    @SubscribeEvent
+    public void render(ItemTooltipRenderEvent e) {
+        if (screenshotSlot == null) return;
+        // has to be called during a render period
+        takeScreenshot(screenshotSlot);
+        screenshotSlot = null;
+    }
+
+    private void takeScreenshot(Slot hoveredSlot) {
         if (!WynnUtils.onWorld()) return;
         Screen screen = McUtils.mc().screen;
         if (!(screen instanceof AbstractContainerScreen<?>)) return;
@@ -58,13 +103,13 @@ public class ItemScreenshotFeature extends Feature {
         List<Component> tooltip = stack.getTooltipLines(McUtils.player(), TooltipFlag.Default.NORMAL);
         removeItemLore(tooltip);
 
-        Font f = McUtils.mc().font;
+        Font font = McUtils.mc().font;
         int width = 0;
         int height = 16;
 
         // width calculation
         for (Component c : tooltip) {
-            int w = f.width(c.getString());
+            int w = font.width(c.getString());
             if (w > width) {
                 width = w;
             }
@@ -76,35 +121,40 @@ public class ItemScreenshotFeature extends Feature {
             height += 2 + (tooltip.size() - 1) * 10;
         }
 
-        // account for text wrapping
-        if (width > screen.width/2 + 8) {
-            int wrappedWidth = 0;
-            int wrappedLines = 0;
-            for (Component c : tooltip) {
-                List<String> wrappedLine = listFormattedStringToWidth(c.toString(), screen.width/2);
-                for (String ws : wrappedLine) {
-                    wrappedLines++;
-                    int w = f.width(ws);
-                    if (w > wrappedWidth) {
-                        wrappedWidth = w;
-                    }
-                }
-            }
-            width = wrappedWidth + 8;
-            height = 16 + (2 + (wrappedLines - 1) * 10);
-        }
-
         // calculate tooltip size to fit to framebuffer
-        float scaleh = (float) screen.height/height;
-        float scalew = (float) screen.width/width;
+        float scaleh = (float) screen.height / height;
+        float scalew = (float) screen.width / width;
 
         // draw tooltip to framebuffer, create image
-        // TODO: figure this out
-        GlStateManager.
+        McUtils.mc().getMainRenderTarget().unbindWrite();
+
+        PoseStack poseStack = new PoseStack();
+        RenderTarget fb = new MainTarget(width * 2, height * 2);
+        fb.setClearColor(1f, 1f, 1f, 0f);
+        fb.createBuffers(width * 2, height * 2, false);
+        fb.bindWrite(false);
+        poseStack.pushPose();
+        poseStack.scale(scalew, scaleh, 1);
+        drawTooltip(
+                tooltip.stream()
+                        .map(Component::getVisualOrderText)
+                        .map(ClientTooltipComponent::create)
+                        .collect(Collectors.toList()),
+                poseStack,
+                font);
+        poseStack.popPose();
+        fb.unbindWrite();
+        McUtils.mc().getMainRenderTarget().bindWrite(true);
+
+        BufferedImage bi = createScreenshot(fb);
 
         // copy to clipboard
         ClipboardImage ci = new ClipboardImage(bi);
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ci, null);
+
+        McUtils.sendMessageToClient(
+                new TranslatableComponent("feature.wynntils.itemScreenshot.message", stack.getHoverName())
+                        .withStyle(ChatFormatting.GREEN));
     }
 
     private void removeItemLore(List<Component> tooltip) {
@@ -115,35 +165,192 @@ public class ItemScreenshotFeature extends Feature {
             Matcher m = ITEM_PATTERN.matcher(c.getString());
             if (!lore && m.find()) {
                 lore = true;
+                continue;
             }
 
-            if (lore && c.getString().contains("§8")) toRemove.add(c);
+            if (lore) toRemove.add(c);
         }
         tooltip.removeAll(toRemove);
     }
 
-    private List<String> listFormattedStringToWidth(String str, int maxWidth) {
-        Font f = McUtils.mc().font;
-        String[] words = str.split(" ");
-        int runningWidth = 0;
-        StringBuilder sb = new StringBuilder();
-        List<String> toReturn = new ArrayList<>();
-        for (String w : words) {
-            if (runningWidth + f.width(w) <= maxWidth) {
-                sb.append(w);
-                runningWidth += f.width(w);
-            } else {
-                toReturn.add(sb.toString());
-                sb = new StringBuilder();
-                sb.append(w);
-                runningWidth = f.width(w);
+    private void drawTooltip(List<ClientTooltipComponent> lines, PoseStack poseStack, Font font) {
+        int tooltipWidth = 0;
+        int tooltipHeight = lines.size() == 1 ? -2 : 0;
+
+        for (ClientTooltipComponent clientTooltipComponent : lines) {
+            int lineWidth = clientTooltipComponent.getWidth(font);
+            if (lineWidth > tooltipWidth) {
+                tooltipWidth = lineWidth;
             }
+            tooltipHeight += clientTooltipComponent.getHeight();
         }
-        return toReturn;
+
+        // background box
+        poseStack.pushPose();
+        int tooltipX = 4;
+        int tooltipY = 4;
+        // somewhat hacky solution to get around transparency issues - these colors were chosen to best match
+        // how tooltips are displayed in-game
+        int backgroundColor = 0xFF100010;
+        int borderColorStart = 0xFF25005B;
+        int borderColorEnd = 0xFF180033;
+        int zLevel = 400;
+        Tesselator tesselator = Tesselator.getInstance();
+        BufferBuilder bufferBuilder = tesselator.getBuilder();
+        RenderSystem.setShader(GameRenderer::getPositionColorShader);
+        bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+        Matrix4f matrix4f = poseStack.last().pose();
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 3,
+                tooltipY - 4,
+                tooltipX + tooltipWidth + 3,
+                tooltipY - 3,
+                zLevel,
+                backgroundColor,
+                backgroundColor);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 3,
+                tooltipY + tooltipHeight + 3,
+                tooltipX + tooltipWidth + 3,
+                tooltipY + tooltipHeight + 4,
+                zLevel,
+                backgroundColor,
+                backgroundColor);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 3,
+                tooltipY - 3,
+                tooltipX + tooltipWidth + 3,
+                tooltipY + tooltipHeight + 3,
+                zLevel,
+                backgroundColor,
+                backgroundColor);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 4,
+                tooltipY - 3,
+                tooltipX - 3,
+                tooltipY + tooltipHeight + 3,
+                zLevel,
+                backgroundColor,
+                backgroundColor);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX + tooltipWidth + 3,
+                tooltipY - 3,
+                tooltipX + tooltipWidth + 4,
+                tooltipY + tooltipHeight + 3,
+                zLevel,
+                backgroundColor,
+                backgroundColor);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 3,
+                tooltipY - 3 + 1,
+                tooltipX - 3 + 1,
+                tooltipY + tooltipHeight + 3 - 1,
+                zLevel,
+                borderColorStart,
+                borderColorEnd);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX + tooltipWidth + 2,
+                tooltipY - 3 + 1,
+                tooltipX + tooltipWidth + 3,
+                tooltipY + tooltipHeight + 3 - 1,
+                zLevel,
+                borderColorStart,
+                borderColorEnd);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 3,
+                tooltipY - 3,
+                tooltipX + tooltipWidth + 3,
+                tooltipY - 3 + 1,
+                zLevel,
+                borderColorStart,
+                borderColorStart);
+        fillGradient(
+                matrix4f,
+                bufferBuilder,
+                tooltipX - 3,
+                tooltipY + tooltipHeight + 2,
+                tooltipX + tooltipWidth + 3,
+                tooltipY + tooltipHeight + 3,
+                zLevel,
+                borderColorEnd,
+                borderColorEnd);
+        RenderSystem.enableDepthTest();
+        RenderSystem.disableTexture();
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        bufferBuilder.end();
+        BufferUploader.end(bufferBuilder);
+        RenderSystem.disableBlend();
+        RenderSystem.enableTexture();
+
+        // text
+        MultiBufferSource.BufferSource bufferSource =
+                MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
+        poseStack.translate(0.0, 0.0, 400.0);
+        int s = tooltipY;
+        boolean first = true;
+        for (ClientTooltipComponent line : lines) {
+            line.renderText(font, tooltipX, s, matrix4f, bufferSource);
+            s += line.getHeight() + (first ? 2 : 0);
+            first = false;
+        }
+        bufferSource.endBatch();
+        poseStack.popPose();
+    }
+
+    protected static void fillGradient(
+            Matrix4f matrix,
+            BufferBuilder builder,
+            int x1,
+            int y1,
+            int x2,
+            int y2,
+            int blitOffset,
+            int colorA,
+            int colorB) {
+        float f = (float) (colorA >> 24 & 0xFF) / 255.0f;
+        float g = (float) (colorA >> 16 & 0xFF) / 255.0f;
+        float h = (float) (colorA >> 8 & 0xFF) / 255.0f;
+        float i = (float) (colorA & 0xFF) / 255.0f;
+        float j = (float) (colorB >> 24 & 0xFF) / 255.0f;
+        float k = (float) (colorB >> 16 & 0xFF) / 255.0f;
+        float l = (float) (colorB >> 8 & 0xFF) / 255.0f;
+        float m = (float) (colorB & 0xFF) / 255.0f;
+        builder.vertex(matrix, x2, y1, blitOffset).color(g, h, i, f).endVertex();
+        builder.vertex(matrix, x1, y1, blitOffset).color(g, h, i, f).endVertex();
+        builder.vertex(matrix, x1, y2, blitOffset).color(k, l, m, j).endVertex();
+        builder.vertex(matrix, x2, y2, blitOffset).color(k, l, m, j).endVertex();
+    }
+
+    private static BufferedImage createScreenshot(RenderTarget fb) {
+        NativeImage image = new NativeImage(fb.width, fb.height, false);
+        RenderSystem.bindTexture(fb.getColorTextureId());
+        image.downloadTexture(0, false);
+        image.flipY();
+
+        int[] pixelValues = image.makePixelArray();
+        BufferedImage bufferedimage = new BufferedImage(fb.width, fb.height, BufferedImage.TYPE_INT_ARGB);
+        bufferedimage.setRGB(0, 0, fb.width, fb.height, pixelValues, 0, fb.width);
+        return bufferedimage;
     }
 
     private static class ClipboardImage implements Transferable {
-
         Image image;
 
         public ClipboardImage(Image image) {
@@ -152,7 +359,7 @@ public class ItemScreenshotFeature extends Feature {
 
         @Override
         public DataFlavor[] getTransferDataFlavors() {
-            return new DataFlavor[] { DataFlavor.imageFlavor };
+            return new DataFlavor[] {DataFlavor.imageFlavor};
         }
 
         @Override
@@ -161,33 +368,9 @@ public class ItemScreenshotFeature extends Feature {
         }
 
         @Override
-        public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+        public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
             if (!DataFlavor.imageFlavor.equals(flavor)) throw new UnsupportedFlavorException(flavor);
             return this.image;
         }
-    }
-
-    @SubscribeEvent
-    private void setHoveredSlot(InventoryRenderEvent e) {
-        hoveredSlot = e.getHoveredSlot();
-    }
-
-    @Override
-    public MutableComponent getNameComponent() {
-        return new TranslatableComponent("feature.wynntils.itemScreenshot.name");
-    }
-
-    @Override
-    protected void onInit(ImmutableList.Builder<Condition> conditions) {}
-
-    @Override
-    protected boolean onEnable() {
-        KeyManager.registerKeybind(itemScreenshotKeybind);
-        return true;
-    }
-
-    @Override
-    protected void onDisable() {
-        KeyManager.unregisterKeybind(itemScreenshotKeybind);
     }
 }

--- a/common/src/main/java/com/wynntils/features/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/ItemScreenshotFeature.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.wynntils.core.features.Feature;
+import com.wynntils.core.features.properties.FeatureInfo;
+import com.wynntils.core.features.properties.GameplayImpact;
+import com.wynntils.core.features.properties.PerformanceImpact;
+import com.wynntils.core.features.properties.Stability;
+import com.wynntils.mc.event.InventoryRenderEvent;
+import com.wynntils.mc.utils.McUtils;
+import com.wynntils.mc.utils.keybinds.KeyHolder;
+import com.wynntils.mc.utils.keybinds.KeyManager;
+import com.wynntils.wc.utils.WynnUtils;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.lwjgl.glfw.GLFW;
+
+import javax.xml.crypto.Data;
+import java.awt.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@FeatureInfo(stability = Stability.INVARIABLE, gameplay = GameplayImpact.LARGE, performance = PerformanceImpact.MEDIUM)
+public class ItemScreenshotFeature extends Feature {
+
+    private static Pattern ITEM_PATTERN = Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
+    Slot hoveredSlot = null;
+
+    private final KeyHolder itemScreenshotKeybind = new KeyHolder("Screenshot Item", GLFW.GLFW_KEY_F4, "Wynntils", true, this::takeScreenshot);
+
+    private void takeScreenshot() {
+        if (!WynnUtils.onWorld()) return;
+        Screen screen = McUtils.mc().screen;
+        if (!(screen instanceof AbstractContainerScreen<?>)) return;
+
+        if (hoveredSlot == null || !hoveredSlot.hasItem()) return;
+        ItemStack stack = hoveredSlot.getItem();
+        List<Component> tooltip = stack.getTooltipLines(McUtils.player(), TooltipFlag.Default.NORMAL);
+        removeItemLore(tooltip);
+
+        Font f = McUtils.mc().font;
+        int width = 0;
+        int height = 16;
+
+        // width calculation
+        for (Component c : tooltip) {
+            int w = f.width(c.getString());
+            if (w > width) {
+                width = w;
+            }
+        }
+        width += 8;
+
+        // height calculation
+        if (tooltip.size() > 1) {
+            height += 2 + (tooltip.size() - 1) * 10;
+        }
+
+        // account for text wrapping
+        if (width > screen.width/2 + 8) {
+            int wrappedWidth = 0;
+            int wrappedLines = 0;
+            for (Component c : tooltip) {
+                List<String> wrappedLine = listFormattedStringToWidth(c.toString(), screen.width/2);
+                for (String ws : wrappedLine) {
+                    wrappedLines++;
+                    int w = f.width(ws);
+                    if (w > wrappedWidth) {
+                        wrappedWidth = w;
+                    }
+                }
+            }
+            width = wrappedWidth + 8;
+            height = 16 + (2 + (wrappedLines - 1) * 10);
+        }
+
+        // calculate tooltip size to fit to framebuffer
+        float scaleh = (float) screen.height/height;
+        float scalew = (float) screen.width/width;
+
+        // draw tooltip to framebuffer, create image
+        // TODO: figure this out
+        GlStateManager.
+
+        // copy to clipboard
+        ClipboardImage ci = new ClipboardImage(bi);
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ci, null);
+    }
+
+    private void removeItemLore(List<Component> tooltip) {
+        List<Component> toRemove = new ArrayList<>();
+        boolean lore = false;
+        for (Component c : tooltip) {
+            // only remove text after the item type indicator
+            Matcher m = ITEM_PATTERN.matcher(c.getString());
+            if (!lore && m.find()) {
+                lore = true;
+            }
+
+            if (lore && c.getString().contains("§8")) toRemove.add(c);
+        }
+        tooltip.removeAll(toRemove);
+    }
+
+    private List<String> listFormattedStringToWidth(String str, int maxWidth) {
+        Font f = McUtils.mc().font;
+        String[] words = str.split(" ");
+        int runningWidth = 0;
+        StringBuilder sb = new StringBuilder();
+        List<String> toReturn = new ArrayList<>();
+        for (String w : words) {
+            if (runningWidth + f.width(w) <= maxWidth) {
+                sb.append(w);
+                runningWidth += f.width(w);
+            } else {
+                toReturn.add(sb.toString());
+                sb = new StringBuilder();
+                sb.append(w);
+                runningWidth = f.width(w);
+            }
+        }
+        return toReturn;
+    }
+
+    private static class ClipboardImage implements Transferable {
+
+        Image image;
+
+        public ClipboardImage(Image image) {
+            this.image = image;
+        }
+
+        @Override
+        public DataFlavor[] getTransferDataFlavors() {
+            return new DataFlavor[] { DataFlavor.imageFlavor };
+        }
+
+        @Override
+        public boolean isDataFlavorSupported(DataFlavor flavor) {
+            return DataFlavor.imageFlavor.equals(flavor);
+        }
+
+        @Override
+        public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+            if (!DataFlavor.imageFlavor.equals(flavor)) throw new UnsupportedFlavorException(flavor);
+            return this.image;
+        }
+    }
+
+    @SubscribeEvent
+    private void setHoveredSlot(InventoryRenderEvent e) {
+        hoveredSlot = e.getHoveredSlot();
+    }
+
+    @Override
+    public MutableComponent getNameComponent() {
+        return new TranslatableComponent("feature.wynntils.itemScreenshot.name");
+    }
+
+    @Override
+    protected void onInit(ImmutableList.Builder<Condition> conditions) {}
+
+    @Override
+    protected boolean onEnable() {
+        KeyManager.registerKeybind(itemScreenshotKeybind);
+        return true;
+    }
+
+    @Override
+    protected void onDisable() {
+        KeyManager.unregisterKeybind(itemScreenshotKeybind);
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -92,6 +92,12 @@ public class EventFactory {
         post(new ItemTooltipRenderEvent(poseStack, stack, mouseX, mouseY));
     }
 
+    public static boolean onInventoryKeyPress(int keyCode, int scanCode, int modifiers, Slot hoveredSlot) {
+        InventoryKeyPressEvent event = new InventoryKeyPressEvent(keyCode, scanCode, modifiers, hoveredSlot);
+        post(event);
+        return event.isCanceled();
+    }
+
     public static void onTabListCustomisation(ClientboundTabListPacket packet) {
         String footer = packet.getFooter().getString();
         post(new PlayerInfoFooterChangedEvent(footer));

--- a/common/src/main/java/com/wynntils/mc/event/InventoryKeyPressEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/InventoryKeyPressEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.world.inventory.Slot;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class InventoryKeyPressEvent extends Event {
+    private final int keyCode;
+    private final int scanCode;
+    private final int modifiers;
+    private final Slot hoveredSlot;
+
+    public InventoryKeyPressEvent(int keyCode, int scanCode, int modifiers, Slot hoveredSlot) {
+        this.keyCode = keyCode;
+        this.scanCode = scanCode;
+        this.modifiers = modifiers;
+        this.hoveredSlot = hoveredSlot;
+    }
+
+    public int getKeyCode() {
+        return keyCode;
+    }
+
+    public int getScanCode() {
+        return scanCode;
+    }
+
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    public Slot getHoveredSlot() {
+        return hoveredSlot;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(AbstractContainerScreen.class)
 public abstract class AbstractContainerScreenMixin extends Screen {
@@ -37,5 +38,14 @@ public abstract class AbstractContainerScreenMixin extends Screen {
         Screen screen = (Screen) (Object) this;
 
         EventFactory.onInventoryRender(screen, client, mouseX, mouseY, partialTicks, this.hoveredSlot);
+    }
+
+    @Inject(method = "keyPressed(III)Z", at = @At("HEAD"), cancellable = true)
+    private void keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        Screen screen = (Screen) (Object) this;
+
+        if (EventFactory.onInventoryKeyPress(keyCode, scanCode, modifiers, this.hoveredSlot)) {
+            cir.setReturnValue(true);
+        }
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -8,6 +8,7 @@
   "feature.wynntils.playerGhostTransparency.name": "Transparent Player Ghost Feature",
   "feature.wynntils.soulPointTimer.name": "Soul Point Timer Feature",
   "feature.wynntils.wynncraftButton.name": "Wynncraft Button Feature",
+  "feature.wynntils.itemScreenshot.name": "Item Screenshot Feature",
   "featureDebug.wynntils.connectionProgress.name": "Connection Progress Feature",
   "featureDebug.wynntils.keyBindTest.name": "Connection Progress Feature",
   "featureDebug.wynntils.packetDebugger.name": "Packet Debugger Feature"

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -9,6 +9,7 @@
   "feature.wynntils.soulPointTimer.name": "Soul Point Timer Feature",
   "feature.wynntils.wynncraftButton.name": "Wynncraft Button Feature",
   "feature.wynntils.itemScreenshot.name": "Item Screenshot Feature",
+  "feature.wynntils.itemScreenshot.message": "Copied %s to clipboard!",
   "featureDebug.wynntils.connectionProgress.name": "Connection Progress Feature",
   "featureDebug.wynntils.keyBindTest.name": "Connection Progress Feature",
   "featureDebug.wynntils.packetDebugger.name": "Packet Debugger Feature"


### PR DESCRIPTION
Functionally identical to the screenshot feature in Wynntils.

I created the KeyPress event because hotkeys don't trigger inside GUIs in Fabric. It might be better to add the functionality directly to KeyHolder instead, but most hotkeys will only have functions exclusively inside or outside GUIs, so it would probably be okay to use this type of workaround - having access to the slot clicked is a notable advantage as well. 

Taking a screenshot will put an error message in the log, but it's actually [some weird JDK debug print related to transparency](https://stackoverflow.com/questions/59140881/error-copying-an-image-object-to-the-clipboard). Some way of suppressing this error would be nice, if there's any clean way of doing that. Alternatively, we could replace the transparent corners in the screenshot with a solid color to avoid the error altogether.