### PR TITLE
Move too heavy mixin code blocks to new feature FixPacketBugsFeature

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -8,6 +8,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.features.overlays.Overlay;
 import com.wynntils.features.DialogueOptionOverrideFeature;
 import com.wynntils.features.EmeraldPouchHotkeyFeature;
+import com.wynntils.features.FixPacketBugsFeature;
 import com.wynntils.features.GammabrightFeature;
 import com.wynntils.features.HealthPotionBlockerFeature;
 import com.wynntils.features.IngredientPouchHotkeyFeature;
@@ -61,25 +62,26 @@ public class FeatureRegistry {
 
     public static void init() {
         // debug
-        registerFeature(new PacketDebuggerFeature());
-        registerFeature(new KeyBindTestFeature());
         registerFeature(new ConnectionProgressFeature());
+        registerFeature(new KeyBindTestFeature());
+        registerFeature(new PacketDebuggerFeature());
 
-        registerFeature(new WynncraftButtonFeature());
-        registerFeature(new SoulPointTimerFeature());
-        registerFeature(new ItemGuessFeature());
+        registerFeature(new DialogueOptionOverrideFeature());
+        registerFeature(new EmeraldPouchHotkeyFeature());
+        registerFeature(new FixPacketBugsFeature());
         registerFeature(new GammabrightFeature());
         registerFeature(new HealthPotionBlockerFeature());
-        registerFeature(new PlayerGhostTransparencyFeature());
-        registerFeature(new ItemStatInfoFeature());
-        registerFeature(new ItemScreenshotFeature());
-        registerFeature(new EmeraldPouchHotkeyFeature());
         registerFeature(new IngredientPouchHotkeyFeature());
-        registerFeature(new DialogueOptionOverrideFeature());
+        registerFeature(new ItemGuessFeature());
+        registerFeature(new ItemHighlightFeature());
+        registerFeature(new ItemScreenshotFeature());
+        registerFeature(new ItemStatInfoFeature());
+        registerFeature(new LootrunFeature());
         registerFeature(new MountHorseHotkeyFeature());
         registerFeature(new MythicBlockerFeature());
-        registerFeature(new ItemHighlightFeature());
-        registerFeature(new LootrunFeature());
+        registerFeature(new PlayerGhostTransparencyFeature());
+        registerFeature(new SoulPointTimerFeature());
+        registerFeature(new WynncraftButtonFeature());
 
         FEATURES.values().forEach(Feature::init);
 

--- a/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
@@ -25,8 +25,8 @@ public class FixPacketBugsFeature extends FeatureBase {
         setupEventListener();
     }
 
-    public static void fixBossEventPackage(ClientboundBossEventPacket packet, Handler handler,
-        Map<UUID, LerpingBossEvent> bossEvents) {
+    public static void fixBossEventPackage(
+            ClientboundBossEventPacket packet, Handler handler, Map<UUID, LerpingBossEvent> bossEvents) {
 
         packet.dispatch(new HandlerWrapper(handler, bossEvents));
     }
@@ -34,37 +34,38 @@ public class FixPacketBugsFeature extends FeatureBase {
     public static void fixSetPlayerTeamPacket(ClientboundSetPlayerTeamPacket packet, CallbackInfo ci) {
         // Work around bug in Wynncraft that causes a lot of NPEs in Vanilla
         if (((ClientboundSetPlayerTeamPacketAccessor) packet).getMethod() != 0
-            && McUtils.mc().level.getScoreboard().getPlayerTeam(packet.getName()) == null) {
+                && McUtils.mc().level.getScoreboard().getPlayerTeam(packet.getName()) == null) {
             ci.cancel();
         }
     }
 
-    public static void fixRemovePlayerFromTeam(PlayerTeam playerTeam, PlayerTeam playerTeamFromUserName, CallbackInfo ci) {
+    public static void fixRemovePlayerFromTeam(
+            PlayerTeam playerTeam, PlayerTeam playerTeamFromUserName, CallbackInfo ci) {
         // Work around bug in Wynncraft that causes NPEs in Vanilla
         if (playerTeamFromUserName != playerTeam) {
             ci.cancel();
         }
     }
+
     private static class HandlerWrapper implements Handler {
         private final Handler wrappedHandler;
         private final Map<UUID, LerpingBossEvent> bossEvents;
 
-        HandlerWrapper(Handler wrappedHandler,
-            Map<UUID, LerpingBossEvent> bossEvents) {
+        HandlerWrapper(Handler wrappedHandler, Map<UUID, LerpingBossEvent> bossEvents) {
             this.wrappedHandler = wrappedHandler;
             this.bossEvents = bossEvents;
         }
 
         @Override
         public void add(
-            UUID id,
-            Component name,
-            float progress,
-            BossBarColor color,
-            BossBarOverlay overlay,
-            boolean darkenScreen,
-            boolean playMusic,
-            boolean createWorldFog) {
+                UUID id,
+                Component name,
+                float progress,
+                BossBarColor color,
+                BossBarOverlay overlay,
+                boolean darkenScreen,
+                boolean playMusic,
+                boolean createWorldFog) {
             wrappedHandler.add(id, name, progress, color, overlay, darkenScreen, playMusic, createWorldFog);
         }
 

--- a/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
@@ -10,16 +10,10 @@ import com.wynntils.mc.event.RemovePlayerFromTeamEvent;
 import com.wynntils.mc.event.SetPlayerTeamEvent;
 import com.wynntils.mc.mixin.accessors.ClientboundBossEventPacketAccessor;
 import com.wynntils.mc.utils.McUtils;
-import java.util.Map;
 import java.util.UUID;
-import net.minecraft.client.gui.components.LerpingBossEvent;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
-import net.minecraft.network.protocol.game.ClientboundBossEventPacket.Handler;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.Operation;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.OperationType;
-import net.minecraft.world.BossEvent.BossBarColor;
-import net.minecraft.world.BossEvent.BossBarOverlay;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 

--- a/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
@@ -5,6 +5,7 @@
 package com.wynntils.features;
 
 import com.wynntils.core.features.FeatureBase;
+import com.wynntils.mc.event.RemovePlayerFromTeamEvent;
 import com.wynntils.mc.event.SetPlayerTeamEvent;
 import com.wynntils.mc.utils.McUtils;
 import java.util.Map;
@@ -17,7 +18,6 @@ import net.minecraft.world.BossEvent.BossBarColor;
 import net.minecraft.world.BossEvent.BossBarOverlay;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 public class FixPacketBugsFeature extends FeatureBase {
 
@@ -41,11 +41,12 @@ public class FixPacketBugsFeature extends FeatureBase {
         }
     }
 
-    public static void fixRemovePlayerFromTeam(
-            PlayerTeam playerTeam, PlayerTeam playerTeamFromUserName, CallbackInfo ci) {
+    @SubscribeEvent
+    public void onRemovePlayerFromTeam(RemovePlayerFromTeamEvent event) {
         // Work around bug in Wynncraft that causes NPEs in Vanilla
-        if (playerTeamFromUserName != playerTeam) {
-            ci.cancel();
+        PlayerTeam playerTeamFromUserName = McUtils.mc().level.getScoreboard().getPlayersTeam(event.getUsername());
+        if (playerTeamFromUserName != event.getPlayerTeam()) {
+            event.setCanceled(true);
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
@@ -31,11 +31,12 @@ public class FixPacketBugsFeature extends FeatureBase {
         OperationType type = operation.getType();
         UUID id = ((ClientboundBossEventPacketAccessor) packet).getId();
 
-        if (type == OperationType.ADD || type == OperationType.REMOVE) return;
-        if (event.getBossEvents().containsKey(id)) return;
-
-        // Any other operation than add/remove with invalid id will cause a NPE
-        event.setCanceled(true);
+        if (type != OperationType.ADD
+                && type != OperationType.REMOVE
+                && !event.getBossEvents().containsKey(id)) {
+            // Any other operation than add/remove with invalid id will cause a NPE
+            event.setCanceled(true);
+        }
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features;
+
+import com.wynntils.core.features.FeatureBase;
+import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
+import com.wynntils.mc.utils.McUtils;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.client.gui.components.LerpingBossEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
+import net.minecraft.network.protocol.game.ClientboundBossEventPacket.Handler;
+import net.minecraft.network.protocol.game.ClientboundSetPlayerTeamPacket;
+import net.minecraft.world.BossEvent.BossBarColor;
+import net.minecraft.world.BossEvent.BossBarOverlay;
+import net.minecraft.world.scores.PlayerTeam;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+public class FixPacketBugsFeature extends FeatureBase {
+
+    public FixPacketBugsFeature() {
+        setupEventListener();
+    }
+
+    public static void fixBossEventPackage(ClientboundBossEventPacket packet, Handler handler,
+        Map<UUID, LerpingBossEvent> bossEvents) {
+
+        packet.dispatch(new HandlerWrapper(handler, bossEvents));
+    }
+
+    public static void fixSetPlayerTeamPacket(ClientboundSetPlayerTeamPacket packet, CallbackInfo ci) {
+        // Work around bug in Wynncraft that causes a lot of NPEs in Vanilla
+        if (((ClientboundSetPlayerTeamPacketAccessor) packet).getMethod() != 0
+            && McUtils.mc().level.getScoreboard().getPlayerTeam(packet.getName()) == null) {
+            ci.cancel();
+        }
+    }
+
+    public static void fixRemovePlayerFromTeam(PlayerTeam playerTeam, PlayerTeam playerTeamFromUserName, CallbackInfo ci) {
+        // Work around bug in Wynncraft that causes NPEs in Vanilla
+        if (playerTeamFromUserName != playerTeam) {
+            ci.cancel();
+        }
+    }
+    private static class HandlerWrapper implements Handler {
+        private final Handler wrappedHandler;
+        private final Map<UUID, LerpingBossEvent> bossEvents;
+
+        HandlerWrapper(Handler wrappedHandler,
+            Map<UUID, LerpingBossEvent> bossEvents) {
+            this.wrappedHandler = wrappedHandler;
+            this.bossEvents = bossEvents;
+        }
+
+        @Override
+        public void add(
+            UUID id,
+            Component name,
+            float progress,
+            BossBarColor color,
+            BossBarOverlay overlay,
+            boolean darkenScreen,
+            boolean playMusic,
+            boolean createWorldFog) {
+            wrappedHandler.add(id, name, progress, color, overlay, darkenScreen, playMusic, createWorldFog);
+        }
+
+        @Override
+        public void remove(UUID id) {
+            wrappedHandler.remove(id);
+        }
+
+        @Override
+        public void updateProgress(UUID id, float progress) {
+            if (!bossEvents.containsKey(id)) return;
+
+            wrappedHandler.updateProgress(id, progress);
+        }
+
+        @Override
+        public void updateName(UUID id, Component name) {
+            if (!bossEvents.containsKey(id)) return;
+
+            wrappedHandler.updateName(id, name);
+        }
+
+        @Override
+        public void updateStyle(UUID id, BossBarColor color, BossBarOverlay overlay) {
+            if (!bossEvents.containsKey(id)) return;
+
+            wrappedHandler.updateStyle(id, color, overlay);
+        }
+
+        @Override
+        public void updateProperties(UUID id, boolean darkenScreen, boolean playMusic, boolean createWorldFog) {
+            if (!bossEvents.containsKey(id)) return;
+
+            wrappedHandler.updateProperties(id, darkenScreen, playMusic, createWorldFog);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/FixPacketBugsFeature.java
@@ -15,6 +15,7 @@ import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.Operation;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.OperationType;
 import net.minecraft.world.scores.PlayerTeam;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class FixPacketBugsFeature extends FeatureBase {
@@ -24,7 +25,7 @@ public class FixPacketBugsFeature extends FeatureBase {
         setupEventListener();
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onBossEventPackageReceived(BossHealthUpdateEvent event) {
         ClientboundBossEventPacket packet = event.getPacket();
         Operation operation = ((ClientboundBossEventPacketAccessor) packet).getOperation();
@@ -39,7 +40,7 @@ public class FixPacketBugsFeature extends FeatureBase {
         }
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onSetPlayerTeamPacket(SetPlayerTeamEvent event) {
         // Work around bug in Wynncraft that causes a lot of NPEs in Vanilla
         if (event.getMethod() != METHOD_ADD
@@ -48,7 +49,7 @@ public class FixPacketBugsFeature extends FeatureBase {
         }
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onRemovePlayerFromTeam(RemovePlayerFromTeamEvent event) {
         // Work around bug in Wynncraft that causes NPEs in Vanilla
         PlayerTeam playerTeamFromUserName = McUtils.mc().level.getScoreboard().getPlayersTeam(event.getUsername());

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -8,6 +8,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
 import com.wynntils.core.WynntilsMod;
+import com.wynntils.mc.event.BossHealthUpdateEvent;
 import com.wynntils.mc.event.ChatSendMessageEvent;
 import com.wynntils.mc.event.ClientTickEvent;
 import com.wynntils.mc.event.ConnectionEvent.ConnectedEvent;
@@ -41,8 +42,11 @@ import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.mc.event.WebSetupEvent;
 import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
@@ -50,6 +54,7 @@ import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
 import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket;
@@ -176,6 +181,12 @@ public class EventFactory {
 
     public static boolean onRemovePlayerFromTeam(String username, PlayerTeam playerTeam) {
         RemovePlayerFromTeamEvent event = new RemovePlayerFromTeamEvent(username, playerTeam);
+        post(event);
+        return event.isCanceled();
+    }
+
+    public static boolean onBossHealthUpdate(ClientboundBossEventPacket packet, Map<UUID, LerpingBossEvent> bossEvents) {
+        BossHealthUpdateEvent event = new BossHealthUpdateEvent(packet, bossEvents);
         post(event);
         return event.isCanceled();
     }

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -33,10 +33,12 @@ import com.wynntils.mc.event.PlayerTeleportEvent;
 import com.wynntils.mc.event.RenderLevelLastEvent;
 import com.wynntils.mc.event.ResourcePackEvent;
 import com.wynntils.mc.event.ScreenOpenedEvent;
+import com.wynntils.mc.event.SetPlayerTeamEvent;
 import com.wynntils.mc.event.SetSpawnEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.mc.event.WebSetupEvent;
+import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
 import java.util.List;
 import java.util.function.Consumer;
 import net.minecraft.client.gui.components.AbstractWidget;
@@ -54,6 +56,7 @@ import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket.Action;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket.PlayerUpdate;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.network.protocol.game.ClientboundResourcePackPacket;
+import net.minecraft.network.protocol.game.ClientboundSetPlayerTeamPacket;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -160,6 +163,13 @@ public class EventFactory {
 
     public static void onResourcePack(ClientboundResourcePackPacket packet) {
         post(new ResourcePackEvent());
+    }
+
+    public static boolean onSetPlayerTeam(ClientboundSetPlayerTeamPacket packet) {
+        SetPlayerTeamEvent event =
+                new SetPlayerTeamEvent(((ClientboundSetPlayerTeamPacketAccessor) packet).getMethod(), packet.getName());
+        post(event);
+        return event.isCanceled();
     }
 
     public static boolean onSetSpawn(BlockPos spawnPos) {

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -185,7 +185,8 @@ public class EventFactory {
         return event.isCanceled();
     }
 
-    public static boolean onBossHealthUpdate(ClientboundBossEventPacket packet, Map<UUID, LerpingBossEvent> bossEvents) {
+    public static boolean onBossHealthUpdate(
+            ClientboundBossEventPacket packet, Map<UUID, LerpingBossEvent> bossEvents) {
         BossHealthUpdateEvent event = new BossHealthUpdateEvent(packet, bossEvents);
         post(event);
         return event.isCanceled();

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -30,6 +30,7 @@ import com.wynntils.mc.event.PlayerInfoEvent.PlayerLogOutEvent;
 import com.wynntils.mc.event.PlayerInfoFooterChangedEvent;
 import com.wynntils.mc.event.PlayerInteractEvent;
 import com.wynntils.mc.event.PlayerTeleportEvent;
+import com.wynntils.mc.event.RemovePlayerFromTeamEvent;
 import com.wynntils.mc.event.RenderLevelLastEvent;
 import com.wynntils.mc.event.ResourcePackEvent;
 import com.wynntils.mc.event.ScreenOpenedEvent;
@@ -66,6 +67,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.scores.PlayerTeam;
 import net.minecraftforge.eventbus.api.Event;
 
 /** Creates events from mixins and platform dependent hooks */
@@ -168,6 +170,12 @@ public class EventFactory {
     public static boolean onSetPlayerTeam(ClientboundSetPlayerTeamPacket packet) {
         SetPlayerTeamEvent event =
                 new SetPlayerTeamEvent(((ClientboundSetPlayerTeamPacketAccessor) packet).getMethod(), packet.getName());
+        post(event);
+        return event.isCanceled();
+    }
+
+    public static boolean onRemovePlayerFromTeam(String username, PlayerTeam playerTeam) {
+        RemovePlayerFromTeamEvent event = new RemovePlayerFromTeamEvent(username, playerTeam);
         post(event);
         return event.isCanceled();
     }

--- a/common/src/main/java/com/wynntils/mc/event/BossHealthUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/BossHealthUpdateEvent.java
@@ -16,8 +16,7 @@ public class BossHealthUpdateEvent extends Event {
     private final ClientboundBossEventPacket packet;
     private final Map<UUID, LerpingBossEvent> bossEvents;
 
-    public BossHealthUpdateEvent(ClientboundBossEventPacket packet,
-        Map<UUID, LerpingBossEvent> bossEvents) {
+    public BossHealthUpdateEvent(ClientboundBossEventPacket packet, Map<UUID, LerpingBossEvent> bossEvents) {
         this.packet = packet;
         this.bossEvents = bossEvents;
     }

--- a/common/src/main/java/com/wynntils/mc/event/BossHealthUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/BossHealthUpdateEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.client.gui.components.LerpingBossEvent;
+import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class BossHealthUpdateEvent extends Event {
+    private final ClientboundBossEventPacket packet;
+    private final Map<UUID, LerpingBossEvent> bossEvents;
+
+    public BossHealthUpdateEvent(ClientboundBossEventPacket packet,
+        Map<UUID, LerpingBossEvent> bossEvents) {
+        this.packet = packet;
+        this.bossEvents = bossEvents;
+    }
+
+    public ClientboundBossEventPacket getPacket() {
+        return packet;
+    }
+
+    public Map<UUID, LerpingBossEvent> getBossEvents() {
+        return bossEvents;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/RemovePlayerFromTeamEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/RemovePlayerFromTeamEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.world.scores.PlayerTeam;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class RemovePlayerFromTeamEvent extends Event {
+    private final String username;
+    private final PlayerTeam playerTeam;
+
+    public RemovePlayerFromTeamEvent(String username, PlayerTeam playerTeam) {
+        this.username = username;
+        this.playerTeam = playerTeam;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public PlayerTeam getPlayerTeam() {
+        return playerTeam;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/SetPlayerTeamEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetPlayerTeamEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class SetPlayerTeamEvent extends Event {
+    private final int method;
+    private final String teamName;
+
+    public SetPlayerTeamEvent(int method, String teamName) {
+        this.method = method;
+        this.teamName = teamName;
+    }
+
+    public int getMethod() {
+        return method;
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
@@ -4,13 +4,12 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.wynntils.features.FixPacketBugsFeature;
 import java.util.Map;
 import java.util.UUID;
 import net.minecraft.client.gui.components.BossHealthOverlay;
 import net.minecraft.client.gui.components.LerpingBossEvent;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
-import net.minecraft.world.BossEvent;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -31,52 +30,6 @@ public abstract class BossHealthOverlayMixin {
                             target =
                                     "Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket;dispatch(Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket$Handler;)V"))
     private void updatePre(ClientboundBossEventPacket packet, ClientboundBossEventPacket.Handler handler) {
-        Map<UUID, LerpingBossEvent> bossEvents = events;
-
-        packet.dispatch(new ClientboundBossEventPacket.Handler() {
-            public void add(
-                    UUID id,
-                    Component name,
-                    float progress,
-                    BossEvent.BossBarColor color,
-                    BossEvent.BossBarOverlay overlay,
-                    boolean darkenScreen,
-                    boolean playMusic,
-                    boolean createWorldFog) {
-                bossEvents.put(
-                        id,
-                        new LerpingBossEvent(
-                                id, name, progress, color, overlay, darkenScreen, playMusic, createWorldFog));
-            }
-
-            public void remove(UUID id) {
-                bossEvents.remove(id);
-            }
-
-            public void updateProgress(UUID id, float progress) {
-                if (!bossEvents.containsKey(id)) return;
-                bossEvents.get(id).setProgress(progress);
-            }
-
-            public void updateName(UUID id, Component name) {
-                if (!bossEvents.containsKey(id)) return;
-                bossEvents.get(id).setName(name);
-            }
-
-            public void updateStyle(UUID id, BossEvent.BossBarColor color, BossEvent.BossBarOverlay overlay) {
-                if (!bossEvents.containsKey(id)) return;
-                LerpingBossEvent lerpingBossEvent = bossEvents.get(id);
-                lerpingBossEvent.setColor(color);
-                lerpingBossEvent.setOverlay(overlay);
-            }
-
-            public void updateProperties(UUID id, boolean darkenScreen, boolean playMusic, boolean createWorldFog) {
-                if (!bossEvents.containsKey(id)) return;
-                LerpingBossEvent lerpingBossEvent = bossEvents.get(id);
-                lerpingBossEvent.setDarkenScreen(darkenScreen);
-                lerpingBossEvent.setPlayBossMusic(playMusic);
-                lerpingBossEvent.setCreateWorldFog(createWorldFog);
-            }
-        });
+        FixPacketBugsFeature.fixBossEventPackage(packet, handler, events);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.mc.mixin;
 
-import com.wynntils.features.FixPacketBugsFeature;
+import com.wynntils.mc.EventFactory;
 import java.util.Map;
 import java.util.UUID;
 import net.minecraft.client.gui.components.BossHealthOverlay;
@@ -14,7 +14,8 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BossHealthOverlay.class)
 public abstract class BossHealthOverlayMixin {
@@ -22,14 +23,15 @@ public abstract class BossHealthOverlayMixin {
     @Shadow
     Map<UUID, LerpingBossEvent> events;
 
-    @Redirect(
-            method = "update",
-            at =
-                    @At(
-                            value = "INVOKE",
-                            target =
-                                    "Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket;dispatch(Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket$Handler;)V"))
-    private void updatePre(ClientboundBossEventPacket packet, ClientboundBossEventPacket.Handler handler) {
-        FixPacketBugsFeature.fixBossEventPackage(packet, handler, events);
+    @Inject(
+            method =
+                    "update(Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket;)V",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void updatePre(
+        ClientboundBossEventPacket packet, CallbackInfo ci) {
+        if (EventFactory.onBossHealthUpdate(packet, events)) {
+            ci.cancel();
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
@@ -24,12 +24,10 @@ public abstract class BossHealthOverlayMixin {
     Map<UUID, LerpingBossEvent> events;
 
     @Inject(
-            method =
-                    "update(Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket;)V",
+            method = "update(Lnet/minecraft/network/protocol/game/ClientboundBossEventPacket;)V",
             at = @At("HEAD"),
             cancellable = true)
-    private void updatePre(
-        ClientboundBossEventPacket packet, CallbackInfo ci) {
+    private void updatePre(ClientboundBossEventPacket packet, CallbackInfo ci) {
         if (EventFactory.onBossHealthUpdate(packet, events)) {
             ci.cancel();
         }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.mc.mixin;
 
-import com.wynntils.features.FixPacketBugsFeature;
 import com.wynntils.mc.EventFactory;
 import com.wynntils.mc.utils.McUtils;
 import java.util.ArrayList;
@@ -77,7 +76,9 @@ public abstract class ClientPacketListenerMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void handleSetPlayerTeamPacketPre(ClientboundSetPlayerTeamPacket packet, CallbackInfo ci) {
-        FixPacketBugsFeature.fixSetPlayerTeamPacket(packet, ci);
+        if (EventFactory.onSetPlayerTeam(packet)) {
+            ci.cancel();
+        }
     }
 
     @Inject(method = "handleSetSpawn", at = @At("HEAD"), cancellable = true)

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -4,8 +4,8 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.wynntils.features.FixPacketBugsFeature;
 import com.wynntils.mc.EventFactory;
-import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
 import com.wynntils.mc.utils.McUtils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,11 +77,7 @@ public abstract class ClientPacketListenerMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void handleSetPlayerTeamPacketPre(ClientboundSetPlayerTeamPacket packet, CallbackInfo ci) {
-        // Work around bug in Wynncraft that causes a lot of NPEs in Vanilla
-        if (((ClientboundSetPlayerTeamPacketAccessor) packet).getMethod() != 0
-                && McUtils.mc().level.getScoreboard().getPlayerTeam(packet.getName()) == null) {
-            ci.cancel();
-        }
+        FixPacketBugsFeature.fixSetPlayerTeamPacket(packet, ci);
     }
 
     @Inject(method = "handleSetSpawn", at = @At("HEAD"), cancellable = true)

--- a/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.wynntils.features.FixPacketBugsFeature;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Scoreboard;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,9 +23,6 @@ public abstract class ScoreboardMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void removePlayerFromTeamPre(String username, PlayerTeam playerTeam, CallbackInfo ci) {
-        // Work around bug in Wynncraft that causes NPEs in Vanilla
-        if (this.getPlayersTeam(username) != playerTeam) {
-            ci.cancel();
-        }
+        FixPacketBugsFeature.fixRemovePlayerFromTeam(playerTeam, this.getPlayersTeam(username), ci);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
@@ -19,6 +19,8 @@ public abstract class ScoreboardMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void removePlayerFromTeamPre(String username, PlayerTeam playerTeam, CallbackInfo ci) {
-        EventFactory.onRemovePlayerFromTeam(username, playerTeam);
+        if (EventFactory.onRemovePlayerFromTeam(username, playerTeam)) {
+            ci.cancel();
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
@@ -4,25 +4,21 @@
  */
 package com.wynntils.mc.mixin;
 
-import com.wynntils.features.FixPacketBugsFeature;
+import com.wynntils.mc.EventFactory;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Scoreboard;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Scoreboard.class)
 public abstract class ScoreboardMixin {
-    @Shadow
-    public abstract PlayerTeam getPlayersTeam(String username);
-
     @Inject(
             method = "removePlayerFromTeam(Ljava/lang/String;Lnet/minecraft/world/scores/PlayerTeam;)V",
             at = @At("HEAD"),
             cancellable = true)
     private void removePlayerFromTeamPre(String username, PlayerTeam playerTeam, CallbackInfo ci) {
-        FixPacketBugsFeature.fixRemovePlayerFromTeam(playerTeam, this.getPlayersTeam(username), ci);
+        EventFactory.onRemovePlayerFromTeam(username, playerTeam);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/ClientboundBossEventPacketAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/ClientboundBossEventPacketAccessor.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin.accessors;
+
+import java.util.UUID;
+import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientboundBossEventPacket.class)
+public interface ClientboundBossEventPacketAccessor {
+    @Accessor("id")
+    UUID getId();
+
+    @Accessor("operation")
+    ClientboundBossEventPacket.Operation getOperation();
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -3,7 +3,7 @@
   "feature.wynntils.emeraldPouchKeybind.multipleFilled": "You have multiple filled emerald pouches in your inventory.",
   "feature.wynntils.emeraldPouchKeybind.name": "Emerald Pouch Keybind Feature",
   "feature.wynntils.emeraldPouchKeybind.noPouch": "You do not have an emerald pouch in your inventory.",
-  "feature.wynntils.fixPacketBugs.name": "Fix Packets Bug Feature",
+  "feature.wynntils.fixPacketBugs.name": "Fix Packet Bugs Feature",
   "feature.wynntils.gammabright.name": "Gammabright Keybind Feature",
   "feature.wynntils.healthPotionBlocker.healthFull": "You are already at full health!",
   "feature.wynntils.healthPotionBlocker.name": "Health Potion Blocker Feature",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -3,6 +3,7 @@
   "feature.wynntils.emeraldPouchKeybind.multipleFilled": "You have multiple filled emerald pouches in your inventory.",
   "feature.wynntils.emeraldPouchKeybind.name": "Emerald Pouch Keybind Feature",
   "feature.wynntils.emeraldPouchKeybind.noPouch": "You do not have an emerald pouch in your inventory.",
+  "feature.wynntils.fixPacketBugs.name": "Fix Packets Bug Feature",
   "feature.wynntils.gammabright.name": "Gammabright Keybind Feature",
   "feature.wynntils.healthPotionBlocker.healthFull": "You are already at full health!",
   "feature.wynntils.healthPotionBlocker.name": "Health Potion Blocker Feature",

--- a/common/src/main/resources/wynntils.accessWidener
+++ b/common/src/main/resources/wynntils.accessWidener
@@ -3,3 +3,5 @@ accessWidener v1 named
 accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType;
 accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;ILnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType;
 extendable class net/minecraft/world/item/ItemStack
+accessible class net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
+accessible class net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType


### PR DESCRIPTION
This fix is halfway there. A few mixin methods had too much logic in them. Three of them are "hacks" that are needed to silence NPEs due to Wynncraft sending broken packets.

I collected all the functionality in FixPacketBugsFeature. So far, I'm pretty happy with the design. The problems comes at the next step -- the feature expose this functionality as public static methods, instead of sending events. I'm not sure if we should always insist on sending events, or if we can hardcode the actual receptors like this in a few cases. 

And *if* we should hardcode the feature, we should probably not do it using static public methods...