### PR TITLE
Fix keybinds not saving on Fabric

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/OptionsMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/OptionsMixin.java
@@ -5,8 +5,6 @@
 package com.wynntils.mc.mixin;
 
 import com.wynntils.core.keybinds.KeyManager;
-import java.io.File;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Options.class)
 public abstract class OptionsMixin {
-    @Inject(method = "<init>", at = @At("RETURN"))
-    public void initPost(Minecraft minecraft, File file, CallbackInfo ci) {
+    @Inject(method = "load()V", at = @At("HEAD"))
+    public void loadPre(CallbackInfo ci) {
         KeyManager.loadKeybinds((Options) (Object) this);
     }
 }


### PR DESCRIPTION
Fixes #73. The original mixin meant to add our keybinds only triggered after Minecraft loaded the keybinds from options.txt, so the saved values were never actually read.