### PR TITLE
Add tooltip scale feature

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -32,6 +32,7 @@ import com.wynntils.features.user.MountHorseHotkeyFeature;
 import com.wynntils.features.user.MythicBlockerFeature;
 import com.wynntils.features.user.PlayerGhostTransparencyFeature;
 import com.wynntils.features.user.SoulPointTimerFeature;
+import com.wynntils.features.user.TooltipScaleFeature;
 import com.wynntils.features.user.WynncraftButtonFeature;
 import com.wynntils.mc.event.ClientTickEvent;
 import com.wynntils.mc.event.RenderEvent;
@@ -152,6 +153,7 @@ public class FeatureRegistry {
         registerFeature(new PlayerGhostTransparencyFeature());
         registerFeature(new SoulPointTimerFeature());
         registerFeature(new WynncraftButtonFeature());
+        registerFeature(new TooltipScaleFeature());
 
         // save/create config file after loading all features' options
         ConfigManager.saveConfig();

--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -31,6 +31,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.lwjgl.glfw.GLFW;
 
@@ -52,7 +53,7 @@ public class ItemScreenshotFeature extends UserFeature {
     }
 
     @SubscribeEvent
-    public void render(ItemTooltipRenderEvent e) {
+    public void render(ItemTooltipRenderEvent.Pre e) {
         if (screenshotSlot == null) return;
 
         // has to be called during a render period
@@ -68,7 +69,7 @@ public class ItemScreenshotFeature extends UserFeature {
         if (hoveredSlot == null || !hoveredSlot.hasItem()) return;
 
         ItemStack stack = hoveredSlot.getItem();
-        List<Component> tooltip = ItemUtils.getTooltipLines(stack);
+        List<Component> tooltip = stack.getTooltipLines(null, TooltipFlag.Default.NORMAL);
         ItemUtils.removeItemLore(tooltip);
 
         Font font = McUtils.mc().font;

--- a/common/src/main/java/com/wynntils/features/user/TooltipScaleFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TooltipScaleFeature.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.user;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.config.properties.ConfigOption;
+import com.wynntils.core.config.properties.Configurable;
+import com.wynntils.core.features.UserFeature;
+import com.wynntils.core.features.properties.EventListener;
+import com.wynntils.core.features.properties.FeatureInfo;
+import com.wynntils.core.features.properties.FeatureInfo.Stability;
+import com.wynntils.mc.event.ItemTooltipRenderEvent;
+import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.mc.utils.McUtils;
+import com.wynntils.wc.utils.WynnUtils;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+@EventListener
+@Configurable(category = "Item Tooltips")
+@FeatureInfo(stability = Stability.STABLE)
+public class TooltipScaleFeature extends UserFeature {
+
+    @ConfigOption(
+            displayName = "Universal Scale",
+            description = "The scale factor that should be applied to every tooltip")
+    public static float universalScale = 1f;
+
+    @ConfigOption(
+            displayName = "Fit to Screen",
+            description = "Whether tooltips should be scaled to always fit on the screen")
+    public static boolean fitToScreen = true;
+
+    private boolean scaledLast = false;
+    private Screen currentScreen = null;
+    private int oldWidth = -1;
+    private int oldHeight = -1;
+
+    @SubscribeEvent
+    public void onTooltipPre(ItemTooltipRenderEvent.Pre e) {
+        if (!WynnUtils.onServer()) return;
+
+        currentScreen = McUtils.mc().screen;
+        if (currentScreen == null) return; // shouldn't be possible
+
+        // calculate scale factor
+        float scaleFactor = universalScale;
+
+        if (fitToScreen) {
+            int lines = ItemUtils.getTooltipLines(e.getItemStack()).size();
+            // this is technically slightly larger than the actual height, but due to the tooltip offset/border, it
+            // works to create a nice buffer at the top/bottom of the screen
+            float tooltipHeight = 22 + (lines - 1) * 10;
+            tooltipHeight *= universalScale;
+
+            if (tooltipHeight > currentScreen.height) scaleFactor *= (currentScreen.height / tooltipHeight);
+        }
+
+        // set new screen dimensions - this is done to avoid issues with tooltip offsets being wrong
+        oldWidth = currentScreen.width;
+        currentScreen.width = (int) (oldWidth / scaleFactor);
+        oldHeight = currentScreen.height;
+        currentScreen.height = (int) (oldHeight / scaleFactor);
+
+        // scale mouse coordinates for same reason
+        e.setMouseX((int) (e.getMouseX() / scaleFactor));
+        e.setMouseY((int) (e.getMouseY() / scaleFactor));
+
+        // push pose before scaling, so we can pop it afterwards
+        PoseStack poseStack = e.getPoseStack();
+        poseStack.pushPose();
+        poseStack.scale(scaleFactor, scaleFactor, 1);
+
+        scaledLast = true;
+    }
+
+    @SubscribeEvent
+    public void onTooltipPost(ItemTooltipRenderEvent.Post e) {
+        if (!WynnUtils.onServer()) return;
+        if (!scaledLast) return;
+
+        e.getPoseStack().popPose();
+        scaledLast = false;
+
+        // reset screen dimensions
+        if (currentScreen != null) {
+            currentScreen.width = oldWidth;
+            currentScreen.height = oldHeight;
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -109,8 +109,13 @@ public class EventFactory {
         // TODO: Not implemented yet
     }
 
-    public static void onItemTooltipRender(PoseStack poseStack, ItemStack stack, int mouseX, int mouseY) {
-        post(new ItemTooltipRenderEvent(poseStack, stack, mouseX, mouseY));
+    public static ItemTooltipRenderEvent onItemTooltipRenderPre(
+            PoseStack poseStack, ItemStack stack, int mouseX, int mouseY) {
+        return post(new ItemTooltipRenderEvent.Pre(poseStack, stack, mouseX, mouseY));
+    }
+
+    public static void onItemTooltipRenderPost(PoseStack poseStack, ItemStack stack, int mouseX, int mouseY) {
+        post(new ItemTooltipRenderEvent.Post(poseStack, stack, mouseX, mouseY));
     }
 
     public static void onSlotRenderPre(Screen screen, Slot slot) {

--- a/common/src/main/java/com/wynntils/mc/event/ItemTooltipRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemTooltipRenderEvent.java
@@ -6,13 +6,14 @@ package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
-public class ItemTooltipRenderEvent extends Event {
+public abstract class ItemTooltipRenderEvent extends Event {
     private final PoseStack poseStack;
-    private final ItemStack itemStack;
-    private final int mouseX;
-    private final int mouseY;
+    private ItemStack itemStack;
+    private int mouseX;
+    private int mouseY;
 
     public ItemTooltipRenderEvent(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY) {
         this.poseStack = poseStack;
@@ -35,5 +36,30 @@ public class ItemTooltipRenderEvent extends Event {
 
     public int getMouseY() {
         return mouseY;
+    }
+
+    public void setItemStack(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public void setMouseX(int mouseX) {
+        this.mouseX = mouseX;
+    }
+
+    public void setMouseY(int mouseY) {
+        this.mouseY = mouseY;
+    }
+
+    @Cancelable
+    public static class Pre extends ItemTooltipRenderEvent {
+        public Pre(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY) {
+            super(poseStack, itemStack, mouseX, mouseY);
+        }
+    }
+
+    public static class Post extends ItemTooltipRenderEvent {
+        public Post(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY) {
+            super(poseStack, itemStack, mouseX, mouseY);
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -6,18 +6,23 @@ package com.wynntils.mc.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.mc.EventFactory;
+import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import java.util.List;
+import java.util.Optional;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Screen.class)
@@ -54,10 +59,39 @@ public abstract class ScreenMixin {
         EventFactory.onScreenCreated(screen, this::addRenderableWidget);
     }
 
+    @Redirect(
+            method = "renderTooltip(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/item/ItemStack;II)V",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/gui/screens/Screen;renderTooltip(Lcom/mojang/blaze3d/vertex/PoseStack;Ljava/util/List;Ljava/util/Optional;II)V"))
+    private void renderTooltipPre(
+            Screen instance,
+            PoseStack poseStack,
+            List<Component> tooltips,
+            Optional<TooltipComponent> visualTooltipComponent,
+            int mouseX,
+            int mouseY,
+            PoseStack poseStack2,
+            ItemStack itemStack,
+            int mouseX2,
+            int mouseY2) {
+        ItemTooltipRenderEvent e = EventFactory.onItemTooltipRenderPre(poseStack, itemStack, mouseX, mouseY);
+        if (e.isCanceled()) return;
+
+        instance.renderTooltip(
+                poseStack,
+                instance.getTooltipFromItem(e.getItemStack()),
+                e.getItemStack().getTooltipImage(),
+                e.getMouseX(),
+                e.getMouseY());
+    }
+
     @Inject(
             method = "renderTooltip(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/item/ItemStack;II)V",
-            at = @At("HEAD"))
-    private void renderTooltipPre(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY, CallbackInfo ci) {
-        EventFactory.onItemTooltipRender(poseStack, itemStack, mouseX, mouseY);
+            at = @At("RETURN"))
+    private void renderTooltipPost(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY, CallbackInfo ci) {
+        EventFactory.onItemTooltipRenderPost(poseStack, itemStack, mouseX, mouseY);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/utils/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/ItemUtils.java
@@ -22,6 +22,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.TooltipFlag.Default;
 
 public class ItemUtils {
 
@@ -185,7 +186,8 @@ public class ItemUtils {
     }
 
     public static List<Component> getTooltipLines(ItemStack stack) {
-        return stack.getTooltipLines(McUtils.player(), TooltipFlag.Default.NORMAL);
+        TooltipFlag flag = McUtils.options().advancedItemTooltips ? Default.ADVANCED : Default.NORMAL;
+        return stack.getTooltipLines(McUtils.player(), flag);
     }
 
     public static boolean isMythic(ItemStack stack) {


### PR DESCRIPTION
This feature has two separate functionalities. The first is to automatically scale tooltips down if they're large enough to go off the screen (this was a feature in 1.12 Wynntils) - thus ensuring that you can always read any tooltip in full. The second is to apply a universal scaling factor to all tooltips, i.e. making every tooltip a certain factor smaller or larger (default is 1x, so no change). These two functionalities can work in tandem with no issues.

Example of a scaled tooltip vs. no scaling:
![image](https://user-images.githubusercontent.com/3767283/171760535-eef47ef4-f30e-4977-b040-00f99d4388e9.png)
![image](https://user-images.githubusercontent.com/3767283/171760594-c484aaaf-e32a-499c-a8ff-1ddc23d925c4.png)
