### PR TITLE
MythicBlockerFeature: Use `ContainerCloseEvent` instead of keybinds

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
@@ -8,7 +8,7 @@ import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.FeatureInfo.Stability;
-import com.wynntils.mc.event.InventoryKeyPressEvent;
+import com.wynntils.mc.event.ContainerCloseEvent;
 import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wc.utils.ContainerUtils;
@@ -24,9 +24,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 public class MythicBlockerFeature extends UserFeature {
 
     @SubscribeEvent
-    public void onChestCloseAttempt(InventoryKeyPressEvent e) {
+    public void onChestCloseAttempt(ContainerCloseEvent.Pre e) {
         if (!WynnUtils.onWorld()) return;
-        if (!McUtils.mc().options.keyInventory.matches(e.getKeyCode(), e.getScanCode())) return;
         if (!ContainerUtils.isLootOrRewardChest(McUtils.mc().screen)) return;
 
         NonNullList<ItemStack> items = ContainerUtils.getItems(McUtils.mc().screen);

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -14,6 +14,7 @@ import com.wynntils.mc.event.ClientTickEvent;
 import com.wynntils.mc.event.ConnectionEvent.ConnectedEvent;
 import com.wynntils.mc.event.ConnectionEvent.DisconnectedEvent;
 import com.wynntils.mc.event.ContainerClickEvent;
+import com.wynntils.mc.event.ContainerCloseEvent;
 import com.wynntils.mc.event.GameMenuInitEvent;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
@@ -149,8 +150,16 @@ public class EventFactory {
     // endregion
 
     // region Container Events
-    public static void onContainerClose(ClientboundContainerClosePacket packet) {
+    public static void onClientboundContainerClosePacket(ClientboundContainerClosePacket packet) {
         post(new MenuClosedEvent());
+    }
+
+    public static ContainerCloseEvent.Pre onCloseContainerPre() {
+        return post(new ContainerCloseEvent.Pre());
+    }
+
+    public static void onCloseContainerPost() {
+        post(new ContainerCloseEvent.Post());
     }
 
     public static void onItemsReceived(List<ItemStack> items, AbstractContainerMenu container) {
@@ -274,5 +283,6 @@ public class EventFactory {
     public static void onTickEnd() {
         post(new ClientTickEvent(ClientTickEvent.Phase.END));
     }
+
     // endregion
 }

--- a/common/src/main/java/com/wynntils/mc/event/ContainerCloseEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerCloseEvent.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+public abstract class ContainerCloseEvent extends Event {
+    @Cancelable
+    public static class Pre extends ContainerCloseEvent {}
+
+    public static class Post extends ContainerCloseEvent {}
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
@@ -52,4 +52,16 @@ public abstract class AbstractContainerScreenMixin {
             cir.setReturnValue(true);
         }
     }
+
+    @Inject(method = "onClose", at = @At("HEAD"), cancellable = true)
+    private void onCloseContainerPre(CallbackInfo ci) {
+        if (EventFactory.onCloseContainerPre().isCanceled()) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "onClose", at = @At("RETURN"))
+    private void onCloseContainerPost(CallbackInfo ci) {
+        EventFactory.onCloseContainerPost();
+    }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -68,7 +68,7 @@ public abstract class ClientPacketListenerMixin {
             method = "handleContainerClose(Lnet/minecraft/network/protocol/game/ClientboundContainerClosePacket;)V",
             at = @At("RETURN"))
     private void handleContainerClosePost(ClientboundContainerClosePacket packet, CallbackInfo ci) {
-        EventFactory.onContainerClose(packet);
+        EventFactory.onClientboundContainerClosePacket(packet);
     }
 
     @Inject(


### PR DESCRIPTION
This way, we don't need to check for any keybinds, as we are hooking into the container closing logic itself.
This commit also renames `EventFactory.onContainerClose` to `EventFactory.onClientboundContainerClosePacket` to highlight the difference between `ContainerCloseEvent` and `MenuCloseEvent`, as the latter is initiated by the server, and the new, `ContainerCloseEvent` is initiated by the client.

Resolves #65.