### PR TITLE
MythicBlockerFeature: Make check stricter by checking item type (and util housekeeping)

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -15,9 +15,9 @@ import com.wynntils.core.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyHolder;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
-import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.mc.utils.RenderUtils;
+import com.wynntils.wc.utils.WynnItemUtils;
 import com.wynntils.wc.utils.WynnUtils;
 import java.awt.image.BufferedImage;
 import java.util.List;
@@ -70,7 +70,7 @@ public class ItemScreenshotFeature extends UserFeature {
 
         ItemStack stack = hoveredSlot.getItem();
         List<Component> tooltip = stack.getTooltipLines(null, TooltipFlag.Default.NORMAL);
-        ItemUtils.removeItemLore(tooltip);
+        WynnItemUtils.removeLoreTooltipLines(tooltip);
 
         Font font = McUtils.mc().font;
         int width = 0;

--- a/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
@@ -9,9 +9,9 @@ import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.FeatureInfo.Stability;
 import com.wynntils.mc.event.ContainerCloseEvent;
-import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wc.utils.ContainerUtils;
+import com.wynntils.wc.utils.WynnItemMatchers;
 import com.wynntils.wc.utils.WynnUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.NonNullList;
@@ -31,8 +31,8 @@ public class MythicBlockerFeature extends UserFeature {
         NonNullList<ItemStack> items = ContainerUtils.getItems(McUtils.mc().screen);
         for (int i = 0; i < 27; i++) {
             ItemStack stack = items.get(i);
-            if (!ItemUtils.isWynnItem(stack) && !ItemUtils.isUnidentifiedItem(stack)) continue;
-            if (ItemUtils.isMythic(stack)) {
+            if (!WynnItemMatchers.isWynnItem(stack) && !WynnItemMatchers.isUnidentified(stack)) continue;
+            if (WynnItemMatchers.isMythic(stack)) {
                 McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.mythicBlocker.closingBlocked")
                         .withStyle(ChatFormatting.RED));
                 e.setCanceled(true);

--- a/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
@@ -31,6 +31,7 @@ public class MythicBlockerFeature extends UserFeature {
         NonNullList<ItemStack> items = ContainerUtils.getItems(McUtils.mc().screen);
         for (int i = 0; i < 27; i++) {
             ItemStack stack = items.get(i);
+            if (!ItemUtils.isWynnItem(stack) && !ItemUtils.isUnidentifiedItem(stack)) continue;
             if (ItemUtils.isMythic(stack)) {
                 McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.mythicBlocker.closingBlocked")
                         .withStyle(ChatFormatting.RED));

--- a/common/src/main/java/com/wynntils/mc/utils/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/ItemUtils.java
@@ -6,6 +6,7 @@ package com.wynntils.mc.utils;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
+import com.wynntils.wc.custom.item.UnidentifiedItemStack;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -183,6 +184,26 @@ public class ItemUtils {
             if (lore) toRemove.add(c);
         }
         tooltip.removeAll(toRemove);
+    }
+
+    /**
+     * Returns true if the passed item is a Wynncraft item (armor, weapon, accessory)
+     */
+    public static boolean isWynnItem(ItemStack itemStack) {
+        for (Component line : getTooltipLines(itemStack)) {
+            Matcher m = ITEM_RARITY_PATTERN.matcher(line.getString());
+            if (m.find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the passed item is an unidentified item
+     */
+    public static boolean isUnidentifiedItem(ItemStack itemStack) {
+        return itemStack instanceof UnidentifiedItemStack;
     }
 
     public static List<Component> getTooltipLines(ItemStack stack) {

--- a/common/src/main/java/com/wynntils/mc/utils/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/ItemUtils.java
@@ -6,15 +6,10 @@ package com.wynntils.mc.utils;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
-import com.wynntils.wc.custom.item.UnidentifiedItemStack;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -26,9 +21,6 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.TooltipFlag.Default;
 
 public class ItemUtils {
-
-    private static final Pattern ITEM_RARITY_PATTERN =
-            Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
 
     /**
      * Get the lore from an item, note that it may not be fully parsed. To do so, check out {@link
@@ -170,48 +162,8 @@ public class ItemUtils {
         return StringTag.valueOf(Component.Serializer.toJson(toConvert));
     }
 
-    public static void removeItemLore(List<Component> tooltip) {
-        List<Component> toRemove = new ArrayList<>();
-        boolean lore = false;
-        for (Component c : tooltip) {
-            // only remove text after the item type indicator
-            Matcher m = ITEM_RARITY_PATTERN.matcher(c.getString());
-            if (!lore && m.find()) {
-                lore = true;
-                continue;
-            }
-
-            if (lore) toRemove.add(c);
-        }
-        tooltip.removeAll(toRemove);
-    }
-
-    /**
-     * Returns true if the passed item is a Wynncraft item (armor, weapon, accessory)
-     */
-    public static boolean isWynnItem(ItemStack itemStack) {
-        for (Component line : getTooltipLines(itemStack)) {
-            Matcher m = ITEM_RARITY_PATTERN.matcher(line.getString());
-            if (m.find()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if the passed item is an unidentified item
-     */
-    public static boolean isUnidentifiedItem(ItemStack itemStack) {
-        return itemStack instanceof UnidentifiedItemStack;
-    }
-
     public static List<Component> getTooltipLines(ItemStack stack) {
         TooltipFlag flag = McUtils.options().advancedItemTooltips ? Default.ADVANCED : Default.NORMAL;
         return stack.getTooltipLines(McUtils.player(), flag);
-    }
-
-    public static boolean isMythic(ItemStack stack) {
-        return stack.getDisplayName().getString().contains(ChatFormatting.DARK_PURPLE.toString());
     }
 }

--- a/common/src/main/java/com/wynntils/wc/utils/WynnItemMatchers.java
+++ b/common/src/main/java/com/wynntils/wc/utils/WynnItemMatchers.java
@@ -8,6 +8,7 @@ import com.wynntils.core.webapi.WebManager;
 import com.wynntils.core.webapi.profiles.item.ItemProfile;
 import com.wynntils.mc.utils.ComponentUtils;
 import com.wynntils.mc.utils.ItemUtils;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.ListTag;
@@ -22,6 +23,9 @@ public class WynnItemMatchers {
     private static final Pattern CONSUMABLE_PATTERN = Pattern.compile("(.+) \\[([0-9]+)/([0-9]+)]");
     private static final Pattern COSMETIC_PATTERN =
             Pattern.compile("(Common|Rare|Epic|Godly|\\|\\|\\| Black Market \\|\\|\\|) Reward");
+
+    private static final Pattern ITEM_RARITY_PATTERN =
+            Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
 
     public static boolean isSoulPoint(ItemStack stack) {
         return !stack.isEmpty()
@@ -85,6 +89,23 @@ public class WynnItemMatchers {
     public static boolean isCosmetic(ItemStack stack) {
         for (Component c : stack.getTooltipLines(null, TooltipFlag.Default.NORMAL)) {
             if (COSMETIC_PATTERN.matcher(c.getString()).matches()) return true;
+        }
+        return false;
+    }
+
+    public static boolean isMythic(ItemStack stack) {
+        return stack.getDisplayName().getString().contains(ChatFormatting.DARK_PURPLE.toString());
+    }
+
+    /**
+     * Returns true if the passed item is a Wynncraft item (armor, weapon, accessory)
+     */
+    public static boolean isWynnItem(ItemStack itemStack) {
+        for (Component line : ItemUtils.getTooltipLines(itemStack)) {
+            Matcher m = ITEM_RARITY_PATTERN.matcher(line.getString());
+            if (m.find()) {
+                return true;
+            }
         }
         return false;
     }

--- a/common/src/main/java/com/wynntils/wc/utils/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/wc/utils/WynnItemUtils.java
@@ -31,6 +31,9 @@ public class WynnItemUtils {
             Pattern.compile("(^\\+?(?<Value>-?\\d+)(?: to \\+?(?<UpperValue>-?\\d+))?(?<Suffix>%|/\\ds|"
                     + " tier)?(?<Stars>\\*{0,3}) (?<ID>[a-zA-Z 0-9]+))");
 
+    private static final Pattern ITEM_RARITY_PATTERN =
+            Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
+
     /**
      * Parse the item ID lore line from a given item, and convert it into an ItemIdentificationContainer
      * Returns null if the given lore line is not a valid ID
@@ -257,5 +260,21 @@ public class WynnItemUtils {
         } else {
             return TextColor.fromLegacyFormat(ChatFormatting.AQUA);
         }
+    }
+
+    public static void removeLoreTooltipLines(List<Component> tooltip) {
+        List<Component> toRemove = new ArrayList<>();
+        boolean lore = false;
+        for (Component c : tooltip) {
+            // only remove text after the item type indicator
+            Matcher m = ITEM_RARITY_PATTERN.matcher(c.getString());
+            if (!lore && m.find()) {
+                lore = true;
+                continue;
+            }
+
+            if (lore) toRemove.add(c);
+        }
+        tooltip.removeAll(toRemove);
     }
 }


### PR DESCRIPTION
Fixes the issue where you cannot close a chest with a 2 start ingredient inside.