### PR TITLE
Add support for config option update listener

### DIFF
--- a/common/src/main/java/com/wynntils/core/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigManager.java
@@ -46,9 +46,6 @@ public class ConfigManager {
         // add configurable to its corresponding category, then try to load it from file
         configContainers.add(configurable);
         loadConfigOptions(configurable);
-
-        // this is called to ensure any necessary setup happens, in case all options are default
-        configurableObject.onUpdate();
     }
 
     public static void init() {

--- a/common/src/main/java/com/wynntils/core/config/Configurable.java
+++ b/common/src/main/java/com/wynntils/core/config/Configurable.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.core.config;
 
+import com.wynntils.core.config.objects.ConfigOptionHolder;
+
 /** Used to indicate that a class contains config options */
 public interface Configurable {
-    default void onUpdate() {}
+    default void onConfigUpdate(ConfigOptionHolder configOption) {}
 }

--- a/common/src/main/java/com/wynntils/core/config/Configurable.java
+++ b/common/src/main/java/com/wynntils/core/config/Configurable.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.config;
+
+/** Used to indicate that a class contains config options */
+public interface Configurable {
+    default void onUpdate() {}
+}

--- a/common/src/main/java/com/wynntils/core/config/objects/ConfigOptionHolder.java
+++ b/common/src/main/java/com/wynntils/core/config/objects/ConfigOptionHolder.java
@@ -5,19 +5,20 @@
 package com.wynntils.core.config.objects;
 
 import com.wynntils.core.Reference;
+import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
 import java.lang.reflect.Field;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
 public class ConfigOptionHolder {
-    private final Object parent;
+    private final Configurable parent;
     private final Field optionField;
     private final Class<?> optionType;
     private final ConfigOption metadata;
 
     private final Object defaultValue;
 
-    public ConfigOptionHolder(Object parent, Field field, ConfigOption metadata) {
+    public ConfigOptionHolder(Configurable parent, Field field, ConfigOption metadata) {
         this.parent = parent;
         this.optionField = field;
         this.optionType = field.getType();
@@ -56,6 +57,7 @@ public class ConfigOptionHolder {
     public void setValue(Object value) {
         try {
             FieldUtils.writeField(optionField, parent, value, true);
+            parent.onUpdate();
         } catch (IllegalAccessException e) {
             Reference.LOGGER.error("Unable to set config option " + getJsonName());
             e.printStackTrace();

--- a/common/src/main/java/com/wynntils/core/config/objects/ConfigOptionHolder.java
+++ b/common/src/main/java/com/wynntils/core/config/objects/ConfigOptionHolder.java
@@ -57,7 +57,7 @@ public class ConfigOptionHolder {
     public void setValue(Object value) {
         try {
             FieldUtils.writeField(optionField, parent, value, true);
-            parent.onUpdate();
+            parent.onConfigUpdate(this);
         } catch (IllegalAccessException e) {
             Reference.LOGGER.error("Unable to set config option " + getJsonName());
             e.printStackTrace();

--- a/common/src/main/java/com/wynntils/core/config/objects/ConfigurableHolder.java
+++ b/common/src/main/java/com/wynntils/core/config/objects/ConfigurableHolder.java
@@ -4,15 +4,15 @@
  */
 package com.wynntils.core.config.objects;
 
-import com.wynntils.core.config.properties.Configurable;
+import com.wynntils.core.config.properties.ConfigurableInfo;
 import java.util.List;
 
 public class ConfigurableHolder {
     private final Class<?> configurableClass;
     private final List<ConfigOptionHolder> options;
-    private final Configurable metadata;
+    private final ConfigurableInfo metadata;
 
-    public ConfigurableHolder(Class<?> configurableClass, List<ConfigOptionHolder> options, Configurable metadata) {
+    public ConfigurableHolder(Class<?> configurableClass, List<ConfigOptionHolder> options, ConfigurableInfo metadata) {
         this.configurableClass = configurableClass;
         this.options = options;
         this.metadata = metadata;
@@ -22,7 +22,7 @@ public class ConfigurableHolder {
         return options;
     }
 
-    public Configurable getMetadata() {
+    public ConfigurableInfo getMetadata() {
         return metadata;
     }
 

--- a/common/src/main/java/com/wynntils/core/config/properties/ConfigurableInfo.java
+++ b/common/src/main/java/com/wynntils/core/config/properties/ConfigurableInfo.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface Configurable {
+public @interface ConfigurableInfo {
     /** The parent category for options within this container. Also defines file structure. */
     String category();
 

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -7,7 +7,7 @@ package com.wynntils.core.features;
 import com.wynntils.core.Reference;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.config.ConfigManager;
-import com.wynntils.core.config.properties.Configurable;
+import com.wynntils.core.config.Configurable;
 import com.wynntils.core.features.overlays.Overlay;
 import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.core.features.properties.RegisterKeyBind;
@@ -99,8 +99,8 @@ public class FeatureRegistry {
 
         // register & load config options
         // this has to be done after the userEnabled handling above, so the default value registers properly
-        if (featureClass.isAnnotationPresent(Configurable.class)) {
-            ConfigManager.registerConfigurable(feature);
+        if (feature instanceof Configurable configurable) {
+            ConfigManager.registerConfigurable(configurable);
         }
 
         // initialize & enable

--- a/common/src/main/java/com/wynntils/core/features/UserFeature.java
+++ b/common/src/main/java/com/wynntils/core/features/UserFeature.java
@@ -4,12 +4,13 @@
  */
 package com.wynntils.core.features;
 
+import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
 
 /**
  * A feature that is enabled & disabled by the user.
  */
-public abstract class UserFeature extends Feature {
+public abstract class UserFeature extends Feature implements Configurable {
     @ConfigOption(displayName = "Enabled", description = "Should this feature be enabled?")
     protected boolean userEnabled = true;
 }

--- a/common/src/main/java/com/wynntils/core/features/UserFeature.java
+++ b/common/src/main/java/com/wynntils/core/features/UserFeature.java
@@ -7,6 +7,7 @@ package com.wynntils.core.features;
 import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.objects.ConfigOptionHolder;
 import com.wynntils.core.config.properties.ConfigOption;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 /**
  * A feature that is enabled & disabled by the user.
@@ -17,6 +18,7 @@ public abstract class UserFeature extends Feature implements Configurable {
 
     /** This handles the user enabling/disabling a feature in-game */
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void onConfigUpdate(ConfigOptionHolder option) {
         if (!option.getField().getName().equals("userEnabled")) return;
 

--- a/common/src/main/java/com/wynntils/core/features/UserFeature.java
+++ b/common/src/main/java/com/wynntils/core/features/UserFeature.java
@@ -18,6 +18,8 @@ public abstract class UserFeature extends Feature implements Configurable {
     /** This handles the user enabling/disabling a feature in-game */
     @Override
     public void onConfigUpdate(ConfigOptionHolder option) {
+        if (!option.getField().getName().equals("userEnabled")) return;
+
         if (userEnabled) {
             tryEnable();
         } else {

--- a/common/src/main/java/com/wynntils/core/features/UserFeature.java
+++ b/common/src/main/java/com/wynntils/core/features/UserFeature.java
@@ -5,6 +5,7 @@
 package com.wynntils.core.features;
 
 import com.wynntils.core.config.Configurable;
+import com.wynntils.core.config.objects.ConfigOptionHolder;
 import com.wynntils.core.config.properties.ConfigOption;
 
 /**
@@ -13,4 +14,14 @@ import com.wynntils.core.config.properties.ConfigOption;
 public abstract class UserFeature extends Feature implements Configurable {
     @ConfigOption(displayName = "Enabled", description = "Should this feature be enabled?")
     protected boolean userEnabled = true;
+
+    /** This handles the user enabling/disabling a feature in-game */
+    @Override
+    public void onConfigUpdate(ConfigOptionHolder option) {
+        if (userEnabled) {
+            tryEnable();
+        } else {
+            tryDisable();
+        }
+    }
 }

--- a/common/src/main/java/com/wynntils/features/user/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemGuessFeature.java
@@ -5,7 +5,6 @@
 package com.wynntils.features.user;
 
 import com.google.common.collect.ImmutableList;
-import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
 import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
@@ -15,7 +14,7 @@ import com.wynntils.core.webapi.WebManager;
 
 @FeatureInfo(stability = Stability.STABLE)
 @ConfigurableInfo(category = "Item Tooltips")
-public class ItemGuessFeature extends UserFeature implements Configurable {
+public class ItemGuessFeature extends UserFeature {
 
     @ConfigOption(displayName = "Show Guess Price")
     public static boolean showGuessesPrice = true;

--- a/common/src/main/java/com/wynntils/features/user/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemGuessFeature.java
@@ -5,16 +5,17 @@
 package com.wynntils.features.user;
 
 import com.google.common.collect.ImmutableList;
+import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
-import com.wynntils.core.config.properties.Configurable;
+import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.FeatureInfo.Stability;
 import com.wynntils.core.webapi.WebManager;
 
 @FeatureInfo(stability = Stability.STABLE)
-@Configurable(category = "Item Tooltips")
-public class ItemGuessFeature extends UserFeature {
+@ConfigurableInfo(category = "Item Tooltips")
+public class ItemGuessFeature extends UserFeature implements Configurable {
 
     @ConfigOption(displayName = "Show Guess Price")
     public static boolean showGuessesPrice = true;

--- a/common/src/main/java/com/wynntils/features/user/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemStatInfoFeature.java
@@ -5,7 +5,6 @@
 package com.wynntils.features.user;
 
 import com.google.common.collect.ImmutableList;
-import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
 import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
@@ -15,7 +14,7 @@ import com.wynntils.core.webapi.WebManager;
 
 @FeatureInfo(stability = Stability.STABLE)
 @ConfigurableInfo(category = "Item Tooltips")
-public class ItemStatInfoFeature extends UserFeature implements Configurable {
+public class ItemStatInfoFeature extends UserFeature {
 
     @ConfigOption(displayName = "Show Stars")
     public static boolean showStars = true;

--- a/common/src/main/java/com/wynntils/features/user/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemStatInfoFeature.java
@@ -5,16 +5,17 @@
 package com.wynntils.features.user;
 
 import com.google.common.collect.ImmutableList;
+import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
-import com.wynntils.core.config.properties.Configurable;
+import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.FeatureInfo.Stability;
 import com.wynntils.core.webapi.WebManager;
 
 @FeatureInfo(stability = Stability.STABLE)
-@Configurable(category = "Item Tooltips")
-public class ItemStatInfoFeature extends UserFeature {
+@ConfigurableInfo(category = "Item Tooltips")
+public class ItemStatInfoFeature extends UserFeature implements Configurable {
 
     @ConfigOption(displayName = "Show Stars")
     public static boolean showStars = true;

--- a/common/src/main/java/com/wynntils/features/user/PlayerGhostTransparencyFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/PlayerGhostTransparencyFeature.java
@@ -5,6 +5,7 @@
 package com.wynntils.features.user;
 
 import com.wynntils.core.config.properties.ConfigOption;
+import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.core.features.properties.FeatureInfo;
@@ -17,6 +18,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @EventListener
 @FeatureInfo(stability = Stability.STABLE)
+@ConfigurableInfo(category = "Utilities")
 public class PlayerGhostTransparencyFeature extends UserFeature {
 
     @ConfigOption(

--- a/common/src/main/java/com/wynntils/features/user/TooltipScaleFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TooltipScaleFeature.java
@@ -5,7 +5,6 @@
 package com.wynntils.features.user;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
 import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
@@ -22,7 +21,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 @EventListener
 @ConfigurableInfo(category = "Item Tooltips")
 @FeatureInfo(stability = Stability.STABLE)
-public class TooltipScaleFeature extends UserFeature implements Configurable {
+public class TooltipScaleFeature extends UserFeature {
 
     @ConfigOption(
             displayName = "Universal Scale",

--- a/common/src/main/java/com/wynntils/features/user/TooltipScaleFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TooltipScaleFeature.java
@@ -5,8 +5,9 @@
 package com.wynntils.features.user;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.config.Configurable;
 import com.wynntils.core.config.properties.ConfigOption;
-import com.wynntils.core.config.properties.Configurable;
+import com.wynntils.core.config.properties.ConfigurableInfo;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.core.features.properties.FeatureInfo;
@@ -19,9 +20,9 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @EventListener
-@Configurable(category = "Item Tooltips")
+@ConfigurableInfo(category = "Item Tooltips")
 @FeatureInfo(stability = Stability.STABLE)
-public class TooltipScaleFeature extends UserFeature {
+public class TooltipScaleFeature extends UserFeature implements Configurable {
 
     @ConfigOption(
             displayName = "Universal Scale",


### PR DESCRIPTION
Classes with config options must now implement the `Configurable` interface, which contains an `onUpdate()` method that gets called any time a config value changes. It's also called when the class is first loaded, to make sure the method runs at least once even if all the contained options are set to default.