### PR TITLE
CustomColor implementation

### DIFF
--- a/common/src/main/java/com/wynntils/core/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigManager.java
@@ -17,6 +17,7 @@ import com.wynntils.core.config.objects.ConfigurableHolder;
 import com.wynntils.core.config.properties.ConfigOption;
 import com.wynntils.core.config.properties.Configurable;
 import com.wynntils.mc.utils.McUtils;
+import com.wynntils.utils.objects.CustomColor;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -49,7 +50,10 @@ public class ConfigManager {
     }
 
     public static void init() {
-        gson = new GsonBuilder().setPrettyPrinting().create();
+        gson = new GsonBuilder()
+                .registerTypeAdapter(CustomColor.class, new CustomColor.CustomColorSerializer())
+                .setPrettyPrinting()
+                .create();
 
         loadConfigFile();
     }

--- a/common/src/main/java/com/wynntils/core/webapi/profiles/item/ItemTier.java
+++ b/common/src/main/java/com/wynntils/core/webapi/profiles/item/ItemTier.java
@@ -4,35 +4,96 @@
  */
 package com.wynntils.core.webapi.profiles.item;
 
+import com.wynntils.features.user.ItemHighlightFeature;
 import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.objects.CustomColor;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.concurrent.Callable;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 
 public enum ItemTier {
-    NORMAL(ChatFormatting.WHITE, -1, 0),
-    UNIQUE(ChatFormatting.YELLOW, 3, 0.5f),
-    RARE(ChatFormatting.LIGHT_PURPLE, 8, 1.2f),
-    SET(ChatFormatting.GREEN, 8, 1.2f),
-    FABLED(ChatFormatting.RED, 12, 4.5f),
-    LEGENDARY(ChatFormatting.AQUA, 16, 8.0f),
-    MYTHIC(ChatFormatting.DARK_PURPLE, 90, 18.0f),
-    CRAFTED(ChatFormatting.DARK_AQUA, -1, 0);
+    NORMAL(
+            ChatFormatting.WHITE,
+            () -> ItemHighlightFeature.normalHighlightColor,
+            () -> ItemHighlightFeature.normalHighlightEnabled,
+            -1,
+            0),
+    UNIQUE(
+            ChatFormatting.YELLOW,
+            () -> ItemHighlightFeature.uniqueHighlightColor,
+            () -> ItemHighlightFeature.uniqueHighlightEnabled,
+            3,
+            0.5f),
+    RARE(
+            ChatFormatting.LIGHT_PURPLE,
+            () -> ItemHighlightFeature.rareHighlightColor,
+            () -> ItemHighlightFeature.rareHighlightEnabled,
+            8,
+            1.2f),
+    SET(
+            ChatFormatting.GREEN,
+            () -> ItemHighlightFeature.setHighlightColor,
+            () -> ItemHighlightFeature.setHighlightEnabled,
+            8,
+            1.2f),
+    FABLED(
+            ChatFormatting.RED,
+            () -> ItemHighlightFeature.fabledHighlightColor,
+            () -> ItemHighlightFeature.fabledHighlightEnabled,
+            12,
+            4.5f),
+    LEGENDARY(
+            ChatFormatting.AQUA,
+            () -> ItemHighlightFeature.legendaryHighlightColor,
+            () -> ItemHighlightFeature.legendaryHighlightEnabled,
+            16,
+            8.0f),
+    MYTHIC(
+            ChatFormatting.DARK_PURPLE,
+            () -> ItemHighlightFeature.mythicHighlightColor,
+            () -> ItemHighlightFeature.mythicHighlightEnabled,
+            90,
+            18.0f),
+    CRAFTED(
+            ChatFormatting.DARK_AQUA,
+            () -> ItemHighlightFeature.craftedHighlightColor,
+            () -> ItemHighlightFeature.craftedHighlightEnabled,
+            -1,
+            0);
 
     private final ChatFormatting chatFormatting;
+    private final Callable<CustomColor> highlightColor;
+    private final Callable<Boolean> highlightEnabled;
     private final int baseCost;
     private final float costMultiplier;
 
-    ItemTier(ChatFormatting chatFormatting, int baseCost, float costMultiplier) {
+    ItemTier(
+            ChatFormatting chatFormatting,
+            Callable<CustomColor> highlightColor,
+            Callable<Boolean> highlightEnabled,
+            int baseCost,
+            float costMultiplier) {
         this.chatFormatting = chatFormatting;
+        this.highlightColor = highlightColor;
+        this.highlightEnabled = highlightEnabled;
         this.baseCost = baseCost;
         this.costMultiplier = costMultiplier;
     }
 
     public ChatFormatting getChatFormatting() {
         return chatFormatting;
+    }
+
+    public CustomColor getHighlightColor() {
+        try {
+            if (highlightEnabled.call()) return highlightColor.call();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return CustomColor.NONE; // either highlight is disabled, or some error occurred
     }
 
     public static ItemTier fromComponent(Component component) {

--- a/common/src/main/java/com/wynntils/features/user/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemHighlightFeature.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.features.user;
 
+import com.wynntils.core.config.properties.ConfigOption;
+import com.wynntils.core.config.properties.Configurable;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.core.features.properties.FeatureInfo;
@@ -11,6 +13,7 @@ import com.wynntils.core.features.properties.FeatureInfo.Stability;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.mc.utils.RenderUtils;
+import com.wynntils.utils.objects.CustomColor;
 import com.wynntils.wc.custom.item.render.HighlightedItem;
 import com.wynntils.wc.custom.item.render.HotbarHighlightedItem;
 import net.minecraft.world.item.ItemStack;
@@ -18,24 +21,98 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @EventListener
 @FeatureInfo(stability = Stability.STABLE)
+@Configurable(category = "Inventory")
 public class ItemHighlightFeature extends UserFeature {
+
+    @ConfigOption(displayName = "Normal Item Highlight")
+    public static boolean normalHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Normal Highlight Color")
+    public static CustomColor normalHighlightColor = new CustomColor(255, 255, 255);
+
+    @ConfigOption(displayName = "Unique Item Highlight")
+    public static boolean uniqueHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Unique Highlight Color")
+    public static CustomColor uniqueHighlightColor = new CustomColor(255, 255, 0);
+
+    @ConfigOption(displayName = "Rare Item Highlight")
+    public static boolean rareHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Rare Highlight Color")
+    public static CustomColor rareHighlightColor = new CustomColor(255, 0, 255);
+
+    @ConfigOption(displayName = "Set Item Highlight")
+    public static boolean setHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Set Highlight Color")
+    public static CustomColor setHighlightColor = new CustomColor(0, 255, 0);
+
+    @ConfigOption(displayName = "Legendary Item Highlight")
+    public static boolean legendaryHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Legendary Highlight Color")
+    public static CustomColor legendaryHighlightColor = new CustomColor(0, 255, 255);
+
+    @ConfigOption(displayName = "Fabled Item Highlight")
+    public static boolean fabledHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Fabled Highlight Color")
+    public static CustomColor fabledHighlightColor = new CustomColor(255, 85, 85);
+
+    @ConfigOption(displayName = "Mythic Item Highlight")
+    public static boolean mythicHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Mythic Highlight Color")
+    public static CustomColor mythicHighlightColor = new CustomColor(76, 0, 76);
+
+    @ConfigOption(displayName = "Crafted Item Highlight")
+    public static boolean craftedHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Crafted Highlight Color")
+    public static CustomColor craftedHighlightColor = new CustomColor(0, 138, 138);
+
+    @ConfigOption(displayName = "Inventory Item Highlights")
+    public static boolean inventoryHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Inventory Highlight Opacity")
+    public static float inventoryOpacity = 1f;
+
+    @ConfigOption(displayName = "Hotbar Item Highlights")
+    public static boolean hotbarHighlightEnabled = true;
+
+    @ConfigOption(displayName = "Hotbar Highlight Opacity")
+    public static float hotbarOpacity = .5f;
 
     @SubscribeEvent
     public void onRenderSlot(SlotRenderEvent.Pre e) {
+        if (!inventoryHighlightEnabled) return;
+
         ItemStack item = e.getSlot().getItem();
         if (!(item instanceof HighlightedItem highlightedItem)) return;
 
-        int color = highlightedItem.getHighlightColor(e.getScreen(), e.getSlot());
+        CustomColor color = highlightedItem.getHighlightColor(e.getScreen(), e.getSlot());
+        if (color == CustomColor.NONE) return;
         RenderUtils.drawTexturedRectWithColor(
-                RenderUtils.highlight, color, e.getSlot().x - 1, e.getSlot().y - 1, 18, 18, 256, 256);
+                RenderUtils.highlight,
+                color.withAlpha(inventoryOpacity),
+                e.getSlot().x - 1,
+                e.getSlot().y - 1,
+                18,
+                18,
+                256,
+                256);
     }
 
     @SubscribeEvent
     public void onRenderHotbarSlot(HotbarSlotRenderEvent.Pre e) {
+        if (!hotbarHighlightEnabled) return;
+
         ItemStack item = e.getStack();
         if (!(item instanceof HotbarHighlightedItem highlightedItem)) return;
 
-        int color = highlightedItem.getHotbarColor();
-        RenderUtils.drawRect(color, e.getX(), e.getY(), 16, 16);
+        CustomColor color = highlightedItem.getHotbarColor();
+        if (color == CustomColor.NONE) return;
+        RenderUtils.drawRect(color.withAlpha(hotbarOpacity), e.getX(), e.getY(), 16, 16);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/utils/RenderUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/RenderUtils.java
@@ -14,6 +14,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.math.Matrix4f;
+import com.wynntils.utils.objects.CustomColor;
 import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
@@ -31,15 +32,15 @@ public class RenderUtils {
 
     public static final ResourceLocation highlight = new ResourceLocation("wynntils", "textures/highlight.png");
 
-    public static void drawRect(int color, int x, int y, int width, int height) {
+    public static void drawRect(CustomColor color, int x, int y, int width, int height) {
         drawRect(new PoseStack(), color, x, y, 0, width, height);
     }
 
-    public static void drawRect(PoseStack poseStack, int color, int x, int y, int z, int width, int height) {
-        int alpha = (color >> 24) & 0xFF;
-        int red = (color >> 16) & 0xFF;
-        int green = (color >> 8) & 0xFF;
-        int blue = color & 0xFF;
+    public static void drawRect(PoseStack poseStack, CustomColor color, int x, int y, int z, int width, int height) {
+        int alpha = color.a & 0xFF;
+        int red = color.r & 0xFF;
+        int green = color.g & 0xFF;
+        int blue = color.b & 0xFF;
 
         Matrix4f matrix = poseStack.last().pose();
 
@@ -116,7 +117,14 @@ public class RenderUtils {
     }
 
     public static void drawTexturedRectWithColor(
-            ResourceLocation tex, int color, int x, int y, int width, int height, int textureWidth, int textureHeight) {
+            ResourceLocation tex,
+            CustomColor color,
+            int x,
+            int y,
+            int width,
+            int height,
+            int textureWidth,
+            int textureHeight) {
         drawTexturedRectWithColor(
                 new PoseStack(), tex, color, x, y, 0, width, height, 0, 0, width, height, textureWidth, textureHeight);
     }
@@ -124,7 +132,7 @@ public class RenderUtils {
     public static void drawTexturedRectWithColor(
             PoseStack poseStack,
             ResourceLocation tex,
-            int color,
+            CustomColor color,
             int x,
             int y,
             int z,
@@ -136,10 +144,10 @@ public class RenderUtils {
             int v,
             int textureWidth,
             int textureHeight) {
-        int alpha = (color >> 24) & 0xFF;
-        int red = (color >> 16) & 0xFF;
-        int green = (color >> 8) & 0xFF;
-        int blue = color & 0xFF;
+        int alpha = color.a & 0xFF;
+        int red = color.r & 0xFF;
+        int green = color.g & 0xFF;
+        int blue = color.b & 0xFF;
 
         float uScale = 1f / textureWidth;
         float vScale = 1f / textureHeight;
@@ -185,20 +193,20 @@ public class RenderUtils {
             int x2,
             int y2,
             int blitOffset,
-            int colorA,
-            int colorB) {
-        float f = (float) (colorA >> 24 & 0xFF) / 255.0f;
-        float g = (float) (colorA >> 16 & 0xFF) / 255.0f;
-        float h = (float) (colorA >> 8 & 0xFF) / 255.0f;
-        float i = (float) (colorA & 0xFF) / 255.0f;
-        float j = (float) (colorB >> 24 & 0xFF) / 255.0f;
-        float k = (float) (colorB >> 16 & 0xFF) / 255.0f;
-        float l = (float) (colorB >> 8 & 0xFF) / 255.0f;
-        float m = (float) (colorB & 0xFF) / 255.0f;
-        builder.vertex(matrix, x2, y1, blitOffset).color(g, h, i, f).endVertex();
-        builder.vertex(matrix, x1, y1, blitOffset).color(g, h, i, f).endVertex();
-        builder.vertex(matrix, x1, y2, blitOffset).color(k, l, m, j).endVertex();
-        builder.vertex(matrix, x2, y2, blitOffset).color(k, l, m, j).endVertex();
+            CustomColor colorA,
+            CustomColor colorB) {
+        int A_a = (colorA.a & 0xFF);
+        int A_r = (colorA.r & 0xFF);
+        int A_g = (colorA.g & 0xFF);
+        int A_b = (colorA.b & 0xFF);
+        int B_a = (colorB.a & 0xFF);
+        int B_r = (colorB.r & 0xFF);
+        int B_g = (colorB.g & 0xFF);
+        int B_b = (colorB.b & 0xFF);
+        builder.vertex(matrix, x2, y1, blitOffset).color(A_r, A_g, A_b, A_a).endVertex();
+        builder.vertex(matrix, x1, y1, blitOffset).color(A_r, A_g, A_b, A_a).endVertex();
+        builder.vertex(matrix, x1, y2, blitOffset).color(B_r, B_g, B_b, B_a).endVertex();
+        builder.vertex(matrix, x2, y2, blitOffset).color(B_r, B_g, B_b, B_a).endVertex();
     }
 
     public static void drawTooltip(List<ClientTooltipComponent> lines, PoseStack poseStack, Font font) {
@@ -219,9 +227,9 @@ public class RenderUtils {
         int tooltipY = 4;
         // somewhat hacky solution to get around transparency issues - these colors were chosen to best match
         // how tooltips are displayed in-game
-        int backgroundColor = 0xFF100010;
-        int borderColorStart = 0xFF25005B;
-        int borderColorEnd = 0xFF180033;
+        CustomColor backgroundColor = CustomColor.fromInt(0xFF100010);
+        CustomColor borderColorStart = CustomColor.fromInt(0xFF25005B);
+        CustomColor borderColorEnd = CustomColor.fromInt(0xFF180033);
         int zLevel = 400;
         Tesselator tesselator = Tesselator.getInstance();
         BufferBuilder bufferBuilder = tesselator.getBuilder();

--- a/common/src/main/java/com/wynntils/utils/objects/CustomColor.java
+++ b/common/src/main/java/com/wynntils/utils/objects/CustomColor.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.objects;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+
+public class CustomColor {
+    public static final CustomColor NONE = new CustomColor(-1, -1, -1, -1);
+
+    private static final Pattern HEX_PATTERN = Pattern.compile("#?([0-9a-fA-F]{6})");
+    private static final Pattern STRING_PATTERN = Pattern.compile("rgba\\((\\d+),(\\d+),(\\d+),(\\d+)\\)");
+
+    public int r, g, b, a;
+
+    public CustomColor(int r, int g, int b) {
+        this(r, g, b, 255);
+    }
+
+    public CustomColor(int r, int g, int b, int a) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+
+    public CustomColor(float r, float g, float b) {
+        this(r, g, b, 1f);
+    }
+
+    public CustomColor(float r, float g, float b, float a) {
+        this.r = (int) (r * 255);
+        this.g = (int) (g * 255);
+        this.b = (int) (b * 255);
+        this.a = (int) (a * 255);
+    }
+
+    public CustomColor(CustomColor color) {
+        this(color.r, color.g, color.b, color.a);
+    }
+
+    public static CustomColor fromChatFormatting(ChatFormatting cf) {
+        return fromInt(cf.getColor() | 0xFF000000);
+    }
+
+    /** 0xAARRGGBB format */
+    public static CustomColor fromInt(int num) {
+        return new CustomColor(num >> 16 & 255, num >> 8 & 255, num & 255, num >> 24 & 255);
+    }
+
+    /** "#rrggbb" or "rrggbb" */
+    public static CustomColor fromHexString(String hex) {
+        hex = hex.trim();
+        Matcher hexMatcher = HEX_PATTERN.matcher(hex);
+
+        // invalid format
+        if (!hexMatcher.matches()) return new CustomColor(0, 0, 0, 0);
+
+        // parse hex
+        return fromInt(Integer.parseInt(hexMatcher.group(1), 16));
+    }
+
+    /** "rgba(r,g,b,a)" format as defined in toString() */
+    public static CustomColor fromString(String string) {
+        string = string.trim();
+        Matcher stringMatcher = STRING_PATTERN.matcher(string);
+
+        // invalid format
+        if (!stringMatcher.matches()) return new CustomColor(0, 0, 0, 0);
+
+        return new CustomColor(
+                Integer.parseInt(stringMatcher.group(1)),
+                Integer.parseInt(stringMatcher.group(2)),
+                Integer.parseInt(stringMatcher.group(3)),
+                Integer.parseInt(stringMatcher.group(4)));
+    }
+
+    public CustomColor setAlpha(int a) {
+        this.a = a;
+        return this;
+    }
+
+    public CustomColor setAlpha(float a) {
+        this.a = (int) (a * 255);
+        return this;
+    }
+
+    public CustomColor withAlpha(int a) {
+        return new CustomColor(this).setAlpha(a);
+    }
+
+    public CustomColor withAlpha(float a) {
+        return new CustomColor(this).setAlpha(a);
+    }
+
+    /** 0xAARRGGBB format */
+    public int asInt() {
+        int a = Math.min(this.a, 255);
+        int r = Math.min(this.r, 255);
+        int g = Math.min(this.g, 255);
+        int b = Math.min(this.b, 255);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+
+    /** #rrggbb format */
+    public String toHexString() {
+        String hex = Integer.toHexString(this.asInt());
+        // whether alpha portion is 1 digit or 2
+        hex = (hex.length() > 7) ? hex.substring(2) : hex.substring(1);
+        hex = "#" + hex;
+
+        return hex;
+    }
+
+    @Override
+    public String toString() {
+        return "rgba(" + r + "," + g + "," + b + "," + a + ")";
+    }
+
+    public static class CustomColorSerializer implements JsonSerializer<CustomColor>, JsonDeserializer<CustomColor> {
+        @Override
+        public CustomColor deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            return CustomColor.fromString(json.getAsString());
+        }
+
+        @Override
+        public JsonElement serialize(CustomColor src, Type typeOfSrc, JsonSerializationContext context) {
+            return context.serialize(src.toString());
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/wc/custom/item/CosmeticItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/CosmeticItemStack.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.wc.custom.item;
 
+import com.wynntils.utils.objects.CustomColor;
 import com.wynntils.wc.custom.item.render.HighlightedItem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
@@ -12,19 +13,20 @@ import net.minecraft.world.item.ItemStack;
 
 public class CosmeticItemStack extends WynnItemStack implements HighlightedItem {
 
-    private ChatFormatting color;
+    private CustomColor highlightColor;
 
     public CosmeticItemStack(ItemStack stack) {
         super(stack);
 
-        color = ChatFormatting.getByCode(stack.getHoverName().getString().charAt(1));
-        if (color == null) color = ChatFormatting.WHITE;
+        ChatFormatting chatColor =
+                ChatFormatting.getByCode(stack.getHoverName().getString().charAt(1));
+        if (chatColor == null) chatColor = ChatFormatting.WHITE;
+
+        highlightColor = CustomColor.fromChatFormatting(chatColor);
     }
 
     @Override
-    public int getHighlightColor(Screen screen, Slot slot) {
-        int highlightColor = color.getColor();
-        highlightColor = 0xFF000000 | highlightColor;
+    public CustomColor getHighlightColor(Screen screen, Slot slot) {
         return highlightColor;
     }
 }

--- a/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
@@ -14,6 +14,7 @@ import com.wynntils.mc.utils.ComponentUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.objects.CustomColor;
 import com.wynntils.wc.custom.item.render.HighlightedItem;
 import com.wynntils.wc.custom.item.render.HotbarHighlightedItem;
 import com.wynntils.wc.objects.ItemIdentificationContainer;
@@ -306,19 +307,13 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
     }
 
     @Override
-    public int getHighlightColor(Screen screen, Slot slot) {
-        int color = itemProfile.getTier().getChatFormatting().getColor();
-        color = 0xFF000000 | color;
-
-        return color;
+    public CustomColor getHighlightColor(Screen screen, Slot slot) {
+        return itemProfile.getTier().getHighlightColor();
     }
 
     @Override
-    public int getHotbarColor() {
-        int color = itemProfile.getTier().getChatFormatting().getColor();
-        color = 0x80000000 | color;
-
-        return color;
+    public CustomColor getHotbarColor() {
+        return itemProfile.getTier().getHighlightColor();
     }
 
     private void parseIDs() {

--- a/common/src/main/java/com/wynntils/wc/custom/item/UnidentifiedItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/UnidentifiedItemStack.java
@@ -11,6 +11,7 @@ import com.wynntils.core.webapi.profiles.item.ItemProfile;
 import com.wynntils.core.webapi.profiles.item.ItemTier;
 import com.wynntils.core.webapi.profiles.item.ItemType;
 import com.wynntils.features.user.ItemGuessFeature;
+import com.wynntils.utils.objects.CustomColor;
 import com.wynntils.utils.reference.EmeraldSymbols;
 import com.wynntils.wc.custom.item.render.HighlightedItem;
 import com.wynntils.wc.custom.item.render.HotbarHighlightedItem;
@@ -104,18 +105,12 @@ public class UnidentifiedItemStack extends WynnItemStack implements HighlightedI
     }
 
     @Override
-    public int getHighlightColor(Screen screen, Slot slot) {
-        int color = tier.getChatFormatting().getColor();
-        color = 0xFF000000 | color;
-
-        return color;
+    public CustomColor getHighlightColor(Screen screen, Slot slot) {
+        return tier.getHighlightColor();
     }
 
     @Override
-    public int getHotbarColor() {
-        int color = tier.getChatFormatting().getColor();
-        color = 0x80000000 | color;
-
-        return color;
+    public CustomColor getHotbarColor() {
+        return tier.getHighlightColor();
     }
 }

--- a/common/src/main/java/com/wynntils/wc/custom/item/render/HighlightedItem.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/render/HighlightedItem.java
@@ -4,9 +4,10 @@
  */
 package com.wynntils.wc.custom.item.render;
 
+import com.wynntils.utils.objects.CustomColor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.inventory.Slot;
 
 public interface HighlightedItem {
-    int getHighlightColor(Screen screen, Slot slot);
+    CustomColor getHighlightColor(Screen screen, Slot slot);
 }

--- a/common/src/main/java/com/wynntils/wc/custom/item/render/HotbarHighlightedItem.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/render/HotbarHighlightedItem.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.wc.custom.item.render;
 
+import com.wynntils.utils.objects.CustomColor;
+
 public interface HotbarHighlightedItem {
-    int getHotbarColor();
+    CustomColor getHotbarColor();
 }


### PR DESCRIPTION
This PR replaces all the old instances of hard-coded integer representations of colors in the rendering system with a new `CustomColor` class, heavily inspired by the class of the same name in legacy Wynntils. I also converted the item tier-based color highlights with config options in `ItemHighlightFeature`, which are accessed by the custom item objects through the `ItemTier` enum. I included a custom, lightweight JSON serializer/deserializer for the `CustomColor` class as well.