### PR TITLE
ItemHighlightFeature: Fix highlights in containers

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemHighlightFeature.java
@@ -85,7 +85,7 @@ public class ItemHighlightFeature extends UserFeature {
     public static float hotbarOpacity = .5f;
 
     @SubscribeEvent
-    public void onRenderSlot(SlotRenderEvent.Pre e) {
+    public void onRenderSlotPre(SlotRenderEvent.Pre e) {
         if (!inventoryHighlightEnabled) return;
 
         ItemStack item = e.getSlot().getItem();
@@ -98,6 +98,7 @@ public class ItemHighlightFeature extends UserFeature {
                 color.withAlpha(inventoryOpacity),
                 e.getSlot().x - 1,
                 e.getSlot().y - 1,
+                200,
                 18,
                 18,
                 256,
@@ -113,6 +114,6 @@ public class ItemHighlightFeature extends UserFeature {
 
         CustomColor color = highlightedItem.getHotbarColor();
         if (color == CustomColor.NONE) return;
-        RenderUtils.drawRect(color.withAlpha(hotbarOpacity), e.getX(), e.getY(), 16, 16);
+        RenderUtils.drawRect(color.withAlpha(hotbarOpacity), e.getX(), e.getY(), 0, 16, 16);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/utils/RenderUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/RenderUtils.java
@@ -32,8 +32,8 @@ public class RenderUtils {
 
     public static final ResourceLocation highlight = new ResourceLocation("wynntils", "textures/highlight.png");
 
-    public static void drawRect(CustomColor color, int x, int y, int width, int height) {
-        drawRect(new PoseStack(), color, x, y, 0, width, height);
+    public static void drawRect(CustomColor color, int x, int y, int z, int width, int height) {
+        drawRect(new PoseStack(), color, x, y, z, width, height);
     }
 
     public static void drawRect(PoseStack poseStack, CustomColor color, int x, int y, int z, int width, int height) {
@@ -121,12 +121,13 @@ public class RenderUtils {
             CustomColor color,
             int x,
             int y,
+            int z,
             int width,
             int height,
             int textureWidth,
             int textureHeight) {
         drawTexturedRectWithColor(
-                new PoseStack(), tex, color, x, y, 0, width, height, 0, 0, width, height, textureWidth, textureHeight);
+                new PoseStack(), tex, color, x, y, z, width, height, 0, 0, width, height, textureWidth, textureHeight);
     }
 
     public static void drawTexturedRectWithColor(


### PR DESCRIPTION
Fixes highlights not rendering because of render Z levels.
-
Before:
![image](https://user-images.githubusercontent.com/49001742/173200823-f677f238-e7f8-4e72-af17-34c178677356.png)

After:
![image](https://user-images.githubusercontent.com/49001742/173200853-462037c8-eafa-4d42-81ca-882daaa96438.png)
