### PR TITLE
Improve config setting saving

### DIFF
--- a/common/src/main/java/com/wynntils/core/config/ConfigHolder.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigHolder.java
@@ -19,6 +19,7 @@ public class ConfigHolder {
     private final Config metadata;
 
     private final Object defaultValue;
+    private boolean userEdited = false;
 
     public ConfigHolder(Feature parent, Field field, String category, Config metadata) {
         this.parent = parent;
@@ -70,6 +71,7 @@ public class ConfigHolder {
         try {
             FieldUtils.writeField(field, parent, value, true);
             parent.updateConfigOption(this);
+            userEdited = true;
             return true;
         } catch (IllegalAccessException e) {
             Reference.LOGGER.error("Unable to set field " + getJsonName());
@@ -78,12 +80,14 @@ public class ConfigHolder {
         }
     }
 
-    public boolean isDefault() {
-        return defaultValue.equals(getValue());
+    public boolean isUserEdited() {
+        return userEdited;
     }
 
     public void reset() {
         setValue(defaultValue);
+        // reset this flag so option is no longer saved to file
+        userEdited = false;
     }
 
     public Object tryParseStringValue(String value) {

--- a/common/src/main/java/com/wynntils/core/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigManager.java
@@ -99,7 +99,7 @@ public class ConfigManager {
             // create json object, with entry for each option of each container
             JsonObject holderJson = new JsonObject();
             for (ConfigHolder holder : CONFIG_HOLDERS) {
-                if (holder.isDefault()) continue; // only save options that are non-default
+                if (!holder.isUserEdited()) continue; // only save options that have been set by the user
 
                 JsonElement holderElement = gson.toJsonTree(holder.getValue());
                 holderJson.add(holder.getJsonName(), holderElement);


### PR DESCRIPTION
This PR changes config functionality from only saving non-default settings to saving any settings that have been edited by the user, regardless of their current value. As already discussed, this prevents intentionally chosen settings from being altered by updates that modify default values - outside of this edge case, all other behavior will be the same.

`ConfigHolder` now has a `userEdited` flag, which defaults to false and is set to true any time `setValue` is called. Since the config file loading code uses `setValue`, any options stored to file (and thus, were at one point modified) will automatically have the flag set properly. If the `reset` function is called, meaning that the option has specifically been reset to the default, the flag is unset.