### PR TITLE
Chat item implementation

### DIFF
--- a/common/src/main/java/com/wynntils/core/commands/ClientCommandManager.java
+++ b/common/src/main/java/com/wynntils/core/commands/ClientCommandManager.java
@@ -15,7 +15,7 @@ import com.wynntils.commands.TerritoryCommand;
 import com.wynntils.commands.TokenCommand;
 import com.wynntils.commands.WynntilsCommand;
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.mc.event.ChatSendMessageEvent;
+import com.wynntils.mc.event.ChatSentEvent;
 import com.wynntils.mc.utils.McUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +57,7 @@ public class ClientCommandManager {
     }
 
     @SubscribeEvent
-    public static void onChatSend(ChatSendMessageEvent e) {
+    public static void onChatSend(ChatSentEvent e) {
         String message = e.getMessage();
 
         if (message.startsWith("/")) {

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -14,6 +14,7 @@ import com.wynntils.core.features.properties.StartDisabled;
 import com.wynntils.core.keybinds.KeyHolder;
 import com.wynntils.features.debug.ConnectionProgressFeature;
 import com.wynntils.features.debug.PacketDebuggerFeature;
+import com.wynntils.features.internal.ChatItemFeature;
 import com.wynntils.features.internal.FixPacketBugsFeature;
 import com.wynntils.features.internal.FixSpellOverwriteFeature;
 import com.wynntils.features.internal.ItemStackTransformerFeature;
@@ -142,6 +143,7 @@ public class FeatureRegistry {
         registerFeature(new FixPacketBugsFeature());
         registerFeature(new ItemStackTransformerFeature());
         registerFeature(new FixSpellOverwriteFeature());
+        registerFeature(new ChatItemFeature());
 
         // user
         registerFeature(new DialogueOptionOverrideFeature());

--- a/common/src/main/java/com/wynntils/features/internal/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/internal/ChatItemFeature.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.internal;
+
+import com.wynntils.core.features.InternalFeature;
+import com.wynntils.core.features.properties.EventListener;
+import com.wynntils.mc.event.ChatReceivedEvent;
+import com.wynntils.mc.event.KeyInputEvent;
+import com.wynntils.mc.mixin.accessors.ChatScreenAccessor;
+import com.wynntils.mc.utils.McUtils;
+import com.wynntils.wc.custom.item.GearItemStack;
+import com.wynntils.wc.utils.ChatItemUtils;
+import com.wynntils.wc.utils.WynnUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.lwjgl.glfw.GLFW;
+
+@EventListener
+public class ChatItemFeature extends InternalFeature {
+
+    private final Map<String, String> chatItems = new HashMap<>();
+
+    @SubscribeEvent
+    public void onKeyTyped(KeyInputEvent e) {
+        if (!WynnUtils.onWorld()) return;
+        if (!(McUtils.mc().screen instanceof ChatScreen chatScreen)) return;
+
+        EditBox chatInput = ((ChatScreenAccessor) chatScreen).getChatInput();
+
+        if (!chatItems.isEmpty() && (e.getKey() == GLFW.GLFW_KEY_ENTER || e.getKey() == GLFW.GLFW_KEY_KP_ENTER)) {
+            // replace the placeholder strings with the actual encoded strings
+            for (Map.Entry<String, String> item : chatItems.entrySet()) {
+                chatInput.setValue(chatInput.getValue().replace("<" + item.getKey() + ">", item.getValue()));
+            }
+            chatItems.clear();
+            return;
+        }
+
+        // replace encoded strings with placeholders for less confusion
+        Matcher m = ChatItemUtils.ENCODED_PATTERN.matcher(chatInput.getValue());
+        while (m.find()) {
+            String encodedItem = m.group();
+            String name = m.group("Name");
+            while (chatItems.containsKey(name)) { // avoid overwriting entries
+                name += "_";
+            }
+
+            chatInput.setValue(chatInput.getValue().replace(encodedItem, "<" + name + ">"));
+            chatItems.put(name, encodedItem);
+        }
+    }
+
+    @SubscribeEvent
+    public void onChatReceived(ChatReceivedEvent e) {
+        if (!WynnUtils.onWorld()) return;
+
+        Component message = e.getMessage();
+        List<Component> components = message.getSiblings();
+        components.add(0, message.plainCopy().withStyle(message.getStyle()));
+
+        // chat item tooltips
+        if (ChatItemUtils.ENCODED_PATTERN.matcher(message.getString()).find()) {
+            MutableComponent temp = new TextComponent("");
+            for (Component comp : components) {
+                Matcher m = ChatItemUtils.ENCODED_PATTERN.matcher(comp.getString());
+                if (!m.find()) {
+                    Component newComponent = comp.copy();
+                    temp.append(newComponent);
+                    continue;
+                }
+
+                do {
+                    String text = comp.getString();
+                    Style style = comp.getStyle();
+
+                    GearItemStack item = ChatItemUtils.decodeItem(m.group());
+                    if (item == null) { // couldn't decode, skip
+                        comp = comp.copy();
+                        continue;
+                    }
+
+                    MutableComponent preText = new TextComponent(text.substring(0, m.start()));
+                    preText.withStyle(style);
+                    temp.append(preText);
+
+                    MutableComponent itemComponent = new TextComponent(item.getSimpleName())
+                            .withStyle(ChatFormatting.UNDERLINE)
+                            .withStyle(item.getItemProfile().getTier().getChatFormatting());
+                    itemComponent.withStyle(s -> s.withHoverEvent(
+                            new HoverEvent(HoverEvent.Action.SHOW_ITEM, new HoverEvent.ItemStackInfo(item))));
+                    temp.append(itemComponent);
+
+                    comp = new TextComponent(text.substring(m.end())).withStyle(style);
+
+                    m = ChatItemUtils.ENCODED_PATTERN.matcher(comp.getString()); // recreate matcher for new substring
+                } while (m.find()); // search for multiple items in the same message
+                temp.append(comp); // leftover text after item(s)
+            }
+
+            // e.setMessage(temp);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/features/internal/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/internal/ChatItemFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.features.properties.EventListener;
 import com.wynntils.mc.event.ChatReceivedEvent;
 import com.wynntils.mc.event.KeyInputEvent;
 import com.wynntils.mc.mixin.accessors.ChatScreenAccessor;
+import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wc.custom.item.GearItemStack;
 import com.wynntils.wc.utils.ChatItemUtils;
@@ -96,11 +97,19 @@ public class ChatItemFeature extends InternalFeature {
                     preText.withStyle(style);
                     temp.append(preText);
 
-                    MutableComponent itemComponent = new TextComponent(item.getSimpleName())
+                    MutableComponent tooltipComponent = new TextComponent("");
+                    for (Component c : ItemUtils.getTooltipLines(item)) {
+                        if (!tooltipComponent.getSiblings().isEmpty()) tooltipComponent.append(new TextComponent("\n"));
+
+                        tooltipComponent.append(c);
+                    }
+
+                    MutableComponent itemComponent = new TextComponent(
+                                    item.getItemProfile().getDisplayName())
                             .withStyle(ChatFormatting.UNDERLINE)
                             .withStyle(item.getItemProfile().getTier().getChatFormatting());
-                    itemComponent.withStyle(s -> s.withHoverEvent(
-                            new HoverEvent(HoverEvent.Action.SHOW_ITEM, new HoverEvent.ItemStackInfo(item))));
+                    itemComponent.withStyle(
+                            s -> s.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltipComponent)));
                     temp.append(itemComponent);
 
                     comp = new TextComponent(text.substring(m.end())).withStyle(style);
@@ -110,7 +119,7 @@ public class ChatItemFeature extends InternalFeature {
                 temp.append(comp); // leftover text after item(s)
             }
 
-            // e.setMessage(temp);
+            e.setMessage(temp);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/internal/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/internal/ChatItemFeature.java
@@ -4,8 +4,10 @@
  */
 package com.wynntils.features.internal;
 
+import com.google.common.collect.ImmutableList;
 import com.wynntils.core.features.InternalFeature;
 import com.wynntils.core.features.properties.EventListener;
+import com.wynntils.core.webapi.WebManager;
 import com.wynntils.mc.event.ChatReceivedEvent;
 import com.wynntils.mc.event.KeyInputEvent;
 import com.wynntils.mc.mixin.accessors.ChatScreenAccessor;
@@ -31,6 +33,16 @@ import org.lwjgl.glfw.GLFW;
 public class ChatItemFeature extends InternalFeature {
 
     private final Map<String, String> chatItems = new HashMap<>();
+
+    @Override
+    protected void onInit(ImmutableList.Builder<Condition> conditions) {
+        conditions.add(new WebLoadedCondition());
+    }
+
+    @Override
+    protected boolean onEnable() {
+        return WebManager.isItemListLoaded() || WebManager.tryLoadItemList();
+    }
 
     @SubscribeEvent
     public void onKeyTyped(KeyInputEvent e) {

--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -17,6 +17,8 @@ import com.wynntils.mc.event.InventoryKeyPressEvent;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.render.RenderUtils;
 import com.wynntils.mc.utils.McUtils;
+import com.wynntils.wc.custom.item.GearItemStack;
+import com.wynntils.wc.utils.ChatItemUtils;
 import com.wynntils.wc.utils.WynnItemUtils;
 import com.wynntils.wc.utils.WynnUtils;
 import java.awt.image.BufferedImage;
@@ -27,7 +29,9 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -121,5 +125,19 @@ public class ItemScreenshotFeature extends UserFeature {
         McUtils.sendMessageToClient(
                 new TranslatableComponent("feature.wynntils.itemScreenshot.message", stack.getHoverName())
                         .withStyle(ChatFormatting.GREEN));
+
+        // chat item
+        if (stack instanceof GearItemStack gearItem) {
+            String encoded = ChatItemUtils.encodeItem(gearItem);
+
+            McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.itemScreenshot.chatItemMessage")
+                    .withStyle(ChatFormatting.DARK_GREEN)
+                    .withStyle(ChatFormatting.UNDERLINE)
+                    .withStyle(s -> s.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, encoded)))
+                    .withStyle(s -> s.withHoverEvent(new HoverEvent(
+                            HoverEvent.Action.SHOW_TEXT,
+                            new TranslatableComponent("feature.wynntils.itemScreenshot.chatItemTooltip")
+                                    .withStyle(ChatFormatting.DARK_AQUA)))));
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -126,7 +126,7 @@ public class ItemScreenshotFeature extends UserFeature {
                 new TranslatableComponent("feature.wynntils.itemScreenshot.message", stack.getHoverName())
                         .withStyle(ChatFormatting.GREEN));
 
-        // chat item
+        // chat item prompt
         if (stack instanceof GearItemStack gearItem) {
             String encoded = ChatItemUtils.encodeItem(gearItem);
 

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -9,7 +9,8 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.mc.event.BossHealthUpdateEvent;
-import com.wynntils.mc.event.ChatSendMessageEvent;
+import com.wynntils.mc.event.ChatReceivedEvent;
+import com.wynntils.mc.event.ChatSentEvent;
 import com.wynntils.mc.event.ClientTickEvent;
 import com.wynntils.mc.event.ConnectionEvent.ConnectedEvent;
 import com.wynntils.mc.event.ConnectionEvent.DisconnectedEvent;
@@ -57,6 +58,8 @@ import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
@@ -205,8 +208,12 @@ public class EventFactory {
     // endregion
 
     // region Chat Events
-    public static ChatSendMessageEvent onChatSend(String message) {
-        return post(new ChatSendMessageEvent(message));
+    public static ChatSentEvent onChatSent(String message) {
+        return post(new ChatSentEvent(message));
+    }
+
+    public static ChatReceivedEvent onChatReceived(ChatType type, Component message) {
+        return post(new ChatReceivedEvent(type, message));
     }
     // endregion
 

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -197,8 +197,8 @@ public class EventFactory {
         post(new PlayerTeleportEvent(newPosition));
     }
 
-    public static void onKeyInput(int key, int scanCode, int action, int modifiers) {
-        post(new KeyInputEvent(key, scanCode, action, modifiers));
+    public static KeyInputEvent onKeyInput(int key, int scanCode, int action, int modifiers) {
+        return post(new KeyInputEvent(key, scanCode, action, modifiers));
     }
 
     public static void onRightClickBlock(Player player, InteractionHand hand, BlockPos pos, BlockHitResult hitVec) {

--- a/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
@@ -12,7 +12,7 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class ChatReceivedEvent extends Event {
     private final ChatType type;
-    private final Component message;
+    private Component message;
 
     public ChatReceivedEvent(ChatType type, Component message) {
         this.type = type;
@@ -23,7 +23,7 @@ public class ChatReceivedEvent extends Event {
         return message;
     }
 
-    public ChatType getType() {
-        return type;
+    public void setMessage(Component message) {
+        this.message = message;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class ChatReceivedEvent extends Event {
+    private final ChatType type;
+    private Component message;
+
+    public ChatReceivedEvent(ChatType type, Component message) {
+        this.type = type;
+        this.message = message;
+    }
+
+    public Component getMessage() {
+        return message;
+    }
+
+    public void setMessage(Component message) {
+        this.message = message;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
@@ -23,6 +23,10 @@ public class ChatReceivedEvent extends Event {
         return message;
     }
 
+    public ChatType getType() {
+        return type;
+    }
+
     public void setMessage(Component message) {
         this.message = message;
     }

--- a/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatReceivedEvent.java
@@ -12,7 +12,7 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class ChatReceivedEvent extends Event {
     private final ChatType type;
-    private Component message;
+    private final Component message;
 
     public ChatReceivedEvent(ChatType type, Component message) {
         this.type = type;
@@ -23,7 +23,7 @@ public class ChatReceivedEvent extends Event {
         return message;
     }
 
-    public void setMessage(Component message) {
-        this.message = message;
+    public ChatType getType() {
+        return type;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/ChatSentEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatSentEvent.java
@@ -4,8 +4,10 @@
  */
 package com.wynntils.mc.event;
 
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+@Cancelable
 public class ChatSentEvent extends Event {
     private String message;
 

--- a/common/src/main/java/com/wynntils/mc/event/ChatSentEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatSentEvent.java
@@ -4,18 +4,20 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
-@Cancelable
-public class ChatSendMessageEvent extends Event {
-    private final String message;
+public class ChatSentEvent extends Event {
+    private String message;
 
-    public ChatSendMessageEvent(String message) {
+    public ChatSentEvent(String message) {
         this.message = message;
     }
 
     public String getMessage() {
         return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/KeyInputEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/KeyInputEvent.java
@@ -4,8 +4,10 @@
  */
 package com.wynntils.mc.event;
 
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+@Cancelable
 public class KeyInputEvent extends Event {
     private final int action;
     private final int key;

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -5,12 +5,16 @@
 package com.wynntils.mc.mixin;
 
 import com.wynntils.mc.EventFactory;
+import com.wynntils.mc.event.ChatReceivedEvent;
 import com.wynntils.mc.utils.McUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.multiplayer.ClientPacketListener;
-import net.minecraft.network.protocol.game.ClientboundChatPacket;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
@@ -28,6 +32,7 @@ import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPacketListener.class)
@@ -132,13 +137,17 @@ public abstract class ClientPacketListenerMixin {
         EventFactory.onSubtitleSetText(packet);
     }
 
-    @Inject(
+    @Redirect(
             method = "handleChat(Lnet/minecraft/network/protocol/game/ClientboundChatPacket;)V",
-            at = @At("HEAD"),
-            cancellable = true)
-    private void redirectHandleChat(ClientboundChatPacket packet, CallbackInfo ci) {
-        if (EventFactory.onChatReceived(packet.getType(), packet.getMessage()).isCanceled()) {
-            ci.cancel();
-        }
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/gui/Gui;handleChat(Lnet/minecraft/network/chat/ChatType;Lnet/minecraft/network/chat/Component;Ljava/util/UUID;)V"))
+    private void redirectHandleChat(Gui gui, ChatType chatType, Component message, UUID uuid) {
+        ChatReceivedEvent result = EventFactory.onChatReceived(chatType, message);
+        if (result.isCanceled()) return;
+
+        gui.handleChat(chatType, result.getMessage(), uuid);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -5,16 +5,12 @@
 package com.wynntils.mc.mixin;
 
 import com.wynntils.mc.EventFactory;
-import com.wynntils.mc.event.ChatReceivedEvent;
 import com.wynntils.mc.utils.McUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.client.multiplayer.ClientPacketListener;
-import net.minecraft.network.chat.ChatType;
-import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundChatPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
@@ -32,7 +28,6 @@ import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPacketListener.class)
@@ -137,17 +132,13 @@ public abstract class ClientPacketListenerMixin {
         EventFactory.onSubtitleSetText(packet);
     }
 
-    @Redirect(
+    @Inject(
             method = "handleChat(Lnet/minecraft/network/protocol/game/ClientboundChatPacket;)V",
-            at =
-                    @At(
-                            value = "INVOKE",
-                            target =
-                                    "Lnet/minecraft/client/gui/Gui;handleChat(Lnet/minecraft/network/chat/ChatType;Lnet/minecraft/network/chat/Component;Ljava/util/UUID;)V"))
-    private void redirectHandleChat(Gui gui, ChatType chatType, Component message, UUID uuid) {
-        ChatReceivedEvent result = EventFactory.onChatReceived(chatType, message);
-        if (result.isCanceled()) return;
-
-        gui.handleChat(chatType, result.getMessage(), uuid);
+            at = @At("HEAD"),
+            cancellable = true)
+    private void redirectHandleChat(ClientboundChatPacket packet, CallbackInfo ci) {
+        if (EventFactory.onChatReceived(packet.getType(), packet.getMessage()).isCanceled()) {
+            ci.cancel();
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/KeyboardHandlerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/KeyboardHandlerMixin.java
@@ -13,8 +13,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(KeyboardHandler.class)
 public abstract class KeyboardHandlerMixin {
-    @Inject(method = "keyPress(JIIII)V", at = @At("RETURN"))
-    private void keyPressPost(long windowPointer, int key, int scanCode, int action, int modifiers, CallbackInfo ci) {
-        EventFactory.onKeyInput(key, scanCode, action, modifiers);
+    @Inject(method = "keyPress(JIIII)V", at = @At("HEAD"))
+    private void keyPressPre(long windowPointer, int key, int scanCode, int action, int modifiers, CallbackInfo ci) {
+        if (EventFactory.onKeyInput(key, scanCode, action, modifiers).isCanceled()) {
+            ci.cancel();
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/LevelRendererMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LevelRendererMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelRenderer.class)
-public class LevelRendererMixin {
+public abstract class LevelRendererMixin {
 
     @Shadow
     @Final

--- a/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
@@ -8,15 +8,12 @@ import com.wynntils.mc.EventFactory;
 import net.minecraft.client.player.LocalPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerMixin {
-    @Inject(method = "chat", at = @At("HEAD"), cancellable = true)
-    private void chatPre(String message, CallbackInfo ci) {
-        if (EventFactory.onChatSend(message).isCanceled()) {
-            ci.cancel();
-        }
+    @ModifyVariable(method = "chat(Ljava/lang/String;)V", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private String modifyChatMessage(String message) {
+        return EventFactory.onChatSent(message).getMessage();
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
@@ -5,15 +5,28 @@
 package com.wynntils.mc.mixin;
 
 import com.wynntils.mc.EventFactory;
+import com.wynntils.mc.event.ChatSentEvent;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundChatPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerMixin {
-    @ModifyVariable(method = "chat(Ljava/lang/String;)V", at = @At("HEAD"), argsOnly = true, ordinal = 0)
-    private String modifyChatMessage(String message) {
-        return EventFactory.onChatSent(message).getMessage();
+    @Redirect(
+            method = "chat(Ljava/lang/String;)V",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/multiplayer/ClientPacketListener;send(Lnet/minecraft/network/protocol/Packet;)V"))
+    private void redirectChat(ClientPacketListener connection, Packet<?> packet, String message) {
+        ChatSentEvent result = EventFactory.onChatSent(message);
+        if (result.isCanceled()) return;
+
+        connection.send(new ServerboundChatPacket(result.getMessage()));
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/ChatScreenAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/ChatScreenAccessor.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin.accessors;
+
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.ChatScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ChatScreen.class)
+public interface ChatScreenAccessor {
+    @Accessor("input")
+    EditBox getChatInput();
+
+    @Accessor("input")
+    void setChatInput(EditBox input);
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/ItemStackInfoAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/ItemStackInfoAccessor.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.mixin.accessors;
 
-import net.minecraft.client.gui.components.EditBox;
-import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(ChatScreen.class)
-public interface ChatScreenAccessor {
-    @Accessor("input")
-    EditBox getChatInput();
+@Mixin(HoverEvent.ItemStackInfo.class)
+public interface ItemStackInfoAccessor {
+    @Accessor("itemStack")
+    void setItemStack(ItemStack itemStack);
 }

--- a/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
@@ -180,6 +180,9 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
             tag.putInt("color", itemProfile.getItemInfo().getArmorColorAsInt());
         this.setTag(tag);
 
+        customName = new TextComponent(itemProfile.getDisplayName())
+                .withStyle(itemProfile.getTier().getChatFormatting());
+
         parseIDs();
         List<Component> baseTooltip = constructBaseTooltip();
         constructTooltips(baseTooltip);
@@ -215,7 +218,7 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
 
     @Override
     public Component getHoverName() {
-        if (isGuideStack) return customName;
+        if (isGuideStack || isChatItem) return customName;
 
         /*
          * This math was originally based off Avaritia code.
@@ -338,7 +341,7 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
         float percentTotal = (float) percents.getSum();
 
         String originalName = WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(getHoverName()));
-        MutableComponent name = new TextComponent(originalName);
+        MutableComponent name = customName == null ? new TextComponent(originalName) : customName.copy();
 
         if (hasNew) {
             name.append(new TextComponent(" [NEW]").withStyle(ChatFormatting.GOLD));

--- a/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
@@ -302,7 +302,7 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
 
         if (isChatItem) {
             tooltip.add(new TextComponent("From chat")
-                    .withStyle(ChatFormatting.GRAY)
+                    .withStyle(ChatFormatting.DARK_GRAY)
                     .withStyle(ChatFormatting.ITALIC));
 
             tooltip.addAll(percentTooltip);
@@ -340,8 +340,12 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
         int idAmount = (int) percents.getCount();
         float percentTotal = (float) percents.getSum();
 
-        String originalName = WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(getHoverName()));
-        MutableComponent name = customName == null ? new TextComponent(originalName) : customName.copy();
+        MutableComponent name;
+        if (customName == null) {
+            name = new TextComponent(WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(getHoverName())));
+        } else {
+            name = customName.copy();
+        }
 
         if (hasNew) {
             name.append(new TextComponent(" [NEW]").withStyle(ChatFormatting.GOLD));
@@ -415,7 +419,11 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
             for (Map.Entry<DamageType, String> entry : damages.entrySet()) {
                 DamageType type = entry.getKey();
                 MutableComponent damage = new TextComponent(type.getSymbol() + " " + type).withStyle(type.getColor());
-                damage.append(new TextComponent(" Damage: " + entry.getValue()).withStyle(ChatFormatting.GRAY));
+                damage.append(new TextComponent(" Damage: " + entry.getValue())
+                        .withStyle(
+                                type == DamageType.NEUTRAL
+                                        ? type.getColor()
+                                        : ChatFormatting.GRAY)); // neutral is all gold
                 baseTooltip.add(damage);
             }
 
@@ -477,7 +485,7 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
                         .withStyle(ChatFormatting.GRAY));
             } else {
                 MutableComponent powderLine = new TextComponent(
-                                "[" + powders.size() + "/" + itemProfile.getPowderAmount() + "]")
+                                "[" + powders.size() + "/" + itemProfile.getPowderAmount() + "] Powder Slots ")
                         .withStyle(ChatFormatting.GRAY);
                 if (powders.size() > 0) {
                     MutableComponent powderList = new TextComponent("[");

--- a/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/GearItemStack.java
@@ -160,13 +160,18 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
         constructTooltips(baseTooltip);
     }
 
+    /** Chat item constructor - used when decoding an encoded chat string */
     public GearItemStack(
-            ItemProfile itemProfile, List<ItemIdentificationContainer> identifications, List<Powder> powders) {
+            ItemProfile itemProfile,
+            List<ItemIdentificationContainer> identifications,
+            List<Powder> powders,
+            int rerolls) {
         super(itemProfile.getItemInfo().asItemStack());
 
         this.itemProfile = itemProfile;
         this.identifications = identifications;
         this.powders = powders;
+        this.rerolls = rerolls;
         isChatItem = true;
 
         CompoundTag tag = this.getOrCreateTag();
@@ -194,6 +199,10 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
 
     public List<ItemIdentificationContainer> getIdentifications() {
         return identifications;
+    }
+
+    public List<ItemIdentificationContainer> getOrderedIdentifications() {
+        return IdentificationOrderer.INSTANCE.orderIdentifications(identifications);
     }
 
     public List<Powder> getPowders() {
@@ -292,6 +301,9 @@ public class GearItemStack extends WynnItemStack implements HighlightedItem, Hot
             tooltip.add(new TextComponent("From chat")
                     .withStyle(ChatFormatting.GRAY)
                     .withStyle(ChatFormatting.ITALIC));
+
+            tooltip.addAll(percentTooltip);
+            return tooltip;
         }
 
         if (GLFW.glfwGetKey(McUtils.mc().getWindow().getWindow(), GLFW.GLFW_KEY_LEFT_SHIFT) == 1) {

--- a/common/src/main/java/com/wynntils/wc/utils/ChatItemUtils.java
+++ b/common/src/main/java/com/wynntils/wc/utils/ChatItemUtils.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wc.utils;
+
+import com.wynntils.core.webapi.WebManager;
+import com.wynntils.core.webapi.profiles.item.IdentificationProfile;
+import com.wynntils.core.webapi.profiles.item.ItemProfile;
+import com.wynntils.wc.custom.item.GearItemStack;
+import com.wynntils.wc.objects.ItemIdentificationContainer;
+import com.wynntils.wc.objects.Powder;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.ArrayUtils;
+
+public class ChatItemUtils {
+
+    // private-use unicode chars
+    private static final String START = new String(Character.toChars(0xF5FF0));
+    private static final String END = new String(Character.toChars(0xF5FF1));
+    private static final String SEPARATOR = new String(Character.toChars(0xF5FF2));
+    private static final String RANGE =
+            "[" + new String(Character.toChars(0xF5000)) + "-" + new String(Character.toChars(0xF5F00)) + "]";
+    private static final int OFFSET = 0xF5000;
+
+    private static final boolean ENCODE_NAME = false;
+
+    public static final Pattern ENCODED_PATTERN = Pattern.compile(START + "(?<Name>.+?)" + SEPARATOR + "(?<Ids>" + RANGE
+            + "*)(?:" + SEPARATOR + "(?<Powders>" + RANGE + "+))?(?<Rerolls>" + RANGE + ")" + END);
+
+    /**
+     * Encodes the given item, as long as it is a standard gear item, into the following format
+     *
+     * START character (U+F5FF0)
+     * Item name (optionally encoded)
+     * SEPARATOR character (U+F5FF2)
+     * Identifications/stars (encoded)
+     * SEPARATOR (only if powdered)
+     * Powders (encoded) (only if powdered)
+     * Rerolls (encoded)
+     * END character (U+F5FF1)
+     *
+     * Any encoded "value" is added to the OFFSET character value U+F5000 and then converted into the corresponding Unicode character:
+     *
+     * The name is encoded based on the ASCII value of each character minus 32
+     *
+     * Identifications are encoded either as the raw value minus the minimum value of that ID, or if the range is larger than 100,
+     * the percent value 0 to 100 of the given roll.
+     * Regardless of either case, this number is multiplied by 4, and the number of stars present on that ID is added.
+     * This ensures that the value and star count can be encoded into a single character and be decoded later.
+     *
+     * Powders are encoded as numerical values 1-5. Up to 4 powders are encoded into a single character - for each new powder,
+     * the running total is multiplied by 6 before the new powder value is added. Thus, each individual powder can be decoded.
+     *
+     * Rerolls are simply encoded as a raw number.
+     *
+     */
+    public static String encodeItem(GearItemStack item) {
+        String itemName = item.getSimpleName();
+
+        // get identification data - ordered for consistency
+        List<ItemIdentificationContainer> sortedIds = item.getOrderedIdentifications();
+
+        // name
+        StringBuilder encoded = new StringBuilder(START);
+        encoded.append(ENCODE_NAME ? encodeString(itemName) : itemName);
+        encoded.append(SEPARATOR);
+
+        // ids
+        for (ItemIdentificationContainer id : sortedIds) {
+            if (id.isFixed()) continue; // don't care about these
+
+            int idValue = id.value();
+            IdentificationProfile idProfile = id.identification();
+
+            int translatedValue = 0;
+            if (Math.abs(idProfile.getBaseValue()) > 100) { // calculate percent
+                translatedValue = (int) Math.round((idValue * 100.0 / idProfile.getBaseValue()) - 30);
+            } else { // raw value
+                translatedValue = idValue - idProfile.getMin();
+            }
+
+            // stars
+            int stars = id.stars();
+
+            // encode value + stars in one character
+            encoded.append(encodeNumber(translatedValue * 4 + stars));
+        }
+
+        // powders
+        List<Powder> powders = item.getPowders();
+        if (!powders.isEmpty()) {
+            encoded.append(SEPARATOR);
+
+            int counter = 0;
+            int encodedPowders = 0;
+            for (Powder p : powders) {
+                encodedPowders *= 6; // shift left
+                encodedPowders += p.ordinal() + 1; // 0 represents no more powders
+                counter++;
+
+                if (counter == 4) { // max # of powders encoded in a single char
+                    encoded.append(encodeNumber(encodedPowders));
+                    encodedPowders = 0;
+                    counter = 0;
+                }
+            }
+            if (encodedPowders != 0) encoded.append(encodeNumber(encodedPowders)); // catch any leftover powders
+        }
+
+        // rerolls
+        encoded.append(encodeNumber(item.getRerolls()));
+
+        encoded.append(END);
+        return encoded.toString();
+    }
+
+    public static GearItemStack decodeItem(String encoded) {
+        Matcher m = ENCODED_PATTERN.matcher(encoded);
+        if (!m.matches()) return null;
+
+        String name = ENCODE_NAME ? decodeString(m.group("Name")) : m.group("Name");
+        int[] ids = decodeNumbers(m.group("Ids"));
+        int[] powders = m.group("Powders") != null ? decodeNumbers(m.group("Powders")) : new int[0];
+        int rerolls = decodeNumbers(m.group("Rerolls"))[0];
+
+        ItemProfile item = WebManager.getItemsMap().get(name);
+        if (item == null) return null;
+
+        // ids
+        List<ItemIdentificationContainer> idContainers = new ArrayList<>();
+
+        List<String> sortedIds = new ArrayList<>(item.getStatuses().keySet());
+        sortedIds.sort(Comparator.comparingInt(IdentificationOrderer.INSTANCE::getOrder));
+
+        int counter = 0; // for id value array
+        for (String shortIdName : sortedIds) {
+            IdentificationProfile status = item.getStatuses().get(shortIdName);
+
+            int value;
+            int stars = 0;
+            if (status.isFixed()) {
+                value = status.getBaseValue();
+            } else {
+                if (counter > ids.length) return null; // some kind of mismatch, abort
+
+                // id value
+                int encodedValue = ids[counter] / 4;
+                if (Math.abs(status.getBaseValue()) > 100) {
+                    // using bigdecimal here for precision when rounding
+                    value = new BigDecimal(encodedValue + 30)
+                            .movePointLeft(2)
+                            .multiply(new BigDecimal(status.getBaseValue()))
+                            .setScale(0, RoundingMode.HALF_UP)
+                            .intValue();
+                } else {
+                    value = encodedValue + status.getMin();
+                }
+
+                // stars
+                stars = ids[counter] % 4;
+
+                counter++;
+            }
+
+            // name
+            String longIdName = IdentificationProfile.getAsLongName(shortIdName);
+
+            // create ID and append to list
+            ItemIdentificationContainer idContainer =
+                    WynnItemUtils.identificationFromValue(null, item, longIdName, shortIdName, value, stars);
+            if (idContainer != null) idContainers.add(idContainer);
+        }
+
+        // powders
+        List<Powder> powderList = new ArrayList<>();
+        if (item.getPowderAmount() > 0 && powders.length > 0) {
+            ArrayUtils.reverse(powders); // must reverse powders so they are read in reverse order
+            for (int powderNum : powders) {
+                // once powderNum is 0, all the powders have been read
+                while (powderNum > 0) {
+                    Powder p = Powder.values()[powderNum % 6 - 1];
+                    powderList.add(0, p); // prepend powders because they are decoded in reverse
+
+                    powderNum /= 6;
+                }
+            }
+        }
+
+        // create chat gear stack
+        return new GearItemStack(item, idContainers, powderList, rerolls);
+    }
+
+    private static String encodeString(String text) {
+        String encoded = "";
+        for (char c : text.toCharArray()) {
+            int value = c - 32; // offset by 32 to ignore ascii control characters
+            encoded += new String(Character.toChars(value + OFFSET)); // get encoded representation
+        }
+        return encoded;
+    }
+
+    private static String encodeNumber(int value) {
+        return new String(Character.toChars(value + OFFSET));
+    }
+
+    private static String decodeString(String text) {
+        String decoded = "";
+        for (int i = 0; i < text.length(); i += 2) {
+            int value = text.codePointAt(i) - OFFSET + 32;
+            decoded += (char) value;
+        }
+        return decoded;
+    }
+
+    private static int[] decodeNumbers(String text) {
+        int decoded[] = new int[text.length() / 2];
+        for (int i = 0; i < text.length(); i += 2) {
+            decoded[i / 2] = text.codePointAt(i) - OFFSET;
+        }
+        return decoded;
+    }
+}

--- a/common/src/main/java/com/wynntils/wc/utils/ChatItemUtils.java
+++ b/common/src/main/java/com/wynntils/wc/utils/ChatItemUtils.java
@@ -7,6 +7,7 @@ package com.wynntils.wc.utils;
 import com.wynntils.core.webapi.WebManager;
 import com.wynntils.core.webapi.profiles.item.IdentificationProfile;
 import com.wynntils.core.webapi.profiles.item.ItemProfile;
+import com.wynntils.mc.mixin.accessors.ItemStackInfoAccessor;
 import com.wynntils.wc.custom.item.GearItemStack;
 import com.wynntils.wc.objects.ItemIdentificationContainer;
 import com.wynntils.wc.objects.Powder;
@@ -17,6 +18,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TextComponent;
 import org.apache.commons.lang3.ArrayUtils;
 
 public class ChatItemUtils {
@@ -195,6 +201,18 @@ public class ChatItemUtils {
 
         // create chat gear stack
         return new GearItemStack(item, idContainers, powderList, rerolls);
+    }
+
+    public static Component createItemComponent(GearItemStack item) {
+        MutableComponent itemComponent = new TextComponent(item.getItemProfile().getDisplayName())
+                .withStyle(ChatFormatting.UNDERLINE)
+                .withStyle(item.getItemProfile().getTier().getChatFormatting());
+
+        HoverEvent.ItemStackInfo itemHoverEvent = new HoverEvent.ItemStackInfo(item);
+        ((ItemStackInfoAccessor) itemHoverEvent).setItemStack(item);
+        itemComponent.withStyle(s -> s.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_ITEM, itemHoverEvent)));
+
+        return itemComponent;
     }
 
     private static String encodeString(String text) {

--- a/common/src/main/java/com/wynntils/wc/utils/ChatItemUtils.java
+++ b/common/src/main/java/com/wynntils/wc/utils/ChatItemUtils.java
@@ -74,7 +74,7 @@ public class ChatItemUtils {
 
         // ids
         for (ItemIdentificationContainer id : sortedIds) {
-            if (id.isFixed()) continue; // don't care about these
+            if (id.identification().isFixed()) continue; // don't care about these
 
             int idValue = id.value();
             IdentificationProfile idProfile = id.identification();
@@ -95,7 +95,7 @@ public class ChatItemUtils {
 
         // powders
         List<Powder> powders = item.getPowders();
-        if (!powders.isEmpty()) {
+        if (powders != null && !powders.isEmpty()) {
             encoded.append(SEPARATOR);
 
             int counter = 0;
@@ -148,7 +148,7 @@ public class ChatItemUtils {
             if (status.isFixed()) {
                 value = status.getBaseValue();
             } else {
-                if (counter > ids.length) return null; // some kind of mismatch, abort
+                if (counter >= ids.length) return null; // some kind of mismatch, abort
 
                 // id value
                 int encodedValue = ids[counter] / 4;

--- a/common/src/main/java/com/wynntils/wc/utils/IdentificationOrderer.java
+++ b/common/src/main/java/com/wynntils/wc/utils/IdentificationOrderer.java
@@ -5,6 +5,7 @@
 package com.wynntils.wc.utils;
 
 import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.wc.objects.ItemIdentificationContainer;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -122,6 +123,12 @@ public class IdentificationOrderer {
 
         ordered.forEach(c -> result.add(c.getValue()));
         return result;
+    }
+
+    public List<ItemIdentificationContainer> orderIdentifications(List<ItemIdentificationContainer> ids) {
+        return ids.stream()
+                .sorted(Comparator.comparingInt(id -> getOrder(id.shortIdName())))
+                .toList();
     }
 
     private void organizeGroups() {

--- a/common/src/main/java/com/wynntils/wc/utils/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/wc/utils/WynnItemUtils.java
@@ -57,6 +57,23 @@ public class WynnItemUtils {
             shortIdName = IdentificationProfile.getAsShortName(idName, isRaw);
         }
 
+        return identificationFromValue(lore, item, idName, shortIdName, value, starCount);
+    }
+
+    /**
+     * Creates an ItemIdentificationContainer from the given item, ID names, ID value, and star count
+     * Returns null if the given ID is not valid
+     *
+     * @param lore the ID lore line component - can be null if ID isn't being created from lore
+     * @param item the ItemProfile of the given item
+     * @param idName the in-game name of the given ID
+     * @param shortIdName the internal wynntils name of the given ID
+     * @param value the raw value of the given ID
+     * @param starCount the number of stars on the given ID
+     * @return the parsed ItemIdentificationContainer, or null if the ID is invalid
+     */
+    public static ItemIdentificationContainer identificationFromValue(
+            Component lore, ItemProfile item, String idName, String shortIdName, int value, int starCount) {
         boolean isInverted = IdentificationOrderer.INSTANCE.isInverted(shortIdName);
         IdentificationProfile idProfile = item.getStatuses().get(shortIdName);
         IdentificationModifier type =
@@ -105,6 +122,9 @@ public class WynnItemUtils {
             rerollLine.append(WynnItemUtils.getRerollChancesComponent(
                     idProfile.getPerfectChance(), chances.increase(), chances.decrease()));
         }
+
+        // lore might be null if this ID is not being created from a lore line
+        if (lore == null) lore = percentLine;
 
         // create container
         return new ItemIdentificationContainer(

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -11,6 +11,8 @@
   "feature.wynntils.itemGuess.name": "Item Guess Feature",
   "feature.wynntils.itemGuess.possibilities": "§a- §7Possibilities: %s",
   "feature.wynntils.itemHighlight.name": "Item Highlights Feature",
+  "feature.wynntils.itemScreenshot.chatItemMessage": "Click here to copy the item for chat!",
+  "feature.wynntils.itemScreenshot.chatItemTooltip": "Paste this text in chat to display your item to other Wynntils users",
   "feature.wynntils.itemScreenshot.message": "Copied %s to clipboard!",
   "feature.wynntils.itemScreenshot.name": "Item Screenshot Feature",
   "feature.wynntils.itemStatInfo.name": "Item Statistics Info Feature",

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -22,7 +22,8 @@
     "SlotMixin",
     "accessors.ClientboundSetPlayerTeamPacketAccessor",
     "accessors.OptionsAccessor",
-    "accessors.GuiAccessor"
+    "accessors.GuiAccessor",
+    "accessors.ChatScreenAccessor"
   ],
   "compatibilityLevel": "JAVA_17",
   "injectors": {

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -23,7 +23,8 @@
     "accessors.ClientboundSetPlayerTeamPacketAccessor",
     "accessors.OptionsAccessor",
     "accessors.GuiAccessor",
-    "accessors.ChatScreenAccessor"
+    "accessors.ChatScreenAccessor",
+    "accessors.ItemStackInfoAccessor"
   ],
   "compatibilityLevel": "JAVA_17",
   "injectors": {


### PR DESCRIPTION
This PR ports legacy's chat item feature to Artemis. The encoding format used is identical, so there is full cross-compatibility with legacy. 

![image](https://user-images.githubusercontent.com/3767283/174689997-1ab72798-fae2-42f8-b9bc-581a49f607f7.png)

To fully accomplish the feature, I created/changed the chat sent and received events. Their respective mixins use redirects now - I'm aware that this is a heavy-handed approach and should be avoided when possible, but the only other way of implementing the ability to modify received messages from multiple different features (which is not something that happens now, but most likely will in the future) would be to have some sort of central chat manager that can simply cancel the chat message and display its own. This is something that probably _should_ happen down the road, but I didn't want to undertake that within this PR.