### PR TITLE
Chore: Update loader versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 archives_base_name=wynntils
 # Minecraft and mappings versions
 minecraft_version=1.18.2
-parchment_version=2022.05.02
+parchment_version=2022.06.26
 # Modding framework versions
-fabric_loader_version=0.13.3
-fabric_version=0.51.1+1.18.2
-forge_version=1.18.2-40.1.0
+fabric_loader_version=0.14.8
+fabric_version=0.57.0+1.18.2
+forge_version=1.18.2-40.1.54
 # Note: Must use same version of eventbus as is used in the above forge version!
 forge_eventbus_version=5.0.+
 # Source code settings
@@ -21,4 +21,4 @@ org.gradle.jvmargs=-Xmx2048M --add-exports jdk.compiler/com.sun.tools.javac.api=
 # --------------------------------------------------------------------------------------------------------------------
 # Mod specific settings
 # DevAuth version
-devauth_version=1.0.0
+devauth_version=1.1.0


### PR DESCRIPTION
Just a quick PR updating Fabric/Forge loaders, Devauth and Parchment versions. 

Tested, seems to work with both loaders. However, if you are using [Hotswap Agent](https://github.com/HotswapProjects/HotswapAgent) with Fabric, you need to disable the `Log4j2` plugin so the game actually loads (the plugin is only used for reloading log4j configs, actual hotswapping still works). (If you are using it, [here](https://github.com/HotswapProjects/HotswapAgent/blob/master/hotswap-agent-core/src/main/resources/hotswap-agent.properties) is the default config file for Hotswap Agent).