### PR TITLE
QuestInfoOverlayFeature: Add QuestInfoOverlayFeature and FontRenderer

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -30,6 +30,7 @@ import com.wynntils.features.user.ItemStatInfoFeature;
 import com.wynntils.features.user.MountHorseHotkeyFeature;
 import com.wynntils.features.user.MythicBlockerFeature;
 import com.wynntils.features.user.PlayerGhostTransparencyFeature;
+import com.wynntils.features.user.QuestInfoOverlayFeature;
 import com.wynntils.features.user.SoulPointTimerFeature;
 import com.wynntils.features.user.TooltipScaleFeature;
 import com.wynntils.features.user.WynncraftButtonFeature;
@@ -149,6 +150,7 @@ public class FeatureRegistry {
         registerFeature(new WynncraftButtonFeature());
         registerFeature(new TooltipScaleFeature());
         registerFeature(new DurabilityArcFeature());
+        registerFeature(new QuestInfoOverlayFeature());
 
         // save/create config file after loading all features' options
         ConfigManager.saveConfig();

--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -8,11 +8,21 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.features.overlays.sizes.FixedOverlaySize;
 import com.wynntils.core.features.overlays.sizes.OverlaySize;
+import com.wynntils.mc.render.HorizontalAlignment;
+import com.wynntils.mc.render.VerticalAlignment;
 
 public abstract class Overlay {
     protected OverlayPosition position;
 
     protected OverlaySize size;
+
+    // This is used in rendering.
+    // Initially we use the overlay position horizontal alignment
+    // but the user can modify this config field to use an override.
+    // Example use case: Overlay is aligned to the left in the TopRight section,
+    //                   but the user wants to use right text alignment
+    protected HorizontalAlignment horizontalAlignmentOverride = null;
+    protected VerticalAlignment verticalAlignmentOverride = null;
 
     public Overlay(OverlayPosition position, float width, float height) {
         this.position = position;
@@ -24,6 +34,17 @@ public abstract class Overlay {
         this.size = size;
     }
 
+    public Overlay(
+            OverlayPosition position,
+            OverlaySize size,
+            HorizontalAlignment horizontalAlignmentOverride,
+            VerticalAlignment verticalAlignmentOverride) {
+        this.position = position;
+        this.size = size;
+        this.horizontalAlignmentOverride = horizontalAlignmentOverride;
+        this.verticalAlignmentOverride = verticalAlignmentOverride;
+    }
+
     public abstract void render(PoseStack poseStack, float partialTicks, Window window);
 
     public float getWidth() {
@@ -32,6 +53,14 @@ public abstract class Overlay {
 
     public float getHeight() {
         return this.size.getHeight();
+    }
+
+    public float getRenderedWidth() {
+        return this.size.getRenderedWidth();
+    }
+
+    public float getRenderedHeight() {
+        return this.size.getRenderedHeight();
     }
 
     // Return the X where the overlay should be rendered
@@ -54,5 +83,13 @@ public abstract class Overlay {
                     + this.position.getVerticalOffset();
             case Bottom -> (int) (section.y2() + this.position.getVerticalOffset() - this.getHeight());
         };
+    }
+
+    public HorizontalAlignment getRenderHorizontalAlignment() {
+        return horizontalAlignmentOverride == null ? position.getHorizontalAlignment() : horizontalAlignmentOverride;
+    }
+
+    public VerticalAlignment getRenderVerticalAlignment() {
+        return verticalAlignmentOverride == null ? position.getVerticalAlignment() : verticalAlignmentOverride;
     }
 }

--- a/common/src/main/java/com/wynntils/core/features/overlays/OverlayPosition.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/OverlayPosition.java
@@ -4,6 +4,9 @@
  */
 package com.wynntils.core.features.overlays;
 
+import com.wynntils.mc.render.HorizontalAlignment;
+import com.wynntils.mc.render.VerticalAlignment;
+
 public class OverlayPosition {
 
     private int verticalOffset;
@@ -67,17 +70,5 @@ public class OverlayPosition {
         public int getIndex() {
             return index;
         }
-    }
-
-    public enum HorizontalAlignment {
-        Left,
-        Center,
-        Right
-    }
-
-    public enum VerticalAlignment {
-        Top,
-        Middle,
-        Bottom
     }
 }

--- a/common/src/main/java/com/wynntils/core/features/overlays/sizes/FixedOverlaySize.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/sizes/FixedOverlaySize.java
@@ -21,4 +21,14 @@ public class FixedOverlaySize extends OverlaySize {
     public float getHeight() {
         return (float) (this.height / McUtils.window().getGuiScale());
     }
+
+    @Override
+    public float getRenderedWidth() {
+        return getWidth();
+    }
+
+    @Override
+    public float getRenderedHeight() {
+        return getHeight();
+    }
 }

--- a/common/src/main/java/com/wynntils/core/features/overlays/sizes/GuiScaledOverlaySize.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/sizes/GuiScaledOverlaySize.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.core.features.overlays.sizes;
 
+import com.wynntils.mc.utils.McUtils;
+
 // Since we use guiScaledWidth/guiScaledHeight for Overlays, we do not need to factor in GUI scale here.
 public class GuiScaledOverlaySize extends OverlaySize {
     public GuiScaledOverlaySize(float width, float height) {
@@ -18,5 +20,15 @@ public class GuiScaledOverlaySize extends OverlaySize {
     @Override
     public float getHeight() {
         return this.height;
+    }
+
+    @Override
+    public float getRenderedWidth() {
+        return (float) (getWidth() * McUtils.window().getGuiScale());
+    }
+
+    @Override
+    public float getRenderedHeight() {
+        return (float) (getHeight() * McUtils.window().getGuiScale());
     }
 }

--- a/common/src/main/java/com/wynntils/core/features/overlays/sizes/OverlaySize.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/sizes/OverlaySize.java
@@ -16,4 +16,8 @@ public abstract class OverlaySize {
     public abstract float getWidth();
 
     public abstract float getHeight();
+
+    public abstract float getRenderedWidth();
+
+    public abstract float getRenderedHeight();
 }

--- a/common/src/main/java/com/wynntils/core/features/overlays/sizes/RestrictedRangeOverlaySize.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/sizes/RestrictedRangeOverlaySize.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.core.features.overlays.sizes;
 
-public class RestrictedRangeOverlaySize extends OverlaySize {
+public class RestrictedRangeOverlaySize extends FixedOverlaySize {
     private final float maxWidth;
     private final float maxHeight;
 
@@ -16,16 +16,6 @@ public class RestrictedRangeOverlaySize extends OverlaySize {
 
         this.maxWidth = maxWidth;
         this.maxHeight = maxHeight;
-    }
-
-    @Override
-    public float getWidth() {
-        return width;
-    }
-
-    @Override
-    public float getHeight() {
-        return height;
     }
 
     public void setWidth(float newWidth) {

--- a/common/src/main/java/com/wynntils/features/user/DummyOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/DummyOverlayFeature.java
@@ -14,12 +14,16 @@ import com.wynntils.core.features.overlays.OverlayPosition;
 import com.wynntils.core.features.overlays.SectionCoordinates;
 import com.wynntils.core.features.overlays.annotations.OverlayInfo;
 import com.wynntils.core.features.overlays.sizes.GuiScaledOverlaySize;
+import com.wynntils.core.features.properties.StartDisabled;
 import com.wynntils.mc.event.RenderEvent;
+import com.wynntils.mc.render.HorizontalAlignment;
 import com.wynntils.mc.render.RenderUtils;
+import com.wynntils.mc.render.VerticalAlignment;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.utils.objects.CustomColor;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+@StartDisabled
 public class DummyOverlayFeature extends DebugFeature {
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI)
     private final Overlay ComplexRedOverlay = new DummyRedComplexOverlay();
@@ -27,22 +31,14 @@ public class DummyOverlayFeature extends DebugFeature {
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI, renderAt = OverlayInfo.RenderState.Pre)
     private final Overlay BasicBlueOverlay = new BasicOverlay(
             new OverlayPosition(
-                    15,
-                    15,
-                    OverlayPosition.VerticalAlignment.Top,
-                    OverlayPosition.HorizontalAlignment.Left,
-                    OverlayPosition.AnchorSection.TopLeft),
+                    15, 15, VerticalAlignment.Top, HorizontalAlignment.Left, OverlayPosition.AnchorSection.TopLeft),
             new GuiScaledOverlaySize(75, 75),
             DummyOverlayFeature::renderBasicBlueBox);
 
     @OverlayInfo(renderType = RenderEvent.ElementType.Crosshair, renderAt = OverlayInfo.RenderState.Replace)
     private final Overlay CrosshairReplacerOverlay = new BasicOverlay(
             new OverlayPosition(
-                    0,
-                    0,
-                    OverlayPosition.VerticalAlignment.Middle,
-                    OverlayPosition.HorizontalAlignment.Center,
-                    OverlayPosition.AnchorSection.Middle),
+                    0, 0, VerticalAlignment.Middle, HorizontalAlignment.Center, OverlayPosition.AnchorSection.Middle),
             new GuiScaledOverlaySize(2, 2),
             DummyOverlayFeature::renderBasicGreenBox);
 
@@ -52,8 +48,8 @@ public class DummyOverlayFeature extends DebugFeature {
                     new OverlayPosition(
                             -15,
                             -30,
-                            OverlayPosition.VerticalAlignment.Bottom,
-                            OverlayPosition.HorizontalAlignment.Right,
+                            VerticalAlignment.Bottom,
+                            HorizontalAlignment.Right,
                             OverlayPosition.AnchorSection.Middle),
                     100,
                     100);

--- a/common/src/main/java/com/wynntils/features/user/QuestInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuestInfoOverlayFeature.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.user;
+
+import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.features.UserFeature;
+import com.wynntils.core.features.overlays.Overlay;
+import com.wynntils.core.features.overlays.OverlayPosition;
+import com.wynntils.core.features.overlays.annotations.OverlayInfo;
+import com.wynntils.core.features.overlays.sizes.GuiScaledOverlaySize;
+import com.wynntils.mc.event.RenderEvent;
+import com.wynntils.mc.render.FontRenderer;
+import com.wynntils.mc.render.HorizontalAlignment;
+import com.wynntils.mc.render.LineRenderTask;
+import com.wynntils.mc.render.VerticalAlignment;
+import com.wynntils.utils.objects.CommonColors;
+import com.wynntils.wc.utils.scoreboard.quests.QuestInfo;
+import com.wynntils.wc.utils.scoreboard.quests.QuestManager;
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuestInfoOverlayFeature extends UserFeature {
+    @OverlayInfo(renderType = RenderEvent.ElementType.GUI)
+    private final Overlay QuestInfoOverlay = new QuestInfoOverlay();
+
+    public static class QuestInfoOverlay extends Overlay {
+        public QuestInfoOverlay() {
+            super(
+                    new OverlayPosition(
+                            5,
+                            -5,
+                            VerticalAlignment.Top,
+                            HorizontalAlignment.Right,
+                            OverlayPosition.AnchorSection.TopRight),
+                    new GuiScaledOverlaySize(300, 50),
+                    HorizontalAlignment.Left,
+                    VerticalAlignment.Middle);
+        }
+
+        @Override
+        public void render(PoseStack poseStack, float partialTicks, Window window) {
+            QuestInfo currentQuest = QuestManager.getCurrentQuest();
+
+            if (currentQuest == null) {
+                return;
+            }
+
+            List<LineRenderTask> toRender = new ArrayList<>();
+
+            toRender.add(LineRenderTask.getWithHorizontalAlignment(
+                    "Tracked Quest Info:", this.getWidth(), CommonColors.GREEN, this.getRenderHorizontalAlignment()));
+            toRender.add(LineRenderTask.getWithHorizontalAlignment(
+                    currentQuest.quest(), this.getWidth(), CommonColors.ORANGE, this.getRenderHorizontalAlignment()));
+            toRender.add(LineRenderTask.getWithHorizontalAlignment(
+                    currentQuest.description(),
+                    this.getWidth(),
+                    CommonColors.WHITE,
+                    this.getRenderHorizontalAlignment()));
+
+            FontRenderer.getInstance()
+                    .drawLinesWithAlignment(
+                            poseStack,
+                            this.getRenderX(),
+                            this.getRenderY(),
+                            toRender,
+                            this.getRenderedWidth(),
+                            this.getRenderedHeight(),
+                            this.getRenderHorizontalAlignment(),
+                            this.getRenderVerticalAlignment());
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/features/user/QuestInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuestInfoOverlayFeature.java
@@ -14,7 +14,7 @@ import com.wynntils.core.features.overlays.sizes.GuiScaledOverlaySize;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.render.FontRenderer;
 import com.wynntils.mc.render.HorizontalAlignment;
-import com.wynntils.mc.render.LineRenderTask;
+import com.wynntils.mc.render.TextRenderTask;
 import com.wynntils.mc.render.VerticalAlignment;
 import com.wynntils.utils.objects.CommonColors;
 import com.wynntils.wc.utils.scoreboard.quests.QuestInfo;
@@ -48,20 +48,20 @@ public class QuestInfoOverlayFeature extends UserFeature {
                 return;
             }
 
-            List<LineRenderTask> toRender = new ArrayList<>();
+            List<TextRenderTask> toRender = new ArrayList<>();
 
-            toRender.add(LineRenderTask.getWithHorizontalAlignment(
+            toRender.add(TextRenderTask.getWithHorizontalAlignment(
                     "Tracked Quest Info:", this.getWidth(), CommonColors.GREEN, this.getRenderHorizontalAlignment()));
-            toRender.add(LineRenderTask.getWithHorizontalAlignment(
+            toRender.add(TextRenderTask.getWithHorizontalAlignment(
                     currentQuest.quest(), this.getWidth(), CommonColors.ORANGE, this.getRenderHorizontalAlignment()));
-            toRender.add(LineRenderTask.getWithHorizontalAlignment(
+            toRender.add(TextRenderTask.getWithHorizontalAlignment(
                     currentQuest.description(),
                     this.getWidth(),
                     CommonColors.WHITE,
                     this.getRenderHorizontalAlignment()));
 
             FontRenderer.getInstance()
-                    .drawLinesWithAlignment(
+                    .renderTextsWithAlignment(
                             poseStack,
                             this.getRenderX(),
                             this.getRenderY(),

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/MinecraftAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/MinecraftAccessor.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin.accessors;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Minecraft.class)
+public interface MinecraftAccessor {
+    @Accessor("font")
+    Font getFont();
+}

--- a/common/src/main/java/com/wynntils/mc/render/FontRenderer.java
+++ b/common/src/main/java/com/wynntils/mc/render/FontRenderer.java
@@ -26,7 +26,7 @@ public class FontRenderer {
         return INSTANCE;
     }
 
-    public int drawLine(
+    public int renderText(
             PoseStack poseStack,
             String text,
             float x,
@@ -40,7 +40,7 @@ public class FontRenderer {
 
         switch (alignment) {
             case CENTER_ALIGNED:
-                return drawLine(
+                return renderText(
                         poseStack,
                         text,
                         x - font.width(text) / 2.0f,
@@ -49,7 +49,7 @@ public class FontRenderer {
                         TextAlignment.LEFT_ALIGNED,
                         shadow);
             case RIGHT_ALIGNED:
-                return drawLine(
+                return renderText(
                         poseStack, text, x - font.width(text), y, customColor, TextAlignment.LEFT_ALIGNED, shadow);
             default: {
                 if (shadow == TextShadow.NORMAL) {
@@ -60,7 +60,7 @@ public class FontRenderer {
         }
     }
 
-    public void drawLine(
+    public void renderText(
             PoseStack poseStack,
             String text,
             float x,
@@ -72,7 +72,7 @@ public class FontRenderer {
         if (text == null) return;
 
         if (maxWidth == 0 || font.width(text) < maxWidth) {
-            drawLine(poseStack, text, x, y, customColor, alignment, shadow);
+            renderText(poseStack, text, x, y, customColor, alignment, shadow);
             return;
         }
 
@@ -84,7 +84,7 @@ public class FontRenderer {
         for (int i = parts.size() - 1; i >= 0 && partBegin < parts.size() - 1; i--) {
             String shortened = String.join(" ", parts.subList(partBegin, i + 1));
             if (font.width(shortened) < maxWidth) {
-                drawLine(poseStack, shortened, x, y + (line * NEWLINE_OFFSET), customColor, alignment, shadow);
+                renderText(poseStack, shortened, x, y + (line * NEWLINE_OFFSET), customColor, alignment, shadow);
                 line++;
                 partBegin = i + 1;
                 i = parts.size();
@@ -92,21 +92,21 @@ public class FontRenderer {
         }
     }
 
-    private void drawLine(PoseStack poseStack, float x, float y, LineRenderTask line) {
-        drawLine(poseStack, line.text(), x, y, line.maxWidth(), line.customColor(), line.alignment(), line.shadow());
+    private void renderText(PoseStack poseStack, float x, float y, TextRenderTask line) {
+        renderText(poseStack, line.text(), x, y, line.maxWidth(), line.customColor(), line.alignment(), line.shadow());
     }
 
-    public void drawLines(PoseStack poseStack, float x, float y, List<LineRenderTask> lines) {
+    public void renderTexts(PoseStack poseStack, float x, float y, List<TextRenderTask> lines) {
         for (int i = 0; i < lines.size(); i++) {
-            drawLine(poseStack, x, y + (NEWLINE_OFFSET * i), lines.get(i));
+            renderText(poseStack, x, y + (NEWLINE_OFFSET * i), lines.get(i));
         }
     }
 
-    public void drawLinesWithAlignment(
+    public void renderTextsWithAlignment(
             PoseStack poseStack,
             float renderX,
             float renderY,
-            List<LineRenderTask> toRender,
+            List<TextRenderTask> toRender,
             float width,
             float height,
             HorizontalAlignment horizontalAlignment,
@@ -124,24 +124,24 @@ public class FontRenderer {
             case Bottom -> renderY += (height - renderHeight) / McUtils.window().getGuiScale();
         }
 
-        drawLines(poseStack, renderX, renderY, toRender);
+        renderTexts(poseStack, renderX, renderY, toRender);
     }
 
-    private float calculateRenderHeight(List<LineRenderTask> toRender) {
+    private float calculateRenderHeight(List<TextRenderTask> toRender) {
         float height = 0;
-        for (LineRenderTask lineRenderTask : toRender) {
-            if (lineRenderTask.maxWidth() == 0) {
+        for (TextRenderTask textRenderTask : toRender) {
+            if (textRenderTask.maxWidth() == 0) {
                 height += font.lineHeight + NEWLINE_OFFSET;
             } else {
                 List<String> parts =
-                        Arrays.stream(lineRenderTask.text().split(" ")).toList();
+                        Arrays.stream(textRenderTask.text().split(" ")).toList();
 
                 int lines = 0;
                 int partBegin = 0;
 
                 for (int i = parts.size() - 1; i >= 0 && partBegin < parts.size() - 1; i--) {
                     String shortened = String.join(" ", parts.subList(partBegin, i + 1));
-                    if (font.width(shortened) < lineRenderTask.maxWidth()) {
+                    if (font.width(shortened) < textRenderTask.maxWidth()) {
                         lines++;
                         partBegin = i + 1;
                         i = parts.size();

--- a/common/src/main/java/com/wynntils/mc/render/FontRenderer.java
+++ b/common/src/main/java/com/wynntils/mc/render/FontRenderer.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.mc.mixin.accessors.MinecraftAccessor;
+import com.wynntils.mc.utils.McUtils;
+import com.wynntils.utils.objects.CustomColor;
+import java.util.Arrays;
+import java.util.List;
+import net.minecraft.client.gui.Font;
+
+public class FontRenderer {
+    private static final FontRenderer INSTANCE = new FontRenderer();
+    private final Font font;
+
+    private static final int NEWLINE_OFFSET = 10;
+
+    public FontRenderer() {
+        this.font = ((MinecraftAccessor) McUtils.mc()).getFont();
+    }
+
+    public static FontRenderer getInstance() {
+        return INSTANCE;
+    }
+
+    public int drawLine(
+            PoseStack poseStack,
+            String text,
+            float x,
+            float y,
+            CustomColor customColor,
+            TextAlignment alignment,
+            TextShadow shadow) {
+        if (text == null) return 0;
+
+        // TODO: Add rainbow color support
+
+        switch (alignment) {
+            case CENTER_ALIGNED:
+                return drawLine(
+                        poseStack,
+                        text,
+                        x - font.width(text) / 2.0f,
+                        y,
+                        customColor,
+                        TextAlignment.LEFT_ALIGNED,
+                        shadow);
+            case RIGHT_ALIGNED:
+                return drawLine(
+                        poseStack, text, x - font.width(text), y, customColor, TextAlignment.LEFT_ALIGNED, shadow);
+            default: {
+                if (shadow == TextShadow.NORMAL) {
+                    return font.drawShadow(poseStack, text, x, y, customColor.asInt());
+                }
+                return font.draw(poseStack, text, x, y, customColor.asInt());
+            }
+        }
+    }
+
+    public void drawLine(
+            PoseStack poseStack,
+            String text,
+            float x,
+            float y,
+            float maxWidth,
+            CustomColor customColor,
+            TextAlignment alignment,
+            TextShadow shadow) {
+        if (text == null) return;
+
+        if (maxWidth == 0 || font.width(text) < maxWidth) {
+            drawLine(poseStack, text, x, y, customColor, alignment, shadow);
+            return;
+        }
+
+        List<String> parts = Arrays.stream(text.split(" ")).toList();
+
+        int line = 0;
+        int partBegin = 0;
+
+        for (int i = parts.size() - 1; i >= 0 && partBegin < parts.size() - 1; i--) {
+            String shortened = String.join(" ", parts.subList(partBegin, i + 1));
+            if (font.width(shortened) < maxWidth) {
+                drawLine(poseStack, shortened, x, y + (line * NEWLINE_OFFSET), customColor, alignment, shadow);
+                line++;
+                partBegin = i + 1;
+                i = parts.size();
+            }
+        }
+    }
+
+    private void drawLine(PoseStack poseStack, float x, float y, LineRenderTask line) {
+        drawLine(poseStack, line.text(), x, y, line.maxWidth(), line.customColor(), line.alignment(), line.shadow());
+    }
+
+    public void drawLines(PoseStack poseStack, float x, float y, List<LineRenderTask> lines) {
+        for (int i = 0; i < lines.size(); i++) {
+            drawLine(poseStack, x, y + (NEWLINE_OFFSET * i), lines.get(i));
+        }
+    }
+
+    public void drawLinesWithAlignment(
+            PoseStack poseStack,
+            float renderX,
+            float renderY,
+            List<LineRenderTask> toRender,
+            float width,
+            float height,
+            HorizontalAlignment horizontalAlignment,
+            VerticalAlignment verticalAlignment) {
+        switch (horizontalAlignment) {
+            case Center -> renderX += width / 2 / McUtils.window().getGuiScale();
+            case Right -> renderX += width / McUtils.window().getGuiScale();
+        }
+
+        float renderHeight = calculateRenderHeight(toRender);
+
+        switch (verticalAlignment) {
+            case Middle -> renderY +=
+                    (height - renderHeight) / 2 / McUtils.window().getGuiScale();
+            case Bottom -> renderY += (height - renderHeight) / McUtils.window().getGuiScale();
+        }
+
+        drawLines(poseStack, renderX, renderY, toRender);
+    }
+
+    private float calculateRenderHeight(List<LineRenderTask> toRender) {
+        float height = 0;
+        for (LineRenderTask lineRenderTask : toRender) {
+            if (lineRenderTask.maxWidth() == 0) {
+                height += font.lineHeight + NEWLINE_OFFSET;
+            } else {
+                List<String> parts =
+                        Arrays.stream(lineRenderTask.text().split(" ")).toList();
+
+                int lines = 0;
+                int partBegin = 0;
+
+                for (int i = parts.size() - 1; i >= 0 && partBegin < parts.size() - 1; i--) {
+                    String shortened = String.join(" ", parts.subList(partBegin, i + 1));
+                    if (font.width(shortened) < lineRenderTask.maxWidth()) {
+                        lines++;
+                        partBegin = i + 1;
+                        i = parts.size();
+                    }
+                }
+
+                height += lines * (font.lineHeight + NEWLINE_OFFSET);
+            }
+        }
+
+        return (float) (height / 2 * McUtils.window().getGuiScale());
+    }
+
+    public enum TextAlignment {
+        LEFT_ALIGNED,
+        CENTER_ALIGNED,
+        RIGHT_ALIGNED
+    }
+
+    public enum TextShadow {
+        NONE,
+        NORMAL
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/render/HorizontalAlignment.java
+++ b/common/src/main/java/com/wynntils/mc/render/HorizontalAlignment.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.render;
+
+public enum HorizontalAlignment {
+    Left,
+    Center,
+    Right
+}

--- a/common/src/main/java/com/wynntils/mc/render/LineRenderTask.java
+++ b/common/src/main/java/com/wynntils/mc/render/LineRenderTask.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.render;
+
+import com.wynntils.utils.objects.CustomColor;
+
+public record LineRenderTask(
+        String text,
+        float maxWidth,
+        CustomColor customColor,
+        FontRenderer.TextAlignment alignment,
+        FontRenderer.TextShadow shadow) {
+
+    public LineRenderTask(String text, float maxWidth, CustomColor customColor) {
+        this(text, maxWidth, customColor, FontRenderer.TextAlignment.LEFT_ALIGNED, FontRenderer.TextShadow.NORMAL);
+    }
+
+    public static LineRenderTask getWithHorizontalAlignment(
+            String text, float maxWidth, CustomColor customColor, HorizontalAlignment horizontalAlignment) {
+        switch (horizontalAlignment) {
+            case Left -> {
+                return new LineRenderTask(
+                        text,
+                        maxWidth,
+                        customColor,
+                        FontRenderer.TextAlignment.LEFT_ALIGNED,
+                        FontRenderer.TextShadow.NORMAL);
+            }
+            case Center -> {
+                return new LineRenderTask(
+                        text,
+                        maxWidth,
+                        customColor,
+                        FontRenderer.TextAlignment.CENTER_ALIGNED,
+                        FontRenderer.TextShadow.NORMAL);
+            }
+            case Right -> {
+                return new LineRenderTask(
+                        text,
+                        maxWidth,
+                        customColor,
+                        FontRenderer.TextAlignment.RIGHT_ALIGNED,
+                        FontRenderer.TextShadow.NORMAL);
+            }
+        }
+
+        return new LineRenderTask(
+                text, maxWidth, customColor, FontRenderer.TextAlignment.LEFT_ALIGNED, FontRenderer.TextShadow.NORMAL);
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/render/TextRenderTask.java
+++ b/common/src/main/java/com/wynntils/mc/render/TextRenderTask.java
@@ -6,22 +6,22 @@ package com.wynntils.mc.render;
 
 import com.wynntils.utils.objects.CustomColor;
 
-public record LineRenderTask(
+public record TextRenderTask(
         String text,
         float maxWidth,
         CustomColor customColor,
         FontRenderer.TextAlignment alignment,
         FontRenderer.TextShadow shadow) {
 
-    public LineRenderTask(String text, float maxWidth, CustomColor customColor) {
+    public TextRenderTask(String text, float maxWidth, CustomColor customColor) {
         this(text, maxWidth, customColor, FontRenderer.TextAlignment.LEFT_ALIGNED, FontRenderer.TextShadow.NORMAL);
     }
 
-    public static LineRenderTask getWithHorizontalAlignment(
+    public static TextRenderTask getWithHorizontalAlignment(
             String text, float maxWidth, CustomColor customColor, HorizontalAlignment horizontalAlignment) {
         switch (horizontalAlignment) {
             case Left -> {
-                return new LineRenderTask(
+                return new TextRenderTask(
                         text,
                         maxWidth,
                         customColor,
@@ -29,7 +29,7 @@ public record LineRenderTask(
                         FontRenderer.TextShadow.NORMAL);
             }
             case Center -> {
-                return new LineRenderTask(
+                return new TextRenderTask(
                         text,
                         maxWidth,
                         customColor,
@@ -37,7 +37,7 @@ public record LineRenderTask(
                         FontRenderer.TextShadow.NORMAL);
             }
             case Right -> {
-                return new LineRenderTask(
+                return new TextRenderTask(
                         text,
                         maxWidth,
                         customColor,
@@ -46,7 +46,7 @@ public record LineRenderTask(
             }
         }
 
-        return new LineRenderTask(
+        return new TextRenderTask(
                 text, maxWidth, customColor, FontRenderer.TextAlignment.LEFT_ALIGNED, FontRenderer.TextShadow.NORMAL);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/render/VerticalAlignment.java
+++ b/common/src/main/java/com/wynntils/mc/render/VerticalAlignment.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.render;
+
+public enum VerticalAlignment {
+    Top,
+    Middle,
+    Bottom
+}

--- a/common/src/main/java/com/wynntils/utils/objects/CommonColors.java
+++ b/common/src/main/java/com/wynntils/utils/objects/CommonColors.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.objects;
+
+public class CommonColors {
+    public static final CustomColor BLACK = CustomColor.fromInt(0x000000);
+    public static final CustomColor RED = CustomColor.fromInt(0xff0000);
+    public static final CustomColor GREEN = CustomColor.fromInt(0x00ff00);
+    public static final CustomColor BLUE = CustomColor.fromInt(0x0000ff);
+    public static final CustomColor YELLOW = CustomColor.fromInt(0xffff00);
+    public static final CustomColor BROWN = CustomColor.fromInt(0x563100);
+    public static final CustomColor PURPLE = CustomColor.fromInt(0xb200ff);
+    public static final CustomColor CYAN = CustomColor.fromInt(0x438e82);
+    public static final CustomColor LIGHT_GRAY = CustomColor.fromInt(0xadadad);
+    public static final CustomColor GRAY = CustomColor.fromInt(0x636363);
+    public static final CustomColor PINK = CustomColor.fromInt(0xffb7b7);
+    public static final CustomColor LIGHT_GREEN = CustomColor.fromInt(0x49ff59);
+    public static final CustomColor LIGHT_BLUE = CustomColor.fromInt(0x00e9ff);
+    public static final CustomColor MAGENTA = CustomColor.fromInt(0xff0083);
+    public static final CustomColor ORANGE = CustomColor.fromInt(0xff9000);
+    public static final CustomColor WHITE = CustomColor.fromInt(0xffffff);
+
+    // TODO Add rainbow
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -114,6 +114,7 @@
   "feature.wynntils.playerGhostTransparency.name": "Transparent Player Ghost Feature",
   "feature.wynntils.playerGhostTransparency.playerGhostTranslucenceLevel.description": "The level of translucence that should be applied to player ghosts",
   "feature.wynntils.playerGhostTransparency.playerGhostTranslucenceLevel.name": "Player Ghost Translucence",
+  "feature.wynntils.questInfoOverlayFeature.name": "Quest Status Overlay Feature",
   "feature.wynntils.soulPointTimer.name": "Soul Point Timer Feature",
   "feature.wynntils.tooltipScale.fitToScreen.description": "Whether tooltips should be scaled to always fit on the screen",
   "feature.wynntils.tooltipScale.fitToScreen.name": "Fit to Screen",

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -25,7 +25,8 @@
     "accessors.GuiAccessor",
     "accessors.ChatScreenAccessor",
     "accessors.ItemStackInfoAccessor",
-    "accessors.ClientboundBossEventPacketAccessor"
+    "accessors.ClientboundBossEventPacketAccessor",
+    "accessors.MinecraftAccessor"
   ],
   "compatibilityLevel": "JAVA_17",
   "injectors": {


### PR DESCRIPTION
The first actual working overlay in Artemis! 🎉

As expected, this PR is a bit bigger in size, since I had to adapt the Overlay framework to fix issues and make it more intuitive and usable. 

Most important changes: 
- `Overlay` class now has vertical and horizontal alignment overrides. This is done so the alignment we use to save the overlay position does not dictate the rendering alignment. These settings are meant to be config options, exposed to the user. If no override is present, the overlay position alignment is used.
- `FontRenderer` class: This class is quite useful even in it's first iteration. It has support for loads of features; we can draw multi-line texts, aligned to our needs, line broken if a max width is present, and GUI scaled. The actual FontRenderer "API" is quite nice too, it is quite easy to do rendering with the wrapper methods. We can improve this class as we are using it, I did not see the need to create a bunch of hypothetically useful methods. 
- `CommonColors` class: Nice to have, easy colors
- Last but not least, `QuestInfoOverlayFeature`'s `QuestInfoOverlay`. As you can see from the code, it is really clean and easy to add overlays.

There are a few smaller changes, mostly based around the changes listed above. 

Few screenshots of the overlay (ignore the red box, it was used as a debug tool):

Alignments: 
  ![image](https://user-images.githubusercontent.com/49001742/177659672-dd097682-1789-439e-a82c-ce3232a02de3.png)
  ![image](https://user-images.githubusercontent.com/49001742/177659690-06b11203-4e17-4c3d-9ff7-517162a86cb3.png)
  ![image](https://user-images.githubusercontent.com/49001742/177659701-4c697f1b-0865-464c-a003-476517b145ba.png)

GUI scaling:
![image](https://user-images.githubusercontent.com/49001742/177659778-a8089479-b2a9-49e1-b121-61681527ae45.png)
![image](https://user-images.githubusercontent.com/49001742/177659788-b4437fb2-c530-43c4-8b66-c839c9f97cf6.png)