### PR TITLE
RenderUtils: Add line rendering!

### DIFF
--- a/common/src/main/java/com/wynntils/utils/objects/CommonColors.java
+++ b/common/src/main/java/com/wynntils/utils/objects/CommonColors.java
@@ -5,22 +5,22 @@
 package com.wynntils.utils.objects;
 
 public class CommonColors {
-    public static final CustomColor BLACK = CustomColor.fromInt(0x000000);
-    public static final CustomColor RED = CustomColor.fromInt(0xff0000);
-    public static final CustomColor GREEN = CustomColor.fromInt(0x00ff00);
-    public static final CustomColor BLUE = CustomColor.fromInt(0x0000ff);
-    public static final CustomColor YELLOW = CustomColor.fromInt(0xffff00);
-    public static final CustomColor BROWN = CustomColor.fromInt(0x563100);
-    public static final CustomColor PURPLE = CustomColor.fromInt(0xb200ff);
-    public static final CustomColor CYAN = CustomColor.fromInt(0x438e82);
-    public static final CustomColor LIGHT_GRAY = CustomColor.fromInt(0xadadad);
-    public static final CustomColor GRAY = CustomColor.fromInt(0x636363);
-    public static final CustomColor PINK = CustomColor.fromInt(0xffb7b7);
-    public static final CustomColor LIGHT_GREEN = CustomColor.fromInt(0x49ff59);
-    public static final CustomColor LIGHT_BLUE = CustomColor.fromInt(0x00e9ff);
-    public static final CustomColor MAGENTA = CustomColor.fromInt(0xff0083);
-    public static final CustomColor ORANGE = CustomColor.fromInt(0xff9000);
-    public static final CustomColor WHITE = CustomColor.fromInt(0xffffff);
+    public static final CustomColor BLACK = CustomColor.fromInt(0x000000).withAlpha(255);
+    public static final CustomColor RED = CustomColor.fromInt(0xff0000).withAlpha(255);
+    public static final CustomColor GREEN = CustomColor.fromInt(0x00ff00).withAlpha(255);
+    public static final CustomColor BLUE = CustomColor.fromInt(0x0000ff).withAlpha(255);
+    public static final CustomColor YELLOW = CustomColor.fromInt(0xffff00).withAlpha(255);
+    public static final CustomColor BROWN = CustomColor.fromInt(0x563100).withAlpha(255);
+    public static final CustomColor PURPLE = CustomColor.fromInt(0xb200ff).withAlpha(255);
+    public static final CustomColor CYAN = CustomColor.fromInt(0x438e82).withAlpha(255);
+    public static final CustomColor LIGHT_GRAY = CustomColor.fromInt(0xadadad).withAlpha(255);
+    public static final CustomColor GRAY = CustomColor.fromInt(0x636363).withAlpha(255);
+    public static final CustomColor PINK = CustomColor.fromInt(0xffb7b7).withAlpha(255);
+    public static final CustomColor LIGHT_GREEN = CustomColor.fromInt(0x49ff59).withAlpha(255);
+    public static final CustomColor LIGHT_BLUE = CustomColor.fromInt(0x00e9ff).withAlpha(255);
+    public static final CustomColor MAGENTA = CustomColor.fromInt(0xff0083).withAlpha(255);
+    public static final CustomColor ORANGE = CustomColor.fromInt(0xff9000).withAlpha(255);
+    public static final CustomColor WHITE = CustomColor.fromInt(0xffffff).withAlpha(255);
 
     // TODO Add rainbow
 }


### PR DESCRIPTION
This took me at least as many hours as the whole overlay manager GUI will. Anyways, I don't know when I can finish that GUI, so I am making this a separate PR just so everyone else can use this in the meantime. 

What happened: (Link to whole issue: https://github.com/MinecraftForge/MinecraftForge/issues/8083)
> Looking at the [specification for OpenGL 3.2 (Core Profile)](https://www.khronos.org/registry/OpenGL/specs/gl/glspec32.core.pdf) and some Minecraft code shows that Nightenom's statements are correct:
> In the case of OpenGL 3.2 Core Profile in a forward-compatible context (which Minecraft uses), LineWidths greater than 1.0 and the quadrilateral primitives (including the drawing mode QUADS) are removed features and cannot be used.
(TLDR: LINES AND LINE_STRIP doesn't work, thank you Mojang. DEBUG_LINES AND DEBUG_LINE_STRIP renders, but line width is now deprecated in OpenGL. Not to mention the hacks we would have to use to even get the debug ones to set the line width in the shader (thank you Mojang)... (been there, done it, it wasn't pretty)
https://cdn.discordapp.com/attachments/942564848330498048/996153061514956850/unknown.png



This pretty much left us with no other options other than `TRIANGLES`/`TRIANGLE_FANS`/`TRIANGLE_STRIPS` for rendering (if we ignore the fact that Mojang "patched" `QUADS`.) This means that we have to use these to render lines with widths greater than 1. (As a general rule of thumb, we should use some kind of triangle vertex mode if we can.)

This `drawLine` implementation should support every use case, (although it is a bit long, it should be really performant).

EDIT: Oh yeah, I made all `CommonColor`s have a default alpha of 255, just so anyone using that won't spend 20 minutes debugging it :).