### PR TITLE
ScoreboardManager: Add a way to disable scoreboard segments within features

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/overlays/QuestInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/QuestInfoOverlayFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.user.overlays;
 
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.config.Config;
 import com.wynntils.core.config.ConfigHolder;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.overlays.Overlay;
@@ -21,14 +22,31 @@ import com.wynntils.mc.render.TextRenderTask;
 import com.wynntils.mc.render.VerticalAlignment;
 import com.wynntils.utils.objects.CommonColors;
 import com.wynntils.utils.objects.CustomColor;
+import com.wynntils.wc.event.ScoreboardSegmentAdditionEvent;
+import com.wynntils.wc.utils.scoreboard.ScoreboardManager;
 import com.wynntils.wc.utils.scoreboard.quests.QuestInfo;
 import com.wynntils.wc.utils.scoreboard.quests.QuestManager;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @FeatureInfo(category = "Overlays")
 public class QuestInfoOverlayFeature extends UserFeature {
+
+    @Config
+    public static boolean disableQuestTrackingOnScoreboard = true;
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onScoreboardSegmentChange(ScoreboardSegmentAdditionEvent event) {
+        if (questInfoOverlay.isEnabled()
+                && disableQuestTrackingOnScoreboard
+                && event.getSegment().getType() == ScoreboardManager.SegmentType.Quest) {
+            event.setCanceled(true);
+        }
+    }
+
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI)
     private final Overlay questInfoOverlay = new QuestInfoOverlay();
 

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -306,8 +306,8 @@ public class EventFactory {
         post(new PlayerInfoFooterChangedEvent(footer));
     }
 
-    public static void onSetScore(ClientboundSetScorePacket packet) {
-        post(new ScoreboardSetScoreEvent(
+    public static ScoreboardSetScoreEvent onSetScore(ClientboundSetScorePacket packet) {
+        return post(new ScoreboardSetScoreEvent(
                 packet.getOwner(), packet.getObjectiveName(), packet.getScore(), packet.getMethod()));
     }
     // endregion

--- a/common/src/main/java/com/wynntils/mc/event/ScoreboardSetScoreEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScoreboardSetScoreEvent.java
@@ -5,8 +5,10 @@
 package com.wynntils.mc.event;
 
 import net.minecraft.server.ServerScoreboard;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+@Cancelable
 public class ScoreboardSetScoreEvent extends Event {
     private final String owner;
     private final String objectiveName;

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -158,8 +158,10 @@ public abstract class ClientPacketListenerMixin {
         gui.handleChat(chatType, result.getMessage(), uuid);
     }
 
-    @Inject(method = "handleSetScore", at = @At("RETURN"))
+    @Inject(method = "handleSetScore", at = @At("HEAD"), cancellable = true)
     private void handleSetScore(ClientboundSetScorePacket packet, CallbackInfo ci) {
-        EventFactory.onSetScore(packet);
+        if (EventFactory.onSetScore(packet).isCanceled()) {
+            ci.cancel();
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/wc/event/ScoreboardSegmentAdditionEvent.java
+++ b/common/src/main/java/com/wynntils/wc/event/ScoreboardSegmentAdditionEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wc.event;
+
+import com.wynntils.wc.utils.scoreboard.Segment;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class ScoreboardSegmentAdditionEvent extends Event {
+    private final Segment segment;
+
+    public ScoreboardSegmentAdditionEvent(Segment segment) {
+        this.segment = segment;
+    }
+
+    public Segment getSegment() {
+        return segment;
+    }
+}

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/Segment.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/Segment.java
@@ -4,11 +4,13 @@
  */
 package com.wynntils.wc.utils.scoreboard;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public final class Segment {
     private final ScoreboardManager.SegmentType type;
     private final String header;
+    private String end;
     private List<String> content = null;
     private final int startIndex;
     private int endIndex = -1;
@@ -52,6 +54,20 @@ public final class Segment {
         return header;
     }
 
+    public String getEnd() {
+        return end;
+    }
+
+    public List<String> getScoreboardLines() {
+        List<String> lines = new ArrayList<>(this.content);
+        lines.add(this.header);
+        if (this.end != null) {
+            lines.add(this.end);
+        }
+
+        return lines;
+    }
+
     public boolean isChanged() {
         return changed;
     }
@@ -66,5 +82,9 @@ public final class Segment {
 
     public void setChanged(boolean changed) {
         this.changed = changed;
+    }
+
+    public void setEnd(String end) {
+        this.end = end;
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -193,6 +193,8 @@
   "feature.wynntils.pouchRedirectFeature.redirectEmeraldPouch.name": "Redirect Emerald Pouch Messages",
   "feature.wynntils.pouchRedirectFeature.redirectIngredientPouch.description": "Should messages about ingredients being added to your pouch be redirected to the game update ticker?",
   "feature.wynntils.pouchRedirectFeature.redirectIngredientPouch.name": "Redirect Ingredient Pouch Messages",
+  "feature.wynntils.questInfoOverlay.disableQuestTrackingOnScoreboard.description": "Should quest tracking be enabled on the scoreboard? This option only works if QuestInfoOverlay is turned on.",
+  "feature.wynntils.questInfoOverlay.disableQuestTrackingOnScoreboard.name": "Disable Scoreboard Quest Tracking",
   "feature.wynntils.questInfoOverlay.name": "Quest Status Overlay Feature",
   "feature.wynntils.questInfoOverlay.overlay.questInfo.description": "Display the currently tracked quest's info",
   "feature.wynntils.questInfoOverlay.overlay.questInfo.name": "Quest Info Tracker",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -193,7 +193,7 @@
   "feature.wynntils.pouchRedirectFeature.redirectEmeraldPouch.name": "Redirect Emerald Pouch Messages",
   "feature.wynntils.pouchRedirectFeature.redirectIngredientPouch.description": "Should messages about ingredients being added to your pouch be redirected to the game update ticker?",
   "feature.wynntils.pouchRedirectFeature.redirectIngredientPouch.name": "Redirect Ingredient Pouch Messages",
-  "feature.wynntils.questInfoOverlay.disableQuestTrackingOnScoreboard.description": "Should quest tracking be enabled on the scoreboard? This option only works if QuestInfoOverlay is turned on.",
+  "feature.wynntils.questInfoOverlay.disableQuestTrackingOnScoreboard.description": "Should quest tracking be removed from the scoreboard? This option only works if QuestInfoOverlay is turned on.",
   "feature.wynntils.questInfoOverlay.disableQuestTrackingOnScoreboard.name": "Disable Scoreboard Quest Tracking",
   "feature.wynntils.questInfoOverlay.name": "Quest Status Overlay Feature",
   "feature.wynntils.questInfoOverlay.overlay.questInfo.description": "Display the currently tracked quest's info",

--- a/common/src/main/resources/wynntils.accessWidener
+++ b/common/src/main/resources/wynntils.accessWidener
@@ -13,3 +13,5 @@ accessible method net/minecraft/client/gui/screens/Screen clearWidgets ()V
 accessible method net/minecraft/client/gui/components/AbstractSelectionList getRowBottom (I)I
 accessible field net/minecraft/client/Minecraft gui Lnet/minecraft/client/gui/Gui;
 accessible method net/minecraft/client/gui/components/ChatComponent addMessage (Lnet/minecraft/network/chat/Component;I)V
+accessible field net/minecraft/world/scores/Scoreboard displayObjectives [Lnet/minecraft/world/scores/Objective;
+accessible field net/minecraft/world/scores/Scoreboard playerScores Ljava/util/Map;


### PR DESCRIPTION
Example implementation of this capability is `QuestInfoOverlayFeature`. 

This PR `ScoreboardManager` bug fixes. Now, the manager is so precise, it can be used to reconstruct the whole scoreboard, without the user even noticing.