### PR TITLE
Silence a few warnings from Qodana

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -7,3 +7,6 @@ include:
   - name: RedundantLabeledSwitchRuleCodeBlock
 exclude:
   - name: UnstableApiUsage
+  - name: RegExpRepeatedSpace
+  - name: RegExpRedundantEscape
+  - name: UnnecessaryReturn


### PR DESCRIPTION
It was a bit tricky to determine the names of the inspections. I ended up downloading the report, looking through the files until I found the `inspectionName` key, and then grepped that. Don't know if there is a better way.