### PR TITLE
Fix spurious disconnect events, causing "onServer" checks to fail

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/ConnectionMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ConnectionMixin.java
@@ -5,6 +5,7 @@
 package com.wynntils.mc.mixin;
 
 import com.wynntils.mc.EventFactory;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -12,14 +13,20 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Connection.class)
 public abstract class ConnectionMixin {
-    @Inject(method = "disconnect(Lnet/minecraft/network/chat/Component;)V", at = @At("RETURN"))
-    private void disconnectPost(Component message, CallbackInfo ci) {
+    @Shadow
+    private Channel channel;
+
+    @Inject(method = "disconnect(Lnet/minecraft/network/chat/Component;)V", at = @At("HEAD"))
+    private void disconnectPre(Component message, CallbackInfo ci) {
+        if (!this.channel.isOpen()) return;
+
         EventFactory.onDisconnect();
     }
 


### PR DESCRIPTION
I believe this will solve #23.

The problem here was that the vanilla disconnect method were called even if the connection was not open (?). I can't say I fully understand why, most likely this is used for different kinds of connections, not only the "main" connection to the server. But this makes us at least avoid the disconnect event that typically happened shortly after logging in. (And that's the reason I've seen to explain the world state info bug.)