### PR TITLE
Fabric build: Include resource loader in built jar

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -56,7 +56,7 @@ repositories {
 
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
-    modImplementation(fabricApi.module("fabric-resource-loader-v0", rootProject.fabric_version));
+    include(modImplementation(fabricApi.module("fabric-resource-loader-v0", rootProject.fabric_version)));
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }


### PR DESCRIPTION
This should make it so we do not need to depend on Fabric API for only the resource loader, as we build it into the mod. (Without resource loader, translations and textures don't load).

This means we reduce dependencies and we make it easier to install the mod on fabric.

```
[21:29:53] [main/INFO]: Loading 5 mods:
	- fabric-resource-loader-v0 0.5.2+446e059560 via wynntils
	- fabricloader 0.14.9
	- java 17
	- minecraft 1.18.2
	- wynntils 1.1.0+DEV.MC1.18.2
```