### PR TITLE
Build Task: Fix gradle caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,10 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
-          cache: "gradle"
 
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
         with:
-          cache: "gradle"
           arguments: spotlessApply --build-cache
 
       - uses: stefanzweifel/git-auto-commit-action@v4
@@ -53,10 +51,8 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
-          cache: "gradle"
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          cache: "gradle"
           arguments: build -x spotlessCheck --no-daemon --build-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Cache Remapped Minecraft
         uses: actions/cache@v3
         with:
-          key: "loom"
+          key: ${{ runner.os }}-gradle-caches-loom-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-loom-${{ env.cache-name }}-
+            ${{ runner.os }}-gradle-caches-loom-
+            ${{ runner.os }}-
           path: |
             ~/.gradle
 
@@ -62,7 +66,11 @@ jobs:
       - name: Cache Remapped Minecraft
         uses: actions/cache@v3
         with:
-          key: "loom"
+          key: ${{ runner.os }}-gradle-caches-loom-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-loom-${{ env.cache-name }}-
+            ${{ runner.os }}-gradle-caches-loom-
+            ${{ runner.os }}-
           path: |
             ~/.gradle
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,33 +25,6 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
-      - name: Cache Gradle Jars
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-gradle-caches-jars-
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-jars-
-          path: |
-            /home/runner/.gradle/caches/jars-*/*
-
-      - name: Cache Gradle Dependencies
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-gradle-caches-deps-
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-deps-
-          path: |
-            /home/runner/.gradle/caches/modules-*/files-*/*/*/*/*
-
-      - name: Cache Remapped Minecraft
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-gradle-caches-loom-
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-loom-
-          path: |
-            ~/.gradle
-
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
         with:
@@ -78,33 +51,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
-
-      - name: Cache Gradle Jars
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-gradle-caches-jars-
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-jars-
-          path: |
-            /home/runner/.gradle/caches/jars-*/*
-
-      - name: Cache Gradle Dependencies
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-gradle-caches-deps-
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-deps-
-          path: |
-            /home/runner/.gradle/caches/modules-*/files-*/*/*/*/*
-
-      - name: Cache Remapped Minecraft
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-gradle-caches-loom-
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-loom-
-          path: |
-            ~/.gradle
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: spotlessApply
+          cache: "gradle"
+          arguments: spotlessApply --build-cache
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
@@ -57,4 +58,5 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build -x spotlessCheck --no-daemon
+          cache: "gradle"
+          arguments: build -x spotlessCheck --no-daemon --build-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,11 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: 17
+          cache: "gradle"
 
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
@@ -51,6 +52,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+          cache: "gradle"
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
+      - name: Cache Remapped Minecraft
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle
+
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
         with:
@@ -51,6 +57,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+
+      - name: Cache Remapped Minecraft
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
-          cache: "gradle"
 
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
@@ -52,7 +51,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
-          cache: "gradle"
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,13 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
+      - name: Cache Remapped Minecraft
+        uses: actions/cache@v3
+        with:
+          key: "loom"
+          path: |
+            ~/.gradle
+
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
         with:
@@ -51,6 +58,13 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+
+      - name: Cache Remapped Minecraft
+        uses: actions/cache@v3
+        with:
+          key: "loom"
+          path: |
+            ~/.gradle
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,30 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
+      - name: Cache Gradle Jars
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-gradle-caches-jars-
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-jars-
+          path: |
+            /home/runner/.gradle/caches/jars-*/*
+
+      - name: Cache Gradle Dependencies
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-gradle-caches-deps-
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-deps-
+          path: |
+            /home/runner/.gradle/caches/modules-*/files-*/*/*/*/*
+
       - name: Cache Remapped Minecraft
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-gradle-caches-loom-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+          key: ${{ runner.os }}-gradle-caches-loom-
           restore-keys: |
-            ${{ runner.os }}-gradle-caches-loom-${{ env.cache-name }}-
             ${{ runner.os }}-gradle-caches-loom-
-            ${{ runner.os }}-
           path: |
             ~/.gradle
 
@@ -63,14 +79,30 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
+      - name: Cache Gradle Jars
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-gradle-caches-jars-
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-jars-
+          path: |
+            /home/runner/.gradle/caches/jars-*/*
+
+      - name: Cache Gradle Dependencies
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-gradle-caches-deps-
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-deps-
+          path: |
+            /home/runner/.gradle/caches/modules-*/files-*/*/*/*/*
+
       - name: Cache Remapped Minecraft
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-gradle-caches-loom-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+          key: ${{ runner.os }}-gradle-caches-loom-
           restore-keys: |
-            ${{ runner.os }}-gradle-caches-loom-${{ env.cache-name }}-
             ${{ runner.os }}-gradle-caches-loom-
-            ${{ runner.os }}-
           path: |
             ~/.gradle
 


### PR DESCRIPTION
Using setup-java caches prevented gradle-build-task from actually caching anything. Build times should be improved now. 