### PR TITLE
ConfigHolder: Do not lose config type override

### DIFF
--- a/common/src/main/java/com/wynntils/core/config/ConfigHolder.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigHolder.java
@@ -55,7 +55,7 @@ public class ConfigHolder {
         this.defaultValue =
                 ConfigManager.getGson().fromJson(ConfigManager.getGson().toJson(getValue()), fieldTypeTemp);
 
-        if (this.defaultValue != null) {
+        if (typeOverride == null && this.defaultValue != null) {
             fieldTypeTemp = defaultValue.getClass();
         }
 


### PR DESCRIPTION
This also fixes ItemLockFeature. Last time I fixed the saving, this time I fixed type override value reading. It should behave now.