### PR TITLE
NpcDialogueOverlayFeature: Better default setting + alignment fix

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/overlays/NpcDialogueOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/NpcDialogueOverlayFeature.java
@@ -67,7 +67,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
                             VerticalAlignment.Top,
                             HorizontalAlignment.Center,
                             OverlayPosition.AnchorSection.Middle),
-                    new GuiScaledOverlaySize(200, 300),
+                    new GuiScaledOverlaySize(200, 150),
                     HorizontalAlignment.Left,
                     VerticalAlignment.Top);
             updateTextRenderSettings();
@@ -129,7 +129,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
                             List.of(new TextRenderTask("§cPress SNEAK to continue", renderSetting)),
                             this.getRenderedWidth() - 15,
                             this.getRenderedHeight() - 15,
-                            HorizontalAlignment.Left,
+                            this.getRenderHorizontalAlignment(),
                             this.getRenderVerticalAlignment());
         }
 


### PR DESCRIPTION
Reduce the default height, as it is quite large and unreasonable. Also add alignment to "Press sneak to continue" text.