### PR TITLE
ScoreboardManager+ObjectiveManager: Fix parsing

### DIFF
--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
@@ -86,12 +86,11 @@ public final class ScoreboardManager {
                         .toList()) {
                     scoreboardLineMap.remove(lineToRemove.index());
                 }
-                continue;
+            } else {
+                ScoreboardLine line = new ScoreboardLine(processed.lineText(), processed.lineIndex());
+                scoreboardLineMap.put(line.index(), line);
+                changedLines.add(processed.lineText());
             }
-
-            ScoreboardLine line = new ScoreboardLine(processed.lineText(), processed.lineIndex());
-            scoreboardLineMap.put(line.index(), line);
-            changedLines.add(processed.lineText());
         }
 
         scoreboardCopy.clear();

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
@@ -180,7 +180,7 @@ public final class ScoreboardManager {
                 objective = scoreboard.addObjective(
                         objectiveName,
                         ObjectiveCriteria.DUMMY,
-                        new TextComponent("play.wynncraft.com")
+                        new TextComponent(" play.wynncraft.com")
                                 .withStyle(ChatFormatting.GOLD)
                                 .withStyle(ChatFormatting.BOLD),
                         ObjectiveCriteria.RenderType.INTEGER);

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
@@ -83,7 +83,9 @@ public class ObjectiveManager implements ScoreboardHandler {
 
     @Override
     public void onSegmentChange(Segment newValue, ScoreboardManager.SegmentType segmentType) {
-        List<WynnObjective> objectives = reparseObjectives(newValue);
+        List<WynnObjective> objectives = reparseObjectives(newValue).stream()
+                .filter(wynnObjective -> wynnObjective.getScore() != wynnObjective.getMaxScore())
+                .toList();
 
         if (segmentType == ScoreboardManager.SegmentType.GuildObjective) {
             for (WynnObjective objective : objectives) {

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
@@ -84,7 +84,7 @@ public class ObjectiveManager implements ScoreboardHandler {
     @Override
     public void onSegmentChange(Segment newValue, ScoreboardManager.SegmentType segmentType) {
         List<WynnObjective> objectives = reparseObjectives(newValue).stream()
-                .filter(wynnObjective -> wynnObjective.getScore() != wynnObjective.getMaxScore())
+                .filter(wynnObjective -> wynnObjective.getScore() < wynnObjective.getMaxScore())
                 .toList();
 
         if (segmentType == ScoreboardManager.SegmentType.GuildObjective) {


### PR DESCRIPTION
I admit this is a bit more heavy handed approach, but this seems to work fine every use case. 

Should fix #259, #235. (In #235, some objectives are just resent as completed by Wynncraft, I have seen this in legacy. /class or rejoin will fix this on Wynn's side. ObjectiveManager will now handle this at parsing.)