### PR TITLE
Fix: Fixed a crash on intelligence sp and daily reward detection on HB

### DIFF
--- a/common/src/main/java/com/wynntils/wc/custom/item/properties/DailyRewardMultiplierProperty.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/properties/DailyRewardMultiplierProperty.java
@@ -5,6 +5,7 @@
 package com.wynntils.wc.custom.item.properties;
 
 import com.wynntils.mc.render.FontRenderer;
+import com.wynntils.mc.utils.ComponentUtils;
 import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.utils.objects.CommonColors;
 import com.wynntils.wc.custom.item.WynnItemStack;
@@ -14,7 +15,9 @@ public class DailyRewardMultiplierProperty extends CustomStackCountProperty {
         super(item);
         try {
             // Multiplier line is always on index 3
-            String value = String.valueOf(ItemUtils.getLore(item).get(3).charAt(25));
+            String loreLine =
+                    ComponentUtils.stripFormatting(ItemUtils.getLore(item).get(3));
+            String value = String.valueOf(loreLine.charAt(loreLine.indexOf("Streak Multiplier: ") + 19));
             this.setCustomStackCount(value, CommonColors.WHITE, FontRenderer.TextShadow.NORMAL);
         } catch (IndexOutOfBoundsException ignored) {
         }

--- a/common/src/main/java/com/wynntils/wc/custom/item/properties/ProfessionLevelProperty.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/properties/ProfessionLevelProperty.java
@@ -9,6 +9,8 @@ import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.utils.objects.CommonColors;
 import com.wynntils.wc.custom.item.WynnItemStack;
 
+// Remove after Spellbound goes live.
+@Deprecated
 public class ProfessionLevelProperty extends CustomStackCountProperty {
     public ProfessionLevelProperty(WynnItemStack item) {
         super(item);

--- a/common/src/main/java/com/wynntils/wc/custom/item/properties/SkillPointProperty.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/properties/SkillPointProperty.java
@@ -10,23 +10,29 @@ import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.utils.objects.CustomColor;
 import com.wynntils.wc.custom.item.WynnItemStack;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
 
 public class SkillPointProperty extends CustomStackCountProperty {
+    private static final Pattern POINT_PATTERN = Pattern.compile("^.+?(\\d+) points .+$");
+
     public SkillPointProperty(WynnItemStack item) {
         super(item);
 
-        try {
-            char colorCode = ComponentUtils.getCoded(item.getHoverName()).charAt(16);
-            // Current skill point amount is always on line 4 i.e. index 3.
-            String pointsLine = ItemUtils.getLore(item).get(3);
-            String points = pointsLine.substring(6, pointsLine.indexOf('p') - 1);
-
-            this.setCustomStackCount(
-                    points,
-                    CustomColor.fromChatFormatting(Objects.requireNonNull(ChatFormatting.getByCode(colorCode))),
-                    FontRenderer.TextShadow.NORMAL);
-        } catch (IndexOutOfBoundsException | NullPointerException ignored) {
+        char colorCode = ComponentUtils.getCoded(item.getHoverName()).charAt(16);
+        String points = "";
+        for (String lore : ItemUtils.getLore(item)) {
+            Matcher m = POINT_PATTERN.matcher(lore);
+            if (m.find()) {
+                points = m.group(1);
+                break;
+            }
         }
+
+        this.setCustomStackCount(
+                points,
+                CustomColor.fromChatFormatting(Objects.requireNonNull(ChatFormatting.getByCode(colorCode))),
+                FontRenderer.TextShadow.NORMAL);
     }
 }

--- a/common/src/main/java/com/wynntils/wc/utils/WynnItemMatchers.java
+++ b/common/src/main/java/com/wynntils/wc/utils/WynnItemMatchers.java
@@ -164,7 +164,7 @@ public final class WynnItemMatchers {
     }
 
     public static boolean isDailyRewardsChest(ItemStack itemStack) {
-        return "§aDaily Rewards".equals(itemStack.getHoverName().getString());
+        return itemStack.getHoverName().getString().contains("Daily Reward");
     }
 
     public static boolean isPowder(ItemStack itemStack) {


### PR DESCRIPTION
Also marked professionproperty as deprecated as the itemstacks will disappear when 2.0 releases.

Note: I was not able to test whether the daily rewards detection continues to work on normal Wynncraft.