### PR TITLE
Add feature to turn off potion glint

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -34,6 +34,7 @@ import com.wynntils.features.user.TranslationFeature;
 import com.wynntils.features.user.WynncraftButtonFeature;
 import com.wynntils.features.user.WynncraftPauseScreenFeature;
 import com.wynntils.features.user.inventory.DurabilityArcFeature;
+import com.wynntils.features.user.inventory.HidePotionGlintFeature;
 import com.wynntils.features.user.inventory.ItemHighlightFeature;
 import com.wynntils.features.user.inventory.ItemTextOverlayFeature;
 import com.wynntils.features.user.inventory.UnidentifiedItemIconFeature;
@@ -154,6 +155,7 @@ public final class FeatureRegistry {
         registerFeature(new GameNotificationOverlayFeature());
         registerFeature(new GammabrightFeature());
         registerFeature(new HealthPotionBlockerFeature());
+        registerFeature(new HidePotionGlintFeature());
         registerFeature(new InfoMessageFilterFeature());
         registerFeature(new IngredientPouchHotkeyFeature());
         registerFeature(new ItemCompareFeature());

--- a/common/src/main/java/com/wynntils/features/user/inventory/HidePotionGlintFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/HidePotionGlintFeature.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.user.inventory;
+
+import com.wynntils.core.features.UserFeature;
+import com.wynntils.core.features.properties.FeatureInfo;
+import com.wynntils.mc.event.DrawPotionGlintEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+@FeatureInfo(category = "Inventory")
+public class HidePotionGlintFeature extends UserFeature {
+    @SubscribeEvent
+    public void onPotionGlint(DrawPotionGlintEvent e) {
+        e.setCanceled(true);
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -20,6 +20,7 @@ import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerCloseEvent;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.mc.event.DisplayResizeEvent;
+import com.wynntils.mc.event.DrawPotionGlintEvent;
 import com.wynntils.mc.event.DropHeldItemEvent;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
@@ -87,6 +88,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.PotionItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.entity.EntityAccess;
 import net.minecraft.world.phys.BlockHitResult;
@@ -165,6 +167,10 @@ public final class EventFactory {
 
     public static void onHotbarSlotRenderPost(ItemStack stack, int x, int y) {
         post(new HotbarSlotRenderEvent.Post(stack, x, y));
+    }
+
+    public static DrawPotionGlintEvent onPotionIsFoil(PotionItem item) {
+        return post(new DrawPotionGlintEvent(item));
     }
     // endregion
 

--- a/common/src/main/java/com/wynntils/mc/event/DrawPotionGlintEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DrawPotionGlintEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.world.item.PotionItem;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+@Cancelable
+public class DrawPotionGlintEvent extends Event {
+    private final PotionItem item;
+
+    public DrawPotionGlintEvent(PotionItem item) {
+        this.item = item;
+    }
+
+    public PotionItem getItem() {
+        return item;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/PotionItemMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/PotionItemMixin.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.wynntils.mc.EventFactory;
+import com.wynntils.mc.event.DrawPotionGlintEvent;
+import net.minecraft.world.item.PotionItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PotionItem.class)
+public abstract class PotionItemMixin {
+    @Inject(method = "isFoil()B", at = @At("HEAD"), cancellable = true)
+    private void isFoilPre(CallbackInfoReturnable<Boolean> cir) {
+        DrawPotionGlintEvent event = EventFactory.onPotionIsFoil((PotionItem) (Object) this);
+        if (event.isCanceled()) {
+            cir.setReturnValue(false);
+            cir.cancel();
+        }
+    }
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -52,6 +52,7 @@
   "feature.wynntils.healthPotionBlocker.threshold.description": "The percentage of your max health that you need to have for the feature to activate",
   "feature.wynntils.healthPotionBlocker.threshold.name": "Threshold (%%)",
   "feature.wynntils.healthPotionBlocker.thresholdReached": "You are already at %s%% of your max health!",
+  "feature.wynntils.hidePotionGlint.name": "Hide Potion Glint Feature",
   "feature.wynntils.infoMessageFilter.hideLevelUp.description": "Should level up messages be hidden?",
   "feature.wynntils.infoMessageFilter.hideLevelUp.name": "Hide Level Up Messages",
   "feature.wynntils.infoMessageFilter.hideSystemInfo.description": "Should Wynncraft info messages be hidden?",

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -19,6 +19,7 @@
     "MinecraftMixin",
     "MultiPlayerGameModeMixin",
     "OptionsMixin",
+    "PotionItemMixin",
     "ScoreboardMixin",
     "ScreenMixin",
     "SlotMixin",


### PR DESCRIPTION
I think 1.18 has redone the potion glint thing, or the resource pack in 1.12 handled this better, or whatever. Now it's turning me crazy, anyway.