### PR TITLE
Scoreboard+ObjectiveManager: Fix concurrent modification crash, rendering flickering and multi-line objective parsing

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/overlays/ObjectivesOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/ObjectivesOverlayFeature.java
@@ -102,18 +102,25 @@ public class ObjectivesOverlayFeature extends UserFeature {
                         case Bottom -> this.getHeight() - renderedHeight;
                     };
 
+            final String text =
+                    guildObjective.getGoal() + ": " + guildObjective.getScore() + "/" + guildObjective.getMaxScore();
             FontRenderer.getInstance()
                     .renderAlignedTextInBox(
                             poseStack,
-                            guildObjective.getGoal() + ": " + guildObjective.getScore() + "/"
-                                    + guildObjective.getMaxScore(),
+                            text,
                             this.getRenderX(),
                             this.getRenderX() + this.getWidth(),
                             renderY,
-                            0,
+                            this.getWidth(),
                             this.textColor,
                             FontRenderer.TextAlignment.fromHorizontalAlignment(this.getRenderHorizontalAlignment()),
                             this.textShadow);
+
+            float height = FontRenderer.getInstance().calculateRenderHeight(List.of(text), this.getWidth());
+
+            if (height > 9) {
+                renderY += height - 9;
+            }
 
             if (this.enableProgressBar) {
                 RenderUtils.drawProgressBar(
@@ -186,17 +193,25 @@ public class ObjectivesOverlayFeature extends UserFeature {
 
                 float renderY = offsetY + this.getRenderY();
 
+                final String text = objective.getGoal() + ": " + objective.getScore() + "/" + objective.getMaxScore();
                 FontRenderer.getInstance()
                         .renderAlignedTextInBox(
                                 poseStack,
-                                objective.getGoal() + ": " + objective.getScore() + "/" + objective.getMaxScore(),
+                                text,
                                 this.getRenderX(),
                                 this.getRenderX() + this.getWidth(),
                                 renderY,
-                                0,
+                                this.getWidth(),
                                 this.textColor,
                                 FontRenderer.TextAlignment.fromHorizontalAlignment(this.getRenderHorizontalAlignment()),
                                 this.textShadow);
+
+                float height = FontRenderer.getInstance().calculateRenderHeight(List.of(text), this.getWidth());
+
+                if (height > 9) {
+                    offsetY += height - 9;
+                    renderY += height - 9;
+                }
 
                 if (this.enableProgressBar) {
                     RenderUtils.drawProgressBar(

--- a/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
@@ -4,16 +4,30 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.google.common.collect.Maps;
 import com.wynntils.mc.EventFactory;
+import java.util.Map;
+import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.PlayerTeam;
+import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Scoreboard.class)
 public abstract class ScoreboardMixin {
+
+    @Shadow
+    public Map<String, Map<Objective, Score>> playerScores;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onCtor(CallbackInfo ci) {
+        this.playerScores = Maps.newConcurrentMap();
+    }
+
     @Inject(
             method = "removePlayerFromTeam(Ljava/lang/String;Lnet/minecraft/world/scores/PlayerTeam;)V",
             at = @At("HEAD"),

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
@@ -197,6 +197,7 @@ public final class ScoreboardManager {
             scoreboard.setDisplayObjective(1, objective);
 
             // Set player team display objective
+            // This fixes scoreboard gui flickering
             PlayerTeam playerTeam = scoreboard.getPlayersTeam(McUtils.player().getScoreboardName());
             if (playerTeam != null) {
                 if (playerTeam.getColor().getId() >= 0) {

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/ScoreboardManager.java
@@ -34,6 +34,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.ServerScoreboard;
 import net.minecraft.world.scores.Objective;
+import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
@@ -194,6 +195,15 @@ public final class ScoreboardManager {
             }
 
             scoreboard.setDisplayObjective(1, objective);
+
+            // Set player team display objective
+            PlayerTeam playerTeam = scoreboard.getPlayersTeam(McUtils.player().getScoreboardName());
+            if (playerTeam != null) {
+                if (playerTeam.getColor().getId() >= 0) {
+                    int id = playerTeam.getColor().getId() + 3;
+                    scoreboard.setDisplayObjective(id, objective);
+                }
+            }
 
             for (Map<Objective, Score> scoreMap : scoreboard.playerScores.values()) {
                 scoreMap.remove(objective);

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
@@ -18,6 +18,8 @@ import java.util.regex.Pattern;
 public class ObjectiveManager implements ScoreboardHandler {
     // §b is guild objective, §a is normal objective and §c is daily objective
     private static final Pattern OBJECTIVE_PATTERN = Pattern.compile("^§([abc])[- ]\\s§7(.*): *§f(\\d+)§7/(\\d+)$");
+    private static final Pattern OBJECTIVE_PATTERN_START = Pattern.compile("^§([abc]).*$");
+    private static final Pattern OBJECTIVE_PATTERN_END = Pattern.compile(".*§f(\\d+)§7/(\\d+)$");
 
     private static WynnObjective guildWynnObjective = null;
 
@@ -117,7 +119,42 @@ public class ObjectiveManager implements ScoreboardHandler {
 
     private List<WynnObjective> reparseObjectives(Segment segment) {
         List<WynnObjective> parsedObjectives = new ArrayList<>();
+
+        List<String> actualContent = new ArrayList<>();
+        StringBuilder scoreLine = new StringBuilder();
+
         for (String line : segment.getContent()) {
+            if (OBJECTIVE_PATTERN.matcher(line).matches()) {
+                actualContent.add(line);
+                continue;
+            }
+
+            if (OBJECTIVE_PATTERN_START.matcher(line).matches()) {
+                if (!scoreLine.isEmpty()) {
+                    WynntilsMod.error("ObjectiveManager: Multiple objective start without and ending:");
+                    WynntilsMod.error("Already got: " + scoreLine);
+                    WynntilsMod.error("Next line: " + line);
+                }
+
+                scoreLine = new StringBuilder(line);
+                continue;
+            }
+
+            if (!scoreLine.isEmpty()) {
+                scoreLine.append(line);
+            }
+
+            if (OBJECTIVE_PATTERN_END.matcher(line).matches()) {
+                actualContent.add(scoreLine.toString());
+                scoreLine = new StringBuilder();
+            }
+        }
+
+        if (!scoreLine.isEmpty()) {
+            WynntilsMod.error("ObjectiveManager: Got a not finished multi-line objective: " + scoreLine);
+        }
+
+        for (String line : actualContent) {
             Matcher objectiveMatcher = OBJECTIVE_PATTERN.matcher(line);
             if (!objectiveMatcher.matches()) {
                 continue;

--- a/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
+++ b/common/src/main/java/com/wynntils/wc/utils/scoreboard/objectives/ObjectiveManager.java
@@ -145,7 +145,7 @@ public class ObjectiveManager implements ScoreboardHandler {
             }
 
             if (OBJECTIVE_PATTERN_END.matcher(line).matches()) {
-                actualContent.add(scoreLine.toString());
+                actualContent.add(scoreLine.toString().trim().replaceAll(" +", " "));
                 scoreLine = new StringBuilder();
             }
         }


### PR DESCRIPTION
I agree that the concurrent modification fix is a little bit unconventional, but I don't think there is a better way to do this.

As for the flickering fix, I sure love undocumented behavior in Minecraft's source code. 