### PR TITLE
Fixes a crash on unknown itemtypes (e.g. tomes)

### DIFF
--- a/common/src/main/java/com/wynntils/core/webapi/profiles/item/ItemType.java
+++ b/common/src/main/java/com/wynntils/core/webapi/profiles/item/ItemType.java
@@ -6,6 +6,7 @@ package com.wynntils.core.webapi.profiles.item;
 
 import com.wynntils.wc.objects.ClassType;
 import java.util.Locale;
+import java.util.Optional;
 
 public enum ItemType {
     SPEAR(ClassType.Warrior, 16 * 1, 16 * 1),
@@ -43,11 +44,11 @@ public enum ItemType {
         return iconTextureY;
     }
 
-    public static ItemType fromString(String typeStr) {
+    public static Optional<ItemType> fromString(String typeStr) {
         try {
-            return ItemType.valueOf(typeStr.toUpperCase(Locale.ROOT));
+            return Optional.of(ItemType.valueOf(typeStr.toUpperCase(Locale.ROOT)));
         } catch (IllegalArgumentException e) {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/inventory/UnidentifiedItemIconFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/UnidentifiedItemIconFeature.java
@@ -42,6 +42,7 @@ public class UnidentifiedItemIconFeature extends UserFeature {
 
     private void drawIcon(ItemStack item, int slotX, int slotY) {
         if (!(item instanceof UnidentifiedItemStack unidentifiedItem)) return;
+        if (unidentifiedItem.getItemType().isEmpty()) return;
 
         RenderUtils.drawTexturedRect(
                 new PoseStack(),
@@ -51,8 +52,8 @@ public class UnidentifiedItemIconFeature extends UserFeature {
                 400,
                 12,
                 12,
-                unidentifiedItem.getItemType().getIconTextureX(),
-                unidentifiedItem.getItemType().getIconTextureY() + texture.getTextureYOffset(),
+                unidentifiedItem.getItemType().get().getIconTextureX(),
+                unidentifiedItem.getItemType().get().getIconTextureY() + texture.getTextureYOffset(),
                 16,
                 16,
                 Texture.GEAR_ICONS.width(),

--- a/common/src/main/java/com/wynntils/wc/custom/item/UnidentifiedItemStack.java
+++ b/common/src/main/java/com/wynntils/wc/custom/item/UnidentifiedItemStack.java
@@ -29,7 +29,7 @@ import net.minecraft.world.item.TooltipFlag;
 
 public class UnidentifiedItemStack extends WynnItemStack {
     private final List<Component> tooltip;
-    private Optional<ItemType> itemType;
+    private ItemType itemType;
 
     public UnidentifiedItemStack(ItemStack stack) {
         super(stack);
@@ -44,11 +44,12 @@ public class UnidentifiedItemStack extends WynnItemStack {
         String itemTypeStr = itemName.split(" ", 2)[1];
         if (itemTypeStr == null) return;
 
-        itemType = ItemType.fromString(itemTypeStr);
-        if (itemType.isEmpty()) {
+        Optional<ItemType> oItemType = ItemType.fromString(itemTypeStr);
+        if (oItemType.isEmpty()) {
             WynntilsMod.warn(String.format("ItemType was invalid for itemType: %s", itemTypeStr));
             return;
         }
+        itemType = oItemType.get();
 
         String levelRange = null;
         for (Component lineComp : tooltip) {
@@ -65,7 +66,7 @@ public class UnidentifiedItemStack extends WynnItemStack {
         ItemGuessProfile guessProfile = WebManager.getItemGuesses().get(levelRange);
         if (guessProfile == null) return;
 
-        Map<ItemTier, List<String>> rarityMap = guessProfile.getItems().get(itemType.get());
+        Map<ItemTier, List<String>> rarityMap = guessProfile.getItems().get(itemType);
         if (rarityMap == null) return;
 
         List<String> items = rarityMap.get(tier);
@@ -123,6 +124,6 @@ public class UnidentifiedItemStack extends WynnItemStack {
     }
 
     public Optional<ItemType> getItemType() {
-        return itemType;
+        return itemType == null ? Optional.empty() : Optional.of(itemType);
     }
 }


### PR DESCRIPTION
I think we should add the texture and itemtype entry when we have/use them. Which is not the case currently.
