### PR TITLE
Create a FilterAdminCommandsFeature

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -16,6 +16,7 @@ import com.wynntils.features.debug.PacketDebuggerFeature;
 import com.wynntils.features.user.ChatItemFeature;
 import com.wynntils.features.user.DialogueOptionOverrideFeature;
 import com.wynntils.features.user.EmeraldPouchHotkeyFeature;
+import com.wynntils.features.user.FilterAdminCommandsFeature;
 import com.wynntils.features.user.FixPacketBugsFeature;
 import com.wynntils.features.user.GammabrightFeature;
 import com.wynntils.features.user.HealthPotionBlockerFeature;
@@ -148,6 +149,7 @@ public final class FeatureRegistry {
         registerFeature(new DialogueOptionOverrideFeature());
         registerFeature(new DurabilityArcFeature());
         registerFeature(new EmeraldPouchHotkeyFeature());
+        registerFeature(new FilterAdminCommandsFeature());
         registerFeature(new GameNotificationOverlayFeature());
         registerFeature(new GammabrightFeature());
         registerFeature(new HealthPotionBlockerFeature());

--- a/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
@@ -15,7 +15,8 @@ import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class FilterAdminCommandsFeature extends UserFeature {
-    private static final List<String> FILTERED_COMMANDS = Arrays.asList("bungee",
+    private static final List<String> FILTERED_COMMANDS = Arrays.asList(
+            "bungee",
             "connect",
             "galert",
             "gcountdown",

--- a/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.user;
+
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import com.wynntils.core.features.UserFeature;
+import com.wynntils.mc.event.CommandsPacketEvent;
+import java.util.Arrays;
+import java.util.List;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class FilterAdminCommandsFeature extends UserFeature {
+    private static final List<String> FILTERED_COMMANDS = Arrays.asList(new String[] {
+        "bungee",
+        "connect",
+        "galert",
+        "gcountdown",
+        "glist",
+        "gsend",
+        "perms",
+        "pfind",
+        "plist",
+        "pwlist",
+        "sendtoall",
+        "servers",
+        "sparkb",
+        "sparkbungee",
+        "wcl",
+        "wynnproxy"
+    });
+
+    @SubscribeEvent
+    public void onCommandPacket(CommandsPacketEvent event) {
+        RootCommandNode<SharedSuggestionProvider> root = event.getRoot();
+
+        RootCommandNode<SharedSuggestionProvider> newRoot = new RootCommandNode<>();
+        for (CommandNode<SharedSuggestionProvider> child : root.getChildren()) {
+            if (!FILTERED_COMMANDS.contains(child.getName())) {
+                newRoot.addChild(child);
+            }
+        }
+
+        // We also need to add the arguments for all commands
+        newRoot.addChild(root.getChild("args"));
+        event.setRoot(newRoot);
+    }
+}

--- a/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
@@ -43,9 +43,6 @@ public class FilterAdminCommandsFeature extends UserFeature {
                 newRoot.addChild(child);
             }
         }
-
-        // We also need to add the arguments for all commands
-        newRoot.addChild(root.getChild("args"));
         event.setRoot(newRoot);
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/FilterAdminCommandsFeature.java
@@ -11,29 +11,28 @@ import com.wynntils.mc.event.CommandsPacketEvent;
 import java.util.Arrays;
 import java.util.List;
 import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class FilterAdminCommandsFeature extends UserFeature {
-    private static final List<String> FILTERED_COMMANDS = Arrays.asList(new String[] {
-        "bungee",
-        "connect",
-        "galert",
-        "gcountdown",
-        "glist",
-        "gsend",
-        "perms",
-        "pfind",
-        "plist",
-        "pwlist",
-        "sendtoall",
-        "servers",
-        "sparkb",
-        "sparkbungee",
-        "wcl",
-        "wynnproxy"
-    });
+    private static final List<String> FILTERED_COMMANDS = Arrays.asList("bungee",
+            "connect",
+            "galert",
+            "gcountdown",
+            "glist",
+            "gsend",
+            "perms",
+            "pfind",
+            "plist",
+            "pwlist",
+            "sendtoall",
+            "servers",
+            "sparkb",
+            "sparkbungee",
+            "wcl",
+            "wynnproxy");
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public void onCommandPacket(CommandsPacketEvent event) {
         RootCommandNode<SharedSuggestionProvider> root = event.getRoot();
 

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -7,6 +7,7 @@ package com.wynntils.mc;
 import com.mojang.authlib.GameProfile;
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.brigadier.tree.RootCommandNode;
 import com.mojang.math.Matrix4f;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.mc.event.AddEntityLookupEvent;
@@ -14,6 +15,7 @@ import com.wynntils.mc.event.BossHealthUpdateEvent;
 import com.wynntils.mc.event.ChatPacketReceivedEvent;
 import com.wynntils.mc.event.ChatSentEvent;
 import com.wynntils.mc.event.ClientTickEvent;
+import com.wynntils.mc.event.CommandsPacketEvent;
 import com.wynntils.mc.event.ConnectionEvent.ConnectedEvent;
 import com.wynntils.mc.event.ConnectionEvent.DisconnectedEvent;
 import com.wynntils.mc.event.ContainerClickEvent;
@@ -65,6 +67,7 @@ import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
 import net.minecraft.network.chat.ChatType;
@@ -271,6 +274,10 @@ public final class EventFactory {
 
     public static void onResourcePack() {
         post(new ResourcePackEvent());
+    }
+
+    public static CommandsPacketEvent onCommandsPacket(RootCommandNode<SharedSuggestionProvider> root) {
+        return post(new CommandsPacketEvent(root));
     }
 
     public static SetPlayerTeamEvent onSetPlayerTeam(ClientboundSetPlayerTeamPacket packet) {

--- a/common/src/main/java/com/wynntils/mc/event/CommandsPacketEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandsPacketEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import com.mojang.brigadier.tree.RootCommandNode;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraftforge.eventbus.api.Event;
+
+public class CommandsPacketEvent extends Event {
+    private RootCommandNode<SharedSuggestionProvider> root;
+
+    public CommandsPacketEvent(RootCommandNode<SharedSuggestionProvider> root) {
+        this.root = root;
+    }
+
+    public RootCommandNode<SharedSuggestionProvider> getRoot() {
+        return root;
+    }
+
+    public void setRoot(RootCommandNode<SharedSuggestionProvider> root) {
+        this.root = root;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -6,11 +6,14 @@ package com.wynntils.mc.mixin;
 
 import com.wynntils.mc.EventFactory;
 import com.wynntils.mc.event.ChatPacketReceivedEvent;
+import com.wynntils.mc.event.CommandsPacketEvent;
+import com.wynntils.mc.mixin.accessors.ClientboundCommandsPacketAccessor;
 import java.util.UUID;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundCommandsPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket;
@@ -31,6 +34,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPacketListener.class)
 public abstract class ClientPacketListenerMixin {
+    @Inject(
+            method = "handleCommands(Lnet/minecraft/network/protocol/game/ClientboundCommandsPacket;)V",
+            at = @At("HEAD"))
+    private void handleCommandsPre(ClientboundCommandsPacket packet, CallbackInfo ci) {
+        CommandsPacketEvent event = EventFactory.onCommandsPacket(packet.getRoot());
+        ((ClientboundCommandsPacketAccessor) packet).setRoot(event.getRoot());
+    }
+
     @Inject(
             method = "handlePlayerInfo(Lnet/minecraft/network/protocol/game/ClientboundPlayerInfoPacket;)V",
             at = @At("RETURN"))

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/ClientboundCommandsPacketAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/ClientboundCommandsPacketAccessor.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin.accessors;
+
+import com.mojang.brigadier.tree.RootCommandNode;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.protocol.game.ClientboundCommandsPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientboundCommandsPacket.class)
+public interface ClientboundCommandsPacketAccessor {
+    @Mutable
+    @Accessor
+    void setRoot(RootCommandNode<SharedSuggestionProvider> root);
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -30,6 +30,7 @@
   "feature.wynntils.emeraldPouchHotkey.multipleFilled": "You have multiple filled emerald pouches in your inventory.",
   "feature.wynntils.emeraldPouchHotkey.name": "Emerald Pouch Hotkey Feature",
   "feature.wynntils.emeraldPouchHotkey.noPouch": "You do not have an emerald pouch in your inventory.",
+  "feature.wynntils.filterAdminCommands.name": "Filter Admin Commands Feature",
   "feature.wynntils.fixPacketBugs.name": "Fix Packet Bugs Feature",
   "feature.wynntils.gameNotificationOverlay.name": "Game Update Overlay Feature",
   "feature.wynntils.gameNotificationOverlay.overlay.gameNotification.description": "Display gameplay related update messages on the screen.",

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -26,6 +26,7 @@
     "SlotMixin",
     "accessors.ChatScreenAccessor",
     "accessors.ClientboundBossEventPacketAccessor",
+    "accessors.ClientboundCommandsPacketAccessor",
     "accessors.ClientboundSetPlayerTeamPacketAccessor",
     "accessors.GuiAccessor",
     "accessors.ItemStackInfoAccessor",


### PR DESCRIPTION
This will hide unusable admin commands such as `/wynnproxy` etc from tab expand.