### PR TITLE
Cache gradle data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle data
-          id: cache-gradle
           uses: actions/cache@v3
           with:
             path: .gradle
@@ -60,7 +59,6 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle data
-          id: cache-gradle
           uses: actions/cache@v3
           with:
             path: .gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,13 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
+      - name: Cache Gradle data
+          id: cache-gradle
+          uses: actions/cache@v3
+          with:
+            path: .gradle
+            key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
+
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
         with:
@@ -52,7 +59,14 @@ jobs:
           distribution: "temurin"
           java-version: 17
 
+      - name: Cache Gradle data
+          id: cache-gradle
+          uses: actions/cache@v3
+          with:
+            path: .gradle
+            key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
+
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build -x spotlessCheck --no-daemon --build-cache
+          arguments: build -x spotlessCheck --build-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle data
-          uses: actions/cache@v3
-          with:
-            path: .gradle
-            key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
+        uses: actions/cache@v3
+        with:
+          path: .gradle
+          key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
 
       - name: Format with spotless
         uses: gradle/gradle-build-action@v2
@@ -59,10 +59,10 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle data
-          uses: actions/cache@v3
-          with:
-            path: .gradle
-            key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
+        uses: actions/cache@v3
+        with:
+          path: .gradle
+          key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Cache Gradle data
         uses: actions/cache@v3
         with:
-          path: .gradle
+          path: '.gradle'
           key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
 
       - name: Format with spotless

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       - '**.md'
 
 jobs:
-  format:
+  format-and-build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
@@ -28,7 +28,7 @@ jobs:
       - name: Cache Gradle data
         uses: actions/cache@v3
         with:
-          path: '.gradle'
+          path: .gradle
           key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
 
       - name: Format with spotless
@@ -41,28 +41,6 @@ jobs:
           commit_user_name: 'Wynntils'
           commit_user_email: 'admin@wynntils.com'
           commit_message: 'chore: spotless formatting'
-
-  build:
-    needs: format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: "temurin"
-          java-version: 17
-
-      - name: Cache Gradle data
-        uses: actions/cache@v3
-        with:
-          path: .gradle
-          key: ${{ runner.os }}-gradle--${{ hashFiles('**/build.gradle', '**/settings.gradle', '**/gradle.properties') }}
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Spotless and Build
 
 on:
   workflow_dispatch:

--- a/common/src/main/java/com/wynntils/commands/ConfigCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ConfigCommand.java
@@ -90,8 +90,7 @@ public class ConfigCommand extends CommandBase {
                     builder);
 
     @Override
-    public void register(CommandDispatcher<CommandSourceStack>
-                                     dispatcher) {
+    public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(Commands.literal("config")
                 .then(this.buildGetConfigNode())
                 .then(this.buildSetConfigNode())

--- a/common/src/main/java/com/wynntils/commands/ConfigCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ConfigCommand.java
@@ -90,7 +90,8 @@ public class ConfigCommand extends CommandBase {
                     builder);
 
     @Override
-    public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+    public void register(CommandDispatcher<CommandSourceStack>
+                                     dispatcher) {
         dispatcher.register(Commands.literal("config")
                 .then(this.buildGetConfigNode())
                 .then(this.buildSetConfigNode())


### PR DESCRIPTION
While the gradle action caches downloaded dependencies, it does not cache Architectury/loom data, which needs to be re-generated each and every build.

Also, if we run the format and build check consecutively we can utilize the gradle cache, source code and jdk that we have already downloaded.

With these changes, formatting and building time goes down to 2 minutes or less.