### PR TITLE
Fix Event thread safety

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.core;
 
+import com.wynntils.core.events.EventBusWrapper;
 import com.wynntils.core.features.FeatureRegistry;
 import com.wynntils.core.managers.CrashReportManager;
 import com.wynntils.core.managers.ManagerRegistry;
@@ -11,7 +12,6 @@ import com.wynntils.mc.utils.McUtils;
 import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.IEventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,15 +22,15 @@ public final class WynntilsMod {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     private static final File MOD_STORAGE_ROOT = new File(McUtils.mc().gameDirectory, MOD_ID);
-    private static final IEventBus EVENT_BUS = BusBuilder.builder().build();
 
     private static String version = "";
     private static int buildNumber = -1;
     private static boolean developmentEnvironment;
     private static boolean featuresInited = false;
+    private static IEventBus eventBus;
 
     public static IEventBus getEventBus() {
-        return EVENT_BUS;
+        return eventBus;
     }
 
     public static String getVersion() {
@@ -81,6 +81,7 @@ public final class WynntilsMod {
         // MC will sometimes think it's running headless and refuse to set clipboard contents
         // making sure this is set to false will fix that
         System.setProperty("java.awt.headless", "false");
+        WynntilsMod.eventBus = EventBusWrapper.createEventBus();
 
         ManagerRegistry.init();
     }

--- a/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
+++ b/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.events;
+
+import com.wynntils.core.WynntilsMod;
+import net.minecraftforge.eventbus.EventBus;
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEventBus;
+
+public class EventBusWrapper extends EventBus {
+    public EventBusWrapper(BusBuilder busBuilder) {
+        super(busBuilder);
+    }
+
+    public static IEventBus createEventBus() {
+        if (WynntilsMod.isDevelopmentEnvironment()) {
+            return new EventBusWrapper(BusBuilder.builder());
+        } else {
+            return BusBuilder.builder().build();
+        }
+    }
+
+    @Override
+    public boolean post(Event event) {
+        Class<? extends Event> eventClass = event.getClass();
+        EventThread threadAnnotation = eventClass.getDeclaredAnnotation(EventThread.class);
+        String threadName = Thread.currentThread().getName();
+        if (threadAnnotation == null) {
+            // Events without annotation are only allowed on Render thread
+            if (!threadName.equals("Render thread")) {
+                WynntilsMod.warn(
+                        "Handling non-annotated event " + eventClass.getSimpleName() + " on thread " + threadName);
+            }
+        } else {
+            // Make sure annotation matches the actual thread
+            boolean threadOk =
+                    switch (threadAnnotation.value()) {
+                        case RENDER -> threadName.equals("Render thread");
+                        case IO -> threadName.startsWith("Netty Client IO #");
+                        case WORKER -> threadName.contains("pool");
+                        case ANY -> true;
+                    };
+            if (!threadOk) {
+                WynntilsMod.warn("Handling event " + eventClass.getSimpleName() + " annotated as "
+                        + threadAnnotation.value() + " on thread " + threadName);
+            }
+        }
+
+        return super.post(event);
+    }
+}

--- a/common/src/main/java/com/wynntils/core/events/EventThread.java
+++ b/common/src/main/java/com/wynntils/core/events/EventThread.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.events;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EventThread {
+    Type value() default Type.RENDER;
+
+    enum Type {
+        RENDER,
+        IO,
+        WORKER,
+        ANY
+    }
+}

--- a/common/src/main/java/com/wynntils/core/events/EventThread.java
+++ b/common/src/main/java/com/wynntils/core/events/EventThread.java
@@ -20,8 +20,8 @@ public @interface EventThread {
 
     enum Type {
         RENDER, // The main thread a.k.a the Render thread
-        IO,     // Any Netty Client IO thread
+        IO, // Any Netty Client IO thread
         WORKER, // A worker thread, from a Minecraft or Wynntils thread pool
-        ANY     // Any thread at all
+        ANY // Any thread at all
     }
 }

--- a/common/src/main/java/com/wynntils/core/events/EventThread.java
+++ b/common/src/main/java/com/wynntils/core/events/EventThread.java
@@ -9,15 +9,19 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Inform what type of thread the event is allowed to be sent on. Events without an
+ * explicit annotation is considered to be allowed on Type == RENDER only.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface EventThread {
     Type value() default Type.RENDER;
 
     enum Type {
-        RENDER,
-        IO,
-        WORKER,
-        ANY
+        RENDER, // The main thread a.k.a the Render thread
+        IO,     // Any Netty Client IO thread
+        WORKER, // A worker thread, from a Minecraft or Wynntils thread pool
+        ANY     // Any thread at all
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/PacketEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PacketEvent.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.EventThread;
 import net.minecraft.network.protocol.Packet;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.GenericEvent;
@@ -28,6 +29,7 @@ public class PacketEvent<T extends Packet<?>> extends GenericEvent<T> {
     }
 
     @Cancelable
+    @EventThread(EventThread.Type.ANY)
     public static class PacketSentEvent<T extends Packet<?>> extends PacketEvent<T> {
         public PacketSentEvent(T packet) {
             super(packet);
@@ -35,6 +37,7 @@ public class PacketEvent<T extends Packet<?>> extends GenericEvent<T> {
     }
 
     @Cancelable
+    @EventThread(EventThread.Type.ANY)
     public static class PacketReceivedEvent<T extends Packet<?>> extends PacketEvent<T> {
         public PacketReceivedEvent(T packet) {
             super(packet);

--- a/common/src/main/java/com/wynntils/mc/event/ResourcePackEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ResourcePackEvent.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.EventThread;
 import net.minecraftforge.eventbus.api.Event;
 
 /** Fires on receiving {@link net.minecraft.network.protocol.game.ClientboundResourcePackPacket} */
+@EventThread(EventThread.Type.IO)
 public class ResourcePackEvent extends Event {}

--- a/common/src/main/java/com/wynntils/mc/event/WebSetupEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/WebSetupEvent.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.EventThread;
 import net.minecraftforge.eventbus.api.Event;
 
 /** Fired on initialization of loading of apiurls in {@link com.wynntils.core.webapi.WebManager} */
+@EventThread(EventThread.Type.WORKER)
 public class WebSetupEvent extends Event {}

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -8,6 +8,7 @@ import com.wynntils.mc.EventFactory;
 import com.wynntils.mc.event.ChatPacketReceivedEvent;
 import com.wynntils.mc.event.CommandsPacketEvent;
 import com.wynntils.mc.mixin.accessors.ClientboundCommandsPacketAccessor;
+import com.wynntils.mc.utils.McUtils;
 import java.util.UUID;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.multiplayer.ClientPacketListener;
@@ -34,10 +35,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPacketListener.class)
 public abstract class ClientPacketListenerMixin {
+    private static boolean isRenderThread() {
+        return (McUtils.mc().isSameThread());
+    }
+
     @Inject(
             method = "handleCommands(Lnet/minecraft/network/protocol/game/ClientboundCommandsPacket;)V",
             at = @At("HEAD"))
     private void handleCommandsPre(ClientboundCommandsPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         CommandsPacketEvent event = EventFactory.onCommandsPacket(packet.getRoot());
         ((ClientboundCommandsPacketAccessor) packet).setRoot(event.getRoot());
     }
@@ -46,6 +52,7 @@ public abstract class ClientPacketListenerMixin {
             method = "handlePlayerInfo(Lnet/minecraft/network/protocol/game/ClientboundPlayerInfoPacket;)V",
             at = @At("RETURN"))
     private void handlePlayerInfoPost(ClientboundPlayerInfoPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         EventFactory.onPlayerInfoPacket(packet);
     }
 
@@ -53,6 +60,7 @@ public abstract class ClientPacketListenerMixin {
             method = "handleTabListCustomisation(Lnet/minecraft/network/protocol/game/ClientboundTabListPacket;)V",
             at = @At("RETURN"))
     private void handleTabListCustomisationPost(ClientboundTabListPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         EventFactory.onTabListCustomisation(packet);
     }
 
@@ -67,6 +75,7 @@ public abstract class ClientPacketListenerMixin {
             method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ClientboundPlayerPositionPacket;)V",
             at = @At("RETURN"))
     private void handleMovePlayerPost(ClientboundPlayerPositionPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         EventFactory.onPlayerMove(packet);
     }
 
@@ -74,6 +83,7 @@ public abstract class ClientPacketListenerMixin {
             method = "handleOpenScreen(Lnet/minecraft/network/protocol/game/ClientboundOpenScreenPacket;)V",
             at = @At("RETURN"))
     private void handleOpenScreenPost(ClientboundOpenScreenPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         EventFactory.onOpenScreen(packet);
     }
 
@@ -81,6 +91,7 @@ public abstract class ClientPacketListenerMixin {
             method = "handleContainerClose(Lnet/minecraft/network/protocol/game/ClientboundContainerClosePacket;)V",
             at = @At("RETURN"))
     private void handleContainerClosePost(ClientboundContainerClosePacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         EventFactory.onClientboundContainerClosePacket();
     }
 
@@ -89,6 +100,7 @@ public abstract class ClientPacketListenerMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void handleSetPlayerTeamPacketPre(ClientboundSetPlayerTeamPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         if (EventFactory.onSetPlayerTeam(packet).isCanceled()) {
             ci.cancel();
         }
@@ -100,6 +112,7 @@ public abstract class ClientPacketListenerMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void handleSetEntityPassengersPacketPre(ClientboundSetPassengersPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         if (EventFactory.onSetEntityPassengers(packet).isCanceled()) {
             ci.cancel();
         }
@@ -107,6 +120,7 @@ public abstract class ClientPacketListenerMixin {
 
     @Inject(method = "handleSetSpawn", at = @At("HEAD"), cancellable = true)
     private void handleSetSpawnPre(ClientboundSetDefaultSpawnPositionPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         if (EventFactory.onSetSpawn(packet.getPos()).isCanceled()) {
             ci.cancel();
         }
@@ -117,6 +131,7 @@ public abstract class ClientPacketListenerMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void setTitleTextPre(ClientboundSetTitleTextPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         if (EventFactory.onTitleSetText(packet).isCanceled()) {
             ci.cancel();
         }
@@ -127,6 +142,7 @@ public abstract class ClientPacketListenerMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void setSubtitleTextPre(ClientboundSetSubtitleTextPacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         if (EventFactory.onSubtitleSetText(packet).isCanceled()) {
             ci.cancel();
         }
@@ -140,6 +156,7 @@ public abstract class ClientPacketListenerMixin {
                             target =
                                     "Lnet/minecraft/client/gui/Gui;handleChat(Lnet/minecraft/network/chat/ChatType;Lnet/minecraft/network/chat/Component;Ljava/util/UUID;)V"))
     private void redirectHandleChat(Gui gui, ChatType chatType, Component message, UUID uuid) {
+        if (!isRenderThread()) return;
         ChatPacketReceivedEvent result = EventFactory.onChatReceived(chatType, message);
         if (result.isCanceled()) return;
 
@@ -148,6 +165,7 @@ public abstract class ClientPacketListenerMixin {
 
     @Inject(method = "handleSetScore", at = @At("HEAD"), cancellable = true)
     private void handleSetScore(ClientboundSetScorePacket packet, CallbackInfo ci) {
+        if (!isRenderThread()) return;
         if (EventFactory.onSetScore(packet).isCanceled()) {
             ci.cancel();
         }

--- a/common/src/main/java/com/wynntils/wynn/event/ScoreboardSegmentAdditionEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/ScoreboardSegmentAdditionEvent.java
@@ -4,11 +4,13 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.core.events.EventThread;
 import com.wynntils.wynn.model.scoreboard.Segment;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
+@EventThread(EventThread.Type.WORKER)
 public class ScoreboardSegmentAdditionEvent extends Event {
     private final Segment segment;
 


### PR DESCRIPTION
This PR fixes:
 * ClientPacketEvents are no longer sent twice, once on the IO thread and once on the main thread, but only on the main thread
 * Events are now annotated if they are sent on anything but the main thread. This is checked while running in development mode

The code will signal one warning, which will be fixed by https://github.com/Wynntils/Artemis/pull/339