### PR TITLE
Make container query more robust (fixes #358)

### DIFF
--- a/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
@@ -25,10 +25,8 @@ public final class KeyBindManager extends CoreManager {
     public static void init() {}
 
     @SubscribeEvent
-    public static void onTick(ClientTickEvent e) {
-        if (e.getTickPhase() == ClientTickEvent.Phase.END) {
-            triggerKeybinds();
-        }
+    public static void onTick(ClientTickEvent.End e) {
+        triggerKeybinds();
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/alwayson/FixSpellOverwriteFeature.java
+++ b/common/src/main/java/com/wynntils/features/alwayson/FixSpellOverwriteFeature.java
@@ -6,7 +6,6 @@ package com.wynntils.features.alwayson;
 
 import com.wynntils.core.features.StateManagedFeature;
 import com.wynntils.mc.event.ClientTickEvent;
-import com.wynntils.mc.event.ClientTickEvent.Phase;
 import com.wynntils.mc.event.SetSlotEvent;
 import com.wynntils.mc.mixin.accessors.GuiAccessor;
 import com.wynntils.mc.utils.McUtils;
@@ -37,8 +36,7 @@ public class FixSpellOverwriteFeature extends StateManagedFeature {
     }
 
     @SubscribeEvent
-    public void onTickEnd(ClientTickEvent event) {
-        if (event.getTickPhase() != Phase.END) return;
+    public void onTickEnd(ClientTickEvent.End event) {
         if (overwriteHighlightTimer <= 0 || overwriteHighlightItem.isEmpty()) return;
 
         Gui gui = McUtils.mc().gui;

--- a/common/src/main/java/com/wynntils/features/alwayson/LootrunFeature.java
+++ b/common/src/main/java/com/wynntils/features/alwayson/LootrunFeature.java
@@ -53,10 +53,8 @@ public class LootrunFeature extends StateManagedFeature {
     }
 
     @SubscribeEvent
-    public void recordMovement(ClientTickEvent event) {
-        if (event.getTickPhase() == ClientTickEvent.Phase.START) {
-            LootrunModel.recordMovementIfRecording();
-        }
+    public void recordMovement(ClientTickEvent.Start event) {
+        LootrunModel.recordMovementIfRecording();
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/user/QuestBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuestBookFeature.java
@@ -31,7 +31,6 @@ public class QuestBookFeature extends UserFeature {
     @SubscribeEvent
     public void onWorldChange(WorldStateEvent e) {
         if (e.getNewState() == WorldStateManager.State.WORLD) {
-            WynntilsMod.info("Scheduling quest book query");
             rescanQuestBook();
         }
     }

--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -173,8 +173,8 @@ public class QuickCastFeature extends UserFeature {
     }
 
     @SubscribeEvent
-    public void onTick(ClientTickEvent e) {
-        if (!WynnUtils.onWorld() || e.getTickPhase() != ClientTickEvent.Phase.END) return;
+    public void onTick(ClientTickEvent.End e) {
+        if (!WynnUtils.onWorld()) return;
 
         // Clear spell after the 40 tick timeout period
         if (spellCountdown > 0 && --spellCountdown <= 0) spellInProgress = NO_SPELL;

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -373,11 +373,11 @@ public final class EventFactory {
 
     // region Game Events
     public static void onTickStart() {
-        post(new ClientTickEvent(ClientTickEvent.Phase.START));
+        post(new ClientTickEvent.Start());
     }
 
     public static void onTickEnd() {
-        post(new ClientTickEvent(ClientTickEvent.Phase.END));
+        post(new ClientTickEvent.End());
     }
 
     public static void onResizeDisplayPost() {

--- a/common/src/main/java/com/wynntils/mc/event/ClientTickEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ClientTickEvent.java
@@ -6,19 +6,8 @@ package com.wynntils.mc.event;
 
 import net.minecraftforge.eventbus.api.Event;
 
-public class ClientTickEvent extends Event {
-    private final Phase phase;
+public abstract class ClientTickEvent extends Event {
+    public static class Start extends ClientTickEvent {}
 
-    public ClientTickEvent(Phase phase) {
-        this.phase = phase;
-    }
-
-    public Phase getTickPhase() {
-        return phase;
-    }
-
-    public enum Phase {
-        START,
-        END
-    }
+    public static class End extends ClientTickEvent {}
 }

--- a/common/src/main/java/com/wynntils/utils/Delay.java
+++ b/common/src/main/java/com/wynntils/utils/Delay.java
@@ -22,8 +22,8 @@ public class Delay {
     }
 
     @SubscribeEvent
-    public void onTick(ClientTickEvent e) {
-        if (e.getTickPhase() == ClientTickEvent.Phase.END && !onPause && isRunning) {
+    public void onTick(ClientTickEvent.End e) {
+        if (!onPause && isRunning) {
             if (delay < 0) {
                 start();
             }

--- a/common/src/main/java/com/wynntils/wynn/model/container/ContainerQueryManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/container/ContainerQueryManager.java
@@ -6,6 +6,7 @@ package com.wynntils.wynn.model.container;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.managers.CoreManager;
+import com.wynntils.mc.event.ClientTickEvent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.mc.event.MenuEvent;
 import com.wynntils.mc.utils.McUtils;
@@ -20,14 +21,17 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 public class ContainerQueryManager extends CoreManager {
     private static final int NO_CONTAINER = -2;
     private static final LinkedList<ContainerQueryStep> queuedQueries = new LinkedList<>();
+    public static final int OPERATION_TIMEOUT_TICKS = 30; // normal operation is ~10 ticks
 
     private static ContainerQueryStep currentStep;
     private static String firstStepName;
+    private static ContainerQueryStep lastStep;
 
     private static Component currentTitle;
     private static MenuType currentMenuType;
     private static int containerId = NO_CONTAINER;
     private static int lastHandledContentId = NO_CONTAINER;
+    private static int ticksRemaining;
 
     public static void init() {}
 
@@ -58,7 +62,8 @@ public class ContainerQueryManager extends CoreManager {
 
         currentStep = firstStep;
         firstStepName = firstStep.getName();
-
+        lastStep = null;
+        resetTimer();
         if (!firstStep.startStep(null)) {
             raiseError("Cannot execute first step");
         }
@@ -66,16 +71,31 @@ public class ContainerQueryManager extends CoreManager {
 
     @SubscribeEvent
     public static void onMenuOpened(MenuEvent.MenuOpenedEvent e) {
-        if (currentStep == null) return;
+        if (currentStep == null && lastStep == null) return;
+        if (currentStep == null && lastStep != null) {
+            // We're in a possibly bad state. We have failed a previous call, but
+            // we might still get the menu opened (perhaps after a lag spike).
+            boolean matches = lastStep.verifyContainer(e.getTitle(), e.getMenuType());
+            if (matches) {
+                WynntilsMod.warn("Closing container '" + e.getTitle().getString()
+                        + "' due to previously aborted container query");
+                lastStep = null;
+                e.setCanceled(true);
+            } else {
+                lastStep = null;
+            }
+            return;
+        }
 
         boolean matches = currentStep.verifyContainer(e.getTitle(), e.getMenuType());
         if (matches) {
             containerId = e.getContainerId();
             currentTitle = e.getTitle();
             currentMenuType = e.getMenuType();
+            resetTimer();
             e.setCanceled(true);
         } else {
-            raiseError("Unexpected container opened: " + e.getTitle().getString());
+            raiseError("Unexpected container opened: '" + e.getTitle().getString() + "'");
         }
     }
 
@@ -95,8 +115,8 @@ public class ContainerQueryManager extends CoreManager {
         if (e.getContainerId() == 0) return;
 
         if (containerId == NO_CONTAINER) {
-            // We have not registered a MenuOpenedEvent
-            raiseError("Container contents without associated container open");
+            // We have not registered a MenuOpenedEvent. Assume this means that this is the
+            // content of another container, so just pass it on
             return;
         }
 
@@ -109,12 +129,14 @@ public class ContainerQueryManager extends CoreManager {
         if (containerId == lastHandledContentId) {
             // Wynncraft sometimes sends contents twice; just drop this silently
             e.setCanceled(true);
+            resetTimer();
             return;
         }
 
         lastHandledContentId = containerId;
         ContainerContent currentContainer =
                 new ContainerContent(e.getItems(), currentTitle, currentMenuType, containerId);
+        resetTimer();
 
         // Now actually process this container
         currentStep.handleContent(currentContainer);
@@ -138,12 +160,24 @@ public class ContainerQueryManager extends CoreManager {
         e.setCanceled(true);
     }
 
+    @SubscribeEvent
+    public static void onTick(ClientTickEvent.Start event) {
+        if (currentStep == null) return;
+
+        ticksRemaining--;
+
+        if (ticksRemaining <= 0) {
+            raiseError("Container reply timed out");
+        }
+    }
+
     private static void raiseError(String errorMsg) {
         if (currentStep == null) {
             WynntilsMod.error("Internal error in ContainerQueryManager: handleError called with no currentStep");
             return;
         }
         currentStep.onError(errorMsg);
+        lastStep = currentStep;
         endQuery();
     }
 
@@ -151,5 +185,9 @@ public class ContainerQueryManager extends CoreManager {
         containerId = NO_CONTAINER;
         lastHandledContentId = NO_CONTAINER;
         currentStep = null;
+    }
+
+    private static void resetTimer() {
+        ticksRemaining = OPERATION_TIMEOUT_TICKS;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/questbook/QuestBookModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/questbook/QuestBookModel.java
@@ -29,7 +29,7 @@ public class QuestBookModel extends Model {
      */
     public static void queryQuestBook() {
         ScriptedContainerQuery.QueryBuilder queryBuilder = ScriptedContainerQuery.builder("Quest Book Query")
-                .onError(msg -> WynntilsMod.warn("Error querying Quest Book:" + msg))
+                .onError(msg -> WynntilsMod.warn("Problem querying Quest Book: " + msg))
                 .useItemInHotbar(InventoryUtils.QUEST_BOOK_SLOT_NUM)
                 .matchTitle(getQuestBookTitle(1))
                 .processContainer(c -> processQuestBookPage(c, 1));


### PR DESCRIPTION
I also refactored the ClientTickEvent. Of all events, this one is sent by far the most often. And yet, all callers needed to check the status and filter away 50% of the calls... Which also robbed the forge event bus of the possibility to optimize away event calls.