### PR TITLE
Fix unnecessary rescan of character info, even if autojoin were not used

### DIFF
--- a/common/src/main/java/com/wynntils/wynn/model/WorldStateManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/WorldStateManager.java
@@ -121,7 +121,11 @@ public class WorldStateManager extends CoreManager {
 
         if (e.getNewPosition().equals(CHARACTER_SELECTION_POSITION)) {
             // We get here even if the character selection menu will not show up because of autojoin
-            setState(State.INTERIM, "");
+            if (getCurrentState() != State.CHARACTER_SELECTION) {
+                // Sometimes the TP comes after the character selection menu, instead of before
+                // Don't lose the CHARACTER_SELECTION state if that is the case
+                setState(State.INTERIM, "");
+            }
         }
     }
 


### PR DESCRIPTION
Sometimes we thought autojoin were used, even if it were not, since we lost track of the fact that we were in the character selection menu. (Probably due to packets arriving out of order)