### PR TITLE
More features should be reset on world state change events

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/overlays/GameNotificationOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/GameNotificationOverlayFeature.java
@@ -25,6 +25,7 @@ import com.wynntils.mc.render.TextRenderSetting;
 import com.wynntils.mc.render.TextRenderTask;
 import com.wynntils.mc.render.VerticalAlignment;
 import com.wynntils.wynn.event.NotificationEvent;
+import com.wynntils.wynn.event.WorldStateEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -39,6 +40,11 @@ public class GameNotificationOverlayFeature extends UserFeature {
 
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI)
     public final GameNotificationOverlay gameNotificationOverlay = new GameNotificationOverlay();
+
+    @SubscribeEvent
+    public void onWorldStateChange(WorldStateEvent event) {
+        messageQueue.clear();
+    }
 
     @SubscribeEvent
     public void onGameNotification(NotificationEvent.Queue event) {

--- a/common/src/main/java/com/wynntils/features/user/overlays/NpcDialogueOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/NpcDialogueOverlayFeature.java
@@ -122,6 +122,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
     @SubscribeEvent
     public void onWorldStateChange(WorldStateEvent e) {
         currentDialogue = null;
+        cancelAutoProgress();
     }
 
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI)

--- a/common/src/main/java/com/wynntils/features/user/redirects/PouchRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/PouchRedirectFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.notifications.MessageContainer;
 import com.wynntils.core.notifications.NotificationManager;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
 import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.event.WorldStateEvent;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.network.chat.Component;
@@ -30,6 +31,12 @@ public class PouchRedirectFeature extends UserFeature {
 
     @Config
     public boolean redirectEmeraldPouch = true;
+
+    @SubscribeEvent
+    public void onWorldStateChange(WorldStateEvent event) {
+        lastEmeraldPouchPickup = 0;
+        emeraldPouchMessage = null;
+    }
 
     @SubscribeEvent
     public void onSubtitleSetText(SubtitleSetTextEvent event) {

--- a/common/src/main/java/com/wynntils/wynn/model/container/ScriptedContainerQuery.java
+++ b/common/src/main/java/com/wynntils/wynn/model/container/ScriptedContainerQuery.java
@@ -92,9 +92,7 @@ public class ScriptedContainerQuery {
         public void onError(String errorMsg) {
             ScriptedContainerQuery.this.errorHandler.accept(errorMsg);
             // Remove all remaining steps
-            while (!ScriptedContainerQuery.this.steps.isEmpty()) {
-                ScriptedContainerQuery.this.steps.removeFirst();
-            }
+            ScriptedContainerQuery.this.steps.clear();
         }
 
         @Override


### PR DESCRIPTION
Inspired by https://github.com/Wynntils/Artemis/pull/372, I checked all non-config non-final instance variables in all features to see if they needed resetting when leaving/joining a world. I found a few.