### PR TITLE
ItemTextOverlayFeature: Fix crash

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ItemTextOverlayFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.user.inventory;
 
 import com.google.common.collect.ImmutableList;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.config.Config;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.FeatureCategory;
@@ -94,6 +95,11 @@ public class ItemTextOverlayFeature extends UserFeature {
             if (!overlayProperty.isTextOverlayEnabled() || !contextEnabled) continue; // not enabled or wrong context
 
             TextOverlayProperty.TextOverlay textOverlay = overlayProperty.getTextOverlay();
+
+            if (textOverlay == null) {
+                WynntilsMod.error(overlayProperty + "'s textOverlay was null.");
+                continue;
+            }
 
             PoseStack poseStack = new PoseStack();
             poseStack.translate(0, 0, 300); // items are drawn at z300, so text has to be as well


### PR DESCRIPTION
This is not a fix for any specific issue, but rather a fail-safe. Without this fail-safe, if we miss-parse an item, we instantly crash the user (and likely soft-lock their class into a crashing state until the specific issue is fixed). I know this is just a bad "patch", but I think it has value.