### PR TITLE
Enable all text overlays for items in hotbar by default.

### DIFF
--- a/common/src/main/java/com/wynntils/wynn/item/properties/ConsumableChargeProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/item/properties/ConsumableChargeProperty.java
@@ -28,9 +28,4 @@ public class ConsumableChargeProperty extends CustomStackCountProperty {
     public boolean isTextOverlayEnabled() {
         return ItemTextOverlayFeature.consumableChargeEnabled;
     }
-
-    @Override
-    public boolean isHotbarText() {
-        return true;
-    }
 }

--- a/common/src/main/java/com/wynntils/wynn/item/properties/SkillIconProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/item/properties/SkillIconProperty.java
@@ -41,9 +41,4 @@ public class SkillIconProperty extends ItemProperty implements TextOverlayProper
     public boolean isTextOverlayEnabled() {
         return true;
     }
-
-    @Override
-    public boolean isHotbarText() {
-        return true;
-    }
 }

--- a/common/src/main/java/com/wynntils/wynn/item/properties/type/TextOverlayProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/item/properties/type/TextOverlayProperty.java
@@ -12,14 +12,18 @@ public interface TextOverlayProperty extends PropertyType {
 
     boolean isTextOverlayEnabled();
 
-    /** Whether this highlight should be shown in inventories */
+    /**
+     * Whether this overlay is allowed to be rendered in inventories.
+     */
     default boolean isInventoryText() {
         return true;
     }
 
-    /** Whether this highlight should be shown in the hotbar */
+    /**
+     * Whether this overlay is allowed to be rendered in the hotbar.
+     */
     default boolean isHotbarText() {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/1730245/188880831-043f6586-871f-4be7-82ca-fd9773d81895.png">
	<td><img src="https://user-images.githubusercontent.com/1730245/188880774-9fe646ab-c764-4f6b-ac19-f7faf6029fa2.png">
</table>

There is a setting for enabling/disabling text overlays in hotbars, however it is disregarded for most items. This pull request makes all items render in the hotbar as expected when the setting is enabled.