### PR TITLE
Do not expose the event bus from WynntilsMod

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.client.Minecraft;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.IEventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +36,16 @@ public final class WynntilsMod {
         return modLoader;
     }
 
-    public static IEventBus getEventBus() {
-        return eventBus;
+    public static void unregisterEventListener(Object object) {
+        eventBus.unregister(object);
+    }
+
+    public static void registerEventListener(Object object) {
+        eventBus.register(object);
+    }
+
+    public static boolean postEvent(Event event) {
+        return eventBus.post(event);
     }
 
     public static String getVersion() {

--- a/common/src/main/java/com/wynntils/core/chat/ChatModel.java
+++ b/common/src/main/java/com/wynntils/core/chat/ChatModel.java
@@ -238,7 +238,7 @@ public final class ChatModel extends Model {
 
         ChatMessageReceivedEvent event =
                 new ChatMessageReceivedEvent(message, codedMessage, messageType, recipientType);
-        WynntilsMod.getEventBus().post(event);
+        WynntilsMod.postEvent(event);
         if (event.isCanceled()) return null;
         return event.getMessage();
     }
@@ -252,7 +252,7 @@ public final class ChatModel extends Model {
                 // Keep going anyway and post the first line of the dialog
             }
             NpcDialogEvent event = new NpcDialogEvent(dialog.isEmpty() ? null : dialog.get(0));
-            WynntilsMod.getEventBus().post(event);
+            WynntilsMod.postEvent(event);
         }
     }
 

--- a/common/src/main/java/com/wynntils/core/features/Feature.java
+++ b/common/src/main/java/com/wynntils/core/features/Feature.java
@@ -157,7 +157,7 @@ public abstract class Feature implements Translatable, Configurable, Comparable<
         }
 
         if (isListener) {
-            WynntilsMod.getEventBus().register(this);
+            WynntilsMod.registerEventListener(this);
         }
         OverlayManager.enableOverlays(this.overlays, false);
         for (KeyBind keyBind : keyBinds) {
@@ -176,7 +176,7 @@ public abstract class Feature implements Translatable, Configurable, Comparable<
         ManagerRegistry.removeAllFeatureDependency(this);
 
         if (isListener) {
-            WynntilsMod.getEventBus().unregister(this);
+            WynntilsMod.unregisterEventListener(this);
         }
         OverlayManager.disableOverlays(this.overlays);
         for (KeyBind keyBind : keyBinds) {
@@ -264,13 +264,13 @@ public abstract class Feature implements Translatable, Configurable, Comparable<
                 return;
             }
 
-            WynntilsMod.getEventBus().register(this);
+            WynntilsMod.registerEventListener(this);
         }
 
         @SubscribeEvent
         public void onWebSetup(WebSetupEvent e) {
             setSatisfied(true);
-            WynntilsMod.getEventBus().unregister(this);
+            WynntilsMod.unregisterEventListener(this);
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
@@ -52,12 +52,12 @@ public final class FunctionManager extends CoreManager {
     public static boolean enableFunction(Function<?> function) {
         if (!(function instanceof ActiveFunction<?> activeFunction)) return true;
 
-        WynntilsMod.getEventBus().register(activeFunction);
+        WynntilsMod.registerEventListener(activeFunction);
 
         boolean enableSucceeded = activeFunction.onEnable();
 
         if (!enableSucceeded) {
-            WynntilsMod.getEventBus().unregister(activeFunction);
+            WynntilsMod.unregisterEventListener(activeFunction);
         }
         ENABLED_FUNCTIONS.add(activeFunction);
         return enableSucceeded;
@@ -66,7 +66,7 @@ public final class FunctionManager extends CoreManager {
     public static void disableFunction(Function<?> function) {
         if (!(function instanceof ActiveFunction<?> activeFunction)) return;
 
-        WynntilsMod.getEventBus().unregister(activeFunction);
+        WynntilsMod.unregisterEventListener(activeFunction);
         activeFunction.onDisable();
         ENABLED_FUNCTIONS.remove(activeFunction);
     }

--- a/common/src/main/java/com/wynntils/core/managers/ManagerRegistry.java
+++ b/common/src/main/java/com/wynntils/core/managers/ManagerRegistry.java
@@ -61,7 +61,7 @@ public final class ManagerRegistry {
         PERSISTENT_CORE_MANAGERS.add(manager);
         ENABLED_MANAGERS.add(manager);
 
-        WynntilsMod.getEventBus().register(manager);
+        WynntilsMod.registerEventListener(manager);
 
         tryInitManager(manager);
     }
@@ -122,7 +122,7 @@ public final class ManagerRegistry {
 
         if (ENABLED_MANAGERS.contains(manager)) {
             if (!hasDependencies) {
-                WynntilsMod.getEventBus().unregister(manager);
+                WynntilsMod.unregisterEventListener(manager);
 
                 ENABLED_MANAGERS.remove(manager);
 
@@ -130,7 +130,7 @@ public final class ManagerRegistry {
             }
         } else {
             if (hasDependencies) {
-                WynntilsMod.getEventBus().register(manager);
+                WynntilsMod.registerEventListener(manager);
 
                 ENABLED_MANAGERS.add(manager);
 

--- a/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
+++ b/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
@@ -30,7 +30,7 @@ public final class NotificationManager {
         WynntilsMod.info("Message Queued: " + message);
         MessageContainer msgContainer = new MessageContainer(message);
 
-        WynntilsMod.getEventBus().post(new NotificationEvent.Queue(msgContainer));
+        WynntilsMod.postEvent(new NotificationEvent.Queue(msgContainer));
 
         // Overlay is not enabled, send in chat
         if (!GameNotificationOverlayFeature.getInstance().isEnabled()) {
@@ -43,7 +43,7 @@ public final class NotificationManager {
     public static void editMessage(MessageContainer msgContainer, String newMessage) {
         msgContainer.editMessage(newMessage);
 
-        WynntilsMod.getEventBus().post(new NotificationEvent.Edit(msgContainer));
+        WynntilsMod.postEvent(new NotificationEvent.Edit(msgContainer));
 
         // Overlay is not enabled, send in chat
         if (!GameNotificationOverlayFeature.getInstance().isEnabled()) {

--- a/common/src/main/java/com/wynntils/core/webapi/WebManager.java
+++ b/common/src/main/java/com/wynntils/core/webapi/WebManager.java
@@ -342,7 +342,7 @@ public final class WebManager extends CoreManager {
                         setup = true;
                     }
 
-                    WynntilsMod.getEventBus().post(new WebSetupEvent());
+                    WynntilsMod.postEvent(new WebSetupEvent());
                     return true;
                 })
                 .build());

--- a/common/src/main/java/com/wynntils/features/user/TranslationFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TranslationFeature.java
@@ -88,13 +88,13 @@ public class TranslationFeature extends UserFeature {
                 String unwrapped = unwrapCoding(translatedMsg);
                 McUtils.mc().doRunTask(() -> {
                     NpcDialogEvent translatedEvent = new TranslatedNpcDialogEvent(unwrapped);
-                    WynntilsMod.getEventBus().post(translatedEvent);
+                    WynntilsMod.postEvent(translatedEvent);
                 });
             });
         } else {
             // We must also pass on the null event to clear the dialogue
             NpcDialogEvent translatedEvent = new TranslatedNpcDialogEvent(null);
-            WynntilsMod.getEventBus().post(translatedEvent);
+            WynntilsMod.postEvent(translatedEvent);
         }
         if (!keepOriginal) {
             e.setCanceled(true);

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -111,7 +111,7 @@ import net.minecraftforge.eventbus.api.Event;
 public final class EventFactory {
     private static <T extends Event> T post(T event) {
         if (WynnUtils.onServer()) {
-            WynntilsMod.getEventBus().post(event);
+            WynntilsMod.postEvent(event);
         }
         return event;
     }
@@ -120,7 +120,7 @@ public final class EventFactory {
      * Post event without checking if we are connected to a Wynncraft server
      */
     private static <T extends Event> T postAlways(T event) {
-        WynntilsMod.getEventBus().post(event);
+        WynntilsMod.postEvent(event);
         return event;
     }
 

--- a/common/src/main/java/com/wynntils/screens/WynntilsQuestBookScreen.java
+++ b/common/src/main/java/com/wynntils/screens/WynntilsQuestBookScreen.java
@@ -67,12 +67,12 @@ public class WynntilsQuestBookScreen extends WynntilsMenuScreenBase implements S
                 this);
 
         // Only register this once
-        WynntilsMod.getEventBus().register(this);
+        WynntilsMod.registerEventListener(this);
     }
 
     @Override
     public void onClose() {
-        WynntilsMod.getEventBus().unregister(this);
+        WynntilsMod.unregisterEventListener(this);
         super.onClose();
     }
 

--- a/common/src/main/java/com/wynntils/utils/Delay.java
+++ b/common/src/main/java/com/wynntils/utils/Delay.java
@@ -18,7 +18,7 @@ public class Delay {
         this.function = function;
         this.delay = delay;
 
-        WynntilsMod.getEventBus().register(this);
+        WynntilsMod.registerEventListener(this);
     }
 
     @SubscribeEvent
@@ -61,6 +61,6 @@ public class Delay {
 
     public void end() {
         isRunning = false;
-        WynntilsMod.getEventBus().unregister(this);
+        WynntilsMod.unregisterEventListener(this);
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/ActionBarModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ActionBarModel.java
@@ -73,9 +73,9 @@ public final class ActionBarModel extends Model {
         ActionBarMessageUpdateEvent.ManaText manaText =
                 new ActionBarMessageUpdateEvent.ManaText("§b✺ " + currentMana + "/" + maxMana);
 
-        WynntilsMod.getEventBus().post(actionText);
-        WynntilsMod.getEventBus().post(healthText);
-        WynntilsMod.getEventBus().post(manaText);
+        WynntilsMod.postEvent(actionText);
+        WynntilsMod.postEvent(healthText);
+        WynntilsMod.postEvent(manaText);
 
         MutableComponent modified = new TextComponent(healthText.getMessage())
                 .append("    ")

--- a/common/src/main/java/com/wynntils/wynn/model/WorldStateManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/WorldStateManager.java
@@ -71,7 +71,7 @@ public class WorldStateManager extends CoreManager {
         // Switch state before sending event
         currentState = newState;
         currentWorldName = newWorldName;
-        WynntilsMod.getEventBus().post(new WorldStateEvent(newState, oldState, newWorldName));
+        WynntilsMod.postEvent(new WorldStateEvent(newState, oldState, newWorldName));
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/wynn/model/questbook/QuestBookManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/questbook/QuestBookManager.java
@@ -80,7 +80,7 @@ public class QuestBookManager extends CoreManager {
         if (page == 4) {
             // Last page finished
             quests = newQuests;
-            WynntilsMod.getEventBus().post(new QuestBookReloadedEvent());
+            WynntilsMod.postEvent(new QuestBookReloadedEvent());
         }
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/scoreboard/ScoreboardModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/scoreboard/ScoreboardModel.java
@@ -187,7 +187,7 @@ public final class ScoreboardModel extends Model {
             List<String> skipped = new ArrayList<>();
 
             for (Segment parsedSegment : segments) {
-                boolean cancelled = WynntilsMod.getEventBus().post(new ScoreboardSegmentAdditionEvent(parsedSegment));
+                boolean cancelled = WynntilsMod.postEvent(new ScoreboardSegmentAdditionEvent(parsedSegment));
 
                 if (cancelled) {
                     skipped.addAll(parsedSegment.getScoreboardLines());


### PR DESCRIPTION
The reason for this is that I want to add functionality to the post() method. (More specifically, exception handling in case one of our event listener crashes.)