### PR TITLE
Make the i18n check at startup not rely on assert but "dev env"

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -169,11 +169,14 @@ public final class WynntilsMod {
     private static void initFeatures() {
         // Init all features. Now resources (i.e I18n) are available.
         FeatureRegistry.init();
+        LOGGER.info(
+                "Wynntils: {} features are now loaded and ready",
+                FeatureRegistry.getFeatures().size());
     }
 
     private static void parseVersion(String versionString) {
         LOGGER.info(
-                "Wynntils version {} (using {} on Minecraft {}) is now loaded",
+                "Wynntils: Starting version {} (using {} on Minecraft {})",
                 versionString,
                 modLoader,
                 Minecraft.getInstance().getLaunchedVersion());

--- a/common/src/main/java/com/wynntils/core/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigManager.java
@@ -201,10 +201,21 @@ public final class ConfigManager extends CoreManager {
             }
 
             ConfigHolder configHolder = new ConfigHolder(parent, configField, category, metadata, type);
-            if (metadata.visible()) {
-                assert !configHolder.getDisplayName().startsWith("feature.wynntils.");
-                assert !configHolder.getDescription().startsWith("feature.wynntils.");
-                assert !configHolder.getDescription().isEmpty();
+            if (WynntilsMod.isDevelopmentEnvironment()) {
+                if (metadata.visible()) {
+                    if (configHolder.getDisplayName().startsWith("feature.wynntils.")) {
+                        WynntilsMod.error("Config displayName i18n is missing for " + configHolder.getDisplayName());
+                        throw new RuntimeException();
+                    }
+                    if (configHolder.getDescription().startsWith("feature.wynntils.")) {
+                        WynntilsMod.error("Config description i18n is missing for " + configHolder.getDescription());
+                        throw new RuntimeException();
+                    }
+                    if (configHolder.getDescription().isEmpty()) {
+                        WynntilsMod.error("Config description is empty for " + configHolder.getDisplayName());
+                        throw new RuntimeException();
+                    }
+                }
             }
             options.add(configHolder);
         }


### PR DESCRIPTION
Apparently some of us has not regenerated our IntelliJ run profiles to include `-ea` ;-)