### PR TITLE
Add exception protection for keybinds as well

### DIFF
--- a/common/src/main/java/com/wynntils/core/keybinds/KeyBind.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/KeyBind.java
@@ -63,4 +63,10 @@ public class KeyBind {
     public String getCategory() {
         return keyMapping.getCategory();
     }
+
+    @Override
+    public String toString() {
+        return "'" + getName() + "' ["
+                + getKeyMapping().getTranslatedKeyMessage().getString() + "]";
+    }
 }


### PR DESCRIPTION
This is the final "entry" point that I indent to add this kind of protection for. We have Functions as well, but they are so simple so I assume they will not crash. (And if they do, they'll propagate it to the InfoBoxOverlay or the `/function` command).

Commands are already protected like this.

There are two more areas that are kind of likely to crash, but that is harder to reach: managers/models -- we can't easily disable those, and GUI/screens, same here, we can't easily disable those. A crash in those places can't really be worked around by disabling some part of the mod.