### PR TITLE
WIP: Handle non-confirmation NPC dialogues

### DIFF
--- a/common/src/main/java/com/wynntils/core/chat/RecipientType.java
+++ b/common/src/main/java/com/wynntils/core/chat/RecipientType.java
@@ -9,6 +9,8 @@ import java.util.regex.Pattern;
 public enum RecipientType {
     INFO(null, null),
     CLIENTSIDE(null, null),
+    // FIXME: NPC cannot really be in the "background"
+    NPC("(?:§r)?§7\\[\\d+\\/\\d+\\] §r§2.+: §r§..*", "(?:§r)?§7\\[\\d+\\/\\d+\\] §r§2.+: §r§..*"),
     GLOBAL(
             "^§8\\[(Lv\\. )?\\d+\\*?/\\d+/..(/[^]]+)?\\]§r§7 \\[[A-Z0-9]+\\]§r.*$",
             "^(§r§8)?\\[(Lv\\. )?\\d+\\*?/\\d+/..(/[^]]+)?\\] \\[[A-Z0-9]+\\](§r§7)?( \\[(§k\\|)?§r§.[A-Z+]+§r§.(§k\\|§r§7)?\\])?(§r§7)? (§r§8)?.*$"),

--- a/common/src/main/java/com/wynntils/features/user/TranslationFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TranslationFeature.java
@@ -89,13 +89,14 @@ public class TranslationFeature extends UserFeature {
                 // This will currently remove all formatting :(
                 Component translatedComponent = new TextComponent(ComponentUtils.stripFormatting(unwrapped));
                 McUtils.mc().doRunTask(() -> {
-                    NpcDialogEvent translatedEvent = new TranslatedNpcDialogEvent(translatedComponent);
+                    NpcDialogEvent translatedEvent =
+                            new TranslatedNpcDialogEvent(translatedComponent, e.needsConfirmation());
                     WynntilsMod.postEvent(translatedEvent);
                 });
             });
         } else {
             // We must also pass on the null event to clear the dialogue
-            NpcDialogEvent translatedEvent = new TranslatedNpcDialogEvent(null);
+            NpcDialogEvent translatedEvent = new TranslatedNpcDialogEvent(null, e.needsConfirmation());
             WynntilsMod.postEvent(translatedEvent);
         }
         if (!keepOriginal) {
@@ -112,8 +113,8 @@ public class TranslationFeature extends UserFeature {
     }
 
     private static class TranslatedNpcDialogEvent extends NpcDialogEvent {
-        protected TranslatedNpcDialogEvent(Component chatMsg) {
-            super(chatMsg);
+        protected TranslatedNpcDialogEvent(Component chatMsg, boolean needsConfirmation) {
+            super(chatMsg, needsConfirmation);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/overlays/NpcDialogueOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/NpcDialogueOverlayFeature.java
@@ -54,6 +54,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
     private ScheduledFuture<?> scheduledAutoProgressKeyPress = null;
 
     private String currentDialogue;
+    private boolean needsConfirmation;
 
     @Config
     public boolean autoProgress = false;
@@ -88,6 +89,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
             NotificationManager.queueMessage(msg);
         }
         currentDialogue = msg;
+        needsConfirmation = e.needsConfirmation();
 
         if (scheduledAutoProgressKeyPress != null) {
             scheduledAutoProgressKeyPress.cancel(true);
@@ -178,7 +180,8 @@ public class NpcDialogueOverlayFeature extends UserFeature {
             }
         }
 
-        private void renderDialogue(PoseStack poseStack, String currentDialogue) {
+        private void renderDialogue(PoseStack poseStack, String currentDialogue, boolean needsConfirmation) {
+            // List<TextRenderTask> dialogueRenderTask = List.of(new TextRenderTask(currentDialogue, renderSetting));
             TextRenderTask dialogueRenderTask = new TextRenderTask(currentDialogue, renderSetting);
 
             if (stripColors) {
@@ -223,8 +226,10 @@ public class NpcDialogueOverlayFeature extends UserFeature {
             if (showHelperTexts) {
                 // Render "To continue" message
                 List<TextRenderTask> renderTaskList = new LinkedList<>();
-                TextRenderTask pressSneakMessage = new TextRenderTask("§cPress SNEAK to continue", renderSetting);
-                renderTaskList.add(pressSneakMessage);
+                if (needsConfirmation) {
+                    TextRenderTask pressSneakMessage = new TextRenderTask("§cPress SNEAK to continue", renderSetting);
+                    renderTaskList.add(pressSneakMessage);
+                }
 
                 if (scheduledAutoProgressKeyPress != null && !scheduledAutoProgressKeyPress.isCancelled()) {
                     long timeUntilProgress = scheduledAutoProgressKeyPress.getDelay(TimeUnit.MILLISECONDS);
@@ -259,7 +264,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
 
             if (currentDialogue == null) return;
 
-            renderDialogue(poseStack, currentDialogue);
+            renderDialogue(poseStack, currentDialogue, NpcDialogueOverlayFeature.this.needsConfirmation);
         }
 
         @Override
@@ -269,7 +274,7 @@ public class NpcDialogueOverlayFeature extends UserFeature {
             // we have to force update every time
             updateTextRenderSettings();
 
-            renderDialogue(poseStack, fakeDialogue);
+            renderDialogue(poseStack, fakeDialogue, true);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/event/NpcDialogEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/NpcDialogEvent.java
@@ -11,9 +11,19 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class NpcDialogEvent extends Event {
     private final Component chatMessage;
+    private final boolean needsConfirmation;
 
-    public NpcDialogEvent(Component chatMessage) {
+    public NpcDialogEvent(Component chatMessage, boolean needsConfirmation) {
         this.chatMessage = chatMessage;
+        this.needsConfirmation = needsConfirmation;
+    }
+
+    /**
+     * Return true if this message needs to be confirmed using the sneak key to
+     * progress the dialogue.
+     */
+    public boolean needsConfirmation() {
+        return needsConfirmation;
     }
 
     public Component getChatMessage() {


### PR DESCRIPTION
These are the ones where the NPC message just goes to the chat as normal, not requiring you to press sneak.

There are actually two kinds of those, "disappearing" and normal chat messages. The "disappearing" ones are just like normal confirmation NPC dialogues, but they do not require sneak. I have only seen those in King's Recruit. These are handled by Wynncraft by sending out "screens", and when the chat is done, the screen is "redrawn" without it.

The second one is just like normal chat messages.

There are a slew of problems with getting these to work as you'd expect. This is just a draft.

Needs fixing in the framework:
- [ ] Disappearing messages should have a NULL sent when they are cleared. 
- [ ] This means we need an enum to separate between "chat style", "need confirmation", "need no confirmation", not just a boolean
- [ ] There is (at least one) bug when different kinds of messages are mixed, so old "chat style" messages pop up in the overlay when new "need no confirmation" messages gets removed, or something like that.

Needs fixing in the Overlay:
- [ ] "chat style" messages needs a time out. Can probably reuse code from @kristofbolyai's old closed PR.
- [ ] "chat style" messages can stack. In King's Recruit you can get several differnt ones at the same time. 
- [ ] This means NPC overlay needs to handle more than one chat line
- [ ] They should probably be displayed like in the chat, one on top of the other, and each one of them having individual timeouts so they disappear one after the other, so timeouts need to be on a per-line basis, not for the entire overlay
- [ ] How handle if "chat style" messages has not yet timed out, when a "need confirmation" message arrive? 