### PR TITLE
CallbackInfo is not needed for events that are not cancelled

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
@@ -22,7 +22,7 @@ public abstract class AbstractContainerScreenMixin {
     public Slot hoveredSlot;
 
     @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At("RETURN"))
-    private void renderPost(PoseStack client, int mouseX, int mouseY, float partialTicks, CallbackInfo info) {
+    private void renderPost(PoseStack client, int mouseX, int mouseY, float partialTicks) {
         EventFactory.onContainerRender(
                 (AbstractContainerScreen<?>) (Object) this, client, mouseX, mouseY, partialTicks, this.hoveredSlot);
     }
@@ -30,14 +30,14 @@ public abstract class AbstractContainerScreenMixin {
     @Inject(
             method = "renderSlot(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/inventory/Slot;)V",
             at = @At("HEAD"))
-    private void renderSlotPre(PoseStack poseStack, Slot slot, CallbackInfo info) {
+    private void renderSlotPre(PoseStack poseStack, Slot slot) {
         EventFactory.onSlotRenderPre((Screen) (Object) this, slot);
     }
 
     @Inject(
             method = "renderSlot(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/inventory/Slot;)V",
             at = @At("RETURN"))
-    private void renderSlotPost(PoseStack poseStack, Slot slot, CallbackInfo info) {
+    private void renderSlotPost(PoseStack poseStack, Slot slot) {
         EventFactory.onSlotRenderPost((Screen) (Object) this, slot);
     }
 
@@ -65,7 +65,7 @@ public abstract class AbstractContainerScreenMixin {
     }
 
     @Inject(method = "onClose", at = @At("RETURN"))
-    private void onCloseContainerPost(CallbackInfo ci) {
+    private void onCloseContainerPost() {
         EventFactory.onCloseContainerPost();
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
@@ -25,7 +25,7 @@ public abstract class BossHealthOverlayMixin {
     public Map<UUID, LerpingBossEvent> events;
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void onCtor(CallbackInfo ci) {
+    private void onCtor() {
         events = Maps.newConcurrentMap();
     }
 

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientLevelMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientLevelMixin.java
@@ -9,12 +9,11 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientLevel.class)
 public abstract class ClientLevelMixin {
     @Inject(method = "disconnect()V", at = @At("HEAD"))
-    private void disconnectPre(CallbackInfo ci) {
+    private void disconnectPre() {
         // User-triggered logoff
         EventFactory.onDisconnect();
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -43,7 +43,7 @@ public abstract class ClientPacketListenerMixin {
     @Inject(
             method = "handleCommands(Lnet/minecraft/network/protocol/game/ClientboundCommandsPacket;)V",
             at = @At("HEAD"))
-    private void handleCommandsPre(ClientboundCommandsPacket packet, CallbackInfo ci) {
+    private void handleCommandsPre(ClientboundCommandsPacket packet) {
         if (!isRenderThread()) return;
         CommandsPacketEvent event = EventFactory.onCommandsPacket(packet.getRoot());
         ((ClientboundCommandsPacketAccessor) packet).setRoot(event.getRoot());
@@ -52,7 +52,7 @@ public abstract class ClientPacketListenerMixin {
     @Inject(
             method = "handlePlayerInfo(Lnet/minecraft/network/protocol/game/ClientboundPlayerInfoPacket;)V",
             at = @At("RETURN"))
-    private void handlePlayerInfoPost(ClientboundPlayerInfoPacket packet, CallbackInfo ci) {
+    private void handlePlayerInfoPost(ClientboundPlayerInfoPacket packet) {
         if (!isRenderThread()) return;
         EventFactory.onPlayerInfoPacket(packet);
     }
@@ -60,7 +60,7 @@ public abstract class ClientPacketListenerMixin {
     @Inject(
             method = "handleTabListCustomisation(Lnet/minecraft/network/protocol/game/ClientboundTabListPacket;)V",
             at = @At("RETURN"))
-    private void handleTabListCustomisationPost(ClientboundTabListPacket packet, CallbackInfo ci) {
+    private void handleTabListCustomisationPost(ClientboundTabListPacket packet) {
         if (!isRenderThread()) return;
         EventFactory.onTabListCustomisation(packet);
     }
@@ -68,14 +68,14 @@ public abstract class ClientPacketListenerMixin {
     @Inject(
             method = "handleResourcePack(Lnet/minecraft/network/protocol/game/ClientboundResourcePackPacket;)V",
             at = @At("RETURN"))
-    private void handleResourcePackPost(ClientboundResourcePackPacket packet, CallbackInfo ci) {
+    private void handleResourcePackPost(ClientboundResourcePackPacket packet) {
         EventFactory.onResourcePack();
     }
 
     @Inject(
             method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ClientboundPlayerPositionPacket;)V",
             at = @At("RETURN"))
-    private void handleMovePlayerPost(ClientboundPlayerPositionPacket packet, CallbackInfo ci) {
+    private void handleMovePlayerPost(ClientboundPlayerPositionPacket packet) {
         if (!isRenderThread()) return;
         EventFactory.onPlayerMove(packet);
     }
@@ -192,7 +192,7 @@ public abstract class ClientPacketListenerMixin {
     }
 
     @Inject(method = "onDisconnect(Lnet/minecraft/network/chat/Component;)V", at = @At("HEAD"))
-    private void onDisconnectPre(Component reason, CallbackInfo ci) {
+    private void onDisconnectPre(Component reason) {
         // Unexpected disconnect
         EventFactory.onDisconnect();
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/ConnectScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ConnectScreenMixin.java
@@ -11,12 +11,11 @@ import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ConnectScreen.class)
 public abstract class ConnectScreenMixin {
     @Inject(method = "connect", at = @At("HEAD"))
-    private void connectPre(Minecraft minecraft, ServerAddress serverAddress, CallbackInfo ci) {
+    private void connectPre(Minecraft minecraft, ServerAddress serverAddress) {
         EventFactory.onConnect(serverAddress.getHost(), serverAddress.getPort());
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/CrashReportMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CrashReportMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.CrashReportCategory;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CrashReport.class)
 public abstract class CrashReportMixin {
@@ -21,7 +20,7 @@ public abstract class CrashReportMixin {
                             value = "INVOKE",
                             target =
                                     "Lnet/minecraft/SystemReport;appendToCrashReportString(Ljava/lang/StringBuilder;)V"))
-    private void addWynntilsDetails(StringBuilder builder, CallbackInfo ci) {
+    private void addWynntilsDetails(StringBuilder builder) {
         CrashReportCategory wynntilsCrashDetails = CrashReportManager.generateDetails();
 
         wynntilsCrashDetails.getDetails(builder);

--- a/common/src/main/java/com/wynntils/mc/mixin/GuiMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/GuiMixin.java
@@ -32,26 +32,26 @@ public abstract class GuiMixin {
     @Inject(
             method = "renderSlot(IIFLnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/ItemStack;I)V",
             at = @At("HEAD"))
-    private void renderSlotPre(int x, int y, float ticks, Player player, ItemStack stack, int i, CallbackInfo info) {
+    private void renderSlotPre(int x, int y, float ticks, Player player, ItemStack stack, int i) {
         EventFactory.onHotbarSlotRenderPre(stack, x, y);
     }
 
     @Inject(
             method = "renderSlot(IIFLnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/ItemStack;I)V",
             at = @At("RETURN"))
-    private void renderSlotPost(int x, int y, float ticks, Player player, ItemStack stack, int i, CallbackInfo info) {
+    private void renderSlotPost(int x, int y, float ticks, Player player, ItemStack stack, int i) {
         EventFactory.onHotbarSlotRenderPost(stack, x, y);
     }
 
     // This does not work on Forge. See ForgeIngameGuiMixin for replacement.
     @Inject(method = "render", at = @At("HEAD"))
-    private void onRenderGuiPre(PoseStack poseStack, float partialTick, CallbackInfo ci) {
+    private void onRenderGuiPre(PoseStack poseStack, float partialTick) {
         EventFactory.onRenderGuiPre(poseStack, partialTick, this.minecraft.getWindow());
     }
 
     // This does not work on Forge. See ForgeIngameGuiMixin for replacement.
     @Inject(method = "render", at = @At("RETURN"))
-    private void onRenderGuiPost(PoseStack poseStack, float partialTick, CallbackInfo ci) {
+    private void onRenderGuiPost(PoseStack poseStack, float partialTick) {
         EventFactory.onRenderGuiPost(poseStack, partialTick, this.minecraft.getWindow());
     }
 

--- a/common/src/main/java/com/wynntils/mc/mixin/KeyMappingMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/KeyMappingMixin.java
@@ -13,7 +13,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(KeyMapping.class)
 public abstract class KeyMappingMixin {
@@ -24,7 +23,7 @@ public abstract class KeyMappingMixin {
     @Inject(
             method = "<init>(Ljava/lang/String;Lcom/mojang/blaze3d/platform/InputConstants$Type;ILjava/lang/String;)V",
             at = @At("RETURN"))
-    private void initPost(String name, InputConstants.Type type, int i, String category, CallbackInfo ci) {
+    private void initPost(String name, InputConstants.Type type, int i, String category) {
         KeyBindManager.initKeyMapping(category, CATEGORY_SORT_ORDER);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/LevelRendererMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LevelRendererMixin.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelRenderer.class)
 public abstract class LevelRendererMixin {
@@ -34,8 +33,7 @@ public abstract class LevelRendererMixin {
             Camera camera,
             GameRenderer gameRenderer,
             LightTexture lightTexture,
-            Matrix4f projectionMatrix,
-            CallbackInfo ci) {
+            Matrix4f projectionMatrix) {
         EventFactory.onRenderLast(
                 this.minecraft.levelRenderer, poseStack, partialTick, projectionMatrix, finishNanoTime);
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/MainMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MainMixin.java
@@ -11,7 +11,6 @@ import net.minecraft.client.main.Main;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // Credits to
 // https://github.com/comp500/ScreenshotToClipboard/blob/1.18-arch/common/src/main/java/link/infra/screenshotclipboard/common/mixin/AWTHackMixin.java
@@ -19,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MainMixin {
     // Inject as early as possible (but after Main statics execute), and disable java.awt.headless on non-macOS systems
     @Inject(method = "main", at = @At("HEAD"), remap = false)
-    private static void awtHack(CallbackInfo ci) {
+    private static void awtHack() {
         // A bit dangerous, but shouldn't technically cause any issues on most platforms - headless mode just disables
         // the awt API
         // Minecraft usually has this enabled because it's using GLFW rather than AWT/Swing

--- a/common/src/main/java/com/wynntils/mc/mixin/MinecraftMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MinecraftMixin.java
@@ -10,12 +10,11 @@ import net.minecraft.client.gui.screens.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
 public abstract class MinecraftMixin {
     @Inject(method = "setScreen(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At("RETURN"))
-    private void setScreenPostPost(Screen screen, CallbackInfo ci) {
+    private void setScreenPostPost(Screen screen) {
         if (screen == null) {
             EventFactory.onScreenClose();
         } else {
@@ -24,17 +23,17 @@ public abstract class MinecraftMixin {
     }
 
     @Inject(method = "tick", at = @At("HEAD"))
-    private void tickPre(CallbackInfo ci) {
+    private void tickPre() {
         EventFactory.onTickStart();
     }
 
     @Inject(method = "tick", at = @At("RETURN"))
-    private void tickPost(CallbackInfo ci) {
+    private void tickPost() {
         EventFactory.onTickEnd();
     }
 
     @Inject(method = "resizeDisplay", at = @At("RETURN"))
-    private void resizeDisplayPost(CallbackInfo ci) {
+    private void resizeDisplayPost() {
         EventFactory.onResizeDisplayPost();
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/MouseHandlerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MouseHandlerMixin.java
@@ -9,13 +9,12 @@ import net.minecraft.client.MouseHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHandler.class)
 public abstract class MouseHandlerMixin {
 
     @Inject(method = "onScroll", at = @At("HEAD"))
-    private void onScroll(long windowPointer, double xOffset, double yOffset, CallbackInfo ci) {
+    private void onScroll(long windowPointer, double xOffset, double yOffset) {
         EventFactory.onMouseScroll(windowPointer, xOffset, yOffset);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ResourceLoadStateTrackerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ResourceLoadStateTrackerMixin.java
@@ -9,12 +9,11 @@ import net.minecraft.client.ResourceLoadStateTracker;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ResourceLoadStateTracker.class)
 public abstract class ResourceLoadStateTrackerMixin {
     @Inject(method = "finishReload()V", at = @At("RETURN"))
-    private void onResourceManagerReloadPost(CallbackInfo info) {
+    private void onResourceManagerReloadPost() {
         // This is the signal that Minecraft has finished loading the initial resources,
         // or a resource pack has been reloaded
         WynntilsMod.onResourcesFinishedLoading();

--- a/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
@@ -24,7 +24,7 @@ public abstract class ScoreboardMixin {
     public Map<String, Map<Objective, Score>> playerScores;
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void onCtor(CallbackInfo ci) {
+    private void onCtor() {
         this.playerScores = Maps.newConcurrentMap();
     }
 

--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -26,7 +26,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Screen.class)
 public abstract class ScreenMixin implements TextboxScreen {
@@ -59,7 +58,7 @@ public abstract class ScreenMixin implements TextboxScreen {
     }
 
     @Inject(method = "init(Lnet/minecraft/client/Minecraft;II)V", at = @At("RETURN"))
-    private void initPost(Minecraft client, int width, int height, CallbackInfo info) {
+    private void initPost(Minecraft client, int width, int height) {
         Screen screen = (Screen) (Object) this;
 
         EventFactory.onScreenCreated(screen, this::addRenderableWidget);
@@ -93,12 +92,12 @@ public abstract class ScreenMixin implements TextboxScreen {
     @Inject(
             method = "renderTooltip(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/item/ItemStack;II)V",
             at = @At("RETURN"))
-    private void renderTooltipPost(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY, CallbackInfo ci) {
+    private void renderTooltipPost(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY) {
         EventFactory.onItemTooltipRenderPost(poseStack, itemStack, mouseX, mouseY);
     }
 
     @Inject(method = "init()V", at = @At("HEAD"))
-    private void onScreenInit(CallbackInfo ci) {
+    private void onScreenInit() {
         EventFactory.onScreenInit((Screen) (Object) this);
     }
 

--- a/forge/src/main/java/com/wynntils/forge/mixins/ForgeIngameGuiMixin.java
+++ b/forge/src/main/java/com/wynntils/forge/mixins/ForgeIngameGuiMixin.java
@@ -19,13 +19,13 @@ public abstract class ForgeIngameGuiMixin {
     // so we have to use the instance.
 
     @Inject(method = "render", at = @At("HEAD"))
-    private void onRenderGuiPre(PoseStack poseStack, float partialTick, CallbackInfo ci) {
+    private void onRenderGuiPre(PoseStack poseStack, float partialTick) {
         EventFactory.onRenderGuiPre(
                 poseStack, partialTick, Minecraft.getInstance().getWindow());
     }
 
     @Inject(method = "render", at = @At("RETURN"))
-    private void onRenderGuiPost(PoseStack poseStack, float partialTick, CallbackInfo ci) {
+    private void onRenderGuiPost(PoseStack poseStack, float partialTick) {
         EventFactory.onRenderGuiPost(
                 poseStack, partialTick, Minecraft.getInstance().getWindow());
     }


### PR DESCRIPTION
I don't know if this has always been the case, or if Fabric has changed, but at least now we don't need to add the CallbackInfo unless we need to cancel the event. And in fact, in the debug log, we'll find tons of warning about "unused callback info".