### PR TITLE
Fix Wynnlib incompatability

### DIFF
--- a/common/src/main/java/com/wynntils/gui/screens/GearViewerScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/GearViewerScreen.java
@@ -112,7 +112,7 @@ public class GearViewerScreen extends Screen {
             return;
         }
 
-        if (hovered instanceof GearItemButton gearItemButton) {
+        if (hovered instanceof GearItemButton gearItemButton && gearItemButton.getItemStack() != null) {
             this.renderTooltip(poseStack, gearItemButton.getItemStack(), mouseX, mouseY);
         }
     }

--- a/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
@@ -136,8 +136,14 @@ public class MainMapScreen extends Screen {
 
         RenderSystem.enableDepthTest();
 
+        RenderUtils.enableScissor(
+                (int) (renderX + renderedBorderXOffset), (int) (renderY + renderedBorderYOffset), (int) mapWidth, (int)
+                        mapHeight);
+
         renderMap(poseStack, mouseX, mouseY);
         renderBackground(poseStack);
+
+        RenderSystem.disableScissor();
 
         renderCursor(poseStack);
 
@@ -180,10 +186,6 @@ public class MainMapScreen extends Screen {
     }
 
     private void renderMap(PoseStack poseStack, int mouseX, int mouseY) {
-        RenderUtils.enableScissor(
-                (int) (renderX + renderedBorderXOffset), (int) (renderY + renderedBorderYOffset), (int) mapWidth, (int)
-                        mapHeight);
-
         // Background black void color
         RenderUtils.drawRect(
                 poseStack,
@@ -218,8 +220,6 @@ public class MainMapScreen extends Screen {
                     false,
                     false);
         }
-
-        RenderSystem.disableScissor();
     }
 
     private void updateMapCenterIfDragging(int mouseX, int mouseY) {

--- a/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
@@ -136,14 +136,8 @@ public class MainMapScreen extends Screen {
 
         RenderSystem.enableDepthTest();
 
-        RenderUtils.enableScissor(
-                (int) (renderX + renderedBorderXOffset), (int) (renderY + renderedBorderYOffset), (int) mapWidth, (int)
-                        mapHeight);
-
         renderMap(poseStack, mouseX, mouseY);
         renderBackground(poseStack);
-
-        RenderSystem.disableScissor();
 
         renderCursor(poseStack);
 
@@ -186,6 +180,10 @@ public class MainMapScreen extends Screen {
     }
 
     private void renderMap(PoseStack poseStack, int mouseX, int mouseY) {
+        RenderUtils.enableScissor(
+                (int) (renderX + renderedBorderXOffset), (int) (renderY + renderedBorderYOffset), (int) mapWidth, (int)
+                        mapHeight);
+
         // Background black void color
         RenderUtils.drawRect(
                 poseStack,
@@ -220,6 +218,8 @@ public class MainMapScreen extends Screen {
                     false,
                     false);
         }
+
+        RenderSystem.disableScissor();
     }
 
     private void updateMapCenterIfDragging(int mouseX, int mouseY) {


### PR DESCRIPTION
```
[19:13:41] [Render thread/ERROR]: Reported exception thrown!
net.minecraft.class_148: Rendering screen
	at net.minecraft.class_757.method_3192(class_757.java:886) ~[client-intermediary.jar:?]
	at net.minecraft.class_310.method_1523(class_310.java:1122) ~[client-intermediary.jar:?]
	at net.minecraft.class_310.method_1514(class_310.java:737) [client-intermediary.jar:?]
	at net.minecraft.client.main.Main.main(Main.java:236) [client-intermediary.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:461) [fabric-loader-0.14.8.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.14.8.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.14.8.jar:?]
Caused by: java.lang.NullPointerException: Parameter specified as non-null is null: method io.github.nbcss.wynnlib.function.AnalyzeMode.getAnalyzeResult, parameter item
	at io.github.nbcss.wynnlib.function.AnalyzeMode.getAnalyzeResult(AnalyzeMode.kt) ~[%5BCI-a8974828%5D%5B1.18%5DWynnLibFabric-0.2.7.jar:?]
	at net.minecraft.class_437.handler$bbf000$renderTooltip(class_437.java:2215) ~[client-intermediary.jar:?]
	at net.minecraft.class_437.method_25409(class_437.java) ~[client-intermediary.jar:?]
	at com.wynntils.gui.screens.GearViewerScreen.renderHoveredTooltip(GearViewerScreen.java:116) ~[wynntils-1.1.0+DEV.MC1.18.2-fabric.jar:?]
	at com.wynntils.gui.screens.GearViewerScreen.method_25394(GearViewerScreen.java:86) ~[wynntils-1.1.0+DEV.MC1.18.2-fabric.jar:?]
	at net.minecraft.class_757.method_3192(class_757.java:877) ~[client-intermediary.jar:?]
	... 6 more
```