### PR TITLE
feat: Item Stat Decimal Setting

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/tooltips/ItemStatInfoFeature.java
@@ -25,6 +25,9 @@ public class ItemStatInfoFeature extends UserFeature {
     public boolean colorLerp = true;
 
     @Config
+    public int decimalPlaces = 1;
+
+    @Config
     public boolean perfect = true;
 
     @Config

--- a/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
@@ -24,6 +24,8 @@ import com.wynntils.wynn.item.parsers.WynnItemMatchers;
 import com.wynntils.wynn.objects.ItemIdentificationContainer;
 import com.wynntils.wynn.objects.Powder;
 import com.wynntils.wynn.objects.SpellType;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -210,7 +212,10 @@ public final class WynnItemUtils {
                                 ? getPercentageColor(percentage)
                                 : getFlatPercentageColor(percentage))
                 .withItalic(false);
-        return new TextComponent(String.format(Utils.getGameLocale(), " [%.1f%%]", percentage)).withStyle(color);
+        String percentString = new BigDecimal(percentage)
+                .setScale(ItemStatInfoFeature.INSTANCE.decimalPlaces, RoundingMode.DOWN)
+                .toPlainString();
+        return new TextComponent(" [" + percentString + "%]").withStyle(color);
     }
 
     /**

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -286,6 +286,8 @@
   "feature.wynntils.itemScreenshot.name": "Item Screenshot",
   "feature.wynntils.itemStatInfo.colorLerp.description": "Should the colored percentage for item ID vary smoothly instead of between fixed levels?",
   "feature.wynntils.itemStatInfo.colorLerp.name": "Color Lerp",
+  "feature.wynntils.itemStatInfo.decimalPlaces.description": "How many decimal places should item stats display?",
+  "feature.wynntils.itemStatInfo.decimalPlaces.name": "Stat Decimal Places",
   "feature.wynntils.itemStatInfo.defective.description": "Should the names of defective (0%) items look garbled?",
   "feature.wynntils.itemStatInfo.defective.name": "Obfuscated Defective Items",
   "feature.wynntils.itemStatInfo.groupIdentifications.description": "Should different IDs be grouped together depending on type of ID?",


### PR DESCRIPTION
Adds a config option for the number of decimals shown in item percentages. This also fixes percentage rounding so it matches legacy behavior.

Examples of increased/decreased decimal places:
![image](https://user-images.githubusercontent.com/3767283/200666375-4d76bdfd-c8a7-4d51-a602-ed88abf491d2.png)
![image](https://user-images.githubusercontent.com/3767283/200666436-f0d22f6a-9e36-4ff9-bb84-ae5d3bd153c5.png)
