### PR TITLE
fix: update spell cost ID ranges

### DIFF
--- a/common/src/main/java/com/wynntils/core/webapi/WebManager.java
+++ b/common/src/main/java/com/wynntils/core/webapi/WebManager.java
@@ -17,7 +17,6 @@ import com.wynntils.core.webapi.profiles.DiscoveryProfile;
 import com.wynntils.core.webapi.profiles.ItemGuessProfile;
 import com.wynntils.core.webapi.profiles.ServerProfile;
 import com.wynntils.core.webapi.profiles.ingredient.IngredientProfile;
-import com.wynntils.core.webapi.profiles.item.IdentificationProfile;
 import com.wynntils.core.webapi.profiles.item.ItemProfile;
 import com.wynntils.core.webapi.profiles.item.ItemType;
 import com.wynntils.core.webapi.profiles.item.MajorIdentification;
@@ -194,7 +193,7 @@ public final class WebManager extends CoreManager {
 
                     HashMap<String, ItemProfile> citems = new HashMap<>();
                     for (ItemProfile prof : gItems) {
-                        prof.getStatuses().values().forEach(IdentificationProfile::calculateMinMax);
+                        prof.getStatuses().forEach((n, p) -> p.calculateMinMax(n));
                         prof.addMajorIds(majorIds);
                         citems.put(prof.getDisplayName(), prof);
                     }

--- a/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
@@ -91,8 +91,9 @@ public final class WynnItemUtils {
      */
     public static ItemIdentificationContainer identificationFromValue(
             Component lore, ItemProfile item, String idName, String shortIdName, int value, int starCount) {
-        boolean isInverted = IdentificationOrderer.INSTANCE.isInverted(shortIdName);
         IdentificationProfile idProfile = item.getStatuses().get(shortIdName);
+        boolean isInverted =
+                idProfile != null ? idProfile.isInverted() : IdentificationOrderer.INSTANCE.isInverted(shortIdName);
         IdentificationModifier type =
                 idProfile != null ? idProfile.getType() : IdentificationProfile.getTypeFromName(shortIdName);
         if (type == null) return null; // not a valid id
@@ -122,13 +123,9 @@ public final class WynnItemUtils {
             int min = idProfile.getMin();
             int max = idProfile.getMax();
 
-            if (isInverted) {
-                percentage = MathUtils.inverseLerp(max, min, value) * 100;
-            } else {
-                percentage = MathUtils.inverseLerp(min, max, value) * 100;
-            }
+            percentage = MathUtils.inverseLerp(min, max, value) * 100;
 
-            IdentificationProfile.ReidentificationChances chances = idProfile.getChances(value, isInverted, starCount);
+            IdentificationProfile.ReidentificationChances chances = idProfile.getChances(value, starCount);
 
             percentLine.append(WynnItemUtils.getPercentageTextComponent(percentage));
 
@@ -171,7 +168,7 @@ public final class WynnItemUtils {
             String idName = entry.getKey();
             MutableComponent line;
 
-            boolean inverted = IdentificationOrderer.INSTANCE.isInverted(idName);
+            boolean inverted = idProfile.isInverted();
             if (idProfile.hasConstantValue()) {
                 int value = idProfile.getBaseValue();
                 line = new TextComponent((value > 0 ? "+" : "") + value + type.getInGame(idName));


### PR DESCRIPTION
Fixes our ID logic to be in line with the new way spell cost IDs are handled by Wynn. `IdentificationProfile` didn't know whether its own ID was inverted (or even what its name was), so I had to pass that info into it via `calculateMinMax` - it's not the cleanest solution but I haven't thought of a better one.