### PR TITLE
fix: Fixes broken LICENSE Link in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ By default, this is `C:\Users\<your username>\.gradle\gradle.properties` on Wind
 License
 ========
 
-Artemis is licensed over the license [GNU Affero General Public License v3.0](https://github.com/Wynntils/Artemis/blob/development/LICENSE)<br>
+Artemis is licensed over the license [GNU Affero General Public License v3.0](https://github.com/Wynntils/Artemis/blob/alpha/LICENSE)<br>
 Unless specified otherwise, All the assets **are over Wynntils domain © Wynntils**.


### PR DESCRIPTION
I was just browsing your repository trying to learn how stuff worked, and I found that your link to the aGPL license was pointing towards an unfindable LICENSE file on a non-existing branch. Another alternative could be to just have it point towards the AGPL website link at https://www.gnu.org/licenses/agpl-3.0.html rather than have it be dependent on a branch (future proofing it). I'll leave this branch open in case you just wanna pass that through before merging it. Thanks for your time.