### PR TITLE
fix: ignore duplicated bomb bell messages

### DIFF
--- a/common/src/main/java/com/wynntils/wynn/model/BombBellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/BombBellModel.java
@@ -38,10 +38,10 @@ public class BombBellModel extends Model {
             String bomb = matcher.group("bomb");
             String server = matcher.group("server");
 
-            BOMB_BELLS.add(new BombInfo(user, BombType.fromString(bomb), server, System.currentTimeMillis()));
-
             // Better to do a bit of processing and clean up the set than leaking memory
             removeOldTimers();
+
+            BOMB_BELLS.add(new BombInfo(user, BombType.fromString(bomb), server, System.currentTimeMillis()));
         }
     }
 

--- a/common/src/main/java/com/wynntils/wynn/objects/BombInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/BombInfo.java
@@ -16,4 +16,12 @@ public record BombInfo(String user, BombType bomb, String server, long startTime
                 TimeUnit.MILLISECONDS.toSeconds(millis)
                         - TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(millis)));
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BombInfo bombInfo)) return false;
+
+        // match user, bomb type, and server, ignoring time
+        return user.equals(bombInfo.user()) && bomb == bombInfo.bomb() && server.equals(bombInfo.server());
+    }
 }


### PR DESCRIPTION
This should fix bomb timers getting duplicated thanks to dialogue re-sending chat - since `BombInfo#equals` ignores the time variable, two bombs of the same type, server, and thrower can't be added to the set. 

For the entirely valid scenario of a bomb getting thrown again after expiring, the check for removing old timers now occurs before we try to add the new bomb.