### PR TITLE
fix: include savior's sacrifice in status overlay

### DIFF
--- a/common/src/main/java/com/wynntils/wynn/model/TabModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/TabModel.java
@@ -30,7 +30,7 @@ public class TabModel extends Model {
      * <p>Originally taken from: <a href="https://github.com/Wynntils/Wynntils/pull/615">Legacy</a>
      */
     private static final Pattern TAB_EFFECT_PATTERN =
-            Pattern.compile("(.+?§7 ?(?:\\d+(?:\\.\\d+)?%)?) ?([%\\-+\\/\\da-zA-Z\\s]+?) §[84a]\\((.+?)\\).*");
+            Pattern.compile("(.+?§7 ?(?:\\d+(?:\\.\\d+)?%)?) ?([%\\-+\\/\\da-zA-Z'\\s]+?) §[84a]\\((.+?)\\).*");
 
     private static final String STATUS_EFFECTS_TITLE = "§d§lStatus Effects";
 


### PR DESCRIPTION
adds an apostrophe to the status name pattern, since it wasn't correctly detecting `Savior's Sacrifice`

![image](https://user-images.githubusercontent.com/3767283/204069987-03b57843-2787-4b62-82d6-bb14ff752e4d.png)
