### PR TITLE
chore: Add Quiltflower decompiler support and greatly improve workspace/development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ About Artemis
 ========
 > Artemis is the greek goddess of hunting and the moon, born of Zeus and Leto, twin of Apollo.
 
-This is a preliminary rewrite of **[Wynntils](https://github.com/Wynntils/Wynntils)** (informally referred to as "Legacy") in 1.18.2 using Architectury, to support Fabric, Forge and Quilt.
+Artemis rewrite of **[Wynntils](https://github.com/Wynntils/Wynntils)** (informally referred to as "Legacy") in 1.18.2 using Architectury, to support **Fabric**, **Forge** and **Quilt**.
 
-Pull Request
+Downloading a release
+========
+You can download the latest build from our [releases page](https://github.com/Wynntils/Artemis/releases). You can also download the latest build from our [Modrinth Page](https://modrinth.com/mod/wynntils) and [CurseForge](https://www.curseforge.com/minecraft/mc-mods/wynntils).
+
+Pull Requests
 ========
 All pull requests are welcome. We'll analyse it and if we determine it should a part of the mod, we'll accept it. Note that the process of a pull request getting merged here is likely more strenuous than legacy. To begin, one pull request could be porting features from legacy.
 
@@ -24,20 +28,32 @@ We welcome all forms of assistance. =)
 
 Workspace Setup
 ========
-To set up the workspace, just import the project as a gradle project into your IDE
-<br> To build the mod just call the ``buildDependents`` and the artifacts should be generated in `fabric/build/libs` and `forge/build/libs`. There are a lot of jars there, but the mod jars are the ones without a dashed suffix at the end.
 
+### Initial Setup
+To set up the workspace, just import the project as a gradle project into your IDE. You might have to run `./gradlew --refresh-dependencies` if your IDE does not automatically do it.
+
+### Building
+To build the mod just call the `buildDependents` and the artifacts should be generated in `fabric/build/libs`, `quilt/build/libs` and `forge/build/libs`. There are a lot of jars there, use the jar which has the respective loader at the end (eg. `wynntils-VERSION-fabric.jar`).
+
+### Code Formatting
 The code format is checked by Spotless using the Palantir engine. To make sure your commits pass the Spotless check, you can install a git pre-commit hook. The hook is optional to use. If you want to use it, you must tell git to pick up hooks from the directory containing the hook. To do this, run this from your repo root: `git config core.hooksPath utils/git-hooks`.
 
 If you are using IntelliJ IDEA, it is recommended to install the [Palantir plugin](https://plugins.jetbrains.com/plugin/13180-palantir-java-format), to get proper formatting using the "Reformat code" command.
 
+### Hot-swapping
 Using the Hotswap Agent is recommended if you want to do live code editing. See [Hotswap Agent installation instructions](http://hotswapagent.org/mydoc_quickstart-jdk17.html),
 but bear in mind that the instructions are incorrect (!). Don't "unpack" `hotswap-agent.jar`, instead
 rename the downloaded jar file to `hotswap-agent.jar`. Finally, add `wynntils.hotswap=true` in your personal `gradle.properties` file.
 By default, this is `C:\Users\<your username>\.gradle\gradle.properties` on Windows, or `~/.gradle/gradle.properties` on Linux/MacOS.
 
 
-<i>TODO Run Configurations and Authenticating</i>
+### Run Configurations and Authenticating
+Architectury Loom currently only supports VSCode and IntelliJ IDEA. Eclipse if not supported by upstream at the moment. After running Initial Setup, run configurations should appear automatically (note that you might have to restart your IDE after Initial Setup).
+
+The project has [DevAuth](https://github.com/DJtheRedstoner/DevAuth) set up by default. When you run the development run configurations, you will get a link to log in with your Microsoft account. After first login, you will be able to run the game like you would in a production environment.
+
+### Quiltflower decompiler
+The project has [LoomQuiltflower](https://github.com/Juuxel/LoomQuiltflower) set-up automatically. This is done so to highly increase the quality of decompiled sources. To use it, run `./gradlew quiltflowerDecompile`. After it finished, the decompiled Minecraft source will be in `minecraft-project-@common-clientOnly-named-sources.jar` You have to attach these sources in Intellij IDEA for Quiltflower to take effect.
 
 License
 ========

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ About Artemis
 ========
 > Artemis is the greek goddess of hunting and the moon, born of Zeus and Leto, twin of Apollo.
 
-Artemis rewrite of **[Wynntils](https://github.com/Wynntils/Wynntils)** (informally referred to as "Legacy") in 1.18.2 using Architectury, to support **Fabric**, **Forge** and **Quilt**.
+Artemis is a rewrite of **[Wynntils](https://github.com/Wynntils/Wynntils)** (informally referred to as "Legacy") in 1.18.2 using Architectury, to support **Fabric**, **Forge** and **Quilt**.
 
 Downloading a release
 ========

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
     id "dev.architectury.loom" version "1.0-SNAPSHOT" apply false
+    id 'io.github.juuxel.loom-quiltflower' version '1.8.0' apply false
     id "com.diffplug.spotless" version "6.3.0"
 }
 
@@ -21,6 +22,7 @@ if (!System.getenv("CI")) {
 
 subprojects {
     apply plugin: "dev.architectury.loom"
+    apply plugin: "io.github.juuxel.loom-quiltflower"
 
     repositories {
         maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }


### PR DESCRIPTION
Quiltflower overall improves decompiled code quality, but it also includes the code comments of the source code, and show useful information like `@Override` annotations.

Example of the `Quiltflower` improvements (compared to `FernFlower`):

FernFlower:
![image](https://user-images.githubusercontent.com/49001742/204393325-cf833ff0-5552-46d1-9645-cc8bf6ff8ad7.png)

QuiltFlower: 
![image](https://user-images.githubusercontent.com/49001742/204393304-15a06dbf-2361-492d-8279-e3a0a5ea8dae.png)

FernFlower:
![image](https://user-images.githubusercontent.com/49001742/204393609-edfc96e9-77b6-4896-8f10-24853d2729d0.png)

QuiltFlower:
![image](https://user-images.githubusercontent.com/49001742/204393584-e217b5ca-4c22-4537-b024-4684cadbc378.png)

FernFlower:
![image](https://user-images.githubusercontent.com/49001742/204393841-17d47cd4-8806-4d0d-a2ad-adacd2fd9c6d.png)

QuiltFlower:
![image](https://user-images.githubusercontent.com/49001742/204393827-9563d63b-3232-4889-9fa1-d06cbd65acf8.png)

