### PR TITLE
feat: Redirects Potion Replaced/At-Limit Messages as notifications

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -93,6 +93,11 @@ public class InfoMessageFilterFeature extends UserFeature {
     private static final Pattern HORSE_DESPAWNED_PATTERN =
             Pattern.compile("§dSince you interacted with your inventory, your horse has despawned.");
 
+    private static final Pattern MAX_POTIONS_ALLOWED_PATTERN =
+            Pattern.compile("§4You already are holding the maximum amount of potions allowed.");
+    private static final Pattern LESS_POWERFUL_POTION_REMOVED_PATTERN =
+            Pattern.compile("§7One less powerful potion was replaced to open space for the added one.");
+
     @Config
     private boolean hideWelcome = true;
 
@@ -131,6 +136,9 @@ public class InfoMessageFilterFeature extends UserFeature {
 
     @Config
     private FilterType horse = FilterType.REDIRECT;
+
+    @Config
+    private FilterType potion = FilterType.REDIRECT;
 
     @SubscribeEvent
     public void onInfoMessage(ChatMessageReceivedEvent e) {
@@ -396,6 +404,35 @@ public class InfoMessageFilterFeature extends UserFeature {
                     return;
                 }
             }
+
+            if (potion != FilterType.KEEP) {
+                Matcher maxPotionsMatcher = MAX_POTIONS_ALLOWED_PATTERN.matcher(msg);
+                if (maxPotionsMatcher.matches()) {
+                    e.setCanceled(true);
+                    if (potion == FilterType.HIDE) {
+                        return;
+                    }
+
+                    NotificationManager.queueMessage(
+                            new TextComponent("At Potion Charge Limit!").withStyle(ChatFormatting.DARK_RED));
+
+                    return;
+                }
+
+                Matcher lessPowerfulPotionMatcher = LESS_POWERFUL_POTION_REMOVED_PATTERN.matcher(msg);
+                if (lessPowerfulPotionMatcher.matches()) {
+                    e.setCanceled(true);
+                    if (potion == FilterType.HIDE) {
+                        return;
+                    }
+
+                    NotificationManager.queueMessage(
+                            new TextComponent("Lesser potion replaced.").withStyle(ChatFormatting.GRAY));
+
+                    return;
+                }
+            }
+
         } else if (messageType == MessageType.BACKGROUND) {
             if (hideSystemInfo) {
                 if (BACKGROUND_SYSTEM_INFO.matcher(msg).find()) {

--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -413,7 +413,7 @@ public class InfoMessageFilterFeature extends UserFeature {
                     }
 
                     NotificationManager.queueMessage(
-                            new TextComponent("At Potion Charge Limit!").withStyle(ChatFormatting.DARK_RED));
+                            new TextComponent("At potion charge limit!").withStyle(ChatFormatting.DARK_RED));
 
                     return;
                 }

--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -59,6 +59,15 @@ public class InfoMessageFilterFeature extends UserFeature {
     private static final Pattern NO_MANA_LEFT_TO_CAST_PATTERN =
             Pattern.compile("^§4You don't have enough mana to cast that spell!$");
 
+    private static final Pattern NO_ROOM_PATTERN = Pattern.compile("§4There is no room for a horse.");
+    private static final Pattern HORSE_DESPAWNED_PATTERN =
+            Pattern.compile("§dSince you interacted with your inventory, your horse has despawned.");
+    
+    private static final Pattern MAX_POTIONS_ALLOWED_PATTERN =
+            Pattern.compile("§4You already are holding the maximum amount of potions allowed.");
+    private static final Pattern LESS_POWERFUL_POTION_REMOVED_PATTERN =
+            Pattern.compile("§7One less powerful potion was replaced to open space for the added one.");  
+
     private static final Pattern HEALED_PATTERN = Pattern.compile("^.+ gave you §r§c\\[\\+(\\d+) ❤\\]$");
 
     private static final Pattern HEAL_PATTERN = Pattern.compile("^§r§c\\[\\+(\\d+) ❤\\]$");
@@ -88,16 +97,6 @@ public class InfoMessageFilterFeature extends UserFeature {
     private static final Pattern BACKGROUND_FRIEND_LEAVE_PATTERN = Pattern.compile("§r§7(?<name>.+) left the game.");
 
     private static final Pattern BACKGROUND_HEALED_PATTERN = Pattern.compile("^.+ gave you §r§7§o\\[\\+(\\d+) ❤\\]$");
-
-    private static final Pattern NO_ROOM_PATTERN = Pattern.compile("§4There is no room for a horse.");
-    private static final Pattern HORSE_DESPAWNED_PATTERN =
-            Pattern.compile("§dSince you interacted with your inventory, your horse has despawned.");
-
-    private static final Pattern MAX_POTIONS_ALLOWED_PATTERN =
-            Pattern.compile("§4You already are holding the maximum amount of potions allowed.");
-    private static final Pattern LESS_POWERFUL_POTION_REMOVED_PATTERN =
-            Pattern.compile("§7One less powerful potion was replaced to open space for the added one.");
-
     @Config
     private boolean hideWelcome = true;
 

--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -62,11 +62,11 @@ public class InfoMessageFilterFeature extends UserFeature {
     private static final Pattern NO_ROOM_PATTERN = Pattern.compile("§4There is no room for a horse.");
     private static final Pattern HORSE_DESPAWNED_PATTERN =
             Pattern.compile("§dSince you interacted with your inventory, your horse has despawned.");
-    
+
     private static final Pattern MAX_POTIONS_ALLOWED_PATTERN =
             Pattern.compile("§4You already are holding the maximum amount of potions allowed.");
     private static final Pattern LESS_POWERFUL_POTION_REMOVED_PATTERN =
-            Pattern.compile("§7One less powerful potion was replaced to open space for the added one.");  
+            Pattern.compile("§7One less powerful potion was replaced to open space for the added one.");
 
     private static final Pattern HEALED_PATTERN = Pattern.compile("^.+ gave you §r§c\\[\\+(\\d+) ❤\\]$");
 
@@ -97,6 +97,7 @@ public class InfoMessageFilterFeature extends UserFeature {
     private static final Pattern BACKGROUND_FRIEND_LEAVE_PATTERN = Pattern.compile("§r§7(?<name>.+) left the game.");
 
     private static final Pattern BACKGROUND_HEALED_PATTERN = Pattern.compile("^.+ gave you §r§7§o\\[\\+(\\d+) ❤\\]$");
+
     @Config
     private boolean hideWelcome = true;
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -197,6 +197,8 @@
   "feature.wynntils.infoMessageFilter.name": "Info Message Filter",
   "feature.wynntils.infoMessageFilter.notEnoughMana.description": "How should messages about not enough mana when casting appear?",
   "feature.wynntils.infoMessageFilter.notEnoughMana.name": "Mana Message Filtering",
+  "feature.wynntils.infoMessageFilter.potion.description": "How should messages relating to your health potion stack appear?",
+  "feature.wynntils.infoMessageFilter.potion.name": "Potion Stack Message Filtering",
   "feature.wynntils.infoMessageFilter.soulPoint.description": "How should soul point messages appear?",
   "feature.wynntils.infoMessageFilter.soulPoint.name": "Soul Point Message Filtering",
   "feature.wynntils.infoMessageFilter.speed.description": "How should messages about speed effect appear?",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34697715/204985131-ccf0c8b3-752e-4fdb-8d6e-6b24b406870f.png)

Let me know if I need to edit the "brief overlay message" formatting, I just went with what sounded best in my head. I also realized I put the "horse" regexes from an earlier PR in the wrong spot, so I adjusted that in this PR since I had just made that mistake again

Note: "Lesser potion replaced" and "At Potion Charge Limit!" are the only two added in this PR, "+3 Potion Charges" was added in a previous PR.