### PR TITLE
feat: Redirects Shaman "No Totems Nearby" message as notification

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -59,6 +59,10 @@ public class InfoMessageFilterFeature extends UserFeature {
     private static final Pattern NO_MANA_LEFT_TO_CAST_PATTERN =
             Pattern.compile("^§4You don't have enough mana to cast that spell!$");
 
+    // Wynncraft forgot the period at the end of this message, so be on the lookout for a potential break in the future
+    // if they fix it.
+    private static final Pattern NO_ACTIVE_TOTEMS_PATTERN = Pattern.compile("§4You have no active totems near you$");
+
     private static final Pattern HEALED_PATTERN = Pattern.compile("^.+ gave you §r§c\\[\\+(\\d+) ❤\\]$");
 
     private static final Pattern HEAL_PATTERN = Pattern.compile("^§r§c\\[\\+(\\d+) ❤\\]$");
@@ -131,6 +135,9 @@ public class InfoMessageFilterFeature extends UserFeature {
 
     @Config
     private FilterType horse = FilterType.REDIRECT;
+
+    @Config
+    private FilterType shaman = FilterType.REDIRECT;
 
     @SubscribeEvent
     public void onInfoMessage(ChatMessageReceivedEvent e) {
@@ -324,6 +331,20 @@ public class InfoMessageFilterFeature extends UserFeature {
                     String playerName = matcher.group("name");
 
                     sendFriendLeaveMessage(playerName);
+                    return;
+                }
+            }
+
+            if (shaman != FilterType.KEEP) {
+                Matcher matcher = NO_ACTIVE_TOTEMS_PATTERN.matcher(msg);
+                if (matcher.matches()) {
+                    e.setCanceled(true);
+                    if (shaman == FilterType.HIDE) {
+                        return;
+                    }
+
+                    NotificationManager.queueMessage(
+                            new TextComponent("No totems nearby!").withStyle(ChatFormatting.DARK_RED));
                     return;
                 }
             }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -197,6 +197,8 @@
   "feature.wynntils.infoMessageFilter.name": "Info Message Filter",
   "feature.wynntils.infoMessageFilter.notEnoughMana.description": "How should messages about not enough mana when casting appear?",
   "feature.wynntils.infoMessageFilter.notEnoughMana.name": "Mana Message Filtering",
+  "feature.wynntils.infoMessageFilter.shaman.description": "How should shaman-specific messages appear?",
+  "feature.wynntils.infoMessageFilter.shaman.name": "Shaman Message Filtering",
   "feature.wynntils.infoMessageFilter.soulPoint.description": "How should soul point messages appear?",
   "feature.wynntils.infoMessageFilter.soulPoint.name": "Soul Point Message Filtering",
   "feature.wynntils.infoMessageFilter.speed.description": "How should messages about speed effect appear?",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34697715/204988569-2a8bed9c-8be2-4c67-9588-badfa752c536.png)

This was getting on my nerves, especially the fact that it lacks a period at the end. If you aren't aware, it's the message that shows up when you try and cast the "Haul" spell as a Shaman/Skyseer without having already placed down a totem. I'm not very far into my playthrough as a shaman, so I set the Config toggle as generic "shaman" in case someone finds something they want to extend in this file (by someone, I probably mean future me). 