### PR TITLE
fix: No config value should be saved to disk unless edited

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CommandAliasesFeature.java
@@ -81,5 +81,19 @@ public class CommandAliasesFeature extends UserFeature {
         public String getOriginalCommand() {
             return originalCommand;
         }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other == null || getClass() != other.getClass()) return false;
+
+            CommandAlias that = (CommandAlias) other;
+            return originalCommand.equals(that.originalCommand) && aliases.equals(that.aliases);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(originalCommand, aliases);
+        }
     }
 }


### PR DESCRIPTION
In a perfect world, our "default", freshly generated config file should be empty. 

During my development of chat tabs, I've noticed this is not the case. I've left the problem back then, noted, but unfixed. Now, I've came back to it, in preparation of my upcoming chat tab changes... 

Only to realize the problem was fixed by me, accidentally. Turns out, I only needed to implement hashCode/equals for `ChatTab`, which I needed before. I have went ahead and tested what needs to be fixed. Turned out, we had only one outlier, `CommandAliasesFeature`. By implementing equals/hashCode, the problem is fixed, and our freshly generated config file is empty!