### PR TITLE
fix: Fix miss-use of CallbackInfoReturnable cancelling

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
@@ -46,6 +46,7 @@ public abstract class AbstractContainerScreenMixin {
         if (EventFactory.onInventoryKeyPress(keyCode, scanCode, modifiers, this.hoveredSlot)
                 .isCanceled()) {
             cir.setReturnValue(true);
+            cir.cancel();
         }
     }
 
@@ -54,6 +55,7 @@ public abstract class AbstractContainerScreenMixin {
         if (EventFactory.onInventoryMouseClick(mouseX, mouseY, button, this.hoveredSlot)
                 .isCanceled()) {
             cir.setReturnValue(true);
+            cir.cancel();
         }
     }
 

--- a/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
@@ -39,6 +39,7 @@ public abstract class LocalPlayerMixin {
     @Inject(method = "drop", at = @At("HEAD"), cancellable = true)
     private void onDropPre(boolean fullStack, CallbackInfoReturnable<Boolean> cir) {
         if (EventFactory.onDropPre(fullStack).isCanceled()) {
+            cir.setReturnValue(false);
             cir.cancel();
         }
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MultiPlayerGameModeMixin.java
@@ -52,6 +52,7 @@ public abstract class MultiPlayerGameModeMixin {
         if (EventFactory.onRightClickBlock(player, hand, blockHitResult.getBlockPos(), blockHitResult)
                 .isCanceled()) {
             cir.setReturnValue(InteractionResult.FAIL);
+            cir.cancel();
         }
     }
 
@@ -60,6 +61,7 @@ public abstract class MultiPlayerGameModeMixin {
             Player player, Level level, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
         if (EventFactory.onUseItem(player, level, hand).isCanceled()) {
             cir.setReturnValue(InteractionResult.FAIL);
+            cir.cancel();
         }
     }
 
@@ -72,6 +74,7 @@ public abstract class MultiPlayerGameModeMixin {
             CallbackInfoReturnable<InteractionResult> cir) {
         if (EventFactory.onInteractAt(player, hand, target, ray).isCanceled()) {
             cir.setReturnValue(InteractionResult.FAIL);
+            cir.cancel();
         }
     }
 
@@ -80,6 +83,7 @@ public abstract class MultiPlayerGameModeMixin {
             Player player, Entity target, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
         if (EventFactory.onInteract(player, hand, target).isCanceled()) {
             cir.setReturnValue(InteractionResult.FAIL);
+            cir.cancel();
         }
     }
 


### PR DESCRIPTION
I am not sure why this mixin worked in the first place. How can we cancel a method with a return value, and not actually set a value for it. Probably, the mixin has a default return value. I am not sure. It is fixed now, this was the only instance we've done this.