### PR TITLE
feat: Poi location and rendering refactors

### DIFF
--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -172,7 +172,7 @@ public class CompassCommand extends CommandBase {
                 .filter(poi -> poi.getKind().equals(selectedKind))
                 .min(Comparator.comparingDouble(poi -> currentLocation.distanceToSqr(
                         poi.getLocation().getX(),
-                        poi.getLocation().getY(),
+                        poi.getLocation().getY().orElse((int) currentLocation.y),
                         poi.getLocation().getZ())));
         if (closestServiceOptional.isEmpty()) {
             // This really should not happen...

--- a/common/src/main/java/com/wynntils/commands/LocateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LocateCommand.java
@@ -92,7 +92,7 @@ public class LocateCommand extends CommandBase {
         Vec3 currentLocation = McUtils.player().position();
         services.sort(Comparator.comparingDouble(poi -> currentLocation.distanceToSqr(
                 poi.getLocation().getX(),
-                poi.getLocation().getY(),
+                poi.getLocation().getY().orElse((int) currentLocation.y),
                 poi.getLocation().getZ())));
         // Removes from element 4 to the end of the list
         services.subList(4, services.size()).clear();
@@ -136,7 +136,7 @@ public class LocateCommand extends CommandBase {
         Vec3 currentLocation = McUtils.player().position();
         places.sort(Comparator.comparingDouble(poi -> currentLocation.distanceToSqr(
                 poi.getLocation().getX(),
-                poi.getLocation().getY(),
+                poi.getLocation().getY().orElse((int) currentLocation.y),
                 poi.getLocation().getZ())));
 
         MutableComponent response =

--- a/common/src/main/java/com/wynntils/features/user/map/MapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/MapFeature.java
@@ -26,7 +26,7 @@ import com.wynntils.mc.utils.McUtils;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.wynn.model.map.MapModel;
 import com.wynntils.wynn.model.map.poi.CustomPoi;
-import com.wynntils.wynn.model.map.poi.MapLocation;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import com.wynntils.wynn.objects.HealthTexture;
 import com.wynntils.wynn.screens.WynnScreenMatchers;
 import java.lang.reflect.Type;
@@ -130,7 +130,7 @@ public class MapFeature extends UserFeature {
 
         if (tier.ordinal() < minTierForAutoWaypoint.ordinal()) return;
 
-        MapLocation location = new MapLocation(lastChestPos.getX(), lastChestPos.getY(), lastChestPos.getZ());
+        PoiLocation location = new PoiLocation(lastChestPos.getX(), lastChestPos.getY(), lastChestPos.getZ());
         CustomPoi newPoi = new CustomPoi(
                 location, tier.getWaypointName(), CommonColors.WHITE, tier.getWaypointTexture(), Integer.MIN_VALUE);
 

--- a/common/src/main/java/com/wynntils/features/user/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/MinimapFeature.java
@@ -254,13 +254,13 @@ public class MinimapFeature extends UserFeature {
             List<PlayerMiniMapPoi> playerPois = HadesUserModel.getHadesUserMap().values().stream()
                     .filter(user -> (user.isPartyMember() && renderRemotePartyPlayers)
                             || (user.isMutualFriend() && renderRemoteFriendPlayers))
-                    .sorted(Comparator.comparing(
-                            hadesUser -> hadesUser.getMapLocation().getY()))
                     .map(PlayerMiniMapPoi::new)
                     .toList();
             poisToRender.addAll(playerPois);
 
-            for (Poi poi : poisToRender) {
+            for (Poi poi : poisToRender.stream()
+                    .sorted(Comparator.comparing(Poi::getRenderPriority))
+                    .toList()) {
                 float dX = (poi.getLocation().getX() - (float) playerX) / scale;
                 float dZ = (poi.getLocation().getZ() - (float) playerZ) / scale;
 

--- a/common/src/main/java/com/wynntils/features/user/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/MinimapFeature.java
@@ -258,9 +258,9 @@ public class MinimapFeature extends UserFeature {
                     .toList();
             poisToRender.addAll(playerPois);
 
-            for (Poi poi : poisToRender.stream()
-                    .sorted(Comparator.comparing(Poi::getRenderPriority).reversed())
-                    .toList()) {
+            // Reverse order to make sure higher priority is drawn later than lower priority to overwrite them
+            poisToRender.sort(Comparator.comparing(Poi::getDisplayPriority).reversed());
+            for (Poi poi : poisToRender) {
                 float dX = (poi.getLocation().getX() - (float) playerX) / scale;
                 float dZ = (poi.getLocation().getZ() - (float) playerZ) / scale;
 

--- a/common/src/main/java/com/wynntils/features/user/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/MinimapFeature.java
@@ -259,7 +259,7 @@ public class MinimapFeature extends UserFeature {
             poisToRender.addAll(playerPois);
 
             for (Poi poi : poisToRender.stream()
-                    .sorted(Comparator.comparing(Poi::getRenderPriority))
+                    .sorted(Comparator.comparing(Poi::getRenderPriority).reversed())
                     .toList()) {
                 float dX = (poi.getLocation().getX() - (float) playerX) / scale;
                 float dZ = (poi.getLocation().getZ() - (float) playerZ) / scale;

--- a/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
@@ -213,14 +213,15 @@ public class MainMapScreen extends AbstractMapScreen {
                         /*|| (hadesUser.isGuildMember() && MapFeature.INSTANCE.renderRemoteGuildPlayers)*/ )
                 .toList();
 
-        pois.sort(Comparator.comparing(Poi::getRenderPriority).reversed());
-
         // Make sure compass and player pois are on top
         pois.addAll(renderedPlayers.stream().map(PlayerMainMapPoi::new).toList());
         CompassModel.getCompassWaypoint().ifPresent(pois::add);
         if (KeyboardUtils.isControlDown()) {
             pois.addAll(TerritoryManager.getTerritoryPois());
         }
+
+        // Reverse order to make sure higher priority is drawn later than lower priority to overwrite them
+        pois.sort(Comparator.comparing(Poi::getDisplayPriority).reversed());
 
         renderPois(
                 pois,

--- a/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
@@ -23,9 +23,9 @@ import com.wynntils.wynn.model.CompassModel;
 import com.wynntils.wynn.model.map.MapModel;
 import com.wynntils.wynn.model.map.poi.CustomPoi;
 import com.wynntils.wynn.model.map.poi.IconPoi;
-import com.wynntils.wynn.model.map.poi.MapLocation;
 import com.wynntils.wynn.model.map.poi.PlayerMainMapPoi;
 import com.wynntils.wynn.model.map.poi.Poi;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import com.wynntils.wynn.model.map.poi.TerritoryPoi;
 import com.wynntils.wynn.model.map.poi.WaypointPoi;
 import java.util.ArrayList;
@@ -211,11 +211,9 @@ public class MainMapScreen extends AbstractMapScreen {
                         hadesUser -> (hadesUser.isPartyMember() && MapFeature.INSTANCE.renderRemotePartyPlayers)
                                 || (hadesUser.isMutualFriend() && MapFeature.INSTANCE.renderRemoteFriendPlayers)
                         /*|| (hadesUser.isGuildMember() && MapFeature.INSTANCE.renderRemoteGuildPlayers)*/ )
-                .sorted(Comparator.comparing(
-                        hadesUser -> hadesUser.getMapLocation().getY()))
                 .toList();
 
-        pois.sort(Comparator.comparing(poi -> poi.getLocation().getY()));
+        pois.sort(Comparator.comparing(Poi::getRenderPriority));
 
         // Make sure compass and player pois are on top
         pois.addAll(renderedPlayers.stream().map(PlayerMainMapPoi::new).toList());
@@ -275,7 +273,7 @@ public class MainMapScreen extends AbstractMapScreen {
                     int gameX = (int) ((mouseX - centerX) / currentZoom + mapCenterX);
                     int gameZ = (int) ((mouseY - centerZ) / currentZoom + mapCenterZ);
 
-                    McUtils.mc().setScreen(new PoiCreationScreen(this, new MapLocation(gameX, 0, gameZ)));
+                    McUtils.mc().setScreen(new PoiCreationScreen(this, new PoiLocation(gameX, null, gameZ)));
                 }
             } else if (KeyboardUtils.isControlDown()) {
                 if (hovered instanceof CustomPoi customPoi) {

--- a/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
@@ -213,7 +213,7 @@ public class MainMapScreen extends AbstractMapScreen {
                         /*|| (hadesUser.isGuildMember() && MapFeature.INSTANCE.renderRemoteGuildPlayers)*/ )
                 .toList();
 
-        pois.sort(Comparator.comparing(Poi::getRenderPriority));
+        pois.sort(Comparator.comparing(Poi::getRenderPriority).reversed());
 
         // Make sure compass and player pois are on top
         pois.addAll(renderedPlayers.stream().map(PlayerMainMapPoi::new).toList());

--- a/common/src/main/java/com/wynntils/gui/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/PoiCreationScreen.java
@@ -20,8 +20,9 @@ import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wynn.model.map.poi.CustomPoi;
-import com.wynntils.wynn.model.map.poi.MapLocation;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
@@ -65,7 +66,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
 
     private final MainMapScreen oldMapScreen;
     private CustomPoi oldPoi;
-    private MapLocation setupLocation;
+    private PoiLocation setupLocation;
     private boolean firstSetup = false;
 
     public PoiCreationScreen(MainMapScreen oldMapScreen) {
@@ -73,7 +74,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
         this.oldMapScreen = oldMapScreen;
     }
 
-    public PoiCreationScreen(MainMapScreen oldMapScreen, MapLocation setupLocation) {
+    public PoiCreationScreen(MainMapScreen oldMapScreen, PoiLocation setupLocation) {
         this(oldMapScreen);
 
         this.setupLocation = setupLocation;
@@ -150,11 +151,13 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
         if (firstSetup) {
             if (oldPoi != null) {
                 xInput.setTextBoxInput(String.valueOf(oldPoi.getLocation().getX()));
-                yInput.setTextBoxInput(String.valueOf(oldPoi.getLocation().getY()));
+                Optional<Integer> y = oldPoi.getLocation().getY();
+                yInput.setTextBoxInput(y.isPresent() ? String.valueOf(y) : "");
                 zInput.setTextBoxInput(String.valueOf(oldPoi.getLocation().getZ()));
             } else if (setupLocation != null) {
                 xInput.setTextBoxInput(String.valueOf(setupLocation.getX()));
-                yInput.setTextBoxInput(String.valueOf(setupLocation.getY()));
+                Optional<Integer> y = setupLocation.getY();
+                yInput.setTextBoxInput(y.isPresent() ? String.valueOf(y) : "");
                 zInput.setTextBoxInput(String.valueOf(setupLocation.getZ()));
             }
         }
@@ -427,15 +430,16 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
         saveButton.active = !nameInput.getTextBoxInput().isBlank()
                 && CustomColor.fromHexString(colorInput.getTextBoxInput()) != CustomColor.NONE
                 && COORDINATE_PATTERN.matcher(xInput.getTextBoxInput()).matches()
-                && COORDINATE_PATTERN.matcher(yInput.getTextBoxInput()).matches()
+                && (COORDINATE_PATTERN.matcher(yInput.getTextBoxInput()).matches()
+                        || yInput.getTextBoxInput().isEmpty())
                 && COORDINATE_PATTERN.matcher(zInput.getTextBoxInput()).matches();
     }
 
     private void savePoi() {
         CustomPoi poi = new CustomPoi(
-                new MapLocation(
+                new PoiLocation(
                         Integer.parseInt(xInput.getTextBoxInput()),
-                        Integer.parseInt(yInput.getTextBoxInput()),
+                        yInput.getTextBoxInput().isEmpty() ? null : Integer.parseInt(yInput.getTextBoxInput()),
                         Integer.parseInt(zInput.getTextBoxInput())),
                 nameInput.getTextBoxInput(),
                 CustomColor.fromHexString(colorInput.getTextBoxInput()),

--- a/common/src/main/java/com/wynntils/mc/objects/Location.java
+++ b/common/src/main/java/com/wynntils/mc/objects/Location.java
@@ -5,7 +5,7 @@
 package com.wynntils.mc.objects;
 
 import com.mojang.math.Vector3d;
-import com.wynntils.wynn.model.map.poi.MapLocation;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
 import net.minecraft.world.entity.Entity;
@@ -24,8 +24,8 @@ public class Location extends Vector3d implements Position {
         this(pos.getX(), pos.getY(), pos.getZ());
     }
 
-    public Location(MapLocation location) {
-        this(location.getX(), location.getY(), location.getZ());
+    public Location(PoiLocation location) {
+        this(location.getX(), location.getY().orElse(0), location.getZ());
     }
 
     public Location(Position location) {

--- a/common/src/main/java/com/wynntils/sockets/objects/HadesUser.java
+++ b/common/src/main/java/com/wynntils/sockets/objects/HadesUser.java
@@ -7,7 +7,7 @@ package com.wynntils.sockets.objects;
 import com.wynntils.hades.protocol.packets.server.HSPacketUpdateMutual;
 import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.mc.objects.CustomColor;
-import com.wynntils.wynn.model.map.poi.MapLocation;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import java.util.UUID;
 
 public class HadesUser {
@@ -18,7 +18,7 @@ public class HadesUser {
     boolean isMutualFriend;
     boolean isGuildMember;
     private float x, y, z;
-    private MapLocation mapLocation;
+    private PoiLocation poiLocation;
     private int health, maxHealth;
     private int mana, maxMana;
 
@@ -61,8 +61,8 @@ public class HadesUser {
         return z;
     }
 
-    public MapLocation getMapLocation() {
-        return mapLocation;
+    public PoiLocation getMapLocation() {
+        return poiLocation;
     }
 
     public int getHealth() {
@@ -85,7 +85,7 @@ public class HadesUser {
         this.x = packet.getX();
         this.y = packet.getY();
         this.z = packet.getZ();
-        this.mapLocation = new MapLocation((int) x, (int) y, (int) z);
+        this.poiLocation = new PoiLocation((int) x, (int) y, (int) z);
 
         this.health = packet.getHealth();
         this.maxHealth = packet.getMaxHealth();

--- a/common/src/main/java/com/wynntils/wynn/model/CompassModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/CompassModel.java
@@ -10,7 +10,7 @@ import com.wynntils.mc.event.ClientTickEvent;
 import com.wynntils.mc.event.SetSpawnEvent;
 import com.wynntils.mc.objects.Location;
 import com.wynntils.mc.utils.McUtils;
-import com.wynntils.wynn.model.map.poi.MapLocation;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import com.wynntils.wynn.model.map.poi.WaypointPoi;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -50,7 +50,7 @@ public final class CompassModel extends Model {
             WaypointPoi waypointPoi = new WaypointPoi(() -> {
                 Location location = locationSupplier.get();
 
-                return MapLocation.fromLocation(location);
+                return PoiLocation.fromLocation(location);
             });
 
             return Optional.of(waypointPoi);

--- a/common/src/main/java/com/wynntils/wynn/model/map/MapModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/MapModel.java
@@ -16,7 +16,7 @@ import com.wynntils.core.webapi.request.RequestHandler;
 import com.wynntils.utils.BoundingBox;
 import com.wynntils.wynn.model.map.poi.Label;
 import com.wynntils.wynn.model.map.poi.LabelPoi;
-import com.wynntils.wynn.model.map.poi.MapLocation;
+import com.wynntils.wynn.model.map.poi.PoiLocation;
 import com.wynntils.wynn.model.map.poi.ServiceKind;
 import com.wynntils.wynn.model.map.poi.ServicePoi;
 import java.io.ByteArrayInputStream;
@@ -131,7 +131,7 @@ public final class MapModel extends Model {
                     for (var service : serviceList) {
                         ServiceKind kind = ServiceKind.fromString(service.type);
                         if (kind != null) {
-                            for (MapLocation location : service.locations) {
+                            for (PoiLocation location : service.locations) {
                                 SERVICE_POIS.add(new ServicePoi(location, kind));
                             }
                         } else {
@@ -150,7 +150,7 @@ public final class MapModel extends Model {
 
     private static class ServiceProfile {
         String type;
-        List<MapLocation> locations;
+        List<PoiLocation> locations;
     }
 
     private static class MapPartProfile {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/CustomPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/CustomPoi.java
@@ -44,8 +44,8 @@ public class CustomPoi extends StaticIconPoi {
     }
 
     @Override
-    public RenderPriority getRenderPriority() {
-        return RenderPriority.LOW;
+    public DisplayPriority getDisplayPriority() {
+        return DisplayPriority.LOW;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/CustomPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/CustomPoi.java
@@ -16,7 +16,7 @@ public class CustomPoi extends StaticIconPoi {
     private Texture icon;
     private float minZoom;
 
-    public CustomPoi(MapLocation location, String name, CustomColor color, Texture icon, float minZoom) {
+    public CustomPoi(PoiLocation location, String name, CustomColor color, Texture icon, float minZoom) {
         super(location);
 
         this.name = name;
@@ -41,6 +41,11 @@ public class CustomPoi extends StaticIconPoi {
 
     public float getMinZoom() {
         return minZoom;
+    }
+
+    @Override
+    public RenderPriority getRenderPriority() {
+        return RenderPriority.NORMAL;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/CustomPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/CustomPoi.java
@@ -45,7 +45,7 @@ public class CustomPoi extends StaticIconPoi {
 
     @Override
     public RenderPriority getRenderPriority() {
-        return RenderPriority.NORMAL;
+        return RenderPriority.LOW;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/DisplayPriority.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/DisplayPriority.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.wynn.model.map.poi;
 
-public enum RenderPriority {
+public enum DisplayPriority {
     HIGHEST,
     HIGH,
     NORMAL,

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/DynamicIconPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/DynamicIconPoi.java
@@ -7,9 +7,9 @@ package com.wynntils.wynn.model.map.poi;
 import java.util.function.Supplier;
 
 public abstract class DynamicIconPoi extends IconPoi {
-    Supplier<MapLocation> locationSupplier;
+    Supplier<PoiLocation> locationSupplier;
 
-    protected DynamicIconPoi(Supplier<MapLocation> locationSupplier) {
+    protected DynamicIconPoi(Supplier<PoiLocation> locationSupplier) {
         this.locationSupplier = locationSupplier;
     }
 
@@ -19,7 +19,7 @@ public abstract class DynamicIconPoi extends IconPoi {
     }
 
     @Override
-    public MapLocation getLocation() {
+    public PoiLocation getLocation() {
         return locationSupplier.get();
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/LabelPoi.java
@@ -42,8 +42,8 @@ public class LabelPoi implements Poi {
     }
 
     @Override
-    public RenderPriority getRenderPriority() {
-        return RenderPriority.HIGH;
+    public DisplayPriority getDisplayPriority() {
+        return DisplayPriority.HIGH;
     }
 
     private float getAlphaFromScale(float zoom) {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/LabelPoi.java
@@ -12,14 +12,12 @@ import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.utils.MathUtils;
 
 public class LabelPoi implements Poi {
-    MapLocation location;
-
-    private static final int LABEL_Y = 1024;
+    PoiLocation location;
 
     private final Label label;
 
     public LabelPoi(Label label) {
-        location = new MapLocation(label.getX(), LABEL_Y, label.getZ());
+        location = new PoiLocation(label.getX(), null, label.getZ());
         this.label = label;
     }
 
@@ -29,7 +27,7 @@ public class LabelPoi implements Poi {
     }
 
     @Override
-    public MapLocation getLocation() {
+    public PoiLocation getLocation() {
         return location;
     }
 
@@ -41,6 +39,11 @@ public class LabelPoi implements Poi {
     @Override
     public int getHeight(float mapZoom, float scale) {
         return (int) (FontRenderer.getInstance().getFont().lineHeight * scale);
+    }
+
+    @Override
+    public RenderPriority getRenderPriority() {
+        return RenderPriority.LOW;
     }
 
     private float getAlphaFromScale(float zoom) {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/LabelPoi.java
@@ -43,7 +43,7 @@ public class LabelPoi implements Poi {
 
     @Override
     public RenderPriority getRenderPriority() {
-        return RenderPriority.LOW;
+        return RenderPriority.HIGH;
     }
 
     private float getAlphaFromScale(float zoom) {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/PlayerPoiBase.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/PlayerPoiBase.java
@@ -19,23 +19,33 @@ public abstract class PlayerPoiBase implements Poi {
         this.playerHeadRenderSize = INITIAL_PLAYER_HEAD_RENDER_SIZE * playerHeadScale;
     }
 
-    public MapLocation getLocation() {
+    @Override
+    public PoiLocation getLocation() {
         return user.getMapLocation();
     }
 
+    @Override
     public boolean hasStaticLocation() {
         return false;
     }
 
+    @Override
     public int getWidth(float mapZoom, float scale) {
         return (int) (playerHeadRenderSize + ADDITIONAL_WIDTH);
     }
 
+    @Override
     public int getHeight(float mapZoom, float scale) {
         return (int) (playerHeadRenderSize + ADDITIONAL_HEIGHT);
     }
 
+    @Override
     public String getName() {
         return user.getName();
+    }
+
+    @Override
+    public RenderPriority getRenderPriority() {
+        return RenderPriority.NORMAL;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/PlayerPoiBase.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/PlayerPoiBase.java
@@ -45,7 +45,7 @@ public abstract class PlayerPoiBase implements Poi {
     }
 
     @Override
-    public RenderPriority getRenderPriority() {
-        return RenderPriority.LOW;
+    public DisplayPriority getDisplayPriority() {
+        return DisplayPriority.LOW;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/PlayerPoiBase.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/PlayerPoiBase.java
@@ -46,6 +46,6 @@ public abstract class PlayerPoiBase implements Poi {
 
     @Override
     public RenderPriority getRenderPriority() {
-        return RenderPriority.NORMAL;
+        return RenderPriority.LOW;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
@@ -8,7 +8,13 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 public interface Poi {
 
-    MapLocation getLocation();
+    PoiLocation getLocation();
+
+    /**
+     * Render priority is used to determine the order in which POIs are rendered.
+     * A lower render priority means, that the POI is rendered later, so it will be on top of other POIs.
+     */
+    RenderPriority getRenderPriority();
 
     boolean hasStaticLocation();
 

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
@@ -11,10 +11,10 @@ public interface Poi {
     PoiLocation getLocation();
 
     /**
-     * Render priority is used to determine the order in which POIs are rendered.
+     * Display priority is used to determine the order in which POIs are rendered.
      * A higher render priority means, that the POI is rendered later, so it will be on top of other POIs.
      */
-    RenderPriority getRenderPriority();
+    DisplayPriority getDisplayPriority();
 
     boolean hasStaticLocation();
 

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
@@ -12,7 +12,7 @@ public interface Poi {
 
     /**
      * Render priority is used to determine the order in which POIs are rendered.
-     * A lower render priority means, that the POI is rendered later, so it will be on top of other POIs.
+     * A higher render priority means, that the POI is rendered later, so it will be on top of other POIs.
      */
     RenderPriority getRenderPriority();
 

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/Poi.java
@@ -12,7 +12,7 @@ public interface Poi {
 
     /**
      * Display priority is used to determine the order in which POIs are rendered.
-     * A higher render priority means, that the POI is rendered later, so it will be on top of other POIs.
+     * A higher display priority means, that the POI is rendered later, so it will be on top of other POIs.
      */
     DisplayPriority getDisplayPriority();
 

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/PoiLocation.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/PoiLocation.java
@@ -6,13 +6,14 @@ package com.wynntils.wynn.model.map.poi;
 
 import com.wynntils.mc.objects.Location;
 import java.util.Objects;
+import java.util.Optional;
 
-public class MapLocation {
+public class PoiLocation {
     private final int x;
-    private final int y;
+    private final Integer y;
     private final int z;
 
-    public MapLocation(int x, int y, int z) {
+    public PoiLocation(int x, Integer y, int z) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -22,8 +23,8 @@ public class MapLocation {
         return x;
     }
 
-    public int getY() {
-        return y;
+    public Optional<Integer> getY() {
+        return Optional.ofNullable(y);
     }
 
     public int getZ() {
@@ -43,10 +44,10 @@ public class MapLocation {
         return x + " " + y + " " + z;
     }
 
-    public static MapLocation fromLocation(Location location) {
+    public static PoiLocation fromLocation(Location location) {
         if (location == null) return null;
 
-        return new MapLocation((int) location.x, (int) location.y, (int) location.z);
+        return new PoiLocation((int) location.x, (int) location.y, (int) location.z);
     }
 
     @Override
@@ -54,8 +55,8 @@ public class MapLocation {
         if (this == other) return true;
         if (other == null || getClass() != other.getClass()) return false;
 
-        MapLocation that = (MapLocation) other;
-        return x == that.x && y == that.y && z == that.z;
+        PoiLocation that = (PoiLocation) other;
+        return x == that.x && Objects.equals(y, that.y) && z == that.z;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/RenderPriority.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/RenderPriority.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.model.map.poi;
+
+public enum RenderPriority {
+    HIGHEST,
+    HIGH,
+    NORMAL,
+    LOW,
+    LOWEST
+}

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/ServicePoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/ServicePoi.java
@@ -29,7 +29,7 @@ public class ServicePoi extends StaticIconPoi {
     }
 
     @Override
-    public RenderPriority getRenderPriority() {
-        return RenderPriority.LOWEST;
+    public DisplayPriority getDisplayPriority() {
+        return DisplayPriority.LOWEST;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/ServicePoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/ServicePoi.java
@@ -9,7 +9,7 @@ import com.wynntils.gui.render.Texture;
 public class ServicePoi extends StaticIconPoi {
     private final ServiceKind kind;
 
-    public ServicePoi(MapLocation location, ServiceKind kind) {
+    public ServicePoi(PoiLocation location, ServiceKind kind) {
         super(location);
         this.kind = kind;
     }
@@ -26,5 +26,10 @@ public class ServicePoi extends StaticIconPoi {
 
     public ServiceKind getKind() {
         return kind;
+    }
+
+    @Override
+    public RenderPriority getRenderPriority() {
+        return RenderPriority.HIGH;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/ServicePoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/ServicePoi.java
@@ -30,6 +30,6 @@ public class ServicePoi extends StaticIconPoi {
 
     @Override
     public RenderPriority getRenderPriority() {
-        return RenderPriority.HIGH;
+        return RenderPriority.LOWEST;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/StaticIconPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/StaticIconPoi.java
@@ -5,9 +5,9 @@
 package com.wynntils.wynn.model.map.poi;
 
 public abstract class StaticIconPoi extends IconPoi {
-    MapLocation location;
+    PoiLocation location;
 
-    protected StaticIconPoi(MapLocation location) {
+    protected StaticIconPoi(PoiLocation location) {
         this.location = location;
     }
 
@@ -17,7 +17,7 @@ public abstract class StaticIconPoi extends IconPoi {
     }
 
     @Override
-    public MapLocation getLocation() {
+    public PoiLocation getLocation() {
         return location;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
@@ -158,8 +158,8 @@ public class TerritoryPoi implements Poi {
     }
 
     @Override
-    public RenderPriority getRenderPriority() {
-        return RenderPriority.HIGHEST;
+    public DisplayPriority getDisplayPriority() {
+        return DisplayPriority.HIGHEST;
     }
 
     public GuildTerritoryInfo getTerritoryInfo() {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
@@ -20,28 +20,22 @@ import com.wynntils.wynn.model.territory.objects.GuildTerritoryInfo;
 
 public class TerritoryPoi implements Poi {
     private final TerritoryProfile territoryProfile;
-    private final MapLocation territoryCenter;
+    private final PoiLocation territoryCenter;
     private final int width;
     private final int height;
 
     private final GuildTerritoryInfo territoryInfo;
 
     public TerritoryPoi(TerritoryProfile territoryProfile) {
-        this.territoryProfile = territoryProfile;
-        this.width = territoryProfile.getEndX() - territoryProfile.getStartX();
-        this.height = territoryProfile.getEndZ() - territoryProfile.getStartZ();
-        this.territoryCenter =
-                new MapLocation(territoryProfile.getStartX() + width / 2, 0, territoryProfile.getStartZ() + height / 2);
-
-        this.territoryInfo = null;
+        this(territoryProfile, null);
     }
 
     public TerritoryPoi(TerritoryProfile territoryProfile, GuildTerritoryInfo territoryInfo) {
         this.territoryProfile = territoryProfile;
         this.width = territoryProfile.getEndX() - territoryProfile.getStartX();
         this.height = territoryProfile.getEndZ() - territoryProfile.getStartZ();
-        this.territoryCenter =
-                new MapLocation(territoryProfile.getStartX() + width / 2, 0, territoryProfile.getStartZ() + height / 2);
+        this.territoryCenter = new PoiLocation(
+                territoryProfile.getStartX() + width / 2, null, territoryProfile.getStartZ() + height / 2);
 
         this.territoryInfo = territoryInfo;
     }
@@ -139,7 +133,7 @@ public class TerritoryPoi implements Poi {
     }
 
     @Override
-    public MapLocation getLocation() {
+    public PoiLocation getLocation() {
         return territoryCenter;
     }
 
@@ -161,6 +155,11 @@ public class TerritoryPoi implements Poi {
     @Override
     public String getName() {
         return territoryProfile.getName();
+    }
+
+    @Override
+    public RenderPriority getRenderPriority() {
+        return RenderPriority.LOWEST;
     }
 
     public GuildTerritoryInfo getTerritoryInfo() {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
@@ -159,7 +159,7 @@ public class TerritoryPoi implements Poi {
 
     @Override
     public RenderPriority getRenderPriority() {
-        return RenderPriority.LOWEST;
+        return RenderPriority.HIGHEST;
     }
 
     public GuildTerritoryInfo getTerritoryInfo() {

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/WaypointPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/WaypointPoi.java
@@ -32,7 +32,7 @@ public class WaypointPoi extends DynamicIconPoi {
 
     @Override
     public RenderPriority getRenderPriority() {
-        return RenderPriority.HIGH;
+        return RenderPriority.NORMAL;
     }
 
     public static class PointerPoi extends DynamicIconPoi {
@@ -53,7 +53,7 @@ public class WaypointPoi extends DynamicIconPoi {
 
         @Override
         public RenderPriority getRenderPriority() {
-            return RenderPriority.HIGH;
+            return RenderPriority.NORMAL;
         }
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/WaypointPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/WaypointPoi.java
@@ -11,7 +11,7 @@ public class WaypointPoi extends DynamicIconPoi {
 
     private final PointerPoi pointer;
 
-    public WaypointPoi(Supplier<MapLocation> locationSupplier) {
+    public WaypointPoi(Supplier<PoiLocation> locationSupplier) {
         super(locationSupplier);
         pointer = new PointerPoi(locationSupplier);
     }
@@ -30,9 +30,14 @@ public class WaypointPoi extends DynamicIconPoi {
         return "Waypoint";
     }
 
+    @Override
+    public RenderPriority getRenderPriority() {
+        return RenderPriority.HIGH;
+    }
+
     public static class PointerPoi extends DynamicIconPoi {
 
-        public PointerPoi(Supplier<MapLocation> locationSupplier) {
+        public PointerPoi(Supplier<PoiLocation> locationSupplier) {
             super(locationSupplier);
         }
 
@@ -44,6 +49,11 @@ public class WaypointPoi extends DynamicIconPoi {
         @Override
         public String getName() {
             return "Waypoint";
+        }
+
+        @Override
+        public RenderPriority getRenderPriority() {
+            return RenderPriority.HIGH;
         }
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/WaypointPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/WaypointPoi.java
@@ -31,8 +31,8 @@ public class WaypointPoi extends DynamicIconPoi {
     }
 
     @Override
-    public RenderPriority getRenderPriority() {
-        return RenderPriority.NORMAL;
+    public DisplayPriority getDisplayPriority() {
+        return DisplayPriority.NORMAL;
     }
 
     public static class PointerPoi extends DynamicIconPoi {
@@ -52,8 +52,8 @@ public class WaypointPoi extends DynamicIconPoi {
         }
 
         @Override
-        public RenderPriority getRenderPriority() {
-            return RenderPriority.NORMAL;
+        public DisplayPriority getDisplayPriority() {
+            return DisplayPriority.NORMAL;
         }
     }
 }


### PR DESCRIPTION
This PR changes a lot of things related to POIs:

- Rename `MapLocation` to `PoiLocation`
- `PoiLocation` Y level is now optional/nullable
- POIs now have render-priority:
  - This is used to keep a sane rendering order of the POIs on the maps, so we don't have to rely on dummy Y levels for POIs that have no logical Y level
  - A lower priority means rendering is done earlier. Highest priority is rendered on top of everything/last.
  - New rendering order (earlier on list means earlier rendering, last to render last):
    - ServicePOIs (Banks, Merchants, Etc)
    - CustomPOIs and PlayerPOIs (Hades Players)
    - WaypointPOIs (Compass)
    - LabelPOIs (Location Labels)
    - TerritoryPOIs (Guild Territories)
- Minor POI code fixes
  - Include `@Override` annotations in cases where it was missing
  - Simplify `TerritoryPoi` constructor