### PR TITLE
fix: Do not use RIGHT_ALL for isShiftDown()

### DIFF
--- a/common/src/main/java/com/wynntils/utils/KeyboardUtils.java
+++ b/common/src/main/java/com/wynntils/utils/KeyboardUtils.java
@@ -13,7 +13,7 @@ public final class KeyboardUtils {
     }
 
     public static boolean isShiftDown() {
-        return isKeyDown(GLFW.GLFW_KEY_LEFT_SHIFT) || isKeyDown(GLFW.GLFW_KEY_RIGHT_ALT);
+        return isKeyDown(GLFW.GLFW_KEY_LEFT_SHIFT) || isKeyDown(GLFW.GLFW_KEY_RIGHT_SHIFT);
     }
 
     public static boolean isControlDown() {


### PR DESCRIPTION
introduced here:
https://github.com/Wynntils/Artemis/pull/784/files#diff-327a8d0017951c176589c00578cedf3eee1e1401dc0b3042435670519011b2ff

Feel free to discard if I'm wrong