### PR TITLE
chore: Remove special DEV version case from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,6 @@ def usingHotswapAgent = project.hasProperty('wynntils.hotswap') ? project.getPro
 // If we are running in a CI environment, we want to use the version else dev version
 // On the release branches, this string will be automatically updated by the bots
 version = "0.0.1-main-dev"
-if (!System.getenv("CI")) {
-    version = "DEV"
-}
 
 subprojects {
     apply plugin: "dev.architectury.loom"

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ architectury {
 // or ~/.gradle/gradle.properties on Linux/MacOS.
 def usingHotswapAgent = project.hasProperty('wynntils.hotswap') ? project.getProperty('wynntils.hotswap') == "true" : false
 
-// If we are running in a CI environment, we want to use the version else dev version
 // On the release branches, this string will be automatically updated by the bots
 version = "0.0.1-main-dev"
 


### PR DESCRIPTION
There is no need for "DEV" version. Also, this is fixed on 1.19.2 branch too. "DEV" version makes forge not launch. This is a good enough back port for now.