### PR TITLE
fix: NotificationManager / MessageContainer refactors + handle editing repeated messages 

### DIFF
--- a/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
@@ -9,7 +9,8 @@ import com.wynntils.gui.render.TextRenderTask;
 import java.util.Objects;
 
 public class MessageContainer {
-    protected TextRenderTask message;
+    protected String message;
+    protected TextRenderTask renderTask;
     private int messageCount;
 
     public MessageContainer(String message) {
@@ -17,21 +18,17 @@ public class MessageContainer {
     }
 
     public MessageContainer(TextRenderTask message) {
-        this.message = message;
+        this.message = message.getText();
+        this.renderTask = message;
         this.messageCount = 1;
     }
 
     public String getMessage() {
-        return message.getText();
+        return message;
     }
 
     public TextRenderTask getRenderTask() {
-        if (this.messageCount == 1) {
-            return message;
-        }
-
-        String messageMultiplier = " §7[x" + this.messageCount + "]";
-        return new TextRenderTask(this.message.getText() + messageMultiplier, this.message.getSetting());
+        return renderTask;
     }
 
     public int getMessageCount() {
@@ -40,11 +37,24 @@ public class MessageContainer {
 
     public void setMessageCount(int newCount) {
         this.messageCount = newCount;
+
+        updateRenderTask();
     }
 
     // Do NOT call this to edit the container. Use NotificationManager methods instead.
     void editMessage(String newMessage) {
-        this.message.setText(newMessage);
+        this.message = newMessage;
+
+        updateRenderTask();
+    }
+
+    private void updateRenderTask() {
+        if (this.messageCount == 1) {
+            this.renderTask = new TextRenderTask(this.message, TextRenderSetting.DEFAULT);
+        } else {
+            String messageMultiplier = " §7[x" + this.messageCount + "]";
+            this.renderTask = new TextRenderTask(this.message + messageMultiplier, this.renderTask.getSetting());
+        }
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
@@ -6,6 +6,7 @@ package com.wynntils.core.notifications;
 
 import com.wynntils.gui.render.TextRenderSetting;
 import com.wynntils.gui.render.TextRenderTask;
+import java.util.Objects;
 
 public class MessageContainer {
     protected TextRenderTask message;
@@ -45,5 +46,19 @@ public class MessageContainer {
     // Do NOT call this to edit the container. Use NotificationManager methods instead.
     void editSettings(TextRenderSetting newSetting) {
         this.message.setSetting(newSetting);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+
+        MessageContainer that = (MessageContainer) other;
+        return messageCount == that.messageCount && message.equals(that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message, messageCount);
     }
 }

--- a/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
@@ -34,18 +34,17 @@ public class MessageContainer {
         return new TextRenderTask(this.message.getText() + messageMultiplier, this.message.getSetting());
     }
 
-    public void incrementMessageCount() {
-        this.messageCount++;
+    public int getMessageCount() {
+        return messageCount;
+    }
+
+    public void setMessageCount(int newCount) {
+        this.messageCount = newCount;
     }
 
     // Do NOT call this to edit the container. Use NotificationManager methods instead.
     void editMessage(String newMessage) {
         this.message.setText(newMessage);
-    }
-
-    // Do NOT call this to edit the container. Use NotificationManager methods instead.
-    void editSettings(TextRenderSetting newSetting) {
-        this.message.setSetting(newSetting);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
@@ -20,7 +20,7 @@ public class MessageContainer {
         this.messageCount = 1;
     }
 
-    public String getOriginalMessage() {
+    public String getMessage() {
         return message.getText();
     }
 
@@ -33,15 +33,17 @@ public class MessageContainer {
         return new TextRenderTask(this.message.getText() + messageMultiplier, this.message.getSetting());
     }
 
-    public void editMessage(String newMessage) {
+    public void incrementMessageCount() {
+        this.messageCount++;
+    }
+
+    // Do NOT call this to edit the container. Use NotificationManager methods instead.
+    void editMessage(String newMessage) {
         this.message.setText(newMessage);
     }
 
-    public void update(MessageContainer other) {
-        this.message = other.message;
-    }
-
-    public void incrementMessageCount() {
-        this.messageCount++;
+    // Do NOT call this to edit the container. Use NotificationManager methods instead.
+    void editSettings(TextRenderSetting newSetting) {
+        this.message.setSetting(newSetting);
     }
 }

--- a/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
+++ b/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
@@ -32,8 +32,8 @@ public final class NotificationManager {
         return queueMessage(new TextRenderTask(message, TextRenderSetting.DEFAULT));
     }
 
-    public static void queueMessage(Component message) {
-        queueMessage(new TextRenderTask(ComponentUtils.getCoded(message), TextRenderSetting.DEFAULT));
+    public static MessageContainer queueMessage(Component message) {
+        return queueMessage(new TextRenderTask(ComponentUtils.getCoded(message), TextRenderSetting.DEFAULT));
     }
 
     public static MessageContainer queueMessage(TextRenderTask message) {
@@ -44,7 +44,7 @@ public final class NotificationManager {
         String messageText = message.getText();
 
         for (MessageContainer cachedContainer : cachedMessageSet) {
-            String checkableMessage = cachedContainer.getOriginalMessage();
+            String checkableMessage = cachedContainer.getMessage();
             if (messageText.equals(checkableMessage)) {
                 cachedContainer.incrementMessageCount();
 
@@ -64,7 +64,12 @@ public final class NotificationManager {
     }
 
     public static void editMessage(MessageContainer msgContainer, String newMessage) {
+        editMessage(msgContainer, newMessage, msgContainer.getRenderTask().getSetting());
+    }
+
+    public static void editMessage(MessageContainer msgContainer, String newMessage, TextRenderSetting newSetting) {
         msgContainer.editMessage(newMessage);
+        msgContainer.editSettings(newSetting);
 
         WynntilsMod.postEvent(new NotificationEvent.Edit(msgContainer));
         sendToChatIfNeeded(msgContainer);

--- a/common/src/main/java/com/wynntils/core/notifications/TimedMessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/TimedMessageContainer.java
@@ -7,7 +7,7 @@ package com.wynntils.core.notifications;
 import com.wynntils.gui.render.TextRenderTask;
 
 public class TimedMessageContainer {
-    private MessageContainer messageContainer;
+    private final MessageContainer messageContainer;
     private long endTime;
 
     public TimedMessageContainer(MessageContainer messageContainer, long messageDisplayLength) {
@@ -17,22 +17,6 @@ public class TimedMessageContainer {
 
     public void resetRemainingTime(long messageDisplayLength) {
         this.endTime = messageDisplayLength + System.currentTimeMillis();
-    }
-
-    public void update(TimedMessageContainer other, long messageDisplayLength) {
-        this.messageContainer = other.messageContainer;
-        resetRemainingTime(messageDisplayLength);
-    }
-
-    public void update(MessageContainer other, long messageDisplayLength) {
-        this.messageContainer.update(other);
-        resetRemainingTime(messageDisplayLength);
-    }
-
-    public TimedMessageContainer editMessage(String newMessage, long messageDisplayLength) {
-        this.messageContainer.message.setText(newMessage);
-        resetRemainingTime(messageDisplayLength);
-        return this;
     }
 
     public MessageContainer getMessageContainer() {

--- a/common/src/main/java/com/wynntils/features/user/overlays/GameNotificationOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/GameNotificationOverlayFeature.java
@@ -48,8 +48,7 @@ public class GameNotificationOverlayFeature extends UserFeature {
 
     @SubscribeEvent
     public void onGameNotification(NotificationEvent.Queue event) {
-        messageQueue.add(new TimedMessageContainer(
-                event.getMessageContainer(), (long) gameNotificationOverlay.messageTimeLimit * 1000));
+        messageQueue.add(new TimedMessageContainer(event.getMessageContainer(), getMessageDisplayLength()));
 
         if (GameNotificationOverlayFeature.INSTANCE.gameNotificationOverlay.overrideNewMessages
                 && messageQueue.size() > GameNotificationOverlayFeature.INSTANCE.gameNotificationOverlay.messageLimit) {
@@ -59,13 +58,19 @@ public class GameNotificationOverlayFeature extends UserFeature {
 
     @SubscribeEvent
     public void onGameNotification(NotificationEvent.Edit event) {
+        // On edit, we want to reset the display time of the message, for the overlay
         MessageContainer newContainer = event.getMessageContainer();
+
         messageQueue.stream()
                 .filter(timedMessageContainer ->
-                        timedMessageContainer.getMessageContainer().hashCode() == newContainer.hashCode())
+                        timedMessageContainer.getMessageContainer().equals(newContainer))
                 .findFirst()
-                .ifPresent(timedMessageContainer -> timedMessageContainer.update(
-                        newContainer, (long) gameNotificationOverlay.messageTimeLimit * 1000));
+                .ifPresent(
+                        timedMessageContainer -> timedMessageContainer.resetRemainingTime(getMessageDisplayLength()));
+    }
+
+    private long getMessageDisplayLength() {
+        return (long) gameNotificationOverlay.messageTimeLimit * 1000;
     }
 
     public static class GameNotificationOverlay extends Overlay {

--- a/common/src/main/java/com/wynntils/features/user/redirects/InventoryRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/InventoryRedirectFeature.java
@@ -69,7 +69,7 @@ public class InventoryRedirectFeature extends UserFeature {
                 // Edit the first message it gave us with the new amount
                 // editMessage doesn't return the new MessageContainer, so we can just keep re-using the first one
                 if (lastEmeraldPouchPickup > System.currentTimeMillis() - 3000 && emeraldPouchMessage != null) {
-                    NotificationManager.editMessage(emeraldPouchMessage, codedString);
+                    emeraldPouchMessage = NotificationManager.editMessage(emeraldPouchMessage, codedString);
                 } else {
                     emeraldPouchMessage = NotificationManager.queueMessage(codedString);
                 }

--- a/common/src/main/java/com/wynntils/features/user/redirects/InventoryRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/InventoryRedirectFeature.java
@@ -75,6 +75,8 @@ public class InventoryRedirectFeature extends UserFeature {
                 }
 
                 lastEmeraldPouchPickup = System.currentTimeMillis();
+
+                return;
             }
         }
 
@@ -85,6 +87,8 @@ public class InventoryRedirectFeature extends UserFeature {
                 String potionCount = matcher.group(1);
                 String potionMessage = String.format("§a+%s Potion Charges", potionCount);
                 NotificationManager.queueMessage(potionMessage);
+
+                return;
             }
         }
     }


### PR DESCRIPTION
The commits are separated into logical parts (imo). Basically, this PR does some refactoring around the above mentioned classes, fixes editing messages, and reintroduces the task render cache, as it is now much more saner to do than before.

Here is a demonstration of how overlay editing works (now correctly):

https://user-images.githubusercontent.com/49001742/206501005-0b546389-f752-49ad-8ffd-417944d3cc7a.mp4


