### PR TITLE
feat: Redirects "Scared Horse" messages to Overlay

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -336,7 +336,7 @@ public class ChatRedirectFeature extends UserFeature {
 
         @Override
         protected String getNotification(Matcher matcher) {
-            return ChatFormatting.DARK_RED + "Too many mobs nearby for horse to spawn!";
+            return ChatFormatting.DARK_RED + "Nearby mobs prevent horse spawning!";
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -67,6 +67,7 @@ public class ChatRedirectFeature extends UserFeature {
         register(new HealRedirector());
         register(new HealedByOtherRedirector());
         register(new HorseDespawnedRedirector());
+        register(new HorseScaredRedirector());
         register(new HorseSpawnFailRedirector());
         register(new LoginRedirector());
         register(new ManaDeficitRedirector());
@@ -316,6 +317,26 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         protected String getNotification(Matcher matcher) {
             return ChatFormatting.DARK_PURPLE + "Your horse has despawned.";
+        }
+    }
+
+    private class HorseScaredRedirector extends SimpleRedirector {
+        private static final Pattern SYSTEM_PATTERN =
+                Pattern.compile("§dYour horse is scared to come out right now, too many mobs are nearby.");
+
+        @Override
+        protected Pattern getSystemPattern() {
+            return SYSTEM_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return horse;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            return ChatFormatting.DARK_RED + "Too many mobs nearby for horse to spawn!";
         }
     }
 


### PR DESCRIPTION
Simple PR with a message I overlooked in #745.

![image](https://user-images.githubusercontent.com/34697715/206590575-f8c477ce-be13-4273-8830-3307fcc9db0d.png)

Changed chat formatting to red since it's an "alert" that the horse can't spawn rather than a "take it or leave it message". If you haven't seen it before, try and spawn a horse in an area crowded with NPCs in Rymek (that's how I discovered it).

I think the message is a bit too long, but I'm not sure what a briefer way to communicate is. Would appreciate any further thoughts.