### PR TITLE
feat: Redirects "Selling Ingredients" Ingredient Pouch Message to Overlay

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -359,11 +359,11 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         protected String getNotification(Matcher matcher) {
             Integer ingredientCount = Integer.parseInt(matcher.group(1));
-            String ingredientString = ingredientCount.toString() + " ingredient" + (ingredientCount == 1 ? "" : "s");
+            String ingredientString = ingredientCount.toString() + " §dingredient" + (ingredientCount == 1 ? "" : "s");
 
             String emeraldString = matcher.group(2);
 
-            String formattedOverlayString = String.format("§dSold §7%s for §a%s§d.", ingredientString, emeraldString);
+            String formattedOverlayString = String.format("§dSold §7%s §dfor §a%s§d.", ingredientString, emeraldString);
 
             return formattedOverlayString;
         }

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.features.user.redirects;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.chat.MessageType;
 import com.wynntils.core.chat.RecipientType;
 import com.wynntils.core.config.Config;
@@ -343,7 +344,7 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class IngredientPouchSellRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile("§4You have sold (.+) ingredients for a total of §r§e(.+)§r§4.");
+        private static final Pattern NORMAL_PATTERN = Pattern.compile("§dYou have sold §r§7(.+)§r§d ingredients for a total of §r§a(.+)§r§d\\.$");
 
         @Override
         protected Pattern getNormalPattern() {

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -359,12 +359,13 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         protected String getNotification(Matcher matcher) {
             Integer ingredientCount = Integer.parseInt(matcher.group(1));
-            String ingredientSting = ingredientCount.toString() + " ingredient" + (ingredientCount == 1 ? "" : "s");
+            String ingredientString = ingredientCount.toString() + " ingredient" + (ingredientCount == 1 ? "" : "s");
 
             String emeraldString = matcher.group(2);
 
-            return ChatFormatting.DARK_PURPLE + "Sold " + ingredientSting + " for " + ChatFormatting.GREEN
-                    + emeraldString + ChatFormatting.DARK_PURPLE + ".";
+            String formattedOverlayString = String.format("§dSold §7%s for §a%s§d.", ingredientString, emeraldString);
+
+            return formattedOverlayString;
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.features.user.redirects;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.chat.MessageType;
 import com.wynntils.core.chat.RecipientType;
 import com.wynntils.core.config.Config;
@@ -344,7 +343,8 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class IngredientPouchSellRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile("§dYou have sold §r§7(.+)§r§d ingredients for a total of §r§a(.+)§r§d\\.$");
+        private static final Pattern NORMAL_PATTERN =
+                Pattern.compile("§dYou have sold §r§7(.+)§r§d ingredients for a total of §r§a(.+)§r§d\\.$");
 
         @Override
         protected Pattern getNormalPattern() {
@@ -360,10 +360,11 @@ public class ChatRedirectFeature extends UserFeature {
         protected String getNotification(Matcher matcher) {
             Integer ingredientCount = Integer.parseInt(matcher.group(1));
             String ingredientSting = ingredientCount.toString() + " ingredient" + (ingredientCount == 1 ? "" : "s");
-            
+
             String emeraldString = matcher.group(2);
 
-            return ChatFormatting.DARK_PURPLE + "Sold " + ingredientSting + " for " + ChatFormatting.GREEN + emeraldString + ChatFormatting.DARK_PURPLE + ".";
+            return ChatFormatting.DARK_PURPLE + "Sold " + ingredientSting + " for " + ChatFormatting.GREEN
+                    + emeraldString + ChatFormatting.DARK_PURPLE + ".";
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -35,6 +35,9 @@ public class ChatRedirectFeature extends UserFeature {
     public RedirectAction horse = RedirectAction.REDIRECT;
 
     @Config
+    public RedirectAction ingredientPouch = RedirectAction.REDIRECT;
+
+    @Config
     public RedirectAction loginAnnouncements = RedirectAction.REDIRECT;
 
     @Config
@@ -68,6 +71,7 @@ public class ChatRedirectFeature extends UserFeature {
         register(new HealedByOtherRedirector());
         register(new HorseDespawnedRedirector());
         register(new HorseSpawnFailRedirector());
+        register(new IngredientPouchSellRedirector());
         register(new LoginRedirector());
         register(new ManaDeficitRedirector());
         register(new NoTotemRedirector());
@@ -335,6 +339,30 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         protected String getNotification(Matcher matcher) {
             return ChatFormatting.DARK_RED + "No room for a horse!";
+        }
+    }
+
+    private class IngredientPouchSellRedirector extends SimpleRedirector {
+        private static final Pattern NORMAL_PATTERN = Pattern.compile("§4You have sold (.+) ingredients for a total of §r§e(.+)§r§4.");
+
+        @Override
+        protected Pattern getNormalPattern() {
+            return NORMAL_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return ingredientPouch;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            Integer ingredientCount = Integer.parseInt(matcher.group(1));
+            String ingredientSting = ingredientCount.toString() + " ingredient" + (ingredientCount == 1 ? "" : "s");
+            
+            String emeraldString = matcher.group(2);
+
+            return ChatFormatting.DARK_PURPLE + "Sold " + ingredientSting + " for " + ChatFormatting.GREEN + emeraldString + ChatFormatting.DARK_PURPLE + ".";
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -343,12 +343,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class IngredientPouchSellRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN =
+        private static final Pattern SYSTEM_PATTERN =
                 Pattern.compile("§dYou have sold §r§7(.+)§r§d ingredients for a total of §r§a(.+)§r§d\\.$");
 
         @Override
-        protected Pattern getNormalPattern() {
-            return NORMAL_PATTERN;
+        protected Pattern getSystemPattern() {
+            return SYSTEM_PATTERN;
         }
 
         @Override

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -40,6 +40,8 @@
   "feature.wynntils.chatRedirect.heal.name": "Heal Message Filtering",
   "feature.wynntils.chatRedirect.horse.description": "How should messages relating to your horse appear?",
   "feature.wynntils.chatRedirect.horse.name": "Horse Message Filtering",
+  "feature.wynntils.chatRedirect.ingredientPouch.description": "How should messages about selling the contents of your ingredient pouch appear?",
+  "feature.wynntils.chatRedirect.ingredientPouch.name": "Ingredient Pouch Sale Message Filtering",
   "feature.wynntils.chatRedirect.loginAnnouncements.description": "How should login messages appear?",
   "feature.wynntils.chatRedirect.loginAnnouncements.name": "Login Message Filtering",
   "feature.wynntils.chatRedirect.name": "Info Message Filter",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34697715/206596085-e566fc7c-9a89-4faa-9b72-4322e2cfe9b1.png)

![image](https://user-images.githubusercontent.com/34697715/206596090-a2662856-3ca5-4358-90ad-e205bd5ecb48.png)

The reason why I chose to do the formatted string is because there's a few moving variables (not unlike #743) in order to get a good-looking message that matches both the Wynncraft Chat Message as well as remain in-line with an already existing Overlay message format (Blacksmith Item Redirect).