### PR TITLE
fix: Clean up ServerListModel and ServerCommand

### DIFF
--- a/common/src/main/java/com/wynntils/commands/ServerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ServerCommand.java
@@ -13,13 +13,8 @@ import com.wynntils.core.commands.CommandBase;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.wynn.model.ServerListModel;
 import com.wynntils.wynn.objects.profiles.ServerProfile;
-import com.wynntils.wynn.utils.WynnUtils;
-import java.io.IOException;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
@@ -28,6 +23,8 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
 
 public class ServerCommand extends CommandBase {
+    private static final int UPDATE_TIME_OUT_MS = 3000;
+
     @Override
     public void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         LiteralCommandNode<CommandSourceStack> node = dispatcher.register(getBaseCommandBuilder());
@@ -82,10 +79,7 @@ public class ServerCommand extends CommandBase {
     }
 
     private int serverInfo(CommandContext<CommandSourceStack> context) {
-        HashMap<String, ServerProfile> servers;
-        try {
-            servers = ServerListModel.getServerList();
-        } catch (IOException e) {
+        if (!ServerListModel.forceUpdate(UPDATE_TIME_OUT_MS)) {
             context.getSource()
                     .sendFailure(
                             new TextComponent("Failed to get server data from API.").withStyle(ChatFormatting.RED));
@@ -102,12 +96,12 @@ public class ServerCommand extends CommandBase {
         } catch (Exception ignored) {
         }
 
-        if (!servers.containsKey(server)) {
+        ServerProfile serverProfile = ServerListModel.getServer(server);
+        if (serverProfile == null) {
             context.getSource().sendFailure(new TextComponent(server + " not found.").withStyle(ChatFormatting.RED));
             return 1;
         }
 
-        ServerProfile serverProfile = servers.get(server);
         Set<String> players = serverProfile.getPlayers();
         MutableComponent message = new TextComponent(server + ":" + "\n")
                 .withStyle(ChatFormatting.GOLD)
@@ -128,10 +122,7 @@ public class ServerCommand extends CommandBase {
     }
 
     private int serverList(CommandContext<CommandSourceStack> context) {
-        Map<String, List<String>> onlinePlayers;
-        try {
-            onlinePlayers = ServerListModel.getOnlinePlayers();
-        } catch (IOException e) {
+        if (!ServerListModel.forceUpdate(3000)) {
             context.getSource()
                     .sendFailure(
                             new TextComponent("Failed to get server data from API.").withStyle(ChatFormatting.RED));
@@ -140,16 +131,8 @@ public class ServerCommand extends CommandBase {
 
         MutableComponent message = new TextComponent("Server list:").withStyle(ChatFormatting.DARK_AQUA);
 
-        for (String serverType : WynnUtils.getWynnServerTypes()) {
-            List<String> currentTypeServers = onlinePlayers.keySet().stream()
-                    .filter(server -> server.startsWith(serverType))
-                    .sorted((o1, o2) -> {
-                        int number1 = Integer.parseInt(o1.substring(serverType.length()));
-                        int number2 = Integer.parseInt(o2.substring(serverType.length()));
-
-                        return number1 - number2;
-                    })
-                    .toList();
+        for (String serverType : ServerListModel.getWynnServerTypes()) {
+            List<String> currentTypeServers = ServerListModel.getServersSortedOnNameOfType(serverType);
 
             if (currentTypeServers.isEmpty()) continue;
 
@@ -168,24 +151,21 @@ public class ServerCommand extends CommandBase {
     }
 
     private int serverUptimeList(CommandContext<CommandSourceStack> context) {
-        HashMap<String, ServerProfile> servers;
-        try {
-            servers = ServerListModel.getServerList();
-        } catch (IOException e) {
+        if (!ServerListModel.forceUpdate(3000)) {
             context.getSource()
                     .sendFailure(
                             new TextComponent("Failed to get server data from API.").withStyle(ChatFormatting.RED));
             return 1;
         }
 
+        List<String> sortedServers = ServerListModel.getServersSortedOnUptime();
+
         MutableComponent message = new TextComponent("Server list:").withStyle(ChatFormatting.DARK_AQUA);
-        for (Map.Entry<String, ServerProfile> entry : servers.entrySet().stream()
-                .sorted(Comparator.comparing(profile -> profile.getValue().getUptime()))
-                .toList()) {
+        for (String server : sortedServers) {
             message.append("\n");
-            message.append(
-                    new TextComponent(entry.getKey() + ": " + entry.getValue().getUptime())
-                            .withStyle(ChatFormatting.AQUA));
+            message.append(new TextComponent(
+                            server + ": " + ServerListModel.getServer(server).getUptime())
+                    .withStyle(ChatFormatting.AQUA));
         }
 
         context.getSource().sendSuccess(message, false);

--- a/common/src/main/java/com/wynntils/wynn/model/ServerListModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ServerListModel.java
@@ -4,12 +4,10 @@
  */
 package com.wynntils.wynn.model;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.managers.Model;
 import com.wynntils.core.net.athena.WynntilsAccountManager;
 import com.wynntils.core.webapi.WebManager;
@@ -17,33 +15,61 @@ import com.wynntils.wynn.event.WorldStateEvent;
 import com.wynntils.wynn.objects.profiles.ServerProfile;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Type;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class ServerListModel extends Model {
-    private static final Gson GSON = new Gson();
+    private static final List<String> SERVER_TYPES = List.of("WC", "lobby", "GM", "DEV", "WAR", "HB", "YT");
+    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
 
+    private static final Gson GSON = new Gson();
     private static Map<String, ServerProfile> availableServers = new HashMap<>();
 
-    public static void init() {}
+    public static void init() {
+        updateServerList(0);
+    }
 
-    public static synchronized void updateServers() {
-        try {
-            availableServers = getServerList();
-        } catch (IOException e) {
-            WynntilsMod.error("Failed to update server list", e);
-        }
+    public static List<String> getWynnServerTypes() {
+        return SERVER_TYPES;
+    }
+
+    public static Set<String> getServers() {
+        return availableServers.keySet();
+    }
+
+    public static List<String> getServersSortedOnUptime() {
+        return getServers().stream()
+                .sorted(Comparator.comparing(profile -> getServer(profile).getUptime()))
+                .toList();
+    }
+
+    public static List<String> getServersSortedOnNameOfType(String serverType) {
+        return getServers().stream()
+                .filter(server -> server.startsWith(serverType))
+                .sorted((o1, o2) -> {
+                    int number1 = Integer.parseInt(o1.substring(serverType.length()));
+                    int number2 = Integer.parseInt(o2.substring(serverType.length()));
+
+                    return number1 - number2;
+                })
+                .toList();
     }
 
     public static ServerProfile getServer(String worldId) {
         return availableServers.get(worldId);
+    }
+
+    public static boolean forceUpdate(int timeOutMs) {
+        // timeOutMs is currently ignored; will be fixed soon
+        return updateNow();
     }
 
     @SubscribeEvent
@@ -51,54 +77,39 @@ public class ServerListModel extends Model {
         if (event.getNewState() != WorldStateManager.State.HUB
                 && event.getNewState() != WorldStateManager.State.CONNECTING) return;
 
-        // Run async to avoid blocking the render thread
-        new Thread(ServerListModel::updateServers).start();
+        updateServerList(0);
     }
 
-    public static HashMap<String, ServerProfile> getServerList() throws IOException {
-        if (WebManager.apiUrls == null || !WynntilsAccountManager.isLoggedIn()) return new HashMap<>();
+    private static boolean updateNow() {
+        if (WebManager.apiUrls == null || !WynntilsAccountManager.isLoggedIn()) return false;
         String url = WebManager.apiUrls.get("Athena") + "/cache/get/serverList";
 
-        URLConnection st = WebManager.generateURLRequest(url);
-        InputStreamReader stInputReader = new InputStreamReader(st.getInputStream(), StandardCharsets.UTF_8);
-        JsonObject json = JsonParser.parseReader(stInputReader).getAsJsonObject();
+        try {
+            URLConnection st = WebManager.generateURLRequest(url);
+            InputStreamReader stInputReader = new InputStreamReader(st.getInputStream(), StandardCharsets.UTF_8);
+            JsonObject json = JsonParser.parseReader(stInputReader).getAsJsonObject();
 
-        JsonObject servers = json.getAsJsonObject("servers");
-        HashMap<String, ServerProfile> result = new HashMap<>();
+            JsonObject servers = json.getAsJsonObject("servers");
+            Map<String, ServerProfile> newMap = new HashMap<>();
 
-        long serverTime = Long.parseLong(st.getHeaderField("timestamp"));
-        for (Map.Entry<String, JsonElement> entry : servers.entrySet()) {
-            ServerProfile profile = GSON.fromJson(entry.getValue(), ServerProfile.class);
-            profile.matchTime(serverTime);
+            long serverTime = Long.parseLong(st.getHeaderField("timestamp"));
+            for (Map.Entry<String, JsonElement> entry : servers.entrySet()) {
+                ServerProfile profile = GSON.fromJson(entry.getValue(), ServerProfile.class);
+                profile.matchTime(serverTime);
 
-            result.put(entry.getKey(), profile);
+                newMap.put(entry.getKey(), profile);
+            }
+
+            availableServers = newMap;
+        } catch (IOException e) {
+            return false;
         }
-
-        return result;
+        return true;
     }
 
-    /**
-     * Request all online players to WynnAPI
-     *
-     * @return a {@link HashMap} who the key is the server and the value is an array containing all
-     *     players on it
-     * @throws IOException thrown by URLConnection
-     */
-    public static Map<String, List<String>> getOnlinePlayers() throws IOException {
-        if (WebManager.apiUrls == null || !WebManager.apiUrls.hasKey("OnlinePlayers")) return new HashMap<>();
-
-        URLConnection st = WebManager.generateURLRequest(WebManager.apiUrls.get("OnlinePlayers"));
-        InputStreamReader stInputReader = new InputStreamReader(st.getInputStream(), StandardCharsets.UTF_8);
-        JsonObject main = JsonParser.parseReader(stInputReader).getAsJsonObject();
-
-        if (!main.has("message")) {
-            main.remove("request");
-
-            Type type = new TypeToken<LinkedHashMap<String, ArrayList<String>>>() {}.getType();
-
-            return GSON.fromJson(main, type);
-        } else {
-            return new HashMap<>();
-        }
+    private static void updateServerList(int timeOutMs) {
+        // Will update in background
+        // timeOutMs is currently ignored; will be fixed soon
+        EXECUTOR.submit(ServerListModel::updateNow);
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/utils/WynnUtils.java
+++ b/common/src/main/java/com/wynntils/wynn/utils/WynnUtils.java
@@ -4,10 +4,8 @@
  */
 package com.wynntils.wynn.utils;
 
-import com.google.common.collect.Lists;
 import com.wynntils.wynn.model.CharacterManager;
 import com.wynntils.wynn.model.WorldStateManager;
-import java.util.List;
 
 public final class WynnUtils {
     /**
@@ -41,9 +39,5 @@ public final class WynnUtils {
 
     public static boolean hasCharacterInfo() {
         return CharacterManager.hasCharacter();
-    }
-
-    public static List<String> getWynnServerTypes() {
-        return Lists.newArrayList("WC", "lobby", "GM", "DEV", "WAR", "HB");
     }
 }


### PR DESCRIPTION
This is in preparation for the webapi refactor. It also fixes some issues with the `/server` command.

Changes: Make ServerListModel take more responsibility for its domain: Move getWynnServerTypes() here, move functionality for returning sorted server lists here.

Fix: stop using Wynncraft API directly, instead always use Athena.

Fix: introduce explicit request to refresh data from Athena before replying to /server commands.

Fix: Add "YT" to server type list.

Modernization: Use ScheduledExecutorService instead of starting a new thread.