### PR TITLE
fix: Healing Yourself With A Potion properly redirects to overlay

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -262,10 +262,16 @@ public class ChatRedirectFeature extends UserFeature {
 
     private class HealRedirector extends SimpleRedirector {
         private static final Pattern NORMAL_PATTERN = Pattern.compile("^§r§c\\[\\+(\\d+) ❤\\]$");
+        private static final Pattern BACKGROUND_PATTERN = Pattern.compile("^§r§7§o\\[\\+(\\d+) ❤\\]$");
 
         @Override
         protected Pattern getNormalPattern() {
             return NORMAL_PATTERN;
+        }
+
+        @Override
+        protected Pattern getBackgroundPattern() {
+            return BACKGROUND_PATTERN;
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -261,17 +261,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class HealRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile("^§r§c\\[\\+(\\d+) ❤\\]$");
-        private static final Pattern BACKGROUND_PATTERN = Pattern.compile("^§r§7§o\\[\\+(\\d+) ❤\\]$");
+        private static final Pattern SYSTEM_PATTERN = Pattern.compile("^§c\\[\\+(\\d+) ❤\\]$");
 
         @Override
-        protected Pattern getNormalPattern() {
-            return NORMAL_PATTERN;
-        }
-
-        @Override
-        protected Pattern getBackgroundPattern() {
-            return BACKGROUND_PATTERN;
+        protected Pattern getSystemPattern() {
+            return SYSTEM_PATTERN;
         }
 
         @Override


### PR DESCRIPTION
This feature was apparently implemented, but it didn't work:
![image](https://user-images.githubusercontent.com/34697715/206886536-9e38af4b-c86d-407d-8e0d-84435c33d9c5.png)

I looked into it, and after a few potions, it turned out that this is actually a system message! How odd, I wonder if that changed at some point in time since the "Healed by Other" message has worked perfectly fine this entire time (which is a Normal/Background message).

Also, we had a `§r` there for some reason, even though Wynncraft sends the message as `§c[+4500 ?]` (pretend the question mark is a heart symbol). Two concurrent bugs, perhaps?

Here's what it looks like now that it's fixed.

![image](https://user-images.githubusercontent.com/34697715/206886553-894dc593-e413-408c-994c-a012d8c2c531.png)