### PR TITLE
fix: Ability Point Redirect Message now works with Pluralization

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -617,7 +617,7 @@ public class ChatRedirectFeature extends UserFeature {
 
     private class UnusedAbilityPointsRedirector extends SimpleRedirector {
         private static final Pattern SYSTEM_PATTERN = Pattern.compile(
-                "^§4You have §r§b§l(\\d+) unused Ability Point?! §r§4Right-Click while holding your compass to use them$");
+                "^§4You have §r§b§l(\\d+) unused Ability Points?! §r§4Right-Click while holding your compass to use them$");
 
         @Override
         protected Pattern getSystemPattern() {
@@ -644,7 +644,7 @@ public class ChatRedirectFeature extends UserFeature {
 
     private class UnusedSkillAndAbilityPointsRedirector implements Redirector {
         private static final Pattern SYSTEM_PATTERN = Pattern.compile(
-                "^§4You have §r§c§l(\\d+) unused Skill Points?§r§4 and §r§b§l(\\d+) unused Ability Point?! §r§4Right-Click while holding your compass to use them$");
+                "^§4You have §r§c§l(\\d+) unused Skill Points?§r§4 and §r§b§l(\\d+) unused Ability Points?! §r§4Right-Click while holding your compass to use them$");
 
         @Override
         public Pattern getPattern(MessageType messageType) {


### PR DESCRIPTION
Seems to have been introduced in #805.

example of this failing:

![image](https://user-images.githubusercontent.com/34697715/206887198-426af55f-5e67-4378-b488-07a1dfc92b63.png)


the `?` was matching to the `t` in `point`, rather than be a pluralization checker for potential `points` message in case someone insane has multiple unused skill points and ability points.