### PR TITLE
fix: Resolve the UrlManager/NetManager circularity

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/NetManager.java
+++ b/common/src/main/java/com/wynntils/core/net/NetManager.java
@@ -33,6 +33,9 @@ public class NetManager extends Manager {
             WynntilsMod.getModLoader());
 
     public NetManager(UrlManager urlManager) {
+        // NetManager is involved in a circular dependency with UrlManager. This means
+        // it will be instantiated twice, first as a throw-away instance local to UrlManager
+        // bootstrapping only, then as the real instance for Managers.
         super(List.of(urlManager));
     }
 


### PR DESCRIPTION
This was introduced with the NetManager rewrite, and meant that the UrlManager did not download new URLs from the net as early as it should