### PR TITLE
fix: Remove all references to Managers.CrashReport in CrashReportManager

### DIFF
--- a/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
+++ b/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
@@ -5,8 +5,6 @@
 package com.wynntils.core.mod;
 
 import com.wynntils.core.managers.Manager;
-import com.wynntils.core.managers.Managers;
-import com.wynntils.mc.utils.McUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
+++ b/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
@@ -15,9 +15,16 @@ import net.minecraft.CrashReportCategory;
 
 public final class CrashReportManager extends Manager {
     private final Map<String, Supplier<String>> crashHandlers = new HashMap<>();
+    private static CrashReportManager instance = null;
 
     public CrashReportManager() {
         super(List.of());
+        if (instance != null) {
+            // Save a local copy since we can't rely on being able to use the
+            // Managers class in case of a crash. Note especially that minecraft does a
+            // CrashReport.preload() early at game startup
+            instance = this;
+        }
     }
 
     public void registerCrashContext(String name, Supplier<String> handler) {
@@ -27,12 +34,12 @@ public final class CrashReportManager extends Manager {
     public static CrashReportCategory generateDetails() {
         CrashReportCategory wynntilsCategory = new CrashReportCategory("Wynntils");
 
-        if (McUtils.mc() == null) {
+        if (instance == null) {
             wynntilsCategory.setDetail("No crash handler loaded yet", "");
             return wynntilsCategory;
         }
 
-        Map<String, Supplier<String>> crashHandlers = Managers.CrashReport.getCrashHandlers();
+        Map<String, Supplier<String>> crashHandlers = instance.getCrashHandlers();
         for (String handlerName : crashHandlers.keySet()) {
             String report = crashHandlers.get(handlerName).get();
             if (report != null) {

--- a/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
+++ b/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
@@ -38,10 +38,10 @@ public final class CrashReportManager extends Manager {
         }
 
         Map<String, Supplier<String>> crashHandlers = instance.getCrashHandlers();
-        for (String handlerName : crashHandlers.keySet()) {
-            String report = crashHandlers.get(handlerName).get();
+        for (Map.Entry<String, Supplier<String>> entry : crashHandlers.entrySet()) {
+            String report = entry.getValue().get();
             if (report != null) {
-                wynntilsCategory.setDetail(handlerName, report);
+                wynntilsCategory.setDetail(entry.getKey(), report);
             }
         }
 


### PR DESCRIPTION
Thanks @P0keDev for fixing the urgent crash. The reason for the crash is that Minecraft does `CrashReport.preload()` very early on in the bootstrapping, to "oil the machinery" for generating crash reports. This ended up calling our hook long before `Managers` where loaded.

P0ke's patch fixed the crash from `preload`, but there still were a reference to `Managers.CrashReport` shortly after, which could have NPE'd if we got an actual crash after the mc instance was non-null, but Managers.CrashReport was not available.

Instead, keep local track of our instance, and use it.