### PR TITLE
feat: Snappier and more robust quest book

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/WynntilsQuestBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/WynntilsQuestBookFeature.java
@@ -62,7 +62,7 @@ public class WynntilsQuestBookFeature extends UserFeature {
         if (itemInHand != null
                 && ComponentUtils.getCoded(itemInHand.getHoverName()).equals(QUEST_BOOK_NAME)) {
             event.setCanceled(true);
-            McUtils.mc().setScreen(new WynntilsMenuScreen());
+            McUtils.mc().setScreen(new WynntilsQuestBookScreen());
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/overlays/QuestInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/QuestInfoOverlayFeature.java
@@ -63,7 +63,7 @@ public class QuestInfoOverlayFeature extends UserFeature {
         if (!autoTrackQuestCoordinates) return;
 
         // set if valid
-        Models.Compass.setDynamicCompassLocation(Managers.Quest::getCurrentQuestLocation);
+        Models.Compass.setDynamicCompassLocation(Managers.Quest::getTrackedQuestNextLocation);
     }
 
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI)
@@ -140,14 +140,14 @@ public class QuestInfoOverlayFeature extends UserFeature {
 
         @Override
         public void render(PoseStack poseStack, float partialTicks, Window window) {
-            QuestInfo currentQuest = Managers.Quest.getCurrentQuest();
+            QuestInfo trackedQuest = Managers.Quest.getTrackedQuest();
 
-            if (currentQuest == null) {
+            if (trackedQuest == null) {
                 return;
             }
 
-            toRender.get(1).setText(currentQuest.getName());
-            toRender.get(2).setText(currentQuest.getNextTask());
+            toRender.get(1).setText(trackedQuest.getName());
+            toRender.get(2).setText(trackedQuest.getNextTask());
 
             FontRenderer.getInstance()
                     .renderTextsWithAlignment(

--- a/common/src/main/java/com/wynntils/gui/widgets/QuestButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/QuestButton.java
@@ -17,6 +17,7 @@ import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.mc.objects.Location;
 import com.wynntils.mc.utils.McUtils;
+import com.wynntils.utils.Pair;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.wynn.model.quests.QuestInfo;
 import java.util.Optional;
@@ -27,10 +28,12 @@ import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
 public class QuestButton extends AbstractButton {
-    private static final CustomColor BUTTON_COLOR = new CustomColor(181, 174, 151);
-    private static final CustomColor BUTTON_COLOR_HOVERED = new CustomColor(121, 116, 101);
-    private static final CustomColor TRACKED_BUTTON_COLOR = new CustomColor(176, 197, 148);
-    private static final CustomColor TRACKED_BUTTON_COLOR_HOVERED = new CustomColor(126, 211, 106);
+    private static final Pair<CustomColor, CustomColor> BUTTON_COLOR =
+            Pair.of(new CustomColor(181, 174, 151), new CustomColor(121, 116, 101));
+    private static final Pair<CustomColor, CustomColor> TRACKED_BUTTON_COLOR =
+            Pair.of(new CustomColor(176, 197, 148), new CustomColor(126, 211, 106));
+    private static final Pair<CustomColor, CustomColor> TRACKING_REQUESTED_BUTTON_COLOR =
+            Pair.of(new CustomColor(255, 206, 127), new CustomColor(255, 196, 50));
     private final QuestInfo questInfo;
     private final WynntilsQuestBookScreen questBookScreen;
 
@@ -42,10 +45,7 @@ public class QuestButton extends AbstractButton {
 
     @Override
     public void renderButton(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
-        CustomColor backgroundColor = questBookScreen.getTracked() == this.questInfo
-                ? (this.isHovered ? TRACKED_BUTTON_COLOR_HOVERED : TRACKED_BUTTON_COLOR)
-                : (this.isHovered ? BUTTON_COLOR_HOVERED : BUTTON_COLOR);
-
+        CustomColor backgroundColor = getBackgroundColor();
         RenderUtils.drawRect(poseStack, backgroundColor, this.x, this.y, 0, this.width, this.height);
 
         int maxTextWidth = this.width - 10 - 11;
@@ -83,6 +83,20 @@ public class QuestButton extends AbstractButton {
                 stateTexture.height());
     }
 
+    private CustomColor getBackgroundColor() {
+        Pair<CustomColor, CustomColor> colors;
+
+        if (this.questInfo.equals(Managers.Quest.getTrackedQuest())) {
+            colors = TRACKED_BUTTON_COLOR;
+        } else if (this.questInfo.equals(questBookScreen.getTrackingRequested())) {
+            colors = TRACKING_REQUESTED_BUTTON_COLOR;
+        } else {
+            colors = BUTTON_COLOR;
+        }
+
+        return (this.isHovered ? colors.b() : colors.a());
+    }
+
     // Not called
     @Override
     public void onPress() {}
@@ -106,12 +120,12 @@ public class QuestButton extends AbstractButton {
     private void trackQuest() {
         if (this.questInfo.isTrackable()) {
             McUtils.playSound(SoundEvents.ANVIL_LAND);
-            Managers.Quest.toggleTracking(this.questInfo);
-
-            if (questBookScreen.getTracked() != this.questInfo) {
-                questBookScreen.setTracked(this.questInfo);
+            if (this.questInfo.equals(Managers.Quest.getTrackedQuest())) {
+                Managers.Quest.stopTracking();
+                questBookScreen.setTrackingRequested(null);
             } else {
-                questBookScreen.setTracked(null);
+                Managers.Quest.startTracking(this.questInfo);
+                questBookScreen.setTrackingRequested(this.questInfo);
             }
         }
     }

--- a/common/src/main/java/com/wynntils/utils/Pair.java
+++ b/common/src/main/java/com/wynntils/utils/Pair.java
@@ -26,4 +26,8 @@ public record Pair<T, J>(T a, J b) {
 
         return Objects.deepEquals(a, other.a) && Objects.deepEquals(b, other.b);
     }
+
+    public static <T, J> Pair of(T a, J b) {
+        return new Pair(a, b);
+    }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestContainerQueries.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestContainerQueries.java
@@ -26,6 +26,7 @@ public class QuestContainerQueries {
 
     private List<QuestInfo> newQuests;
     private List<QuestInfo> newMiniQuests;
+    private QuestInfo trackedQuest;
 
     /**
      * Trigger a rescan of the quest book. When the rescan is done, a QuestBookReloadedEvent will
@@ -71,12 +72,15 @@ public class QuestContainerQueries {
                 if (questInfo == null) continue;
 
                 newQuests.add(questInfo);
+                if (questInfo.isTracked()) {
+                    trackedQuest = questInfo;
+                }
             }
         }
 
         if (page == 4) {
             // Last page finished
-            Managers.Quest.setQuests(newQuests);
+            Managers.Quest.updateQuestsFromQuery(newQuests, trackedQuest);
         }
     }
 
@@ -123,13 +127,16 @@ public class QuestContainerQueries {
                 QuestInfo questInfo = QuestInfoParser.parseItem(item, page, true);
                 if (questInfo == null) continue;
 
+                if (questInfo.isTracked()) {
+                    trackedQuest = questInfo;
+                }
                 newMiniQuests.add(questInfo);
             }
         }
 
         if (page == 3) {
             // Last page finished
-            Managers.Quest.setMiniQuests(newMiniQuests);
+            Managers.Quest.updateMiniQuestsFromQuery(newMiniQuests, trackedQuest);
         }
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
@@ -126,28 +126,24 @@ public class QuestInfo {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-
-        if (o == null || getClass() != o.getClass()) return false;
-
-        QuestInfo questInfo = (QuestInfo) o;
+        if (o == null || (!(o instanceof QuestInfo questInfo))) return false;
 
         // Consider it the same quest just based on "constant" aspects of the quest
-        return new EqualsBuilder()
-                .append(level, questInfo.level)
-                .append(isMiniQuest, questInfo.isMiniQuest)
-                .append(name, questInfo.name)
-                .append(length, questInfo.length)
-                .isEquals();
+        if (level != questInfo.level) return false;
+        if (isMiniQuest != questInfo.isMiniQuest) return false;
+        if (!name.equals(questInfo.name)) return false;
+        if (length != questInfo.length) return false;
+        return additionalRequirements.equals(questInfo.additionalRequirements);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(name)
-                .append(length)
-                .append(level)
-                .append(isMiniQuest)
-                .toHashCode();
+        int result = name.hashCode();
+        result = 31 * result + length.hashCode();
+        result = 31 * result + level;
+        result = 31 * result + additionalRequirements.hashCode();
+        result = 31 * result + (isMiniQuest ? 1 : 0);
+        return result;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
@@ -132,12 +132,22 @@ public class QuestInfo {
         QuestInfo questInfo = (QuestInfo) o;
 
         // Consider it the same quest just based on "constant" aspects of the quest
-        return new EqualsBuilder().append(level, questInfo.level).append(isMiniQuest, questInfo.isMiniQuest).append(name, questInfo.name).append(length, questInfo.length).isEquals();
+        return new EqualsBuilder()
+                .append(level, questInfo.level)
+                .append(isMiniQuest, questInfo.isMiniQuest)
+                .append(name, questInfo.name)
+                .append(length, questInfo.length)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37).append(name).append(length).append(level).append(isMiniQuest).toHashCode();
+        return new HashCodeBuilder(17, 37)
+                .append(name)
+                .append(length)
+                .append(level)
+                .append(isMiniQuest)
+                .toHashCode();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
@@ -13,6 +13,7 @@ import com.wynntils.wynn.objects.profiles.ingredient.ProfessionType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -124,24 +125,18 @@ public class QuestInfo {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || (!(o instanceof QuestInfo questInfo))) return false;
-
-        // Consider it the same quest just based on "constant" aspects of the quest
-        if (level != questInfo.level) return false;
-        if (isMiniQuest != questInfo.isMiniQuest) return false;
-        if (!name.equals(questInfo.name)) return false;
-        if (length != questInfo.length) return false;
-        return additionalRequirements.equals(questInfo.additionalRequirements);
+        if (o == null || getClass() != o.getClass()) return false;
+        QuestInfo questInfo = (QuestInfo) o;
+        return level == questInfo.level
+                && isMiniQuest == questInfo.isMiniQuest
+                && Objects.equals(name, questInfo.name)
+                && length == questInfo.length
+                && Objects.equals(additionalRequirements, questInfo.additionalRequirements);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + length.hashCode();
-        result = 31 * result + level;
-        result = 31 * result + additionalRequirements.hashCode();
-        result = 31 * result + (isMiniQuest ? 1 : 0);
-        return result;
+        return Objects.hash(name, length, level, additionalRequirements, isMiniQuest);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
@@ -20,8 +20,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class QuestInfo {
     private static final int NEXT_TASK_MAX_WIDTH = 200;

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
@@ -20,6 +20,8 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class QuestInfo {
     private static final int NEXT_TASK_MAX_WIDTH = 200;
@@ -119,6 +121,23 @@ public class QuestInfo {
 
     public boolean isMiniQuest() {
         return isMiniQuest;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QuestInfo questInfo = (QuestInfo) o;
+
+        // Consider it the same quest just based on "constant" aspects of the quest
+        return new EqualsBuilder().append(level, questInfo.level).append(isMiniQuest, questInfo.isMiniQuest).append(name, questInfo.name).append(length, questInfo.length).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).append(name).append(length).append(level).append(isMiniQuest).toHashCode();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.apache.commons.lang3.StringUtils;
 
 public final class QuestManager extends Manager {
     public static final QuestScoreboardHandler SCOREBOARD_HANDLER = new QuestScoreboardHandler();
@@ -31,7 +32,9 @@ public final class QuestManager extends Manager {
     private List<QuestInfo> quests = List.of();
     private List<QuestInfo> miniQuests = List.of();
     private List<List<String>> dialogueHistory = List.of();
-    private QuestInfo currentQuest = null;
+    private QuestInfo trackedQuest = null;
+    private String afterRescanName;
+    private String afterRescanTask;
 
     public QuestManager(NetManager netManager) {
         super(List.of(netManager));
@@ -39,8 +42,16 @@ public final class QuestManager extends Manager {
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onWorldStateChanged(WorldStateEvent e) {
+        reset();
+    }
+
+    private void reset() {
         quests = List.of();
+        miniQuests = List.of();
         dialogueHistory = List.of();
+        trackedQuest = null;
+        afterRescanName = null;
+        afterRescanTask = null;
     }
 
     public void rescanQuestBook(boolean includeQuests, boolean includeMiniQuests) {
@@ -87,16 +98,16 @@ public final class QuestManager extends Manager {
         };
     }
 
-    public Optional<QuestInfo> getQuestFromName(String name) {
-        return quests.stream().filter(quest -> quest.getName().equals(name)).findFirst();
-    }
-
     public List<List<String>> getDialogueHistory() {
         return dialogueHistory;
     }
 
-    public void toggleTracking(QuestInfo questInfo) {
+    public void startTracking(QuestInfo questInfo) {
         CONTAINER_QUERIES.toggleTracking(questInfo);
+    }
+
+    public void stopTracking() {
+        McUtils.player().chat("/tracking");
     }
 
     public void openQuestOnWiki(QuestInfo questInfo) {
@@ -117,12 +128,12 @@ public final class QuestManager extends Manager {
         });
     }
 
-    public QuestInfo getCurrentQuest() {
-        return currentQuest;
+    public QuestInfo getTrackedQuest() {
+        return trackedQuest;
     }
 
-    public Location getCurrentQuestLocation() {
-        QuestInfo questInfo = getCurrentQuest();
+    public Location getTrackedQuestNextLocation() {
+        QuestInfo questInfo = getTrackedQuest();
 
         if (questInfo == null) return null;
 
@@ -133,19 +144,94 @@ public final class QuestManager extends Manager {
         return location.get();
     }
 
-    protected void setCurrentQuest(QuestInfo questInfo) {
-        currentQuest = questInfo;
-        WynntilsMod.postEvent(new TrackedQuestUpdateEvent(currentQuest));
+    public void clearTrackedQuestFromScoreBoard() {
+        updateTrackedQuest(null);
     }
 
-    protected void setQuests(List<QuestInfo> newQuests) {
+    public void updateTrackedQuestFromScoreboard(String name, String nextTask) {
+        // If our quest book has not yet been scanned, we can't update now
+        // but will do after scanning is complete
+        if (updateAfterRescan(name, nextTask)) return;
+
+        Optional<QuestInfo> questInfoOpt;
+        questInfoOpt = getQuestInfoFromName(name);
+        if (questInfoOpt.isEmpty()) {
+            WynntilsMod.warn("Cannot match quest from scoreboard to actual quest: " + name);
+            return;
+        }
+
+        QuestInfo questInfo = questInfoOpt.get();
+        questInfo.setNextTask(nextTask);
+
+        updateTrackedQuest(questInfo);
+    }
+
+    private void updateTrackedQuest(QuestInfo questInfo) {
+        trackedQuest = questInfo;
+        WynntilsMod.postEvent(new TrackedQuestUpdateEvent(trackedQuest));
+    }
+
+    private Optional<QuestInfo> getQuestInfoFromName(String name) {
+        Optional<QuestInfo> questInfoOpt;
+        if (name.startsWith("Mini-Quest - ")) {
+            String shortName = StringUtils.replaceOnce(name, "Mini-Quest - ", "");
+            questInfoOpt = Managers.Quest.miniQuests.stream()
+                    .filter(quest -> quest.getName().equals(shortName))
+                    .findFirst();
+        } else {
+            questInfoOpt = Managers.Quest.quests.stream()
+                    .filter(quest -> quest.getName().equals(name))
+                    .findFirst();
+        }
+        return questInfoOpt;
+    }
+
+    private boolean updateAfterRescan(String name, String nextTask) {
+        if (name.startsWith("Mini-Quest - ")) {
+            if (miniQuests.isEmpty()) {
+                afterRescanTask = nextTask;
+                String shortName = StringUtils.replaceOnce(name, "Mini-Quest - ", "");
+                afterRescanName = shortName;
+                rescanQuestBook(false, true);
+                return true;
+            }
+            return false;
+        } else {
+            if (quests.isEmpty()) {
+                afterRescanTask = nextTask;
+                afterRescanName = name;
+                rescanQuestBook(true, false);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    protected void updateQuestsFromQuery(List<QuestInfo> newQuests, QuestInfo trackedQuest) {
         quests = newQuests;
+        maybeUpdateTrackedQuest(trackedQuest);
         WynntilsMod.postEvent(new QuestBookReloadedEvent.QuestsReloaded());
     }
 
-    protected void setMiniQuests(List<QuestInfo> newMiniQuests) {
+    protected void updateMiniQuestsFromQuery(List<QuestInfo> newMiniQuests, QuestInfo trackedQuest) {
         miniQuests = newMiniQuests;
+        maybeUpdateTrackedQuest(trackedQuest);
         WynntilsMod.postEvent(new QuestBookReloadedEvent.MiniQuestsReloaded());
+    }
+
+    private void maybeUpdateTrackedQuest(QuestInfo trackedQuest) {
+        if (trackedQuest != this.trackedQuest) {
+            if (trackedQuest != null && trackedQuest.getName().equals(afterRescanName)) {
+                // We have stored the current task from last scoreboard update,
+                // now we can finally present it
+                trackedQuest.setNextTask(afterRescanTask);
+                afterRescanName = null;
+                afterRescanTask = null;
+                Managers.Quest.updateTrackedQuest(trackedQuest);
+            }
+            WynntilsMod.warn("Tracked Quest according to scoreboard is " + this.trackedQuest
+                    + " but query says " + trackedQuest);
+        }
     }
 
     protected void setDialogueHistory(List<List<String>> newDialogueHistory) {

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
@@ -153,8 +153,7 @@ public final class QuestManager extends Manager {
         // but will do after scanning is complete
         if (updateAfterRescan(name, nextTask)) return;
 
-        Optional<QuestInfo> questInfoOpt;
-        questInfoOpt = getQuestInfoFromName(name);
+        Optional<QuestInfo> questInfoOpt = getQuestInfoFromName(name);
         if (questInfoOpt.isEmpty()) {
             WynntilsMod.warn("Cannot match quest from scoreboard to actual quest: " + name);
             return;

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
@@ -229,8 +229,8 @@ public final class QuestManager extends Manager {
                 afterRescanTask = null;
                 Managers.Quest.updateTrackedQuest(trackedQuest);
             }
-            WynntilsMod.warn("Tracked Quest according to scoreboard is " + this.trackedQuest
-                    + " but query says " + trackedQuest);
+            WynntilsMod.warn("Tracked Quest according to scoreboard is " + this.trackedQuest + " but query says "
+                    + trackedQuest);
         }
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
@@ -172,8 +172,7 @@ public final class QuestManager extends Manager {
     }
 
     private Optional<QuestInfo> getQuestInfoFromName(String name) {
-        List<QuestInfo> questInfoList = name.startsWith(MINI_QUEST_PREFIX) ?
-                miniQuests : quests;
+        List<QuestInfo> questInfoList = name.startsWith(MINI_QUEST_PREFIX) ? miniQuests : quests;
 
         return questInfoList.stream()
                 .filter(quest -> quest.getName().equals(stripPrefix(name)))
@@ -182,8 +181,7 @@ public final class QuestManager extends Manager {
 
     private boolean updateAfterRescan(String name, String nextTask) {
         boolean isMiniQuest = name.startsWith(MINI_QUEST_PREFIX);
-        List<QuestInfo> questInfoList = isMiniQuest ?
-                miniQuests : quests;
+        List<QuestInfo> questInfoList = isMiniQuest ? miniQuests : quests;
 
         if (questInfoList.isEmpty()) {
             afterRescanTask = nextTask;

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestScoreboardHandler.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestScoreboardHandler.java
@@ -12,7 +12,6 @@ import com.wynntils.wynn.model.scoreboard.ScoreboardModel;
 import com.wynntils.wynn.model.scoreboard.Segment;
 import com.wynntils.wynn.utils.WynnUtils;
 import java.util.List;
-import java.util.Optional;
 import net.minecraft.ChatFormatting;
 
 public class QuestScoreboardHandler implements ScoreboardHandler {
@@ -37,26 +36,18 @@ public class QuestScoreboardHandler implements ScoreboardHandler {
             }
         }
 
-        Optional<QuestInfo> questInfoOpt = Managers.Quest.getQuestFromName(
-                WynnUtils.normalizeBadString(questName.toString().trim()));
-        if (questInfoOpt.isEmpty()) {
-            WynntilsMod.warn("Cannot match quest from scoreboard to actual quest: " + questName);
-            return;
-        }
-
-        QuestInfo questInfo = questInfoOpt.get();
-        questInfo.setNextTask(nextTask.toString().trim());
-
-        Managers.Quest.setCurrentQuest(questInfo);
+        String fixedName = WynnUtils.normalizeBadString(questName.toString().trim());
+        String fixedNextTask = WynnUtils.normalizeBadString(nextTask.toString().trim());
+        Managers.Quest.updateTrackedQuestFromScoreboard(fixedName, fixedNextTask);
     }
 
     @Override
     public void onSegmentRemove(Segment segment, ScoreboardModel.SegmentType segmentType) {
-        Managers.Quest.setCurrentQuest(null);
+        Managers.Quest.clearTrackedQuestFromScoreBoard();
     }
 
     @Override
     public void resetHandler() {
-        Managers.Quest.setCurrentQuest(null);
+        Managers.Quest.clearTrackedQuestFromScoreBoard();
     }
 }


### PR DESCRIPTION
There are a lot of fixes here. On the top of my mind:
* Mini-Quests scoreboard where not properly updated since they could not be found; the name started with "Mini-Quest - " from the scoreboard but we stripped that away in the miniQuests list of QuestInfo, so no match was ever found.
* If a quest was tracked without the quest book ever read by us, scoreboard updates would fail. This could happen if you used the vanilla Wynncraft quest book to start tracking a quest, instead of our own Quest Book Screen.
* We tried to track finished quests from the GUI which did not work
* Quest Book Screen now starts showing the cached copy of quests, and triggers a rescan in the background. Quest list is updated once the rescan completes.
* QuestManager has now the sole responsibility of knowing which quest is tracked. This is interpreted as "showing up on the score board".
* The Quest Book Screen now has an "intermediate" state for quests, to signal that we have requested tracking but not yet got confirmation from Wynncraft, shown in a orange hue. Once the tracking is confirmed, it reverts to the normal green for tracked quests.
* Switching between quests and miniquests is snappy, and never loses track of which quest was selected.
* When choosing to replace the vanilla quest book, the main menu was opened instead of the quest book.
* I have now consistently called the tracked quest "tracked", instead of "pinned" or "current".
* When untracking a quest, do as vanilla Wynncraft and use the `/tracking` command. That's one container query less, at least.

Overall, I have tested all manner of combinations of using our GUI and using the Wynncraft vanilla quest book, in different order, before or after we have our quest book query run, using normal quests and mini-quests. I think it works pretty fine right now.