### PR TITLE
fix: Crash in Forge at startup

### DIFF
--- a/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
@@ -14,7 +14,6 @@ import com.wynntils.functions.LootrunFunctions;
 import com.wynntils.functions.MinecraftFunctions;
 import com.wynntils.functions.WorldFunction;
 import com.wynntils.mc.utils.McUtils;
-import com.wynntils.wynn.model.item.ItemStackTransformManager;
 import com.wynntils.wynn.objects.EmeraldSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -50,7 +49,7 @@ public final class FunctionManager extends Manager {
      * functions with the proper models.
      */
     public void activateAllFunctions() {
-        for(Function<?> function: functions) {
+        for (Function<?> function : functions) {
             if (function instanceof DependantFunction<?> dependantFunction) {
                 ModelRegistry.addAllDependencies(dependantFunction);
             }

--- a/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
@@ -40,27 +40,23 @@ public final class FunctionManager extends Manager {
     private final Set<ActiveFunction<?>> enabledFunctions = new HashSet<>();
     private final Set<Function<?>> crashedFunctions = new HashSet<>();
 
-    public FunctionManager(ItemStackTransformManager itemStackTransformManager) {
-        // FIXME: The dependency is a hack
+    public FunctionManager() {
         super(List.of());
         registerAllFunctions();
     }
 
-    private void registerFunction(Function<?> function) {
-        functions.add(function);
-        if (function instanceof ActiveFunction<?> activeFunction) {
-            activeFunction.init();
-        }
-        // FIXME: This is sort of hacky. We should have these as ActiveFunctions instead,
-        //        and register/unregister the model dependency when enabling/disabling
-
-        // FIXME: This is double bad, since we are setting up a manager and not all
-        // managers might be in place, and now we start setting up models,
-        // which might depend on managers.
-        // We have a hacky workaround for an actual issue where
-        // HorsePropertyModel depends on Managers.ItemStackTransform
-        if (function instanceof DependantFunction<?> dependantFunction) {
-            ModelRegistry.addAllDependencies(dependantFunction);
+    /**
+     * This needs to be called after Models are setup, to associate all
+     * functions with the proper models.
+     */
+    public void activateAllFunctions() {
+        for(Function<?> function: functions) {
+            if (function instanceof DependantFunction<?> dependantFunction) {
+                ModelRegistry.addAllDependencies(dependantFunction);
+            }
+            if (function instanceof ActiveFunction<?> activeFunction) {
+                activeFunction.init();
+            }
         }
     }
 
@@ -306,6 +302,10 @@ public final class FunctionManager extends Manager {
         };
     }
     // endregion
+
+    private void registerFunction(Function<?> function) {
+        functions.add(function);
+    }
 
     private void registerAllFunctions() {
         registerFunction(new WorldFunction());

--- a/common/src/main/java/com/wynntils/core/managers/Managers.java
+++ b/common/src/main/java/com/wynntils/core/managers/Managers.java
@@ -39,6 +39,7 @@ public final class Managers {
     public static final ConfigManager Config = new ConfigManager();
     public static final ContainerQueryManager ContainerQuery = new ContainerQueryManager();
     public static final CrashReportManager CrashReport = new CrashReportManager();
+    public static final FunctionManager Function = new FunctionManager();
     public static final ItemStackTransformManager ItemStackTransform = new ItemStackTransformManager();
     public static final KeyBindManager KeyBind = new KeyBindManager();
     public static final MinecraftSchedulerManager MinecraftScheduler = new MinecraftSchedulerManager();
@@ -46,7 +47,6 @@ public final class Managers {
 
     // Managers with dependencies, ordered by dependency and then alphabetically
     public static final NetManager Net = new NetManager(Url);
-    public static final FunctionManager Function = new FunctionManager(ItemStackTransform);
     public static final ItemProfilesManager ItemProfiles = new ItemProfilesManager(Net);
     public static final OverlayManager Overlay = new OverlayManager(CrashReport);
     public static final QuestManager Quest = new QuestManager(Net);

--- a/common/src/main/java/com/wynntils/core/managers/ModelRegistry.java
+++ b/common/src/main/java/com/wynntils/core/managers/ModelRegistry.java
@@ -20,6 +20,9 @@ public final class ModelRegistry {
     private static final Collection<Model> ENABLED_MODELS = new HashSet<>();
 
     public static void init() {
+        // When the model registry is in place, we can activate the functions
+        Managers.Function.activateAllFunctions();
+
         addCrashCallbacks();
     }
 


### PR DESCRIPTION
The manager refactoring caused a crash at startup for forge, due to models being registered while setting up managers (via functions). This ugly thing is now completely fixed.