### PR TITLE
fix: Crash at startup in KeyMappingMixin

### DIFF
--- a/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
@@ -140,7 +140,10 @@ public final class KeyBindManager extends Manager {
         return keyBinds.stream().anyMatch(k -> k.getName().equals(name));
     }
 
-    public void initKeyMapping(String category, Map<String, Integer> categorySortOrder) {
+    /**
+     * Note: this is called directly from a mixin!
+     */
+    public static void initKeyMapping(String category, Map<String, Integer> categorySortOrder) {
         if (categorySortOrder.containsKey(category)) return;
 
         int max = 0;

--- a/common/src/main/java/com/wynntils/mc/mixin/KeyMappingMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/KeyMappingMixin.java
@@ -5,7 +5,7 @@
 package com.wynntils.mc.mixin;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import com.wynntils.core.managers.Managers;
+import com.wynntils.core.keybinds.KeyBindManager;
 import java.util.Map;
 import net.minecraft.client.KeyMapping;
 import org.spongepowered.asm.mixin.Final;
@@ -25,6 +25,6 @@ public abstract class KeyMappingMixin {
             method = "<init>(Ljava/lang/String;Lcom/mojang/blaze3d/platform/InputConstants$Type;ILjava/lang/String;)V",
             at = @At("RETURN"))
     private void initPost(String name, InputConstants.Type type, int i, String category, CallbackInfo ci) {
-        Managers.KeyBind.initKeyMapping(category, CATEGORY_SORT_ORDER);
+        KeyBindManager.initKeyMapping(category, CATEGORY_SORT_ORDER);
     }
 }


### PR DESCRIPTION
The KeyMappingMixin does not just call an event, as usual for our mixins, but call the KeyBindManager directly. This means it must go directly to a static method in the KeyBindManager class, and not via Managers.