### PR TITLE
fix: Patches Up SpeedBoostRedirector

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -642,7 +642,7 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class SpeedBoostRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile("^\\+3 minutes speed boost.$");
+        private static final Pattern NORMAL_PATTERN = Pattern.compile("^§b\\+([23]) minutes§r§7 speed boost.$");
 
         @Override
         protected Pattern getNormalPattern() {
@@ -656,7 +656,8 @@ public class ChatRedirectFeature extends UserFeature {
 
         @Override
         protected String getNotification(Matcher matcher) {
-            return ChatFormatting.AQUA + "+3 minutes" + ChatFormatting.GRAY + " speed boost";
+            String minutesString = String.format("+%s minutes", matcher.group(1));
+            return ChatFormatting.AQUA + minutesString + ChatFormatting.GRAY + " speed boost";
         }
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34697715/208184074-9bae9e3d-5c85-42a9-9c1d-3d5ffc950114.png)

Few flaws the original implementation had:

A) Didn't account for archers who had not fully unlocked Windy Feet, and could only do a 2 minutes boost (only accounted for 3 minutes boost).

B) This was also an uncolored pattern in disguise, as Wynncraft sends it with the same Aqua/Gray formatting you see in the getNotification method. This means that it actually just never worked at all.

I just made the regex work, as well as account for the 2/3 minutes distinction in both the pattern and the notification.