### PR TITLE
chore: Bumps actions/setup-java to v3 for Qodana CI

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           cp ./.idea/misc-example.xml ./.idea/misc.xml
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: 17


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34697715/208186026-60e8e7f4-c71c-4f37-bc1b-6851952c0541.png)

GitHub CI Runners are doing a lot of deprecation lately, which is easily resolved by bumping the actions version to v3. Just to make sure, I ran a test case of this on my fork at https://github.com/san7890/Artemis-bruh/actions/runs/3716411603 and it seems to work alright (in comparison to the errors at https://github.com/Wynntils/Artemis/actions/runs/3716329395).

I believe the new error is due to how my repository is set up? Unsure, but looking at this repository's caches at https://github.com/Wynntils/Artemis/actions/caches it seems we aren't really using any cache (takes 10 minutes to build for qodana, and we generate a new cache every time). Might have to look at that later. 