### PR TITLE
fix: Create WynntilsScreenWrapper#instanceOf and use it

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.TextComponent;
@@ -80,11 +81,10 @@ public final class OverlayManager extends Manager {
         boolean testMode = false;
         boolean shouldRender = true;
 
-        if (McUtils.mc().screen instanceof WynntilsScreenWrapper wrapper) {
-            if (wrapper.getDelegate() instanceof OverlayManagementScreen screen) {
-                testMode = screen.isTestMode();
-                shouldRender = false;
-            }
+        Optional<OverlayManagementScreen> screen = WynntilsScreenWrapper.instanceOf(OverlayManagementScreen.class);
+        if (screen.isPresent()) {
+            testMode = screen.get().isTestMode();
+            shouldRender = false;
         }
 
         List<Overlay> crashedOverlays = new LinkedList<>();

--- a/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.managers.Managers;
 import com.wynntils.core.managers.Model;
 import com.wynntils.core.managers.Models;
 import com.wynntils.gui.screens.GearViewerScreen;
+import com.wynntils.gui.screens.WynntilsScreenWrapper;
 import com.wynntils.mc.event.NametagRenderEvent;
 import com.wynntils.mc.event.RenderLevelEvent;
 import com.wynntils.mc.utils.McUtils;
@@ -46,8 +47,8 @@ public class CustomNametagRendererFeature extends UserFeature {
         }
 
         // If we are viewing this player's gears, do not show plus info
-        if (McUtils.mc().screen instanceof GearViewerScreen gearViewerScreen
-                && gearViewerScreen.getPlayer() == event.getEntity()) {
+        Optional<GearViewerScreen> screen = WynntilsScreenWrapper.instanceOf(GearViewerScreen.class);
+        if (screen.isPresent() && screen.get().getPlayer() == event.getEntity()) {
             return;
         }
 

--- a/common/src/main/java/com/wynntils/features/user/map/GuildMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/GuildMapFeature.java
@@ -10,9 +10,11 @@ import com.wynntils.core.features.properties.FeatureCategory;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
+import com.wynntils.gui.screens.WynntilsScreenWrapper;
 import com.wynntils.gui.screens.maps.GuildMapScreen;
 import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.mc.utils.McUtils;
+import java.util.Optional;
 import org.lwjgl.glfw.GLFW;
 
 @FeatureInfo(category = FeatureCategory.MAP)
@@ -32,8 +34,9 @@ public class GuildMapFeature extends UserFeature {
     public final KeyBind openGuildMapKeybind = new KeyBind("Open Guild Map", GLFW.GLFW_KEY_J, false, () -> {
         // If the current screen is already the map, and we get this event, this means we are holding the keybind
         // and should signal that we should close when the key is not held anymore.
-        if (McUtils.mc().screen instanceof GuildMapScreen guildMapScreen) {
-            guildMapScreen.setHoldingMapKey(true);
+        Optional<GuildMapScreen> screen = WynntilsScreenWrapper.instanceOf(GuildMapScreen.class);
+        if (screen.isPresent()) {
+            screen.get().setHoldingMapKey(true);
             return;
         }
 

--- a/common/src/main/java/com/wynntils/features/user/map/MapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/MapFeature.java
@@ -18,6 +18,7 @@ import com.wynntils.core.managers.Models;
 import com.wynntils.core.notifications.NotificationManager;
 import com.wynntils.gui.render.FontRenderer;
 import com.wynntils.gui.render.Texture;
+import com.wynntils.gui.screens.WynntilsScreenWrapper;
 import com.wynntils.gui.screens.maps.MainMapScreen;
 import com.wynntils.mc.event.PlayerInteractEvent;
 import com.wynntils.mc.event.ScreenOpenedEvent;
@@ -32,6 +33,7 @@ import com.wynntils.wynn.screens.WynnScreenMatchers;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.inventory.ContainerScreen;
@@ -118,8 +120,9 @@ public class MapFeature extends UserFeature {
     public final KeyBind openMapKeybind = new KeyBind("Open Main Map", GLFW.GLFW_KEY_M, false, () -> {
         // If the current screen is already the map, and we get this event, this means we are holding the keybind
         // and should signal that we should close when the key is not held anymore.
-        if (McUtils.mc().screen instanceof MainMapScreen mainMapScreen) {
-            mainMapScreen.setHoldingMapKey(true);
+        Optional<MainMapScreen> screen = WynntilsScreenWrapper.instanceOf(MainMapScreen.class);
+        if (screen.isPresent()) {
+            screen.get().setHoldingMapKey(true);
             return;
         }
 

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsScreenWrapper.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsScreenWrapper.java
@@ -40,6 +40,14 @@ public class WynntilsScreenWrapper extends Screen {
         return delegate;
     }
 
+    public static <T extends Screen> Optional<T> instanceOf(Class<T> clazz) {
+        if (McUtils.mc().screen instanceof WynntilsScreenWrapper wrapper) {
+            return clazz.isInstance(wrapper.delegate) ? Optional.of(clazz.cast(wrapper.delegate)) : Optional.empty();
+        }
+
+        return Optional.empty();
+    }
+
     private void failure(String method, Throwable e) {
         WynntilsMod.error("Failure in " + delegate.getClass().getSimpleName() + "." + method + "()", e);
         McUtils.sendMessageToClient(new TextComponent("Wynntils: Failure in " + method + " in "

--- a/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ConfigurableButton.java
+++ b/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ConfigurableButton.java
@@ -12,10 +12,11 @@ import com.wynntils.core.features.overlays.Overlay;
 import com.wynntils.gui.render.FontRenderer;
 import com.wynntils.gui.render.HorizontalAlignment;
 import com.wynntils.gui.render.VerticalAlignment;
+import com.wynntils.gui.screens.WynntilsScreenWrapper;
 import com.wynntils.gui.screens.settings.WynntilsBookSettingsScreen;
 import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.mc.objects.CustomColor;
-import com.wynntils.mc.utils.McUtils;
+import java.util.Optional;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.TextComponent;
@@ -32,10 +33,12 @@ public class ConfigurableButton extends AbstractButton {
     public void renderButton(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
         CustomColor color = isHovered ? CommonColors.YELLOW : CommonColors.WHITE;
 
-        if (McUtils.mc().screen instanceof WynntilsBookSettingsScreen bookSettingsScreen) {
-            if (bookSettingsScreen.getSelectedFeature() == configurable) {
+        Optional<WynntilsBookSettingsScreen> screen =
+                WynntilsScreenWrapper.instanceOf(WynntilsBookSettingsScreen.class);
+        if (screen.isPresent()) {
+            if (screen.get().getSelectedFeature() == configurable) {
                 color = CommonColors.GRAY;
-            } else if (bookSettingsScreen.getSelectedOverlay() == configurable) {
+            } else if (screen.get().getSelectedOverlay() == configurable) {
                 color = CommonColors.GRAY;
             }
         }
@@ -56,11 +59,13 @@ public class ConfigurableButton extends AbstractButton {
 
     @Override
     public void onPress() {
-        if (McUtils.mc().screen instanceof WynntilsBookSettingsScreen bookSettingsScreen) {
+        Optional<WynntilsBookSettingsScreen> screen =
+                WynntilsScreenWrapper.instanceOf(WynntilsBookSettingsScreen.class);
+        if (screen.isPresent()) {
             if (configurable instanceof Feature feature) {
-                bookSettingsScreen.setSelectedFeature(feature);
+                screen.get().setSelectedFeature(feature);
             } else if (configurable instanceof Overlay overlay) {
-                bookSettingsScreen.setSelectedOverlay(overlay);
+                screen.get().setSelectedOverlay(overlay);
             }
         }
     }

--- a/common/src/main/java/com/wynntils/wynn/model/CharacterSelectionManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/CharacterSelectionManager.java
@@ -17,6 +17,7 @@ import com.wynntils.wynn.objects.ClassType;
 import com.wynntils.wynn.utils.ContainerUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -50,13 +51,12 @@ public final class CharacterSelectionManager extends Manager {
 
     @SubscribeEvent
     public void onScreenOpened(ScreenOpenedEvent event) {
-        if (event.getScreen() instanceof WynntilsScreenWrapper wynntilsScreenWrapper) {
-            if (wynntilsScreenWrapper.getDelegate() instanceof CharacterSelectorScreen characterSelectorScreen) {
-                currentScreen = characterSelectorScreen;
+        Optional<CharacterSelectorScreen> screen = WynntilsScreenWrapper.instanceOf(CharacterSelectorScreen.class);
+        if (screen.isPresent()) {
+            currentScreen = screen.get();
 
-                currentScreen.setClassInfoList(classInfoList);
-                currentScreen.setFirstNewCharacterSlot(firstNewCharacterSlot);
-            }
+            currentScreen.setClassInfoList(classInfoList);
+            currentScreen.setFirstNewCharacterSlot(firstNewCharacterSlot);
         }
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/poi/TerritoryPoi.java
@@ -11,12 +11,13 @@ import com.wynntils.gui.render.HorizontalAlignment;
 import com.wynntils.gui.render.RenderUtils;
 import com.wynntils.gui.render.Texture;
 import com.wynntils.gui.render.VerticalAlignment;
+import com.wynntils.gui.screens.WynntilsScreenWrapper;
 import com.wynntils.gui.screens.maps.GuildMapScreen;
 import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.mc.objects.CustomColor;
-import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wynn.model.territory.objects.TerritoryInfo;
 import com.wynntils.wynn.objects.profiles.TerritoryProfile;
+import java.util.Optional;
 
 public class TerritoryPoi implements Poi {
     private final TerritoryProfile territoryProfile;
@@ -53,9 +54,8 @@ public class TerritoryPoi implements Poi {
         final float actualRenderZ = renderZ - renderHeight / 2f;
 
         CustomColor color;
-        if (territoryInfo != null
-                && McUtils.mc().screen instanceof GuildMapScreen guildMapScreen
-                && guildMapScreen.isResourceMode()) {
+        Optional<GuildMapScreen> screen = WynntilsScreenWrapper.instanceOf(GuildMapScreen.class);
+        if (territoryInfo != null && screen.isPresent() && screen.get().isResourceMode()) {
             color = territoryInfo.getColor();
         } else {
             color = territoryProfile.getGuildColor();


### PR DESCRIPTION
I am not sure how this happened..

@magicus, I think you may have used search wrongly or overlooked something. There are quite a few instances where we used instanceof. I think I fixed all of them. It is a bit sad that we had to do this, but it might be worth for crash protection.