### PR TITLE
refactor: Use 1.19 component factories

### DIFF
--- a/common/src/main/java/com/wynntils/commands/BombBellCommand.java
+++ b/common/src/main/java/com/wynntils/commands/BombBellCommand.java
@@ -20,8 +20,8 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 public class BombBellCommand extends CommandBase {
     private final SuggestionProvider<CommandSourceStack> bombTypeSuggestionProvider = (context, builder) ->
@@ -43,7 +43,8 @@ public class BombBellCommand extends CommandBase {
         try {
             bombType = BombType.valueOf(context.getArgument("bombType", String.class));
         } catch (IllegalArgumentException e) {
-            context.getSource().sendFailure(new TextComponent("Invalid bomb type").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Invalid bomb type").withStyle(ChatFormatting.RED));
             return 0;
         }
 
@@ -69,14 +70,14 @@ public class BombBellCommand extends CommandBase {
     }
 
     private static MutableComponent getBombListComponent(Set<BombInfo> bombBells) {
-        MutableComponent response = new TextComponent("Bomb Bells: ").withStyle(ChatFormatting.GOLD);
+        MutableComponent response = Component.literal("Bomb Bells: ").withStyle(ChatFormatting.GOLD);
 
         if (bombBells.isEmpty()) {
-            response.append(new TextComponent(
+            response.append(Component.literal(
                                     "There are no active bombs at the moment! This might be because you do not have the ")
                             .withStyle(ChatFormatting.RED))
-                    .append(new TextComponent("CHAMPION").withStyle(ChatFormatting.YELLOW))
-                    .append(new TextComponent(" rank on Wynncraft, which is necessary to use this feature.")
+                    .append(Component.literal("CHAMPION").withStyle(ChatFormatting.YELLOW))
+                    .append(Component.literal(" rank on Wynncraft, which is necessary to use this feature.")
                             .withStyle(ChatFormatting.RED));
             return response;
         }
@@ -87,13 +88,13 @@ public class BombBellCommand extends CommandBase {
                         .thenComparing(BombInfo::startTime)
                         .reversed())
                 .toList()) {
-            response.append(new TextComponent("\n" + bomb.bomb().getName())
+            response.append(Component.literal("\n" + bomb.bomb().getName())
                             .withStyle(ChatFormatting.WHITE)
-                            .append(new TextComponent(" on ").withStyle(ChatFormatting.GRAY))
-                            .append(new TextComponent(bomb.server()).withStyle(ChatFormatting.WHITE)))
-                    .append(new TextComponent(" for: ")
+                            .append(Component.literal(" on ").withStyle(ChatFormatting.GRAY))
+                            .append(Component.literal(bomb.server()).withStyle(ChatFormatting.WHITE)))
+                    .append(Component.literal(" for: ")
                             .withStyle(ChatFormatting.GRAY)
-                            .append(new TextComponent(bomb.getRemainingString()).withStyle(ChatFormatting.WHITE)));
+                            .append(Component.literal(bomb.getRemainingString()).withStyle(ChatFormatting.WHITE)));
         }
 
         return response;

--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -29,8 +29,8 @@ import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.arguments.coordinates.Coordinates;
 import net.minecraft.commands.arguments.coordinates.Vec3Argument;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 
@@ -94,7 +94,8 @@ public class CompassCommand extends CommandBase {
 
         if (compassLocation.isEmpty()) {
             context.getSource()
-                    .sendFailure(new TextComponent("You don't have a compass set!").withStyle(ChatFormatting.RED));
+                    .sendFailure(
+                            Component.literal("You don't have a compass set!").withStyle(ChatFormatting.RED));
             return 1;
         }
 
@@ -118,8 +119,8 @@ public class CompassCommand extends CommandBase {
         Location location = new Location(coordinates.getBlockPos(context.getSource()));
         Models.Compass.setCompassLocation(location);
 
-        MutableComponent response = new TextComponent("Compass set to ").withStyle(ChatFormatting.AQUA);
-        response.append(new TextComponent(location.toString()).withStyle(ChatFormatting.WHITE));
+        MutableComponent response = Component.literal("Compass set to ").withStyle(ChatFormatting.AQUA);
+        response.append(Component.literal(location.toString()).withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }
@@ -128,14 +129,14 @@ public class CompassCommand extends CommandBase {
         String coordinates = StringArgumentType.getString(context, "location");
         Optional<Location> location = LocationUtils.parseFromString(coordinates);
         if (location.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Incorrect coordinates!"));
+            context.getSource().sendFailure(Component.literal("Incorrect coordinates!"));
             return 0;
         }
 
         Models.Compass.setCompassLocation(location.get());
 
-        MutableComponent response = new TextComponent("Compass set to ").withStyle(ChatFormatting.AQUA);
-        response.append(new TextComponent(location.get().toString()).withStyle(ChatFormatting.WHITE));
+        MutableComponent response = Component.literal("Compass set to ").withStyle(ChatFormatting.AQUA);
+        response.append(Component.literal(location.get().toString()).withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }
@@ -148,17 +149,17 @@ public class CompassCommand extends CommandBase {
                 .toList();
 
         if (matchedKinds.isEmpty()) {
-            MutableComponent response = new TextComponent("Found no services matching '" + searchedName + "'")
+            MutableComponent response = Component.literal("Found no services matching '" + searchedName + "'")
                     .withStyle(ChatFormatting.RED);
             context.getSource().sendFailure(response);
             return 0;
         }
 
         if (matchedKinds.size() > 1) {
-            MutableComponent response = new TextComponent("Found multiple services matching '" + searchedName
+            MutableComponent response = Component.literal("Found multiple services matching '" + searchedName
                             + "'. Pleace specify with more detail. Matching: ")
                     .withStyle(ChatFormatting.RED);
-            response.append(new TextComponent(String.join(
+            response.append(Component.literal(String.join(
                     ", ", matchedKinds.stream().map(ServiceKind::getName).toList())));
             context.getSource().sendFailure(response);
             return 0;
@@ -175,7 +176,7 @@ public class CompassCommand extends CommandBase {
                         poi.getLocation().getZ())));
         if (closestServiceOptional.isEmpty()) {
             // This really should not happen...
-            MutableComponent response = new TextComponent("Found no services of kind '" + selectedKind.getName() + "'")
+            MutableComponent response = Component.literal("Found no services of kind '" + selectedKind.getName() + "'")
                     .withStyle(ChatFormatting.RED);
             context.getSource().sendFailure(response);
             return 0;
@@ -185,9 +186,10 @@ public class CompassCommand extends CommandBase {
                 closestService.getLocation().asLocation(),
                 closestServiceOptional.get().getIcon());
 
-        MutableComponent response =
-                new TextComponent("Compass set to " + selectedKind.getName() + " at ").withStyle(ChatFormatting.AQUA);
-        response.append(new TextComponent(closestService.getLocation().toString()).withStyle(ChatFormatting.WHITE));
+        MutableComponent response = Component.literal("Compass set to " + selectedKind.getName() + " at ")
+                .withStyle(ChatFormatting.AQUA);
+        response.append(
+                Component.literal(closestService.getLocation().toString()).withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }
@@ -200,8 +202,8 @@ public class CompassCommand extends CommandBase {
                 .toList());
 
         if (places.isEmpty()) {
-            MutableComponent response =
-                    new TextComponent("Found no places matching '" + searchedName + "'").withStyle(ChatFormatting.RED);
+            MutableComponent response = Component.literal("Found no places matching '" + searchedName + "'")
+                    .withStyle(ChatFormatting.RED);
             context.getSource().sendFailure(response);
             return 0;
         }
@@ -214,10 +216,10 @@ public class CompassCommand extends CommandBase {
                     .filter(poi -> poi.getName().equals(searchedName))
                     .findFirst();
             if (exactMatch.isEmpty()) {
-                MutableComponent response = new TextComponent("Found multiple places matching '" + searchedName
+                MutableComponent response = Component.literal("Found multiple places matching '" + searchedName
                                 + "', but none matched exactly. Matching: ")
                         .withStyle(ChatFormatting.RED);
-                response.append(new TextComponent(
+                response.append(Component.literal(
                         String.join(", ", places.stream().map(Poi::getName).toList())));
                 context.getSource().sendFailure(response);
                 return 0;
@@ -229,9 +231,9 @@ public class CompassCommand extends CommandBase {
 
         Models.Compass.setCompassLocation(place.getLocation().asLocation());
 
-        MutableComponent response =
-                new TextComponent("Setting compass to " + place.getName() + " at ").withStyle(ChatFormatting.AQUA);
-        response.append(new TextComponent(place.getLocation().toString()).withStyle(ChatFormatting.WHITE));
+        MutableComponent response = Component.literal("Setting compass to " + place.getName() + " at ")
+                .withStyle(ChatFormatting.AQUA);
+        response.append(Component.literal(place.getLocation().toString()).withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }
@@ -239,18 +241,18 @@ public class CompassCommand extends CommandBase {
     private int compassClear(CommandContext<CommandSourceStack> context) {
         Models.Compass.reset();
 
-        MutableComponent response = new TextComponent("Compass cleared").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal("Compass cleared").withStyle(ChatFormatting.AQUA);
         context.getSource().sendSuccess(response, false);
         return 1;
     }
 
     private int notImplemented(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Not implemented yet").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Not implemented yet").withStyle(ChatFormatting.RED));
         return 0;
     }
 
     private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Missing argument").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
         return 0;
     }
 }

--- a/common/src/main/java/com/wynntils/commands/ConfigCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ConfigCommand.java
@@ -26,9 +26,9 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import org.apache.commons.lang3.StringUtils;
 
 public class ConfigCommand extends CommandBase {
@@ -99,7 +99,7 @@ public class ConfigCommand extends CommandBase {
     }
 
     private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Missing argument").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
         return 0;
     }
 
@@ -194,7 +194,8 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully reloaded configs from file.").withStyle(ChatFormatting.GREEN),
+                        Component.literal("Successfully reloaded configs from file.")
+                                .withStyle(ChatFormatting.GREEN),
                         false);
 
         return 1;
@@ -217,12 +218,12 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully reset ")
+                        Component.literal("Successfully reset ")
                                 .withStyle(ChatFormatting.GREEN)
-                                .append(new TextComponent(config.getDisplayName())
+                                .append(Component.literal(config.getDisplayName())
                                         .withStyle(ChatFormatting.UNDERLINE)
                                         .withStyle(ChatFormatting.YELLOW))
-                                .append(new TextComponent(".").withStyle(ChatFormatting.GREEN)),
+                                .append(Component.literal(".").withStyle(ChatFormatting.GREEN)),
                         false);
 
         return 1;
@@ -241,10 +242,10 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully reset ")
+                        Component.literal("Successfully reset ")
                                 .withStyle(ChatFormatting.GREEN)
-                                .append(new TextComponent(featureName).withStyle(ChatFormatting.YELLOW))
-                                .append(new TextComponent("'s config options.").withStyle(ChatFormatting.GREEN)),
+                                .append(Component.literal(featureName).withStyle(ChatFormatting.YELLOW))
+                                .append(Component.literal("'s config options.").withStyle(ChatFormatting.GREEN)),
                         false);
         return 1;
     }
@@ -256,9 +257,9 @@ public class ConfigCommand extends CommandBase {
         Overlay overlay = getOverlayFromArguments(context, featureName, overlayName);
         if (overlay == null) return 0;
 
-        MutableComponent response = new TextComponent(overlayName)
+        MutableComponent response = Component.literal(overlayName)
                 .withStyle(ChatFormatting.AQUA)
-                .append(new TextComponent("'s config options:\n").withStyle(ChatFormatting.WHITE));
+                .append(Component.literal("'s config options:\n").withStyle(ChatFormatting.WHITE));
 
         for (ConfigHolder config : overlay.getVisibleConfigOptions()) {
             MutableComponent current = getComponentForConfigHolder(config);
@@ -293,7 +294,7 @@ public class ConfigCommand extends CommandBase {
                 .map(StringUtils::capitalize)
                 .collect(Collectors.joining(" "));
 
-        MutableComponent response = new TextComponent(longParentName + "\n").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal(longParentName + "\n").withStyle(ChatFormatting.AQUA);
 
         response.append(getSpecificConfigComponent(configHolder));
 
@@ -318,7 +319,7 @@ public class ConfigCommand extends CommandBase {
 
         if (parsedValue == null) {
             context.getSource()
-                    .sendFailure(new TextComponent("Failed to parse the inputted value to the correct type!")
+                    .sendFailure(Component.literal("Failed to parse the inputted value to the correct type!")
                             .withStyle(ChatFormatting.RED));
             return 0;
         }
@@ -327,14 +328,15 @@ public class ConfigCommand extends CommandBase {
 
         if (Objects.equals(oldValue, parsedValue)) {
             context.getSource()
-                    .sendFailure(new TextComponent("The new value is the same as the current setting.")
+                    .sendFailure(Component.literal("The new value is the same as the current setting.")
                             .withStyle(ChatFormatting.RED));
             return 0;
         }
 
         if (!config.setValue(parsedValue)) {
             context.getSource()
-                    .sendFailure(new TextComponent("Failed to set config field!").withStyle(ChatFormatting.RED));
+                    .sendFailure(
+                            Component.literal("Failed to set config field!").withStyle(ChatFormatting.RED));
             return 0;
         }
 
@@ -342,20 +344,20 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully set ")
+                        Component.literal("Successfully set ")
                                 .withStyle(ChatFormatting.GREEN)
-                                .append(new TextComponent(config.getDisplayName())
+                                .append(Component.literal(config.getDisplayName())
                                         .withStyle(ChatFormatting.UNDERLINE)
                                         .withStyle(ChatFormatting.YELLOW))
-                                .append(new TextComponent(" from ").withStyle(ChatFormatting.GREEN))
-                                .append(new TextComponent(oldValue == null ? "null" : oldValue.toString())
+                                .append(Component.literal(" from ").withStyle(ChatFormatting.GREEN))
+                                .append(Component.literal(oldValue == null ? "null" : oldValue.toString())
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.RED))
-                                .append(new TextComponent(" to ").withStyle(ChatFormatting.GREEN))
-                                .append(new TextComponent(parsedValue.toString())
+                                .append(Component.literal(" to ").withStyle(ChatFormatting.GREEN))
+                                .append(Component.literal(parsedValue.toString())
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GREEN))
-                                .append(new TextComponent(".").withStyle(ChatFormatting.GREEN)),
+                                .append(Component.literal(".").withStyle(ChatFormatting.GREEN)),
                         false);
 
         return 1;
@@ -377,7 +379,7 @@ public class ConfigCommand extends CommandBase {
                 .map(StringUtils::capitalize)
                 .collect(Collectors.joining(" "));
 
-        MutableComponent response = new TextComponent(longParentName + "\n").withStyle(ChatFormatting.YELLOW);
+        MutableComponent response = Component.literal(longParentName + "\n").withStyle(ChatFormatting.YELLOW);
 
         response.append(getSpecificConfigComponent(configHolder));
 
@@ -392,9 +394,9 @@ public class ConfigCommand extends CommandBase {
         Feature feature = getFeatureFromArguments(context, featureName);
         if (feature == null) return 0;
 
-        MutableComponent response = new TextComponent(featureName)
+        MutableComponent response = Component.literal(featureName)
                 .withStyle(ChatFormatting.YELLOW)
-                .append(new TextComponent("'s config options:\n").withStyle(ChatFormatting.WHITE));
+                .append(Component.literal("'s config options:\n").withStyle(ChatFormatting.WHITE));
 
         for (ConfigHolder config : feature.getVisibleConfigOptions()) {
             MutableComponent current = getComponentForConfigHolder(config);
@@ -408,9 +410,9 @@ public class ConfigCommand extends CommandBase {
 
         // list overlays
         response.append("\n")
-                .append(new TextComponent(featureName)
+                .append(Component.literal(featureName)
                         .withStyle(ChatFormatting.YELLOW)
-                        .append(new TextComponent("'s overlays:\n").withStyle(ChatFormatting.WHITE)));
+                        .append(Component.literal("'s overlays:\n").withStyle(ChatFormatting.WHITE)));
 
         for (Overlay overlay : feature.getOverlays()) {
             MutableComponent current = getComponentForOverlay(overlay);
@@ -442,7 +444,7 @@ public class ConfigCommand extends CommandBase {
 
         if (parsedValue == null) {
             context.getSource()
-                    .sendFailure(new TextComponent("Failed to parse the inputted value to the correct type!")
+                    .sendFailure(Component.literal("Failed to parse the inputted value to the correct type!")
                             .withStyle(ChatFormatting.RED));
             return 0;
         }
@@ -451,14 +453,15 @@ public class ConfigCommand extends CommandBase {
 
         if (Objects.equals(oldValue, parsedValue)) {
             context.getSource()
-                    .sendFailure(new TextComponent("The new value is the same as the current setting.")
+                    .sendFailure(Component.literal("The new value is the same as the current setting.")
                             .withStyle(ChatFormatting.RED));
             return 0;
         }
 
         if (!config.setValue(parsedValue)) {
             context.getSource()
-                    .sendFailure(new TextComponent("Failed to set config field!").withStyle(ChatFormatting.RED));
+                    .sendFailure(
+                            Component.literal("Failed to set config field!").withStyle(ChatFormatting.RED));
             return 0;
         }
 
@@ -466,20 +469,20 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully set ")
+                        Component.literal("Successfully set ")
                                 .withStyle(ChatFormatting.GREEN)
-                                .append(new TextComponent(config.getDisplayName())
+                                .append(Component.literal(config.getDisplayName())
                                         .withStyle(ChatFormatting.UNDERLINE)
                                         .withStyle(ChatFormatting.YELLOW))
-                                .append(new TextComponent(" from ").withStyle(ChatFormatting.GREEN))
-                                .append(new TextComponent(oldValue == null ? "null" : oldValue.toString())
+                                .append(Component.literal(" from ").withStyle(ChatFormatting.GREEN))
+                                .append(Component.literal(oldValue == null ? "null" : oldValue.toString())
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.RED))
-                                .append(new TextComponent(" to ").withStyle(ChatFormatting.GREEN))
-                                .append(new TextComponent(parsedValue.toString())
+                                .append(Component.literal(" to ").withStyle(ChatFormatting.GREEN))
+                                .append(Component.literal(parsedValue.toString())
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GREEN))
-                                .append(new TextComponent(".").withStyle(ChatFormatting.GREEN)),
+                                .append(Component.literal(".").withStyle(ChatFormatting.GREEN)),
                         false);
 
         return 1;
@@ -501,12 +504,12 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully reset ")
+                        Component.literal("Successfully reset ")
                                 .withStyle(ChatFormatting.GREEN)
-                                .append(new TextComponent(config.getDisplayName())
+                                .append(Component.literal(config.getDisplayName())
                                         .withStyle(ChatFormatting.UNDERLINE)
                                         .withStyle(ChatFormatting.YELLOW))
-                                .append(new TextComponent(".").withStyle(ChatFormatting.GREEN)),
+                                .append(Component.literal(".").withStyle(ChatFormatting.GREEN)),
                         false);
         return 1;
     }
@@ -522,10 +525,10 @@ public class ConfigCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent("Successfully reset ")
+                        Component.literal("Successfully reset ")
                                 .withStyle(ChatFormatting.GREEN)
-                                .append(new TextComponent(featureName).withStyle(ChatFormatting.YELLOW))
-                                .append(new TextComponent("'s config options.").withStyle(ChatFormatting.GREEN)),
+                                .append(Component.literal(featureName).withStyle(ChatFormatting.YELLOW))
+                                .append(Component.literal("'s config options.").withStyle(ChatFormatting.GREEN)),
                         false);
         return 1;
     }
@@ -534,7 +537,8 @@ public class ConfigCommand extends CommandBase {
         Optional<Feature> featureOptional = FeatureRegistry.getFeatureFromString(featureName);
 
         if (featureOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Feature not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Feature not found!").withStyle(ChatFormatting.RED));
             return null;
         }
 
@@ -550,7 +554,8 @@ public class ConfigCommand extends CommandBase {
         Optional<ConfigHolder> configOptional = feature.getConfigOptionFromString(configName);
 
         if (configOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Config not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Config not found!").withStyle(ChatFormatting.RED));
             return null;
         }
 
@@ -566,7 +571,8 @@ public class ConfigCommand extends CommandBase {
         Optional<ConfigHolder> configOptional = overlay.getConfigOptionFromString(configName);
 
         if (configOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Config not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Config not found!").withStyle(ChatFormatting.RED));
             return null;
         }
 
@@ -578,7 +584,8 @@ public class ConfigCommand extends CommandBase {
         Feature feature = getFeatureFromArguments(context, featureName);
 
         if (feature == null) {
-            context.getSource().sendFailure(new TextComponent("Feature not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Feature not found!").withStyle(ChatFormatting.RED));
             return null;
         }
 
@@ -587,7 +594,8 @@ public class ConfigCommand extends CommandBase {
                 .findFirst();
 
         if (overlayOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Overlay not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Overlay not found!").withStyle(ChatFormatting.RED));
             return null;
         }
 
@@ -601,27 +609,27 @@ public class ConfigCommand extends CommandBase {
         String configTypeString = " (" + ((Class<?>) config.getType()).getSimpleName() + ")";
         String valueString = value == null ? "Value is null." : value.toString();
 
-        return new TextComponent("\n - ")
+        return Component.literal("\n - ")
                 .withStyle(ChatFormatting.GRAY)
-                .append(new TextComponent(configNameString)
+                .append(Component.literal(configNameString)
                         .withStyle(style -> style.withHoverEvent(new HoverEvent(
                                 HoverEvent.Action.SHOW_TEXT,
-                                new TextComponent("Description: " + config.getDescription())
+                                Component.literal("Description: " + config.getDescription())
                                         .withStyle(ChatFormatting.LIGHT_PURPLE))))
                         .withStyle(ChatFormatting.YELLOW)
-                        .append(new TextComponent(configTypeString).withStyle(ChatFormatting.WHITE))
-                        .append(new TextComponent(": "))
-                        .append(new TextComponent(valueString)
+                        .append(Component.literal(configTypeString).withStyle(ChatFormatting.WHITE))
+                        .append(Component.literal(": "))
+                        .append(Component.literal(valueString)
                                 .withStyle(ChatFormatting.GREEN)
                                 .withStyle(style -> style.withHoverEvent(new HoverEvent(
                                         HoverEvent.Action.SHOW_TEXT,
-                                        new TextComponent("Click here to change this setting."))))));
+                                        Component.literal("Click here to change this setting."))))));
     }
 
     private MutableComponent getComponentForOverlay(Overlay overlay) {
-        return new TextComponent("\n - ")
+        return Component.literal("\n - ")
                 .withStyle(ChatFormatting.GRAY)
-                .append(new TextComponent(overlay.getShortName()).withStyle(ChatFormatting.AQUA));
+                .append(Component.literal(overlay.getShortName()).withStyle(ChatFormatting.AQUA));
     }
 
     private MutableComponent getSpecificConfigComponent(ConfigHolder config) {
@@ -630,25 +638,25 @@ public class ConfigCommand extends CommandBase {
         String valueString = value == null ? "Value is null." : value.toString();
         String configTypeString = "(" + ((Class<?>) config.getType()).getSimpleName() + ")";
 
-        MutableComponent response = new TextComponent("");
-        response.append(new TextComponent("Config option: ")
+        MutableComponent response = Component.literal("");
+        response.append(Component.literal("Config option: ")
                 .withStyle(ChatFormatting.WHITE)
-                .append(new TextComponent(config.getDisplayName()).withStyle(ChatFormatting.YELLOW))
+                .append(Component.literal(config.getDisplayName()).withStyle(ChatFormatting.YELLOW))
                 .append("\n"));
 
-        response.append(new TextComponent("Value: ")
+        response.append(Component.literal("Value: ")
                         .withStyle(ChatFormatting.WHITE)
-                        .append(new TextComponent(configTypeString))
-                        .append(new TextComponent(": "))
-                        .append(new TextComponent(valueString).withStyle(ChatFormatting.GREEN)))
+                        .append(Component.literal(configTypeString))
+                        .append(Component.literal(": "))
+                        .append(Component.literal(valueString).withStyle(ChatFormatting.GREEN)))
                 .append("\n");
-        response.append(new TextComponent("Subcategory: ")
+        response.append(Component.literal("Subcategory: ")
                         .withStyle(ChatFormatting.WHITE)
-                        .append(new TextComponent(config.getMetadata().subcategory())))
+                        .append(Component.literal(config.getMetadata().subcategory())))
                 .append("\n");
-        response.append(new TextComponent("Description: ")
+        response.append(Component.literal("Description: ")
                         .withStyle(ChatFormatting.WHITE)
-                        .append(new TextComponent(config.getDescription())))
+                        .append(Component.literal(config.getDescription())))
                 .append("\n");
         return response;
     }

--- a/common/src/main/java/com/wynntils/commands/FeatureCommand.java
+++ b/common/src/main/java/com/wynntils/commands/FeatureCommand.java
@@ -25,9 +25,9 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 public class FeatureCommand extends CommandBase {
     private static final SuggestionProvider<CommandSourceStack> USER_FEATURE_SUGGESTION_PROVIDER =
@@ -48,7 +48,7 @@ public class FeatureCommand extends CommandBase {
     }
 
     private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Missing argument").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
         return 0;
     }
 
@@ -62,7 +62,8 @@ public class FeatureCommand extends CommandBase {
                 .sorted(Feature::compareTo)
                 .toList();
 
-        MutableComponent response = new TextComponent("Currently registered features:").withStyle(ChatFormatting.AQUA);
+        MutableComponent response =
+                Component.literal("Currently registered features:").withStyle(ChatFormatting.AQUA);
 
         FeatureCategory lastCategory = null;
 
@@ -90,15 +91,15 @@ public class FeatureCommand extends CommandBase {
 
             if (!Objects.equals(lastCategory, feature.getCategory())) {
                 lastCategory = feature.getCategory();
-                response.append(new TextComponent("\n" + lastCategory.toString() + ":")
+                response.append(Component.literal("\n" + lastCategory.toString() + ":")
                         .withStyle(ChatFormatting.LIGHT_PURPLE)
                         .withStyle(ChatFormatting.BOLD));
             }
 
-            response.append(new TextComponent("\n - ").withStyle(ChatFormatting.GRAY))
-                    .append(new TextComponent(translatedName)
+            response.append(Component.literal("\n - ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(translatedName)
                             .withStyle(style -> style.withHoverEvent(new HoverEvent(
-                                    HoverEvent.Action.SHOW_TEXT, new TextComponent(superclass.getSimpleName()))))
+                                    HoverEvent.Action.SHOW_TEXT, Component.literal(superclass.getSimpleName()))))
                             .withStyle(color));
         }
 
@@ -121,13 +122,14 @@ public class FeatureCommand extends CommandBase {
         Optional<Feature> featureOptional = FeatureRegistry.getFeatureFromString(featureName);
 
         if (featureOptional.isEmpty() || !(featureOptional.get() instanceof UserFeature feature)) {
-            context.getSource().sendFailure(new TextComponent("Feature not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Feature not found!").withStyle(ChatFormatting.RED));
             return 0;
         }
 
         if (feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName() + " is already enabled!")
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName() + " is already enabled!")
                             .withStyle(ChatFormatting.RED));
             return 1;
         }
@@ -137,7 +139,7 @@ public class FeatureCommand extends CommandBase {
 
         if (!feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName() + " could not be enabled!")
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName() + " could not be enabled!")
                             .withStyle(ChatFormatting.RED));
             return 1;
         }
@@ -146,7 +148,7 @@ public class FeatureCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent(feature.getTranslatedName() + " was enabled successfully.")
+                        Component.literal(feature.getTranslatedName() + " was enabled successfully.")
                                 .withStyle(ChatFormatting.GREEN),
                         false);
 
@@ -167,13 +169,14 @@ public class FeatureCommand extends CommandBase {
         Optional<Feature> featureOptional = FeatureRegistry.getFeatureFromString(featureName);
 
         if (featureOptional.isEmpty() || !(featureOptional.get() instanceof UserFeature feature)) {
-            context.getSource().sendFailure(new TextComponent("Feature not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Feature not found!").withStyle(ChatFormatting.RED));
             return 0;
         }
 
         if (!feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName() + " is already disabled!")
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName() + " is already disabled!")
                             .withStyle(ChatFormatting.RED));
             return 1;
         }
@@ -183,7 +186,7 @@ public class FeatureCommand extends CommandBase {
 
         if (feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName() + " could not be disabled!")
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName() + " could not be disabled!")
                             .withStyle(ChatFormatting.RED));
             return 1;
         }
@@ -192,7 +195,7 @@ public class FeatureCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent(feature.getTranslatedName() + " was disabled successfully.")
+                        Component.literal(feature.getTranslatedName() + " was disabled successfully.")
                                 .withStyle(ChatFormatting.GREEN),
                         false);
 
@@ -213,13 +216,14 @@ public class FeatureCommand extends CommandBase {
         Optional<Feature> featureOptional = FeatureRegistry.getFeatureFromString(featureName);
 
         if (featureOptional.isEmpty() || !(featureOptional.get() instanceof UserFeature feature)) {
-            context.getSource().sendFailure(new TextComponent("Feature not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Feature not found!").withStyle(ChatFormatting.RED));
             return 0;
         }
 
         if (!feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName()
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName()
                                     + " is already disabled, cannot reload a disabled feature!")
                             .withStyle(ChatFormatting.RED));
             return 1;
@@ -229,7 +233,7 @@ public class FeatureCommand extends CommandBase {
 
         if (feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName() + " could not be disabled!")
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName() + " could not be disabled!")
                             .withStyle(ChatFormatting.RED));
             return 1;
         }
@@ -238,14 +242,14 @@ public class FeatureCommand extends CommandBase {
 
         if (!feature.isEnabled()) {
             context.getSource()
-                    .sendFailure(new TextComponent("Feature " + feature.getTranslatedName() + " could not be enabled!")
+                    .sendFailure(Component.literal("Feature " + feature.getTranslatedName() + " could not be enabled!")
                             .withStyle(ChatFormatting.RED));
             return 1;
         }
 
         context.getSource()
                 .sendSuccess(
-                        new TextComponent(feature.getTranslatedName() + " was reloaded successfully.")
+                        Component.literal(feature.getTranslatedName() + " was reloaded successfully.")
                                 .withStyle(ChatFormatting.GREEN),
                         false);
 

--- a/common/src/main/java/com/wynntils/commands/FunctionCommand.java
+++ b/common/src/main/java/com/wynntils/commands/FunctionCommand.java
@@ -23,7 +23,6 @@ import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 public class FunctionCommand extends CommandBase {
@@ -40,7 +39,7 @@ public class FunctionCommand extends CommandBase {
     }
 
     private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Missing argument").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
         return 0;
     }
 
@@ -64,23 +63,23 @@ public class FunctionCommand extends CommandBase {
                 .sorted(Comparator.comparing(Function::getName))
                 .toList();
 
-        MutableComponent response = new TextComponent("Available functions:").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal("Available functions:").withStyle(ChatFormatting.AQUA);
 
         for (Function<?> function : functions) {
-            MutableComponent functionComponent = new TextComponent("\n - ").withStyle(ChatFormatting.GRAY);
+            MutableComponent functionComponent = Component.literal("\n - ").withStyle(ChatFormatting.GRAY);
 
-            functionComponent.append(new TextComponent(function.getName()).withStyle(ChatFormatting.YELLOW));
+            functionComponent.append(Component.literal(function.getName()).withStyle(ChatFormatting.YELLOW));
             if (!function.getAliases().isEmpty()) {
                 String aliasList = String.join(", ", function.getAliases());
 
                 functionComponent
-                        .append(new TextComponent(" [alias: ").withStyle(ChatFormatting.GRAY))
-                        .append(new TextComponent(aliasList).withStyle(ChatFormatting.WHITE))
-                        .append(new TextComponent("]").withStyle(ChatFormatting.GRAY));
+                        .append(Component.literal(" [alias: ").withStyle(ChatFormatting.GRAY))
+                        .append(Component.literal(aliasList).withStyle(ChatFormatting.WHITE))
+                        .append(Component.literal("]").withStyle(ChatFormatting.GRAY));
             }
 
             functionComponent.withStyle(style -> style.withHoverEvent(
-                    new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent(function.getDescription()))));
+                    new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(function.getDescription()))));
 
             response.append(functionComponent);
         }
@@ -104,15 +103,16 @@ public class FunctionCommand extends CommandBase {
         Optional<Function<?>> functionOptional = Managers.Function.forName(functionName);
 
         if (functionOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Function not found!").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Function not found!").withStyle(ChatFormatting.RED));
             return 0;
         }
 
         Function<?> function = functionOptional.get();
         if (!(function instanceof ActiveFunction<?> activeFunction)) {
             context.getSource()
-                    .sendFailure(
-                            new TextComponent("Function does not need to be enabled").withStyle(ChatFormatting.RED));
+                    .sendFailure(Component.literal("Function does not need to be enabled")
+                            .withStyle(ChatFormatting.RED));
             return 0;
         }
 
@@ -120,13 +120,14 @@ public class FunctionCommand extends CommandBase {
 
         if (!success) {
             context.getSource()
-                    .sendFailure(new TextComponent("Function could not be enabled").withStyle(ChatFormatting.RED));
+                    .sendFailure(
+                            Component.literal("Function could not be enabled").withStyle(ChatFormatting.RED));
             return 0;
         }
 
-        Component response = new TextComponent(function.getName())
+        Component response = Component.literal(function.getName())
                 .withStyle(ChatFormatting.AQUA)
-                .append(new TextComponent(" is now enabled").withStyle(ChatFormatting.WHITE));
+                .append(Component.literal(" is now enabled").withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }
@@ -145,22 +146,24 @@ public class FunctionCommand extends CommandBase {
         Optional<Function<?>> functionOptional = Managers.Function.forName(functionName);
 
         if (functionOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Function not found").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Function not found").withStyle(ChatFormatting.RED));
             return 0;
         }
 
         Function<?> function = functionOptional.get();
         if (!(function instanceof ActiveFunction<?> activeFunction)) {
             context.getSource()
-                    .sendFailure(new TextComponent("Function can not be disabled").withStyle(ChatFormatting.RED));
+                    .sendFailure(
+                            Component.literal("Function can not be disabled").withStyle(ChatFormatting.RED));
             return 0;
         }
 
         Managers.Function.disableFunction(activeFunction);
 
-        Component response = new TextComponent(function.getName())
+        Component response = Component.literal(function.getName())
                 .withStyle(ChatFormatting.AQUA)
-                .append(new TextComponent(" is now disabled").withStyle(ChatFormatting.WHITE));
+                .append(Component.literal(" is now disabled").withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }
@@ -185,16 +188,17 @@ public class FunctionCommand extends CommandBase {
     private int getValue(CommandContext<CommandSourceStack> context) {
         Component argument;
         try {
-            argument = new TextComponent(StringArgumentType.getString(context, "argument"));
+            argument = Component.literal(StringArgumentType.getString(context, "argument"));
         } catch (IllegalArgumentException e) {
-            argument = new TextComponent("");
+            argument = Component.literal("");
         }
 
         String functionName = context.getArgument("function", String.class);
         Optional<Function<?>> functionOptional = Managers.Function.forName(functionName);
 
         if (functionOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Function not found").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Function not found").withStyle(ChatFormatting.RED));
             return 0;
         }
         Function<?> function = functionOptional.get();
@@ -213,11 +217,11 @@ public class FunctionCommand extends CommandBase {
             extraInfo = activeInfo.toString();
         }
 
-        MutableComponent result = new TextComponent("");
+        MutableComponent result = Component.literal("");
         result.append(
                 Managers.Function.getSimpleValueString(function, argument.getString(), ChatFormatting.YELLOW, true));
         if (!extraInfo.isEmpty()) {
-            result.append(new TextComponent(extraInfo).withStyle(ChatFormatting.GRAY));
+            result.append(Component.literal(extraInfo).withStyle(ChatFormatting.GRAY));
         }
         context.getSource().sendSuccess(result, false);
         return 1;
@@ -237,7 +241,8 @@ public class FunctionCommand extends CommandBase {
         Optional<Function<?>> functionOptional = Managers.Function.forName(functionName);
 
         if (functionOptional.isEmpty()) {
-            context.getSource().sendFailure(new TextComponent("Function not found").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Function not found").withStyle(ChatFormatting.RED));
             return 0;
         }
 
@@ -245,9 +250,9 @@ public class FunctionCommand extends CommandBase {
 
         String helpText = function.getDescription();
 
-        Component response = new TextComponent(function.getName() + ": ")
+        Component response = Component.literal(function.getName() + ": ")
                 .withStyle(ChatFormatting.AQUA)
-                .append(new TextComponent(helpText).withStyle(ChatFormatting.WHITE));
+                .append(Component.literal(helpText).withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(response, false);
         return 1;
     }

--- a/common/src/main/java/com/wynntils/commands/LocateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LocateCommand.java
@@ -23,8 +23,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.phys.Vec3;
 
 public class LocateCommand extends CommandBase {
@@ -66,17 +66,17 @@ public class LocateCommand extends CommandBase {
                 .toList();
 
         if (matchedKinds.isEmpty()) {
-            MutableComponent response = new TextComponent("Found no services matching '" + searchedName + "'")
+            MutableComponent response = Component.literal("Found no services matching '" + searchedName + "'")
                     .withStyle(ChatFormatting.RED);
             context.getSource().sendFailure(response);
             return 0;
         }
 
         if (matchedKinds.size() > 1) {
-            MutableComponent response = new TextComponent("Found multiple services matching '" + searchedName
+            MutableComponent response = Component.literal("Found multiple services matching '" + searchedName
                             + "'. Pleace specify with more detail. Matching: ")
                     .withStyle(ChatFormatting.RED);
-            response.append(new TextComponent(String.join(
+            response.append(Component.literal(String.join(
                     ", ", matchedKinds.stream().map(ServiceKind::getName).toList())));
             context.getSource().sendFailure(response);
             return 0;
@@ -97,17 +97,17 @@ public class LocateCommand extends CommandBase {
         // Removes from element 4 to the end of the list
         services.subList(4, services.size()).clear();
 
-        MutableComponent response =
-                new TextComponent("Found " + selectedKind.getName() + " services:").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal("Found " + selectedKind.getName() + " services:")
+                .withStyle(ChatFormatting.AQUA);
 
         for (Poi service : services) {
-            response.append(new TextComponent("\n - ").withStyle(ChatFormatting.GRAY))
-                    .append(new TextComponent(service.getName() + " ")
+            response.append(Component.literal("\n - ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(service.getName() + " ")
                             .withStyle(ChatFormatting.YELLOW)
                             .withStyle((style) -> style.withClickEvent(new ClickEvent(
                                     ClickEvent.Action.RUN_COMMAND,
                                     "/compass at " + service.getLocation().asChatCoordinates()))))
-                    .append(new TextComponent(service.getLocation().toString())
+                    .append(Component.literal(service.getLocation().toString())
                             .withStyle(ChatFormatting.WHITE)
                             .withStyle((style) -> style.withClickEvent(new ClickEvent(
                                     ClickEvent.Action.RUN_COMMAND,
@@ -126,8 +126,8 @@ public class LocateCommand extends CommandBase {
                 .toList());
 
         if (places.isEmpty()) {
-            MutableComponent response =
-                    new TextComponent("Found no places matching '" + searchedName + "'").withStyle(ChatFormatting.RED);
+            MutableComponent response = Component.literal("Found no places matching '" + searchedName + "'")
+                    .withStyle(ChatFormatting.RED);
             context.getSource().sendFailure(response);
             return 0;
         }
@@ -139,16 +139,16 @@ public class LocateCommand extends CommandBase {
                 poi.getLocation().getY().orElse((int) currentLocation.y),
                 poi.getLocation().getZ())));
 
-        MutableComponent response =
-                new TextComponent("Found places matching '" + searchedName + "':").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal("Found places matching '" + searchedName + "':")
+                .withStyle(ChatFormatting.AQUA);
 
         for (Poi place : places) {
-            response.append(new TextComponent("\n - ").withStyle(ChatFormatting.GRAY))
-                    .append(new TextComponent(place.getName() + " ")
+            response.append(Component.literal("\n - ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(place.getName() + " ")
                             .withStyle(ChatFormatting.YELLOW)
                             .withStyle((style) -> style.withClickEvent(new ClickEvent(
                                     ClickEvent.Action.RUN_COMMAND, "/compass place " + place.getName()))))
-                    .append(new TextComponent(place.getLocation().toString())
+                    .append(Component.literal(place.getLocation().toString())
                             .withStyle(ChatFormatting.WHITE)
                             .withStyle((style) -> style.withClickEvent(new ClickEvent(
                                     ClickEvent.Action.RUN_COMMAND, "/compass place " + place.getName()))));
@@ -159,12 +159,12 @@ public class LocateCommand extends CommandBase {
     }
 
     private int notImplemented(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Not implemented yet").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Not implemented yet").withStyle(ChatFormatting.RED));
         return 0;
     }
 
     private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Missing argument").withStyle(ChatFormatting.RED));
+        context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
         return 0;
     }
 }

--- a/common/src/main/java/com/wynntils/commands/LootrunCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LootrunCommand.java
@@ -30,8 +30,6 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
@@ -51,7 +49,7 @@ public class LootrunCommand extends CommandBase {
 
         if (!successful || startingPoint == null) {
             context.getSource()
-                    .sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.lootrunCouldNotBeLoaded")
+                    .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.lootrunCouldNotBeLoaded")
                             .withStyle(ChatFormatting.RED));
             return 0;
         }
@@ -59,7 +57,7 @@ public class LootrunCommand extends CommandBase {
         BlockPos start = new BlockPos(startingPoint);
         context.getSource()
                 .sendSuccess(
-                        new TranslatableComponent(
+                        Component.translatable(
                                         "feature.wynntils.lootrunUtils.lootrunStart",
                                         start.getX(),
                                         start.getY(),
@@ -74,9 +72,9 @@ public class LootrunCommand extends CommandBase {
             Models.Lootrun.startRecording();
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent(
+                            Component.translatable(
                                     "feature.wynntils.lootrunUtils.recordStart",
-                                    new TextComponent("/lootrun record")
+                                    Component.literal("/lootrun record")
                                             .withStyle(ChatFormatting.UNDERLINE)
                                             .withStyle((style) -> style.withClickEvent(
                                                     new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/lootrun record")))),
@@ -85,17 +83,17 @@ public class LootrunCommand extends CommandBase {
             Models.Lootrun.stopRecording();
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent(
+                            Component.translatable(
                                             "feature.wynntils.lootrunUtils.recordStop1",
-                                            new TextComponent("/lootrun clear")
+                                            Component.literal("/lootrun clear")
                                                     .withStyle(ChatFormatting.UNDERLINE)
                                                     .withStyle((style) -> style.withClickEvent(new ClickEvent(
                                                             ClickEvent.Action.RUN_COMMAND, "/lootrun clear"))))
                                     .withStyle(ChatFormatting.RED)
                                     .append("\n")
-                                    .append(new TranslatableComponent(
+                                    .append(Component.translatable(
                                                     "feature.wynntils.lootrunUtils.recordStop2",
-                                                    new TextComponent("/lootrun save <name>")
+                                                    Component.literal("/lootrun save <name>")
                                                             .withStyle(ChatFormatting.UNDERLINE)
                                                             .withStyle((style) -> style.withClickEvent(new ClickEvent(
                                                                     ClickEvent.Action.SUGGEST_COMMAND,
@@ -118,22 +116,22 @@ public class LootrunCommand extends CommandBase {
             case SAVED -> {
                 context.getSource()
                         .sendSuccess(
-                                new TranslatableComponent("feature.wynntils.lootrunUtils.savedLootrun")
+                                Component.translatable("feature.wynntils.lootrunUtils.savedLootrun")
                                         .withStyle(ChatFormatting.GREEN),
                                 false);
                 return 1;
             }
             case ERROR_SAVING -> {
                 context.getSource()
-                        .sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.errorSavingLootrun")
+                        .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.errorSavingLootrun")
                                 .withStyle(ChatFormatting.RED));
                 return 0;
             }
             case ERROR_ALREADY_EXISTS -> {
                 context.getSource()
-                        .sendFailure(new TranslatableComponent(
-                                        "feature.wynntils.lootrunUtils.errorSavingLootrunAlreadyExists")
-                                .withStyle(ChatFormatting.RED));
+                        .sendFailure(
+                                Component.translatable("feature.wynntils.lootrunUtils.errorSavingLootrunAlreadyExists")
+                                        .withStyle(ChatFormatting.RED));
                 return 0;
             }
         }
@@ -146,19 +144,19 @@ public class LootrunCommand extends CommandBase {
         BlockPos pos = root.blockPosition();
         context.getSource()
                 .sendSuccess(
-                        new TranslatableComponent("feature.wynntils.lootrunUtils.addedNote", pos.toShortString())
+                        Component.translatable("feature.wynntils.lootrunUtils.addedNote", pos.toShortString())
                                 .append("\n" + text),
                         false);
         return Models.Lootrun.addNote(text);
     }
 
     private int addTextLootrunNote(CommandContext<CommandSourceStack> context) {
-        Component text = new TextComponent(StringArgumentType.getString(context, "text"));
+        Component text = Component.literal(StringArgumentType.getString(context, "text"));
         Entity root = McUtils.player().getRootVehicle();
         BlockPos pos = root.blockPosition();
         context.getSource()
                 .sendSuccess(
-                        new TranslatableComponent("feature.wynntils.lootrunUtils.addedNote", pos.toShortString())
+                        Component.translatable("feature.wynntils.lootrunUtils.addedNote", pos.toShortString())
                                 .append("\n" + text),
                         false);
         return Models.Lootrun.addNote(text);
@@ -167,18 +165,18 @@ public class LootrunCommand extends CommandBase {
     private int listLootrunNote(CommandContext<CommandSourceStack> context) {
         List<LootrunModel.Note> notes = Models.Lootrun.getCurrentNotes();
         if (notes.isEmpty()) {
-            context.getSource().sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.listNoteNoNote"));
+            context.getSource().sendFailure(Component.translatable("feature.wynntils.lootrunUtils.listNoteNoNote"));
         } else {
-            MutableComponent component = new TranslatableComponent("feature.wynntils.lootrunUtils.listNoteHeader");
+            MutableComponent component = Component.translatable("feature.wynntils.lootrunUtils.listNoteHeader");
             for (LootrunModel.Note note : notes) {
                 BlockPos pos = new BlockPos(note.position());
                 String posString = pos.toShortString();
 
                 component
                         .append("\n")
-                        .append(new TextComponent("[X]").withStyle((style) -> style.withHoverEvent(new HoverEvent(
+                        .append(Component.literal("[X]").withStyle((style) -> style.withHoverEvent(new HoverEvent(
                                         HoverEvent.Action.SHOW_TEXT,
-                                        new TranslatableComponent("feature.wynntils.lootrunUtils.listClickToDelete")))
+                                        Component.translatable("feature.wynntils.lootrunUtils.listClickToDelete")))
                                 .withClickEvent(new ClickEvent(
                                         ClickEvent.Action.RUN_COMMAND,
                                         "/lootrun note delete " + posString.replace(",", "")))
@@ -198,7 +196,7 @@ public class LootrunCommand extends CommandBase {
         if (removedNote != null) {
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent(
+                            Component.translatable(
                                             "feature.wynntils.lootrunUtils.noteRemovedSuccessfully",
                                             removedNote.component())
                                     .withStyle(ChatFormatting.GREEN),
@@ -206,15 +204,14 @@ public class LootrunCommand extends CommandBase {
         } else {
             String posString = pos.toShortString();
             context.getSource()
-                    .sendFailure(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.noteUnableToFind", posString));
+                    .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.noteUnableToFind", posString));
         }
         return Models.Lootrun.recompileLootrun(true);
     }
 
     private int clearLootrun(CommandContext<CommandSourceStack> context) {
         if (Models.Lootrun.getState() == LootrunModel.LootrunState.DISABLED) {
-            context.getSource().sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.noActiveLootrun"));
+            context.getSource().sendFailure(Component.translatable("feature.wynntils.lootrunUtils.noActiveLootrun"));
             return 0;
         }
 
@@ -222,7 +219,7 @@ public class LootrunCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TranslatableComponent("feature.wynntils.lootrunUtils.clearSuccessful")
+                        Component.translatable("feature.wynntils.lootrunUtils.clearSuccessful")
                                 .withStyle(ChatFormatting.GREEN),
                         false);
         return 1;
@@ -233,18 +230,18 @@ public class LootrunCommand extends CommandBase {
         File file = new File(Models.Lootrun.LOOTRUNS, name + ".json");
         if (!file.exists()) {
             context.getSource()
-                    .sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.lootrunDoesntExist", name));
+                    .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.lootrunDoesntExist", name));
         } else if (file.delete()) {
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.lootrunDeleted", name)
+                            Component.translatable("feature.wynntils.lootrunUtils.lootrunDeleted", name)
                                     .withStyle(ChatFormatting.GREEN),
                             false);
             return 1;
         } else {
             context.getSource()
                     .sendFailure(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.lootrunCouldNotBeDeleted", name));
+                            Component.translatable("feature.wynntils.lootrunUtils.lootrunCouldNotBeDeleted", name));
         }
         return 0;
     }
@@ -256,18 +253,17 @@ public class LootrunCommand extends CommandBase {
         File newFile = new File(Models.Lootrun.LOOTRUNS, newName + ".json");
         if (!oldFile.exists()) {
             context.getSource()
-                    .sendFailure(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.lootrunDoesntExist", oldName));
+                    .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.lootrunDoesntExist", oldName));
         } else if (oldFile.renameTo(newFile)) {
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.lootrunRenamed", oldName, newName)
+                            Component.translatable("feature.wynntils.lootrunUtils.lootrunRenamed", oldName, newName)
                                     .withStyle(ChatFormatting.GREEN),
                             false);
             return 1;
         } else {
             context.getSource()
-                    .sendFailure(new TranslatableComponent(
+                    .sendFailure(Component.translatable(
                             "feature.wynntils.lootrunUtils.lootrunCouldNotBeRenamed", oldName, newName));
         }
         return 0;
@@ -281,12 +277,12 @@ public class LootrunCommand extends CommandBase {
         if (successful) {
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.chestAdded", pos.toShortString())
+                            Component.translatable("feature.wynntils.lootrunUtils.chestAdded", pos.toShortString())
                                     .withStyle(ChatFormatting.GREEN),
                             false);
         } else {
             context.getSource()
-                    .sendFailure(new TranslatableComponent(
+                    .sendFailure(Component.translatable(
                             "feature.wynntils.lootrunUtils.chestAlreadyAdded", pos.toShortString()));
         }
 
@@ -301,12 +297,12 @@ public class LootrunCommand extends CommandBase {
         if (successful) {
             context.getSource()
                     .sendSuccess(
-                            new TranslatableComponent("feature.wynntils.lootrunUtils.chestRemoved", pos.toShortString())
+                            Component.translatable("feature.wynntils.lootrunUtils.chestRemoved", pos.toShortString())
                                     .withStyle(ChatFormatting.GREEN),
                             false);
         } else {
             context.getSource()
-                    .sendFailure(new TranslatableComponent(
+                    .sendFailure(Component.translatable(
                             "feature.wynntils.lootrunUtils.chestDoesNotExist", pos.toShortString()));
         }
 
@@ -315,24 +311,23 @@ public class LootrunCommand extends CommandBase {
 
     private int undoLootrun(CommandContext<CommandSourceStack> context) {
         if (Models.Lootrun.getState() != LootrunModel.LootrunState.RECORDING) {
-            context.getSource().sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.notRecording"));
+            context.getSource().sendFailure(Component.translatable("feature.wynntils.lootrunUtils.notRecording"));
         } else {
             LootrunModel.LootrunUndoResult lootrunUndoResult = Models.Lootrun.tryUndo();
             switch (lootrunUndoResult) {
                 case SUCCESSFUL -> {
                     context.getSource()
-                            .sendSuccess(
-                                    new TranslatableComponent("feature.wynntils.lootrunUtils.undoSuccessful"), false);
+                            .sendSuccess(Component.translatable("feature.wynntils.lootrunUtils.undoSuccessful"), false);
                     return 1;
                 }
                 case ERROR_STAND_NEAR_POINT -> {
                     context.getSource()
-                            .sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.undoStandNear"));
+                            .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.undoStandNear"));
                     return 0;
                 }
                 case ERROR_NOT_FAR_ENOUGH -> {
                     context.getSource()
-                            .sendFailure(new TranslatableComponent("feature.wynntils.lootrunUtils.undoNotFarEnough"));
+                            .sendFailure(Component.translatable("feature.wynntils.lootrunUtils.undoNotFarEnough"));
                     return 0;
                 }
             }
@@ -346,7 +341,8 @@ public class LootrunCommand extends CommandBase {
     }
 
     private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TextComponent("Missing Commands.argument").withStyle(ChatFormatting.RED));
+        context.getSource()
+                .sendFailure(Component.literal("Missing Commands.argument").withStyle(ChatFormatting.RED));
         return 0;
     }
 

--- a/common/src/main/java/com/wynntils/commands/ServerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ServerCommand.java
@@ -19,8 +19,8 @@ import java.util.Set;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 public class ServerCommand extends CommandBase {
     private static final int UPDATE_TIME_OUT_MS = 3000;
@@ -55,13 +55,13 @@ public class ServerCommand extends CommandBase {
 
     private int serverInfoHelp(CommandContext<CommandSourceStack> context) {
         context.getSource()
-                .sendFailure(new TextComponent("Usage: /s i,info <server> | Example: \"/s i WC1\"")
+                .sendFailure(Component.literal("Usage: /s i,info <server> | Example: \"/s i WC1\"")
                         .withStyle(ChatFormatting.RED));
         return 1;
     }
 
     private int serverHelp(CommandContext<CommandSourceStack> context) {
-        MutableComponent text = new TextComponent(
+        MutableComponent text = Component.literal(
                         """
                 /s <command> [options]
 
@@ -81,8 +81,8 @@ public class ServerCommand extends CommandBase {
     private int serverInfo(CommandContext<CommandSourceStack> context) {
         if (!Models.ServerList.forceUpdate(UPDATE_TIME_OUT_MS)) {
             context.getSource()
-                    .sendFailure(
-                            new TextComponent("Network problems; using cached data").withStyle(ChatFormatting.RED));
+                    .sendFailure(Component.literal("Network problems; using cached data")
+                            .withStyle(ChatFormatting.RED));
         }
 
         String server = context.getArgument("server", String.class);
@@ -97,22 +97,23 @@ public class ServerCommand extends CommandBase {
 
         ServerProfile serverProfile = Models.ServerList.getServer(server);
         if (serverProfile == null) {
-            context.getSource().sendFailure(new TextComponent(server + " not found.").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal(server + " not found.").withStyle(ChatFormatting.RED));
             return 1;
         }
 
         Set<String> players = serverProfile.getPlayers();
-        MutableComponent message = new TextComponent(server + ":" + "\n")
+        MutableComponent message = Component.literal(server + ":" + "\n")
                 .withStyle(ChatFormatting.GOLD)
-                .append(new TextComponent("Uptime: " + serverProfile.getUptime() + "\n")
+                .append(Component.literal("Uptime: " + serverProfile.getUptime() + "\n")
                         .withStyle(ChatFormatting.DARK_AQUA))
-                .append(new TextComponent("Online players on " + server + ": " + players.size() + "\n")
+                .append(Component.literal("Online players on " + server + ": " + players.size() + "\n")
                         .withStyle(ChatFormatting.DARK_AQUA));
 
         if (players.isEmpty()) {
-            message.append(new TextComponent("No players!").withStyle(ChatFormatting.AQUA));
+            message.append(Component.literal("No players!").withStyle(ChatFormatting.AQUA));
         } else {
-            message.append(new TextComponent(String.join(", ", players)).withStyle(ChatFormatting.AQUA));
+            message.append(Component.literal(String.join(", ", players)).withStyle(ChatFormatting.AQUA));
         }
 
         context.getSource().sendSuccess(message, false);
@@ -123,11 +124,11 @@ public class ServerCommand extends CommandBase {
     private int serverList(CommandContext<CommandSourceStack> context) {
         if (!Models.ServerList.forceUpdate(3000)) {
             context.getSource()
-                    .sendFailure(
-                            new TextComponent("Network problems; using cached data").withStyle(ChatFormatting.RED));
+                    .sendFailure(Component.literal("Network problems; using cached data")
+                            .withStyle(ChatFormatting.RED));
         }
 
-        MutableComponent message = new TextComponent("Server list:").withStyle(ChatFormatting.DARK_AQUA);
+        MutableComponent message = Component.literal("Server list:").withStyle(ChatFormatting.DARK_AQUA);
 
         for (String serverType : Models.ServerList.getWynnServerTypes()) {
             List<String> currentTypeServers = Models.ServerList.getServersSortedOnNameOfType(serverType);
@@ -136,11 +137,12 @@ public class ServerCommand extends CommandBase {
 
             message.append("\n");
 
-            message.append(new TextComponent(
+            message.append(Component.literal(
                             StringUtils.capitalizeFirst(serverType) + " (" + currentTypeServers.size() + "):\n")
                     .withStyle(ChatFormatting.GOLD));
 
-            message.append(new TextComponent(String.join(", ", currentTypeServers)).withStyle(ChatFormatting.AQUA));
+            message.append(
+                    Component.literal(String.join(", ", currentTypeServers)).withStyle(ChatFormatting.AQUA));
         }
 
         context.getSource().sendSuccess(message, false);
@@ -151,16 +153,16 @@ public class ServerCommand extends CommandBase {
     private int serverUptimeList(CommandContext<CommandSourceStack> context) {
         if (!Models.ServerList.forceUpdate(3000)) {
             context.getSource()
-                    .sendFailure(
-                            new TextComponent("Network problems; using cached data").withStyle(ChatFormatting.RED));
+                    .sendFailure(Component.literal("Network problems; using cached data")
+                            .withStyle(ChatFormatting.RED));
         }
 
         List<String> sortedServers = Models.ServerList.getServersSortedOnUptime();
 
-        MutableComponent message = new TextComponent("Server list:").withStyle(ChatFormatting.DARK_AQUA);
+        MutableComponent message = Component.literal("Server list:").withStyle(ChatFormatting.DARK_AQUA);
         for (String server : sortedServers) {
             message.append("\n");
-            message.append(new TextComponent(
+            message.append(Component.literal(
                             server + ": " + Models.ServerList.getServer(server).getUptime())
                     .withStyle(ChatFormatting.AQUA));
         }

--- a/common/src/main/java/com/wynntils/commands/TerritoryCommand.java
+++ b/common/src/main/java/com/wynntils/commands/TerritoryCommand.java
@@ -17,9 +17,9 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 
 public class TerritoryCommand extends CommandBase {
     @Override
@@ -38,7 +38,8 @@ public class TerritoryCommand extends CommandBase {
     }
 
     private MutableComponent helpComponent() {
-        return new TextComponent("Usage: /territory [name] | Ex: /territory Detlas").withStyle(ChatFormatting.RED);
+        return Component.literal("Usage: /territory [name] | Ex: /territory Detlas")
+                .withStyle(ChatFormatting.RED);
     }
 
     private int territory(CommandContext<CommandSourceStack> context) {
@@ -48,7 +49,7 @@ public class TerritoryCommand extends CommandBase {
 
         if (territoryProfile == null) {
             context.getSource()
-                    .sendFailure(new TextComponent(
+                    .sendFailure(Component.literal(
                                     "Can't access territory " + "\"" + territoryArg + "\". There likely is a typo.")
                             .withStyle(ChatFormatting.RED));
             return 1;
@@ -57,34 +58,35 @@ public class TerritoryCommand extends CommandBase {
         int xMiddle = (territoryProfile.getStartX() + territoryProfile.getEndX()) / 2;
         int zMiddle = (territoryProfile.getStartZ() + territoryProfile.getEndZ()) / 2;
 
-        MutableComponent territoryComponent = new TextComponent(territoryProfile.getFriendlyName())
+        MutableComponent territoryComponent = Component.literal(territoryProfile.getFriendlyName())
                 .withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GREEN).withUnderlined(true));
 
         if (!ModelRegistry.isEnabled(Models.Compass.getClass())) {
             MutableComponent success = territoryComponent
                     .append(": ")
-                    .append(new TextComponent(" (" + xMiddle + ", " + zMiddle + ")").withStyle(ChatFormatting.GREEN));
+                    .append(Component.literal(" (" + xMiddle + ", " + zMiddle + ")")
+                            .withStyle(ChatFormatting.GREEN));
             context.getSource().sendSuccess(success, false);
             return 1;
         }
 
         Models.Compass.setCompassLocation(new Location(xMiddle, 0, zMiddle)); // update
 
-        MutableComponent separator = new TextComponent("-----------------------------------------------------")
+        MutableComponent separator = Component.literal("-----------------------------------------------------")
                 .withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY).withStrikethrough(true));
 
-        MutableComponent finalMessage = new TextComponent("");
+        MutableComponent finalMessage = Component.literal("");
 
         finalMessage.append(separator);
 
-        MutableComponent success = new TextComponent("The compass is now pointing towards ")
+        MutableComponent success = Component.literal("The compass is now pointing towards ")
                 .withStyle(ChatFormatting.GREEN)
                 .append(territoryComponent)
-                .append(new TextComponent(" (" + xMiddle + ", " + zMiddle + ")").withStyle(ChatFormatting.GREEN));
+                .append(Component.literal(" (" + xMiddle + ", " + zMiddle + ")").withStyle(ChatFormatting.GREEN));
 
         finalMessage.append("\n").append(success);
 
-        MutableComponent warn = new TextComponent(
+        MutableComponent warn = Component.literal(
                         "Note that this command redirects your" + " compass to the middle of said territory.")
                 .withStyle(ChatFormatting.AQUA);
 

--- a/common/src/main/java/com/wynntils/commands/TokenCommand.java
+++ b/common/src/main/java/com/wynntils/commands/TokenCommand.java
@@ -14,10 +14,10 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 
 public class TokenCommand extends CommandBase {
     @Override
@@ -27,10 +27,10 @@ public class TokenCommand extends CommandBase {
 
     private int token(CommandContext<CommandSourceStack> context) {
         if (!Managers.WynntilsAccount.isLoggedIn()) {
-            MutableComponent failed = new TextComponent(
+            MutableComponent failed = Component.literal(
                             "Either setting up your Wynntils account or accessing the token failed. To try to set up the Wynntils account again, run ")
                     .withStyle(ChatFormatting.GREEN);
-            failed.append(new TextComponent("/wynntils reload")
+            failed.append(Component.literal("/wynntils reload")
                     .withStyle(Style.EMPTY
                             .withColor(ChatFormatting.AQUA)
                             .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reload"))));
@@ -40,11 +40,11 @@ public class TokenCommand extends CommandBase {
 
         String token = Managers.WynntilsAccount.getToken();
 
-        MutableComponent text = new TextComponent("Wynntils Token ").withStyle(ChatFormatting.AQUA);
-        MutableComponent response = new TextComponent(token)
+        MutableComponent text = Component.literal("Wynntils Token ").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal(token)
                 .withStyle(Style.EMPTY
                         .withHoverEvent(new HoverEvent(
-                                HoverEvent.Action.SHOW_TEXT, new TextComponent("Click me to register an account.")))
+                                HoverEvent.Action.SHOW_TEXT, Component.literal("Click me to register an account.")))
                         .withClickEvent((new ClickEvent(
                                 ClickEvent.Action.OPEN_URL,
                                 Managers.Url.buildUrl(UrlId.LINK_WYNNTILS_REGISTER_ACCOUNT, Map.of("token", token)))))

--- a/common/src/main/java/com/wynntils/commands/UpdateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/UpdateCommand.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 
 public class UpdateCommand extends CommandBase {
     @Override
@@ -26,7 +26,7 @@ public class UpdateCommand extends CommandBase {
     private int update(CommandContext<CommandSourceStack> context) {
         if (WynntilsMod.isDevelopmentEnvironment()) {
             context.getSource()
-                    .sendFailure(new TranslatableComponent("feature.wynntils.updates.error.development")
+                    .sendFailure(Component.translatable("feature.wynntils.updates.error.development")
                             .withStyle(ChatFormatting.DARK_RED));
             WynntilsMod.error("Development environment detected, cannot update!");
             return 0;
@@ -39,16 +39,16 @@ public class UpdateCommand extends CommandBase {
             completableFuture.whenComplete((result, throwable) -> {
                 switch (result) {
                     case SUCCESSFUL -> McUtils.sendMessageToClient(
-                            new TranslatableComponent("feature.wynntils.updates.result.successful")
+                            Component.translatable("feature.wynntils.updates.result.successful")
                                     .withStyle(ChatFormatting.DARK_GREEN));
                     case ERROR -> McUtils.sendMessageToClient(
-                            new TranslatableComponent("feature.wynntils.updates.result.error")
+                            Component.translatable("feature.wynntils.updates.result.error")
                                     .withStyle(ChatFormatting.DARK_RED));
                     case ALREADY_ON_LATEST -> McUtils.sendMessageToClient(
-                            new TranslatableComponent("feature.wynntils.updates.result.latest")
+                            Component.translatable("feature.wynntils.updates.result.latest")
                                     .withStyle(ChatFormatting.YELLOW));
                     case UPDATE_PENDING -> McUtils.sendMessageToClient(
-                            new TranslatableComponent("feature.wynntils.updates.result.pending")
+                            Component.translatable("feature.wynntils.updates.result.pending")
                                     .withStyle(ChatFormatting.YELLOW));
                 }
             });
@@ -56,7 +56,8 @@ public class UpdateCommand extends CommandBase {
 
         context.getSource()
                 .sendSuccess(
-                        new TranslatableComponent("feature.wynntils.updates.checking").withStyle(ChatFormatting.GREEN),
+                        Component.translatable("feature.wynntils.updates.checking")
+                                .withStyle(ChatFormatting.GREEN),
                         false);
 
         return 1;

--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -20,10 +20,10 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 
 public class WynntilsCommand extends CommandBase {
     @Override
@@ -61,11 +61,11 @@ public class WynntilsCommand extends CommandBase {
         MutableComponent buildText;
 
         if (WynntilsMod.getVersion().isEmpty()) {
-            buildText = new TextComponent("Unknown Version");
+            buildText = Component.literal("Unknown Version");
         } else if (WynntilsMod.isDevelopmentBuild()) {
-            buildText = new TextComponent("Development Build");
+            buildText = Component.literal("Development Build");
         } else {
-            buildText = new TextComponent("Version " + WynntilsMod.getVersion());
+            buildText = Component.literal("Version " + WynntilsMod.getVersion());
         }
 
         buildText.setStyle(buildText.getStyle().withColor(ChatFormatting.YELLOW));
@@ -98,28 +98,30 @@ public class WynntilsCommand extends CommandBase {
                 feature.enable();
 
                 if (feature.isEnabled()) {
-                    McUtils.sendMessageToClient(new TextComponent("Reloaded ")
+                    McUtils.sendMessageToClient(Component.literal("Reloaded ")
                             .withStyle(ChatFormatting.GREEN)
-                            .append(new TextComponent(feature.getTranslatedName()).withStyle(ChatFormatting.AQUA)));
+                            .append(Component.literal(feature.getTranslatedName())
+                                    .withStyle(ChatFormatting.AQUA)));
 
                     continue;
                 }
             }
 
-            McUtils.sendMessageToClient(new TextComponent("Failed to reload ")
+            McUtils.sendMessageToClient(Component.literal("Failed to reload ")
                     .withStyle(ChatFormatting.GREEN)
-                    .append(new TextComponent(feature.getTranslatedName()).withStyle(ChatFormatting.RED)));
+                    .append(Component.literal(feature.getTranslatedName()).withStyle(ChatFormatting.RED)));
         }
 
         context.getSource()
-                .sendSuccess(new TextComponent("Finished reloading everything").withStyle(ChatFormatting.GREEN), false);
+                .sendSuccess(Component.literal("Finished reloading everything").withStyle(ChatFormatting.GREEN), false);
 
         return 1;
     }
 
     private int donateLink(CommandContext<CommandSourceStack> context) {
-        MutableComponent c = new TextComponent("You can donate to Wynntils at: ").withStyle(ChatFormatting.AQUA);
-        MutableComponent url = new TextComponent(Managers.Url.getUrl(UrlId.LINK_WYNNTILS_PATREON))
+        MutableComponent c =
+                Component.literal("You can donate to Wynntils at: ").withStyle(ChatFormatting.AQUA);
+        MutableComponent url = Component.literal(Managers.Url.getUrl(UrlId.LINK_WYNNTILS_PATREON))
                 .withStyle(Style.EMPTY
                         .withColor(ChatFormatting.LIGHT_PURPLE)
                         .withUnderlined(true)
@@ -127,7 +129,7 @@ public class WynntilsCommand extends CommandBase {
                                 ClickEvent.Action.OPEN_URL, Managers.Url.getUrl(UrlId.LINK_WYNNTILS_PATREON)))
                         .withHoverEvent(new HoverEvent(
                                 HoverEvent.Action.SHOW_TEXT,
-                                new TextComponent("Click here to open in your" + " browser."))));
+                                Component.literal("Click here to open in your" + " browser."))));
 
         context.getSource().sendSuccess(c.append(url), false);
         return 1;
@@ -135,7 +137,7 @@ public class WynntilsCommand extends CommandBase {
 
     private int help(CommandContext<CommandSourceStack> context) {
         MutableComponent text =
-                new TextComponent("Wynntils' command list: ").withStyle(Style.EMPTY.withColor(ChatFormatting.GOLD));
+                Component.literal("Wynntils' command list: ").withStyle(Style.EMPTY.withColor(ChatFormatting.GOLD));
         addCommandDescription(
                 text, "wynntils", List.of("help"), "This shows a list of all available commands for Wynntils.");
         addCommandDescription(
@@ -158,16 +160,16 @@ public class WynntilsCommand extends CommandBase {
     }
 
     private int discordLink(CommandContext<CommandSourceStack> context) {
-        MutableComponent msg =
-                new TextComponent("You're welcome to join our Discord server at:\n").withStyle(ChatFormatting.GOLD);
+        MutableComponent msg = Component.literal("You're welcome to join our Discord server at:\n")
+                .withStyle(ChatFormatting.GOLD);
         String discordInvite = Managers.Url.getUrl(UrlId.LINK_WYNNTILS_DISCORD_INVITE);
         MutableComponent link =
-                new TextComponent(discordInvite).withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_AQUA));
+                Component.literal(discordInvite).withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_AQUA));
         link.setStyle(link.getStyle()
                 .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, discordInvite))
                 .withHoverEvent(new HoverEvent(
                         HoverEvent.Action.SHOW_TEXT,
-                        new TextComponent("Click here to join our Discord" + " server."))));
+                        Component.literal("Click here to join our Discord" + " server."))));
         context.getSource().sendSuccess(msg.append(link), false);
         return 1;
     }
@@ -182,26 +184,27 @@ public class WynntilsCommand extends CommandBase {
             suffixString.append(" ").append(argument);
         }
 
-        MutableComponent clickComponent = new TextComponent("");
+        MutableComponent clickComponent = Component.literal("");
         {
             clickComponent.setStyle(clickComponent
                     .getStyle()
                     .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/" + prefix + suffixString))
                     .withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT, new TextComponent("Click here to run this command."))));
+                            HoverEvent.Action.SHOW_TEXT, Component.literal("Click here to run this command."))));
 
-            MutableComponent prefixText = new TextComponent("-" + prefix).withStyle(ChatFormatting.DARK_GRAY);
+            MutableComponent prefixText = Component.literal("-" + prefix).withStyle(ChatFormatting.DARK_GRAY);
             clickComponent.append(prefixText);
 
             if (!suffix.isEmpty()) {
-                MutableComponent nameText = new TextComponent(suffixString.toString()).withStyle(ChatFormatting.GREEN);
+                MutableComponent nameText =
+                        Component.literal(suffixString.toString()).withStyle(ChatFormatting.GREEN);
                 clickComponent.append(nameText);
             }
 
             clickComponent.append(" ");
 
             MutableComponent descriptionText =
-                    new TextComponent(description).withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY));
+                    Component.literal(description).withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY));
             clickComponent.append(descriptionText);
         }
 

--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -19,7 +19,7 @@ import java.io.InputStream;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.IEventBus;
 import org.slf4j.Logger;
@@ -99,7 +99,7 @@ public final class WynntilsMod {
         //       event, and we send a new message about disabling X feature,
         //       causing a new exception in client-side message event.
         if (!(event instanceof ClientsideMessageEvent)) {
-            McUtils.sendMessageToClient(new TextComponent("Wynntils error: Feature '" + feature.getTranslatedName()
+            McUtils.sendMessageToClient(Component.literal("Wynntils error: Feature '" + feature.getTranslatedName()
                             + "' has crashed and will be disabled")
                     .withStyle(ChatFormatting.RED));
         }

--- a/common/src/main/java/com/wynntils/core/commands/ClientCommandManager.java
+++ b/common/src/main/java/com/wynntils/core/commands/ClientCommandManager.java
@@ -35,11 +35,11 @@ import net.minecraft.commands.CommandRuntimeException;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 
 // Credits to Earthcomputer and Forge
 // Parts of this code originates from https://github.com/Earthcomputer/clientcommands, and other
@@ -128,12 +128,12 @@ public final class ClientCommandManager extends Manager {
         try {
             clientDispatcher.execute(parse);
         } catch (CommandRuntimeException e) {
-            sendError(new TextComponent(e.getMessage()));
+            sendError(Component.literal(e.getMessage()));
         } catch (CommandSyntaxException e) {
-            sendError(new TextComponent(e.getRawMessage().getString()));
+            sendError(Component.literal(e.getRawMessage().getString()));
             if (e.getInput() != null && e.getCursor() >= 0) {
                 int cursor = Math.min(e.getCursor(), e.getInput().length());
-                MutableComponent text = new TextComponent("")
+                MutableComponent text = Component.literal("")
                         .withStyle(Style.EMPTY
                                 .withColor(ChatFormatting.GRAY)
                                 .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command)));
@@ -141,18 +141,18 @@ public final class ClientCommandManager extends Manager {
 
                 text.append(e.getInput().substring(Math.max(0, cursor - 10), cursor));
                 if (cursor < e.getInput().length()) {
-                    text.append(new TextComponent(e.getInput().substring(cursor))
+                    text.append(Component.literal(e.getInput().substring(cursor))
                             .withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE));
                 }
 
-                text.append(new TranslatableComponent("command.context.here")
+                text.append(Component.translatable("command.context.here")
                         .withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
                 sendError(text);
             }
         } catch (RuntimeException e) {
             TextComponent error =
-                    new TextComponent(e.getMessage() == null ? e.getClass().getName() : e.getMessage());
-            sendError(new TranslatableComponent("command.failed")
+                    Component.literal(e.getMessage() == null ? e.getClass().getName() : e.getMessage());
+            sendError(Component.translatable("command.failed")
                     .withStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, error))));
             WynntilsMod.error("Failed to execute command.", e);
         }

--- a/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class OverlayManager extends Manager {
@@ -117,7 +117,7 @@ public final class OverlayManager extends Manager {
             } catch (Throwable t) {
                 WynntilsMod.error("Exception when rendering overlay " + overlay.getTranslatedName(), t);
                 WynntilsMod.warn("This overlay will be disabled");
-                McUtils.sendMessageToClient(new TextComponent("Wynntils error: Overlay '" + overlay.getTranslatedName()
+                McUtils.sendMessageToClient(Component.literal("Wynntils error: Overlay '" + overlay.getTranslatedName()
                                 + "' has crashed and will be disabled")
                         .withStyle(ChatFormatting.RED));
                 // We can't disable it right away since that will cause ConcurrentModificationException

--- a/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 /** Manage all built-in {@link Function}s */
 public final class FunctionManager extends Manager {
@@ -122,7 +121,7 @@ public final class FunctionManager extends Manager {
             return Optional.ofNullable(value);
         } catch (Throwable throwable) {
             WynntilsMod.warn("Exception when trying to get value of function " + function, throwable);
-            McUtils.sendMessageToClient(new TextComponent(String.format(
+            McUtils.sendMessageToClient(Component.literal(String.format(
                             "Function '%s' was disabled due to an exception.", function.getTranslatedName()))
                     .withStyle(ChatFormatting.RED));
 
@@ -136,17 +135,17 @@ public final class FunctionManager extends Manager {
     public Component getSimpleValueString(
             Function<?> function, String argument, ChatFormatting color, boolean includeName) {
         MutableComponent header = includeName
-                ? new TextComponent(function.getTranslatedName() + ": ").withStyle(ChatFormatting.WHITE)
-                : new TextComponent("");
+                ? Component.literal(function.getTranslatedName() + ": ").withStyle(ChatFormatting.WHITE)
+                : Component.literal("");
 
         Optional<Object> value = getFunctionValueSafely(function, argument);
         if (value.isEmpty()) {
-            return header.append(new TextComponent("??"));
+            return header.append(Component.literal("??"));
         }
 
         String formattedValue = format(value.get());
 
-        return header.append(new TextComponent(formattedValue).withStyle(color));
+        return header.append(Component.literal(formattedValue).withStyle(color));
     }
 
     public String getRawValueString(Function<?> function, String argument) {
@@ -173,7 +172,7 @@ public final class FunctionManager extends Manager {
      */
     public Component getStringFromTemplate(String template) {
         // FIXME: implement template parser
-        return new TextComponent(template);
+        return Component.literal(template);
     }
 
     /**

--- a/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 /** Registers and handles keybinds */
@@ -123,7 +123,7 @@ public final class KeyBindManager extends Manager {
                 WynntilsMod.error("Exception when handling key bind " + keyBind, t);
                 WynntilsMod.warn("This key bind will be disabled");
                 McUtils.sendMessageToClient(
-                        new TextComponent("Wynntils error: Key bind " + keyBind + " has crashed and will be disabled")
+                        Component.literal("Wynntils error: Key bind " + keyBind + " has crashed and will be disabled")
                                 .withStyle(ChatFormatting.RED));
                 // We can't disable it right away since that will cause ConcurrentModificationException
                 crashedKeyBinds.add(keyBind);

--- a/common/src/main/java/com/wynntils/core/net/athena/WynntilsAccountManager.java
+++ b/common/src/main/java/com/wynntils/core/net/athena/WynntilsAccountManager.java
@@ -26,9 +26,9 @@ import java.util.concurrent.TimeoutException;
 import javax.crypto.SecretKey;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.Crypt;
 import org.apache.commons.codec.binary.Hex;
 
@@ -56,11 +56,11 @@ public final class WynntilsAccountManager extends Manager {
         doLogin();
 
         if (!loggedIn) {
-            MutableComponent failed = new TextComponent(
+            MutableComponent failed = Component.literal(
                             "Welps! Trying to connect and set up the Wynntils Account with your data has failed. "
                                     + "Most notably, cloud config syncing will not work. To try this action again, run ")
                     .withStyle(ChatFormatting.GREEN);
-            failed.append(new TextComponent("/wynntils reload")
+            failed.append(Component.literal("/wynntils reload")
                     .withStyle(Style.EMPTY
                             .withColor(ChatFormatting.AQUA)
                             .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reload"))));

--- a/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
+++ b/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
@@ -16,7 +16,6 @@ import com.wynntils.wynn.event.WorldStateEvent;
 import com.wynntils.wynn.utils.WynnUtils;
 import java.util.concurrent.TimeUnit;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class NotificationManager {
@@ -107,6 +106,6 @@ public final class NotificationManager {
         McUtils.mc()
                 .gui
                 .getChat()
-                .addMessage(new TextComponent(msgContainer.getRenderTask().getText()), msgContainer.hashCode());
+                .addMessage(Component.literal(msgContainer.getRenderTask().getText()), msgContainer.hashCode());
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/AbbreviateMobHealthFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/AbbreviateMobHealthFeature.java
@@ -12,7 +12,6 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.AddOperation;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.Operation;
@@ -48,6 +47,6 @@ public class AbbreviateMobHealthFeature extends UserFeature {
         String formattedHealth = StringUtils.integerToShortString(rawHealth).toUpperCase(Locale.ROOT);
 
         String formattedName = healthMatcher.replaceAll("$1" + formattedHealth + "$3");
-        return new TextComponent(formattedName);
+        return Component.literal(formattedName);
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/ChatCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ChatCoordinatesFeature.java
@@ -22,7 +22,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -50,7 +49,7 @@ public class ChatCoordinatesFeature extends UserFeature {
                 message.getSiblings().stream().map(Component::copy).collect(Collectors.toList());
         components.add(0, message.plainCopy().withStyle(message.getStyle()));
 
-        MutableComponent temp = new TextComponent("");
+        MutableComponent temp = Component.literal("");
 
         for (Component comp : components) {
             Matcher m = LocationUtils.strictCoordinateMatcher((ComponentUtils.getCoded(comp)));
@@ -70,7 +69,7 @@ public class ChatCoordinatesFeature extends UserFeature {
                     continue;
                 }
 
-                MutableComponent preText = new TextComponent(text.substring(0, m.start()));
+                MutableComponent preText = Component.literal(text.substring(0, m.start()));
                 preText.withStyle(style);
                 temp.append(preText);
 
@@ -78,7 +77,7 @@ public class ChatCoordinatesFeature extends UserFeature {
                 Component compassComponent = createLocationComponent(location.get());
                 temp.append(compassComponent);
 
-                comp = new TextComponent(ComponentUtils.getLastPartCodes(ComponentUtils.getCoded(preText))
+                comp = Component.literal(ComponentUtils.getLastPartCodes(ComponentUtils.getCoded(preText))
                                 + text.substring(m.end()))
                         .withStyle(style);
                 m = LocationUtils.strictCoordinateMatcher(
@@ -92,7 +91,7 @@ public class ChatCoordinatesFeature extends UserFeature {
     }
 
     private static Component createLocationComponent(Location location) {
-        MutableComponent component = new TextComponent(
+        MutableComponent component = Component.literal(
                         "[%d, %d, %d]".formatted((int) location.x, (int) location.y, (int) location.z))
                 .withStyle(ChatFormatting.DARK_AQUA)
                 .withStyle(ChatFormatting.UNDERLINE);
@@ -100,7 +99,7 @@ public class ChatCoordinatesFeature extends UserFeature {
         component.withStyle(style -> style.withClickEvent(new ClickEvent(
                 ClickEvent.Action.RUN_COMMAND, "/compass at " + location.x + " " + location.y + " " + location.z)));
         component.withStyle(style -> style.withHoverEvent(new HoverEvent(
-                HoverEvent.Action.SHOW_TEXT, new TextComponent("Click here to set your compass to this location"))));
+                HoverEvent.Action.SHOW_TEXT, Component.literal("Click here to set your compass to this location"))));
 
         return component;
     }

--- a/common/src/main/java/com/wynntils/features/user/ChatTimestampFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ChatTimestampFeature.java
@@ -17,8 +17,6 @@ import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -41,7 +39,7 @@ public class ChatTimestampFeature extends UserFeature {
         } catch (Exception e) {
             formatter = null;
 
-            McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.chatTimestamp.invalidFormatMsg")
+            McUtils.sendMessageToClient(Component.translatable("feature.wynntils.chatTimestamp.invalidFormatMsg")
                     .withStyle(ChatFormatting.DARK_RED));
         }
     }
@@ -53,7 +51,7 @@ public class ChatTimestampFeature extends UserFeature {
         Component message = event.getMessage();
 
         LocalDateTime date = LocalDateTime.now();
-        MutableComponent timestamp = new TextComponent("§8[§7" + date.format(formatter) + "§8]§r ");
+        MutableComponent timestamp = Component.literal("§8[§7" + date.format(formatter) + "§8]§r ");
 
         timestamp.append(message);
 

--- a/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -86,7 +86,7 @@ public class CustomNametagRendererFeature extends UserFeature {
         String itemName = WynnItemUtils.getTranslatedName(itemStack);
 
         if (itemName.contains("Crafted")) {
-            event.addInjectedLine(new TextComponent(itemName).withStyle(ChatFormatting.DARK_AQUA));
+            event.addInjectedLine(Component.literal(itemName).withStyle(ChatFormatting.DARK_AQUA));
             return;
         }
 
@@ -98,12 +98,12 @@ public class CustomNametagRendererFeature extends UserFeature {
         if (itemStack.getItem() == Items.STONE_SHOVEL
                 && itemStack.getDamageValue() >= 1
                 && itemStack.getDamageValue() <= 6) {
-            event.addInjectedLine(new TextComponent("Unidentified Item")
+            event.addInjectedLine(Component.literal("Unidentified Item")
                     .withStyle(itemProfile.getTier().getChatFormatting()));
             return;
         }
 
-        event.addInjectedLine(new TextComponent(itemProfile.getDisplayName())
+        event.addInjectedLine(Component.literal(itemProfile.getDisplayName())
                 .withStyle(itemProfile.getTier().getChatFormatting()));
     }
 

--- a/common/src/main/java/com/wynntils/features/user/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/HealthPotionBlockerFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wynn.item.parsers.WynnItemMatchers;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -50,9 +49,9 @@ public class HealthPotionBlockerFeature extends UserFeature {
         if (Models.ActionBar.getCurrentHealth() * 100 < Models.ActionBar.getMaxHealth() * threshold) return null;
 
         if (threshold < 100)
-            return new TranslatableComponent("feature.wynntils.healthPotionBlocker.thresholdReached", threshold)
+            return Component.translatable("feature.wynntils.healthPotionBlocker.thresholdReached", threshold)
                     .withStyle(ChatFormatting.RED);
-        return new TranslatableComponent("feature.wynntils.healthPotionBlocker.healthFull")
+        return Component.translatable("feature.wynntils.healthPotionBlocker.healthFull")
                 .withStyle(ChatFormatting.RED);
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/ItemFavoriteFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemFavoriteFeature.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Set;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -58,7 +58,7 @@ public class ItemFavoriteFeature extends UserFeature {
             ItemStack stack = items.get(i);
 
             if (isFavorited(stack)) {
-                McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.itemFavorite.closingBlocked")
+                McUtils.sendMessageToClient(Component.translatable("feature.wynntils.itemFavorite.closingBlocked")
                         .withStyle(ChatFormatting.RED));
                 e.setCanceled(true);
                 return;

--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -31,7 +31,6 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -109,12 +108,12 @@ public class ItemScreenshotFeature extends UserFeature {
         try {
             RenderUtils.copyImageToClipboard(bi);
             McUtils.sendMessageToClient(
-                    new TranslatableComponent("feature.wynntils.itemScreenshot.message", stack.getHoverName())
+                    Component.translatable("feature.wynntils.itemScreenshot.message", stack.getHoverName())
                             .withStyle(ChatFormatting.GREEN));
         } catch (HeadlessException ex) {
             WynntilsMod.error("Failed to copy image to clipboard", ex);
             McUtils.sendMessageToClient(
-                    new TranslatableComponent("feature.wynntils.itemScreenshot.error", stack.getHoverName())
+                    Component.translatable("feature.wynntils.itemScreenshot.error", stack.getHoverName())
                             .withStyle(ChatFormatting.RED));
         }
 
@@ -122,13 +121,13 @@ public class ItemScreenshotFeature extends UserFeature {
         if (stack instanceof GearItemStack gearItem) {
             String encoded = Models.ChatItem.encodeItem(gearItem);
 
-            McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.itemScreenshot.chatItemMessage")
+            McUtils.sendMessageToClient(Component.translatable("feature.wynntils.itemScreenshot.chatItemMessage")
                     .withStyle(ChatFormatting.DARK_GREEN)
                     .withStyle(ChatFormatting.UNDERLINE)
                     .withStyle(s -> s.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, encoded)))
                     .withStyle(s -> s.withHoverEvent(new HoverEvent(
                             HoverEvent.Action.SHOW_TEXT,
-                            new TranslatableComponent("feature.wynntils.itemScreenshot.chatItemTooltip")
+                            Component.translatable("feature.wynntils.itemScreenshot.chatItemTooltip")
                                     .withStyle(ChatFormatting.DARK_AQUA)))));
         }
     }

--- a/common/src/main/java/com/wynntils/features/user/MountHorseHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/MountHorseHotkeyFeature.java
@@ -16,7 +16,7 @@ import com.wynntils.wynn.utils.EntityUtils;
 import com.wynntils.wynn.utils.InventoryUtils;
 import com.wynntils.wynn.utils.WynnUtils;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
@@ -99,7 +99,7 @@ public class MountHorseHotkeyFeature extends UserFeature {
     private static void postHorseErrorMessage(MountHorseStatus status) {
 
         NotificationManager.queueMessage(
-                new TranslatableComponent(status.getTcString()).withStyle(ChatFormatting.DARK_RED));
+                Component.translatable(status.getTcString()).withStyle(ChatFormatting.DARK_RED));
     }
 
     private enum MountHorseStatus {

--- a/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
@@ -15,7 +15,7 @@ import com.wynntils.wynn.utils.ContainerUtils;
 import com.wynntils.wynn.utils.WynnUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -30,7 +30,7 @@ public class MythicBlockerFeature extends UserFeature {
         for (int i = 0; i < 27; i++) {
             ItemStack stack = items.get(i);
             if (WynnItemMatchers.isMythic(stack)) {
-                McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.mythicBlocker.closingBlocked")
+                McUtils.sendMessageToClient(Component.translatable("feature.wynntils.mythicBlocker.closingBlocked")
                         .withStyle(ChatFormatting.RED));
                 e.setCanceled(true);
                 return;

--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -26,8 +26,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
 import net.minecraft.network.protocol.game.ServerboundSwingPacket;
@@ -126,14 +126,14 @@ public class QuickCastFeature extends UserFeature {
 
     private void tryCastSpell(SpellUnit a, SpellUnit b, SpellUnit c) {
         if (!SPELL_PACKET_QUEUE.isEmpty()) {
-            sendCancelReason(new TranslatableComponent("feature.wynntils.quickCast.anotherInProgress"));
+            sendCancelReason(Component.translatable("feature.wynntils.quickCast.anotherInProgress"));
             return;
         }
 
         ItemStack heldItem = McUtils.player().getItemInHand(InteractionHand.MAIN_HAND);
 
         if (!WynnItemMatchers.isWeapon(heldItem)) {
-            sendCancelReason(new TranslatableComponent("feature.wynntils.quickCast.notAWeapon"));
+            sendCancelReason(Component.translatable("feature.wynntils.quickCast.notAWeapon"));
             return;
         }
 
@@ -144,14 +144,14 @@ public class QuickCastFeature extends UserFeature {
             if (lore.contains("Archer/Hunter")) isArcher = true;
             Matcher matcher = INCORRECT_CLASS_PATTERN.matcher(lore);
             if (!matcher.matches()) continue;
-            sendCancelReason(new TranslatableComponent("feature.wynntils.quickCast.classMismatch", matcher.group(1)));
+            sendCancelReason(Component.translatable("feature.wynntils.quickCast.classMismatch", matcher.group(1)));
             return;
         }
 
         for (String lore : loreLines) {
             Matcher matcher = LVL_MIN_NOT_REACHED_PATTERN.matcher(lore);
             if (!matcher.matches()) continue;
-            sendCancelReason(new TranslatableComponent(
+            sendCancelReason(Component.translatable(
                     "feature.wynntils.quickCast.levelRequirementNotReached", matcher.group(1), matcher.group(2)));
             return;
         }
@@ -162,7 +162,7 @@ public class QuickCastFeature extends UserFeature {
                 .toList();
         for (int i = 0; i < spellInProgress.length; ++i) {
             if (spellInProgress[i] != spell.get(i)) {
-                sendCancelReason(new TranslatableComponent("feature.wynntils.quickCast.incompatibleInProgress"));
+                sendCancelReason(Component.translatable("feature.wynntils.quickCast.incompatibleInProgress"));
                 return;
             }
         }

--- a/common/src/main/java/com/wynntils/features/user/TranslationFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TranslationFeature.java
@@ -18,7 +18,6 @@ import com.wynntils.wynn.event.ChatMessageReceivedEvent;
 import com.wynntils.wynn.event.NpcDialogEvent;
 import java.util.List;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -69,7 +68,7 @@ public class TranslationFeature extends UserFeature {
                 // We failed to get a translation; send the original message so it's not lost
                 messageToSend = origCoded;
             }
-            McUtils.mc().doRunTask(() -> McUtils.sendMessageToClient(new TextComponent(messageToSend)));
+            McUtils.mc().doRunTask(() -> McUtils.sendMessageToClient(Component.literal(messageToSend)));
         });
         if (!keepOriginal) {
             e.setCanceled(true);
@@ -88,7 +87,7 @@ public class TranslationFeature extends UserFeature {
                 String unwrapped = unwrapCoding(translatedMsg);
                 // FIXME: We need a ComponentUtils.componentFromCoded()...
                 // This will currently remove all formatting :(
-                Component translatedComponent = new TextComponent(ComponentUtils.stripFormatting(unwrapped));
+                Component translatedComponent = Component.literal(ComponentUtils.stripFormatting(unwrapped));
                 McUtils.mc().doRunTask(() -> {
                     NpcDialogEvent translatedEvent = new TranslatedNpcDialogEvent(translatedComponent);
                     WynntilsMod.postEvent(translatedEvent);

--- a/common/src/main/java/com/wynntils/features/user/UpdatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/UpdatesFeature.java
@@ -16,9 +16,8 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class UpdatesFeature extends UserFeature {
@@ -66,7 +65,7 @@ public class UpdatesFeature extends UserFeature {
 
                         WynntilsMod.info("Attempting to auto-update.");
 
-                        McUtils.sendMessageToClient(new TranslatableComponent("feature.wynntils.updates.updating")
+                        McUtils.sendMessageToClient(Component.translatable("feature.wynntils.updates.updating")
                                 .withStyle(ChatFormatting.YELLOW));
 
                         CompletableFuture<UpdateManager.UpdateResult> completableFuture = Managers.Update.tryUpdate();
@@ -74,16 +73,16 @@ public class UpdatesFeature extends UserFeature {
                         completableFuture.whenCompleteAsync((result, t) -> {
                             switch (result) {
                                 case SUCCESSFUL -> McUtils.sendMessageToClient(
-                                        new TranslatableComponent("feature.wynntils.updates.result.successful")
+                                        Component.translatable("feature.wynntils.updates.result.successful")
                                                 .withStyle(ChatFormatting.DARK_GREEN));
                                 case ERROR -> McUtils.sendMessageToClient(
-                                        new TranslatableComponent("feature.wynntils.updates.result.error")
+                                        Component.translatable("feature.wynntils.updates.result.error")
                                                 .withStyle(ChatFormatting.DARK_RED));
                                 case ALREADY_ON_LATEST -> McUtils.sendMessageToClient(
-                                        new TranslatableComponent("feature.wynntils.updates.result.latest")
+                                        Component.translatable("feature.wynntils.updates.result.latest")
                                                 .withStyle(ChatFormatting.YELLOW));
                                 case UPDATE_PENDING -> McUtils.sendMessageToClient(
-                                        new TranslatableComponent("feature.wynntils.updates.result.pending")
+                                        Component.translatable("feature.wynntils.updates.result.pending")
                                                 .withStyle(ChatFormatting.YELLOW));
                             }
                         });
@@ -92,20 +91,20 @@ public class UpdatesFeature extends UserFeature {
     }
 
     private static void remindToUpdateIfExists(String newVersion) {
-        MutableComponent clickable = new TranslatableComponent("feature.wynntils.updates.reminder.clickable");
+        MutableComponent clickable = Component.translatable("feature.wynntils.updates.reminder.clickable");
         clickable.setStyle(clickable
                 .getStyle()
                 .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/update"))
                 .withUnderlined(true)
                 .withBold(true));
 
-        McUtils.sendMessageToClient(new TextComponent("[Wynntils/Artemis]: ")
+        McUtils.sendMessageToClient(Component.literal("[Wynntils/Artemis]: ")
                 .withStyle(ChatFormatting.GREEN)
-                .append(new TranslatableComponent(
+                .append(Component.translatable(
                                 "feature.wynntils.updates.reminder", WynntilsMod.getVersion(), newVersion)
                         .append(clickable)
-                        .append(new TextComponent("\n"))
-                        .append(new TranslatableComponent("feature.wynntils.updates.reminder.alpha"))
+                        .append(Component.literal("\n"))
+                        .append(Component.translatable("feature.wynntils.updates.reminder.alpha"))
                         .withStyle(ChatFormatting.GREEN)));
     }
 }

--- a/common/src/main/java/com/wynntils/features/user/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/WynncraftButtonFeature.java
@@ -18,7 +18,7 @@ import net.minecraft.client.gui.screens.ConnectScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @FeatureInfo(stability = Stability.INVARIABLE)
@@ -49,7 +49,7 @@ public class WynncraftButtonFeature extends UserFeature {
 
         // TODO tooltip
         WynncraftButton(Screen backScreen, ServerData serverData, int x, int y) {
-            super(x, y, 20, 20, new TranslatableComponent(""), WynncraftButton::onPress);
+            super(x, y, 20, 20, Component.translatable(""), WynncraftButton::onPress);
             this.serverData = serverData;
             this.backScreen = backScreen;
 

--- a/common/src/main/java/com/wynntils/features/user/WynncraftPauseScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/WynncraftPauseScreenFeature.java
@@ -17,7 +17,6 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class WynncraftPauseScreenFeature extends UserFeature {
@@ -28,20 +27,20 @@ public class WynncraftPauseScreenFeature extends UserFeature {
 
         Button territoryMap = replaceButtonFunction(
                 (Button) renderables.get(1),
-                new TranslatableComponent("feature.wynntils.wynncraftPauseScreen.territoryMap.name")
+                Component.translatable("feature.wynntils.wynncraftPauseScreen.territoryMap.name")
                         .withStyle(ChatFormatting.DARK_AQUA),
                 (button) -> McUtils.mc().setScreen(GuildMapScreen.create()));
         renderables.set(1, territoryMap);
 
         Button wynntilsMenu = replaceButtonFunction(
                 (Button) renderables.get(2),
-                new TranslatableComponent("feature.wynntils.wynncraftPauseScreen.wynntilsMenuButton.name"),
+                Component.translatable("feature.wynntils.wynncraftPauseScreen.wynntilsMenuButton.name"),
                 (button) -> McUtils.mc().setScreen(WynntilsMenuScreen.create()));
         renderables.set(2, wynntilsMenu);
 
         Button classSelection = replaceButtonFunction(
                 (Button) renderables.get(3),
-                new TranslatableComponent("feature.wynntils.wynncraftPauseScreen.classSelectionButton.name"),
+                Component.translatable("feature.wynntils.wynncraftPauseScreen.classSelectionButton.name"),
                 (button) -> {
                     McUtils.mc().setScreen(null);
                     McUtils.mc().mouseHandler.grabMouse();
@@ -52,7 +51,7 @@ public class WynncraftPauseScreenFeature extends UserFeature {
 
         Button hub = replaceButtonFunction(
                 (Button) renderables.get(4),
-                new TranslatableComponent("feature.wynntils.wynncraftPauseScreen.hubButton.name"),
+                Component.translatable("feature.wynntils.wynncraftPauseScreen.hubButton.name"),
                 (button) -> {
                     McUtils.mc().setScreen(null);
                     McUtils.mc().mouseHandler.grabMouse();

--- a/common/src/main/java/com/wynntils/features/user/map/MapFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/map/MapFeature.java
@@ -38,7 +38,7 @@ import java.util.regex.Matcher;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.inventory.ContainerScreen;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -169,7 +169,7 @@ public class MapFeature extends UserFeature {
             MapFeature.INSTANCE.customPois.add(newPoi);
 
             // TODO: Replace this notification with a popup
-            NotificationManager.queueMessage(new TextComponent("Added new waypoint for " + tier.getWaypointName())
+            NotificationManager.queueMessage(Component.literal("Added new waypoint for " + tier.getWaypointName())
                     .withStyle(ChatFormatting.AQUA));
 
             Managers.Config.saveConfig();

--- a/common/src/main/java/com/wynntils/gui/screens/CharacterSelectorScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/CharacterSelectorScreen.java
@@ -27,7 +27,7 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 
 public class CharacterSelectorScreen extends Screen {
     private static final int CHARACTER_INFO_PER_PAGE = 7;
@@ -44,7 +44,7 @@ public class CharacterSelectorScreen extends Screen {
     private ClassInfoButton selected = null;
 
     private CharacterSelectorScreen() {
-        super(new TranslatableComponent("screens.wynntils.characterSelection.name"));
+        super(Component.translatable("screens.wynntils.characterSelection.name"));
 
         if (McUtils.mc().screen instanceof AbstractContainerScreen<?> abstractContainerScreen) {
             actualClassSelectionScreen = abstractContainerScreen;

--- a/common/src/main/java/com/wynntils/gui/screens/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/ChatTabEditingScreen.java
@@ -26,8 +26,7 @@ import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class ChatTabEditingScreen extends Screen implements TextboxScreen {
@@ -51,7 +50,7 @@ public class ChatTabEditingScreen extends Screen implements TextboxScreen {
     }
 
     private ChatTabEditingScreen(ChatTab tab) {
-        super(new TextComponent("Chat Tab Editing Screen"));
+        super(Component.literal("Chat Tab Editing Screen"));
 
         this.edited = tab;
         this.firstSetup = true;
@@ -137,7 +136,7 @@ public class ChatTabEditingScreen extends Screen implements TextboxScreen {
                             || edited.getFilteredTypes().contains(type));
             boolean ticked = oldCheckboxSelected || editedFirstSetupSelected;
 
-            Checkbox newBox = new Checkbox(x, y, 20, 20, new TextComponent(type.getName()), ticked, true);
+            Checkbox newBox = new Checkbox(x, y, 20, 20, Component.literal(type.getName()), ticked, true);
             this.addRenderableWidget(newBox);
             recipientTypeBoxes.add(newBox);
 
@@ -162,7 +161,7 @@ public class ChatTabEditingScreen extends Screen implements TextboxScreen {
                         this.height / 2 + 75,
                         20,
                         20,
-                        new TranslatableComponent("screens.wynntils.chatTabsGui.consuming"),
+                        Component.translatable("screens.wynntils.chatTabsGui.consuming"),
                         consumingCheckbox != null && consumingCheckbox.selected(),
                         true));
         if (firstSetup && edited != null) {
@@ -177,7 +176,7 @@ public class ChatTabEditingScreen extends Screen implements TextboxScreen {
                         this.height - 40,
                         100,
                         20,
-                        new TranslatableComponent("screens.wynntils.chatTabsGui.save")
+                        Component.translatable("screens.wynntils.chatTabsGui.save")
                                 .withStyle(ChatFormatting.DARK_GREEN),
                         (button) -> {
                             saveChatTab();
@@ -190,7 +189,7 @@ public class ChatTabEditingScreen extends Screen implements TextboxScreen {
                         this.height - 40,
                         100,
                         20,
-                        new TranslatableComponent("screens.wynntils.chatTabsGui.delete")
+                        Component.translatable("screens.wynntils.chatTabsGui.delete")
                                 .withStyle(ChatFormatting.DARK_RED),
                         (button) -> {
                             deleteChatTab();
@@ -202,7 +201,7 @@ public class ChatTabEditingScreen extends Screen implements TextboxScreen {
                 this.height - 40,
                 100,
                 20,
-                new TranslatableComponent("screens.wynntils.chatTabsGui.cancel"),
+                Component.translatable("screens.wynntils.chatTabsGui.cancel"),
                 (button) -> this.onClose()));
         // endregion
 

--- a/common/src/main/java/com/wynntils/gui/screens/GearViewerScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/GearViewerScreen.java
@@ -22,13 +22,12 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
 public class GearViewerScreen extends Screen {
     private static final List<Component> VIEW_STATS_TOOLTIP =
-            List.of(new TranslatableComponent("screens.wynntils.gearViewer.viewStats"));
+            List.of(Component.translatable("screens.wynntils.gearViewer.viewStats"));
 
     private final Player player;
     private final ItemStack heldItem;

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsDialogueHistoryScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsDialogueHistoryScreen.java
@@ -30,17 +30,15 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class WynntilsDialogueHistoryScreen extends WynntilsMenuPagedScreenBase {
     private static final int LINES_PER_PAGE = 16;
 
     private static final List<Component> RELOAD_TOOLTIP = List.of(
-            new TranslatableComponent("screens.wynntils.wynntilsDialogueHistory.reload.name")
+            Component.translatable("screens.wynntils.wynntilsDialogueHistory.reload.name")
                     .withStyle(ChatFormatting.WHITE),
-            new TranslatableComponent("screens.wynntils.wynntilsDialogueHistory.reload.description")
+            Component.translatable("screens.wynntils.wynntilsDialogueHistory.reload.description")
                     .withStyle(ChatFormatting.GRAY));
     private Widget hovered = null;
 
@@ -48,7 +46,7 @@ public class WynntilsDialogueHistoryScreen extends WynntilsMenuPagedScreenBase {
     private List<List<String>> dialogues = new ArrayList<>();
 
     private WynntilsDialogueHistoryScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsDialogueHistory.name"));
+        super(Component.translatable("screens.wynntils.wynntilsDialogueHistory.name"));
 
         // Only register this once
         WynntilsMod.registerEventListener(this);
@@ -200,16 +198,16 @@ public class WynntilsDialogueHistoryScreen extends WynntilsMenuPagedScreenBase {
 
         if (this.hovered instanceof QuestsPageButton) {
             List<Component> tooltipLines = List.of(
-                    new TextComponent("[>] ")
+                    Component.literal("[>] ")
                             .withStyle(ChatFormatting.GOLD)
-                            .append(new TranslatableComponent(
+                            .append(Component.translatable(
                                             "screens.wynntils.wynntilsDialogueHistory.questsPageButton.name")
                                     .withStyle(ChatFormatting.BOLD)
                                     .withStyle(ChatFormatting.GOLD)),
-                    new TranslatableComponent("screens.wynntils.wynntilsDialogueHistory.questsPageButton.description")
+                    Component.translatable("screens.wynntils.wynntilsDialogueHistory.questsPageButton.description")
                             .withStyle(ChatFormatting.GRAY),
-                    new TextComponent(""),
-                    new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                    Component.literal(""),
+                    Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                             .withStyle(ChatFormatting.GREEN));
 
             RenderUtils.drawTooltipAt(

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsDiscoveriesScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsDiscoveriesScreen.java
@@ -31,15 +31,13 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryInfo, DiscoveryButton> {
     private static final List<Component> RELOAD_TOOLTIP = List.of(
-            new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.reload.name")
+            Component.translatable("screens.wynntils.wynntilsDiscoveries.reload.name")
                     .withStyle(ChatFormatting.WHITE),
-            new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.reload.description")
+            Component.translatable("screens.wynntils.wynntilsDiscoveries.reload.description")
                     .withStyle(ChatFormatting.GRAY));
 
     private final List<DiscoveryFilterButton> filterButtons = new ArrayList<>();
@@ -53,7 +51,7 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
     private boolean showUndiscoveredTerritory = false;
 
     private WynntilsDiscoveriesScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.name"));
+        super(Component.translatable("screens.wynntils.wynntilsDiscoveries.name"));
 
         // Only register this once
         WynntilsMod.registerEventListener(this);
@@ -95,10 +93,9 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
                 30,
                 Texture.DISCOVERED_TERRITORY,
                 true,
-                List.of(new TextComponent("[>] ")
+                List.of(Component.literal("[>] ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TranslatableComponent(
-                                        "screens.wynntils.wynntilsDiscoveries.showFoundTerritory.name")
+                        .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.showFoundTerritory.name")
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
@@ -113,9 +110,9 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
                 30,
                 Texture.DISCOVERED_WORLD,
                 true,
-                List.of(new TextComponent("[>] ")
+                List.of(Component.literal("[>] ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.showFoundWorld.name")
+                        .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.showFoundWorld.name")
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
@@ -130,9 +127,9 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
                 30,
                 Texture.DISCOVERED_SECRET,
                 true,
-                List.of(new TextComponent("[>] ")
+                List.of(Component.literal("[>] ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.showFoundSecret.name")
+                        .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.showFoundSecret.name")
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
@@ -147,10 +144,9 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
                 30,
                 Texture.UNDISCOVERED_TERRITORY,
                 true,
-                List.of(new TextComponent("[>] ")
+                List.of(Component.literal("[>] ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TranslatableComponent(
-                                        "screens.wynntils.wynntilsDiscoveries.showUnfoundTerritory.name")
+                        .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.showUnfoundTerritory.name")
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
@@ -165,9 +161,9 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
                 30,
                 Texture.UNDISCOVERED_WORLD,
                 true,
-                List.of(new TextComponent("[>] ")
+                List.of(Component.literal("[>] ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.showUnfoundWorld.name")
+                        .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.showUnfoundWorld.name")
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
@@ -182,9 +178,9 @@ public class WynntilsDiscoveriesScreen extends WynntilsMenuListScreen<DiscoveryI
                 30,
                 Texture.UNDISCOVERED_SECRET,
                 true,
-                List.of(new TextComponent("[>] ")
+                List.of(Component.literal("[>] ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.showUnfoundSecret.name")
+                        .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.showUnfoundSecret.name")
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsGuidesListScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsGuidesListScreen.java
@@ -22,7 +22,7 @@ import com.wynntils.utils.StringUtils;
 import java.util.List;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 
 public class WynntilsGuidesListScreen extends WynntilsMenuListScreen<Screen, GuidesButton> {
     private final List<Screen> GUIDES = List.of(
@@ -32,7 +32,7 @@ public class WynntilsGuidesListScreen extends WynntilsMenuListScreen<Screen, Gui
             WynntilsPowderGuideScreen.create());
 
     private WynntilsGuidesListScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsGuides.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.name"));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsLootrunsScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsLootrunsScreen.java
@@ -24,13 +24,11 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.phys.Vec3;
 
 public class WynntilsLootrunsScreen extends WynntilsMenuListScreen<LootrunModel.LootrunInstance, LootrunButton> {
     private WynntilsLootrunsScreen() {
-        super(new TranslatableComponent("screens.wynntils.lootruns.name"));
+        super(Component.translatable("screens.wynntils.lootruns.name"));
     }
 
     public static Screen create() {
@@ -80,25 +78,25 @@ public class WynntilsLootrunsScreen extends WynntilsMenuListScreen<LootrunModel.
             if (currentLootrun != null
                     && Objects.equals(lootrunButton.getLootrun().name(), currentLootrun.name())) {
                 tooltipLines = List.of(
-                        new TextComponent(lootrunButton.getLootrun().name()).withStyle(ChatFormatting.BOLD),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.loaded")
+                        Component.literal(lootrunButton.getLootrun().name()).withStyle(ChatFormatting.BOLD),
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.loaded")
                                 .withStyle(ChatFormatting.YELLOW),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.viewInFolder")
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.viewInFolder")
                                 .withStyle(ChatFormatting.GOLD),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.openOnMap")
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.openOnMap")
                                 .withStyle(ChatFormatting.BLUE),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.unload")
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.unload")
                                 .withStyle(ChatFormatting.GREEN));
             } else {
                 tooltipLines = List.of(
-                        new TextComponent(lootrunButton.getLootrun().name()).withStyle(ChatFormatting.BOLD),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.load")
+                        Component.literal(lootrunButton.getLootrun().name()).withStyle(ChatFormatting.BOLD),
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.load")
                                 .withStyle(ChatFormatting.GREEN),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.viewInFolder")
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.viewInFolder")
                                 .withStyle(ChatFormatting.GOLD),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.openOnMap")
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.openOnMap")
                                 .withStyle(ChatFormatting.BLUE),
-                        new TranslatableComponent("screens.wynntils.lootruns.lootrunButton.remove")
+                        Component.translatable("screens.wynntils.lootruns.lootrunButton.remove")
                                 .withStyle(ChatFormatting.RED));
             }
 

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsMenuScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsMenuScreen.java
@@ -27,8 +27,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
@@ -43,7 +42,7 @@ public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
     private static final Screen settingsScreenInstance = WynntilsBookSettingsScreen.create();
 
     private WynntilsMenuScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsMenu.name"));
+        super(Component.translatable("screens.wynntils.wynntilsMenu.name"));
         setup();
     }
 
@@ -57,61 +56,61 @@ public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
                 true,
                 WynntilsQuestBookScreen.create(),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent("screens.wynntils.wynntilsMenu.questBook.name")
+                                .append(Component.translatable("screens.wynntils.wynntilsMenu.questBook.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.questBook.description")
+                        Component.translatable("screens.wynntils.wynntilsMenu.questBook.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
         buttons.add(new WynntilsMenuButton(
                 Texture.SETTINGS_ICON,
                 true,
                 settingsScreenInstance,
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent("screens.wynntils.wynntilsMenu.configs.name")
+                                .append(Component.translatable("screens.wynntils.wynntilsMenu.configs.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.configs.description")
+                        Component.translatable("screens.wynntils.wynntilsMenu.configs.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
         buttons.add(new WynntilsMenuButton(
                 Texture.OVERLAYS_ICON,
                 true,
                 OverlaySelectionScreen.create(),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent("screens.wynntils.wynntilsMenu.overlayConfig.name")
+                                .append(Component.translatable("screens.wynntils.wynntilsMenu.overlayConfig.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.overlayConfig.description")
+                        Component.translatable("screens.wynntils.wynntilsMenu.overlayConfig.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
         buttons.add(new WynntilsMenuButton(
                 Texture.DIALOGUE_BUTTON,
                 false,
                 WynntilsDialogueHistoryScreen.create(),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent(
+                                .append(Component.translatable(
                                                 "screens.wynntils.wynntilsQuestBook.dialogueHistory.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.dialogueHistory.description")
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.dialogueHistory.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
         if (MapFeature.INSTANCE.isEnabled()) {
             buttons.add(new WynntilsMenuButton(
@@ -119,15 +118,15 @@ public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
                     true,
                     MainMapScreen.create(),
                     List.of(
-                            new TextComponent("[>] ")
+                            Component.literal("[>] ")
                                     .withStyle(ChatFormatting.GOLD)
-                                    .append(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.mainMap.name")
+                                    .append(Component.translatable("screens.wynntils.wynntilsQuestBook.mainMap.name")
                                             .withStyle(ChatFormatting.BOLD)
                                             .withStyle(ChatFormatting.GOLD)),
-                            new TranslatableComponent("screens.wynntils.wynntilsQuestBook.mainMap.description")
+                            Component.translatable("screens.wynntils.wynntilsQuestBook.mainMap.description")
                                     .withStyle(ChatFormatting.GRAY),
-                            new TextComponent(""),
-                            new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                            Component.literal(""),
+                            Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                     .withStyle(ChatFormatting.GREEN))));
         }
         buttons.add(new WynntilsMenuButton(
@@ -135,15 +134,15 @@ public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
                 true,
                 WynntilsLootrunsScreen.create(),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.lootruns.name")
+                                .append(Component.translatable("screens.wynntils.wynntilsQuestBook.lootruns.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.lootruns.description")
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.lootruns.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
 
         buttons.add(new WynntilsMenuButton(
@@ -151,15 +150,15 @@ public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
                 true,
                 WynntilsGuidesListScreen.create(),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent("screens.wynntils.wynntilsGuides.name")
+                                .append(Component.translatable("screens.wynntils.wynntilsGuides.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsGuides.description")
+                        Component.translatable("screens.wynntils.wynntilsGuides.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
 
         buttons.add(new WynntilsMenuButton(
@@ -167,15 +166,15 @@ public class WynntilsMenuScreen extends WynntilsMenuScreenBase {
                 true,
                 WynntilsDiscoveriesScreen.create(),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.name")
+                                .append(Component.translatable("screens.wynntils.wynntilsDiscoveries.name")
                                         .withStyle(ChatFormatting.BOLD)
                                         .withStyle(ChatFormatting.GOLD)),
-                        new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.description")
+                        Component.translatable("screens.wynntils.wynntilsDiscoveries.description")
                                 .withStyle(ChatFormatting.GRAY),
-                        new TextComponent(""),
-                        new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                        Component.literal(""),
+                        Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                                 .withStyle(ChatFormatting.GREEN))));
 
         assert buttons.size() <= 8;

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsQuestBookScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsQuestBookScreen.java
@@ -34,15 +34,14 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, QuestButton> {
     private static final List<Component> RELOAD_TOOLTIP = List.of(
-            new TranslatableComponent("screens.wynntils.wynntilsQuestBook.reload.name").withStyle(ChatFormatting.WHITE),
-            new TranslatableComponent("screens.wynntils.wynntilsQuestBook.reload.description")
+            Component.translatable("screens.wynntils.wynntilsQuestBook.reload.name")
+                    .withStyle(ChatFormatting.WHITE),
+            Component.translatable("screens.wynntils.wynntilsQuestBook.reload.description")
                     .withStyle(ChatFormatting.GRAY));
 
     private QuestInfo trackingRequested = null;
@@ -50,7 +49,7 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
     private QuestSortOrder questSortOrder = QuestSortOrder.LEVEL;
 
     private WynntilsQuestBookScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.name"));
+        super(Component.translatable("screens.wynntils.wynntilsQuestBook.name"));
 
         // Only register this once
         WynntilsMod.registerEventListener(this);
@@ -210,39 +209,39 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
 
             tooltipLines = QuestInfo.generateTooltipForQuest(questInfo);
 
-            tooltipLines.add(new TextComponent(""));
+            tooltipLines.add(Component.literal(""));
 
             if (questInfo.isTrackable()) {
                 if (questInfo.equals(Managers.Quest.getTrackedQuest())) {
-                    tooltipLines.add(new TextComponent("Left click to stop tracking it!")
+                    tooltipLines.add(Component.literal("Left click to stop tracking it!")
                             .withStyle(ChatFormatting.RED)
                             .withStyle(ChatFormatting.BOLD));
                 } else {
-                    tooltipLines.add(new TextComponent("Left click to track it!")
+                    tooltipLines.add(Component.literal("Left click to track it!")
                             .withStyle(ChatFormatting.GREEN)
                             .withStyle(ChatFormatting.BOLD));
                 }
             }
 
-            tooltipLines.add(new TextComponent("Middle click to view on map!")
+            tooltipLines.add(Component.literal("Middle click to view on map!")
                     .withStyle(ChatFormatting.YELLOW)
                     .withStyle(ChatFormatting.BOLD));
-            tooltipLines.add(new TextComponent("Right to open on the wiki!")
+            tooltipLines.add(Component.literal("Right to open on the wiki!")
                     .withStyle(ChatFormatting.GOLD)
                     .withStyle(ChatFormatting.BOLD));
         }
 
         if (this.hovered instanceof DialogueHistoryButton) {
             tooltipLines = List.of(
-                    new TextComponent("[>] ")
+                    Component.literal("[>] ")
                             .withStyle(ChatFormatting.GOLD)
-                            .append(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.dialogueHistory.name")
+                            .append(Component.translatable("screens.wynntils.wynntilsQuestBook.dialogueHistory.name")
                                     .withStyle(ChatFormatting.BOLD)
                                     .withStyle(ChatFormatting.GOLD)),
-                    new TranslatableComponent("screens.wynntils.wynntilsQuestBook.dialogueHistory.description")
+                    Component.translatable("screens.wynntils.wynntilsQuestBook.dialogueHistory.description")
                             .withStyle(ChatFormatting.GRAY),
-                    new TextComponent(""),
-                    new TranslatableComponent("screens.wynntils.wynntilsMenu.leftClickToSelect")
+                    Component.literal(""),
+                    Component.translatable("screens.wynntils.wynntilsMenu.leftClickToSelect")
                             .withStyle(ChatFormatting.GREEN));
         }
 
@@ -250,9 +249,9 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
             tooltipLines = new ArrayList<>();
 
             if (miniQuestMode) {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.miniQuestInfo.name"));
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsQuestBook.miniQuestInfo.name"));
             } else {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.questInfo.name"));
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsQuestBook.questInfo.name"));
             }
 
             for (int i = 1; i <= 100; i += 25) {
@@ -269,8 +268,8 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
                                 && questInfo.getSortLevel() <= maxLevel)
                         .count();
 
-                tooltipLines.add(new TextComponent("- Lv. " + minLevel + "-" + maxLevel)
-                        .append(new TextComponent(" [" + completedCount + "/" + count + "]")
+                tooltipLines.add(Component.literal("- Lv. " + minLevel + "-" + maxLevel)
+                        .append(Component.literal(" [" + completedCount + "/" + count + "]")
                                 .withStyle(ChatFormatting.GRAY))
                         .append(" ")
                         .append(getPercentageComponent((int) completedCount, (int) count, 5)));
@@ -286,8 +285,8 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
                         .filter(questInfo ->
                                 questInfo.getStatus() == QuestStatus.COMPLETED && questInfo.getSortLevel() >= 101)
                         .count();
-                tooltipLines.add(new TextComponent("- Lv. 101+")
-                        .append(new TextComponent(" [" + completedCount + "/" + count + "]")
+                tooltipLines.add(Component.literal("- Lv. 101+")
+                        .append(Component.literal(" [" + completedCount + "/" + count + "]")
                                 .withStyle(ChatFormatting.GRAY))
                         .append(" ")
                         .append(getPercentageComponent((int) completedCount, (int) count, 5)));
@@ -298,19 +297,19 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
                     .filter(questInfo -> questInfo.getStatus() == QuestStatus.COMPLETED)
                     .count();
 
-            tooltipLines.add(new TextComponent(""));
-            tooltipLines.add(new TextComponent(this.miniQuestMode ? "Total Mini-Quests: " : "Total Quests: ")
+            tooltipLines.add(Component.literal(""));
+            tooltipLines.add(Component.literal(this.miniQuestMode ? "Total Mini-Quests: " : "Total Quests: ")
                     .withStyle(ChatFormatting.AQUA)
-                    .append(new TextComponent("[" + completedCount + "/" + count + "]")
+                    .append(Component.literal("[" + completedCount + "/" + count + "]")
                             .withStyle(ChatFormatting.DARK_AQUA)));
             tooltipLines.add(getPercentageComponent((int) completedCount, (int) count, 15));
-            tooltipLines.add(new TextComponent(""));
+            tooltipLines.add(Component.literal(""));
 
             if (!this.miniQuestMode) {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.questInfo.click")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsQuestBook.questInfo.click")
                         .withStyle(ChatFormatting.GREEN));
             } else {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsQuestBook.miniQuestInfo.click")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsQuestBook.miniQuestInfo.click")
                         .withStyle(ChatFormatting.GREEN));
             }
         }
@@ -318,14 +317,14 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
         if (this.hovered instanceof SortOrderWidget) {
             switch (questSortOrder) {
                 case LEVEL -> tooltipLines = List.of(
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.sort.level.name"),
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.sort.level.description"));
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.sort.level.name"),
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.sort.level.description"));
                 case DISTANCE -> tooltipLines = List.of(
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.sort.distance.name"),
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.sort.distance.description"));
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.sort.distance.name"),
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.sort.distance.description"));
                 case ALPHABETIC -> tooltipLines = List.of(
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.sort.alphabetical.name"),
-                        new TranslatableComponent("screens.wynntils.wynntilsQuestBook.sort.alphabetical.description"));
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.sort.alphabetical.name"),
+                        Component.translatable("screens.wynntils.wynntilsQuestBook.sort.alphabetical.description"));
             }
         }
 
@@ -401,10 +400,10 @@ public class WynntilsQuestBookScreen extends WynntilsMenuListScreen<QuestInfo, Q
                 Math.min(insideText.length(), Math.round((insideText.length() - 2) * (float) count / totalCount) + 2);
         insideText.insert(insertAt, ChatFormatting.DARK_GRAY);
 
-        return new TextComponent("[")
+        return Component.literal("[")
                 .withStyle(braceColor)
-                .append(new TextComponent(insideText.toString()))
-                .append(new TextComponent("]").withStyle(braceColor));
+                .append(Component.literal(insideText.toString()))
+                .append(Component.literal("]").withStyle(braceColor));
     }
 
     private List<QuestInfo> getSortedQuests() {

--- a/common/src/main/java/com/wynntils/gui/screens/WynntilsScreenWrapper.java
+++ b/common/src/main/java/com/wynntils/gui/screens/WynntilsScreenWrapper.java
@@ -18,7 +18,6 @@ import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
@@ -50,7 +49,7 @@ public class WynntilsScreenWrapper extends Screen {
 
     private void failure(String method, Throwable e) {
         WynntilsMod.error("Failure in " + delegate.getClass().getSimpleName() + "." + method + "()", e);
-        McUtils.sendMessageToClient(new TextComponent("Wynntils: Failure in " + method + " in "
+        McUtils.sendMessageToClient(Component.literal("Wynntils: Failure in " + method + " in "
                 + delegate.getClass().getSimpleName() + ". Screen forcefully closed."));
         McUtils.mc().setScreen(null);
     }

--- a/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsEmeraldPouchGuideScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsEmeraldPouchGuideScreen.java
@@ -29,7 +29,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.TooltipFlag;
 
 public class WynntilsEmeraldPouchGuideScreen
@@ -40,7 +39,7 @@ public class WynntilsEmeraldPouchGuideScreen
     private List<EmeraldPouchItemStack> parsedItemCache;
 
     private WynntilsEmeraldPouchGuideScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsGuides.emeraldPouch.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.emeraldPouch.name"));
     }
 
     public static Screen create() {
@@ -146,10 +145,10 @@ public class WynntilsEmeraldPouchGuideScreen
             tooltipLines.add(TextComponent.EMPTY);
             if (ItemFavoriteFeature.INSTANCE.favoriteItems.contains(
                     ComponentUtils.getUnformatted(itemStack.getHoverName()))) {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
                         .withStyle(ChatFormatting.YELLOW));
             } else {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.favorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.favorite")
                         .withStyle(ChatFormatting.GREEN));
             }
 

--- a/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsIngredientGuideScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsIngredientGuideScreen.java
@@ -29,7 +29,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.TooltipFlag;
 
 public class WynntilsIngredientGuideScreen
@@ -40,7 +39,7 @@ public class WynntilsIngredientGuideScreen
     private List<IngredientItemStack> parsedItemCache;
 
     private WynntilsIngredientGuideScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsGuides.ingredientGuide.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.ingredientGuide.name"));
     }
 
     public static Screen create() {
@@ -145,13 +144,13 @@ public class WynntilsIngredientGuideScreen
 
             String unformattedName = itemStack.getIngredientProfile().getDisplayName();
             if (ItemFavoriteFeature.INSTANCE.favoriteItems.contains(unformattedName)) {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
                         .withStyle(ChatFormatting.YELLOW));
             } else {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.favorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.favorite")
                         .withStyle(ChatFormatting.GREEN));
             }
-            tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.open")
+            tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.open")
                     .withStyle(ChatFormatting.RED));
             RenderUtils.drawTooltipAt(
                     poseStack,

--- a/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsItemGuideScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsItemGuideScreen.java
@@ -29,7 +29,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.TooltipFlag;
 
 public class WynntilsItemGuideScreen extends WynntilsMenuListScreen<GearItemStack, GuideGearItemStack> {
@@ -39,7 +38,7 @@ public class WynntilsItemGuideScreen extends WynntilsMenuListScreen<GearItemStac
     private List<GearItemStack> parsedItemCache;
 
     private WynntilsItemGuideScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"));
     }
 
     public static Screen create() {
@@ -120,13 +119,13 @@ public class WynntilsItemGuideScreen extends WynntilsMenuListScreen<GearItemStac
             tooltipLines.add(TextComponent.EMPTY);
             if (ItemFavoriteFeature.INSTANCE.favoriteItems.contains(
                     ComponentUtils.getUnformatted(itemStack.getHoverName()))) {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
                         .withStyle(ChatFormatting.YELLOW));
             } else {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.favorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.favorite")
                         .withStyle(ChatFormatting.GREEN));
             }
-            tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.open")
+            tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.open")
                     .withStyle(ChatFormatting.RED));
             RenderUtils.drawTooltipAt(
                     poseStack,

--- a/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsPowderGuideScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/WynntilsPowderGuideScreen.java
@@ -29,7 +29,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.TooltipFlag;
 
 public class WynntilsPowderGuideScreen extends WynntilsMenuListScreen<PowderItemStack, GuidePowderItemStack> {
@@ -39,7 +38,7 @@ public class WynntilsPowderGuideScreen extends WynntilsMenuListScreen<PowderItem
     private List<PowderItemStack> parsedItemCache;
 
     private WynntilsPowderGuideScreen() {
-        super(new TranslatableComponent("screens.wynntils.wynntilsGuides.powder.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.powder.name"));
     }
 
     public static Screen create() {
@@ -120,10 +119,10 @@ public class WynntilsPowderGuideScreen extends WynntilsMenuListScreen<PowderItem
             tooltipLines.add(TextComponent.EMPTY);
             if (ItemFavoriteFeature.INSTANCE.favoriteItems.contains(
                     ComponentUtils.getUnformatted(itemStack.getHoverName()))) {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.unfavorite")
                         .withStyle(ChatFormatting.YELLOW));
             } else {
-                tooltipLines.add(new TranslatableComponent("screens.wynntils.wynntilsGuides.itemGuide.favorite")
+                tooltipLines.add(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.favorite")
                         .withStyle(ChatFormatting.GREEN));
             }
 

--- a/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuideEmeraldPouchItemStack.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuideEmeraldPouchItemStack.java
@@ -20,7 +20,7 @@ import com.wynntils.wynn.item.EmeraldPouchItemStack;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class GuideEmeraldPouchItemStack extends AbstractButton {
@@ -34,7 +34,7 @@ public class GuideEmeraldPouchItemStack extends AbstractButton {
             int height,
             EmeraldPouchItemStack itemStack,
             WynntilsEmeraldPouchGuideScreen screen) {
-        super(x, y, width, height, new TextComponent("Guide EmeraldPouchItemStack Button"));
+        super(x, y, width, height, Component.literal("Guide EmeraldPouchItemStack Button"));
         this.itemStack = itemStack;
         this.screen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuideGearItemStack.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuideGearItemStack.java
@@ -18,7 +18,7 @@ import com.wynntils.wynn.item.GearItemStack;
 import java.util.Map;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class GuideGearItemStack extends AbstractButton {
@@ -27,7 +27,7 @@ public class GuideGearItemStack extends AbstractButton {
 
     public GuideGearItemStack(
             int x, int y, int width, int height, GearItemStack itemStack, WynntilsItemGuideScreen screen) {
-        super(x, y, width, height, new TextComponent("Guide GearItemStack Button"));
+        super(x, y, width, height, Component.literal("Guide GearItemStack Button"));
         this.itemStack = itemStack;
         this.screen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuideIngredientItemStack.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuideIngredientItemStack.java
@@ -17,7 +17,7 @@ import com.wynntils.wynn.item.IngredientItemStack;
 import java.util.Map;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class GuideIngredientItemStack extends AbstractButton {
@@ -26,7 +26,7 @@ public class GuideIngredientItemStack extends AbstractButton {
 
     public GuideIngredientItemStack(
             int x, int y, int width, int height, IngredientItemStack itemStack, WynntilsIngredientGuideScreen screen) {
-        super(x, y, width, height, new TextComponent("Guide IngredientItemStack Button"));
+        super(x, y, width, height, Component.literal("Guide IngredientItemStack Button"));
         this.itemStack = itemStack;
         this.screen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuidePowderItemStack.java
+++ b/common/src/main/java/com/wynntils/gui/screens/guides/widgets/GuidePowderItemStack.java
@@ -19,7 +19,7 @@ import com.wynntils.utils.MathUtils;
 import com.wynntils.wynn.item.PowderItemStack;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class GuidePowderItemStack extends AbstractButton {
@@ -28,7 +28,7 @@ public class GuidePowderItemStack extends AbstractButton {
 
     public GuidePowderItemStack(
             int x, int y, int width, int height, PowderItemStack itemStack, WynntilsPowderGuideScreen screen) {
-        super(x, y, width, height, new TextComponent("Guide PowderItemStack Button"));
+        super(x, y, width, height, Component.literal("Guide PowderItemStack Button"));
         this.itemStack = itemStack;
         this.screen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/AbstractMapScreen.java
@@ -30,7 +30,7 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public abstract class AbstractMapScreen extends Screen {
@@ -69,12 +69,12 @@ public abstract class AbstractMapScreen extends Screen {
     protected Poi hovered = null;
 
     public AbstractMapScreen() {
-        super(new TextComponent("Map"));
+        super(Component.literal("Map"));
         centerMapAroundPlayer();
     }
 
     public AbstractMapScreen(float mapCenterX, float mapCenterZ) {
-        super(new TextComponent("Map"));
+        super(Component.literal("Map"));
         updateMapCenter(mapCenterX, mapCenterZ);
     }
 

--- a/common/src/main/java/com/wynntils/gui/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/GuildMapScreen.java
@@ -32,8 +32,6 @@ import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import org.lwjgl.glfw.GLFW;
 
 public class GuildMapScreen extends AbstractMapScreen {
@@ -67,12 +65,12 @@ public class GuildMapScreen extends AbstractMapScreen {
                 Texture.MAP_HELP_BUTTON,
                 (b) -> {},
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.YELLOW)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.name")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.name")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.guildMap.help.description1")))));
+                                .append(Component.translatable("screens.wynntils.guildMap.help.description1")))));
 
         territoryDefenseFilterButton = this.addRenderableWidget(new BasicTexturedButton(
                 width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20,
@@ -125,11 +123,10 @@ public class GuildMapScreen extends AbstractMapScreen {
                 Texture.MAP_ADD_BUTTON,
                 (b) -> resourceMode = !resourceMode,
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.GOLD)
-                                .append(new TranslatableComponent(
-                                        "screens.wynntils.guildMap.toggleResourceColor.name")),
-                        new TranslatableComponent("screens.wynntils.guildMap.toggleResourceColor.description")
+                                .append(Component.translatable("screens.wynntils.guildMap.toggleResourceColor.name")),
+                        Component.translatable("screens.wynntils.guildMap.toggleResourceColor.description")
                                 .withStyle(ChatFormatting.GRAY))));
     }
 
@@ -386,22 +383,22 @@ public class GuildMapScreen extends AbstractMapScreen {
 
     private List<Component> getCompleteFilterTooltip() {
         Component lastLine = territoryDefenseFilterEnabled
-                ? new TranslatableComponent("screens.wynntils.guildMap.cycleDefenseFilter.description4")
+                ? Component.translatable("screens.wynntils.guildMap.cycleDefenseFilter.description4")
                         .withStyle(ChatFormatting.GRAY)
                         .append(territoryDefenseFilterLevel.asColoredString())
                         .append(territoryDefenseFilterType.asComponent())
-                : new TranslatableComponent("screens.wynntils.guildMap.cycleDefenseFilter.description4")
+                : Component.translatable("screens.wynntils.guildMap.cycleDefenseFilter.description4")
                         .withStyle(ChatFormatting.GRAY)
                         .append("Off");
         return List.of(
-                new TextComponent("[>] ")
+                Component.literal("[>] ")
                         .withStyle(ChatFormatting.BLUE)
-                        .append(new TranslatableComponent("screens.wynntils.guildMap.cycleDefenseFilter.name")),
-                new TranslatableComponent("screens.wynntils.guildMap.cycleDefenseFilter.description1")
+                        .append(Component.translatable("screens.wynntils.guildMap.cycleDefenseFilter.name")),
+                Component.translatable("screens.wynntils.guildMap.cycleDefenseFilter.description1")
                         .withStyle(ChatFormatting.GRAY),
-                new TranslatableComponent("screens.wynntils.guildMap.cycleDefenseFilter.description2")
+                Component.translatable("screens.wynntils.guildMap.cycleDefenseFilter.description2")
                         .withStyle(ChatFormatting.GRAY),
-                new TranslatableComponent("screens.wynntils.guildMap.cycleDefenseFilter.description3")
+                Component.translatable("screens.wynntils.guildMap.cycleDefenseFilter.description3")
                         .withStyle(ChatFormatting.GRAY),
                 lastLine);
     }

--- a/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/MainMapScreen.java
@@ -31,8 +31,7 @@ import java.util.Comparator;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
@@ -70,36 +69,36 @@ public class MainMapScreen extends AbstractMapScreen {
                 Texture.MAP_HELP_BUTTON,
                 (b) -> {},
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.YELLOW)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.name")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.name")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description1")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description1")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description2")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description2")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description3")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description3")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description4")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description4")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description5")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description5")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description6")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description6")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description7")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description7")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description8")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.help.description8")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.help.description9")))));
+                                .append(Component.translatable("screens.wynntils.map.help.description9")))));
 
         this.addRenderableWidget(new BasicTexturedButton(
                 width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20 * 2,
@@ -112,12 +111,12 @@ public class MainMapScreen extends AbstractMapScreen {
                 Texture.MAP_SHARE_BUTTON,
                 this::shareLocationOrCompass,
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.DARK_AQUA)
-                                .append(new TranslatableComponent("screens.wynntils.map.share.name")),
-                        new TranslatableComponent("screens.wynntils.map.share.description1"),
-                        new TranslatableComponent("screens.wynntils.map.share.description2"),
-                        new TranslatableComponent("screens.wynntils.map.share.description3"))));
+                                .append(Component.translatable("screens.wynntils.map.share.name")),
+                        Component.translatable("screens.wynntils.map.share.description1"),
+                        Component.translatable("screens.wynntils.map.share.description2"),
+                        Component.translatable("screens.wynntils.map.share.description3"))));
 
         this.addRenderableWidget(new BasicTexturedButton(
                 width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20,
@@ -140,15 +139,15 @@ public class MainMapScreen extends AbstractMapScreen {
                     }
                 },
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.YELLOW)
-                                .append(new TranslatableComponent("screens.wynntils.map.focus.name")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.focus.name")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.focus.description1")),
-                        new TextComponent("- ")
+                                .append(Component.translatable("screens.wynntils.map.focus.description1")),
+                        Component.literal("- ")
                                 .withStyle(ChatFormatting.GRAY)
-                                .append(new TranslatableComponent("screens.wynntils.map.focus.description2")))));
+                                .append(Component.translatable("screens.wynntils.map.focus.description2")))));
 
         this.addRenderableWidget(new BasicTexturedButton(
                 width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6,
@@ -161,10 +160,10 @@ public class MainMapScreen extends AbstractMapScreen {
                 Texture.MAP_ADD_BUTTON,
                 (b) -> McUtils.mc().setScreen(PoiCreationScreen.create(this)),
                 List.of(
-                        new TextComponent("[>] ")
+                        Component.literal("[>] ")
                                 .withStyle(ChatFormatting.DARK_GREEN)
-                                .append(new TranslatableComponent("screens.wynntils.map.waypoints.add.name")),
-                        new TranslatableComponent("screens.wynntils.map.waypoints.add.description")
+                                .append(Component.translatable("screens.wynntils.map.waypoints.add.name")),
+                        Component.translatable("screens.wynntils.map.waypoints.add.description")
                                 .withStyle(ChatFormatting.GRAY))));
     }
 

--- a/common/src/main/java/com/wynntils/gui/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/PoiCreationScreen.java
@@ -28,8 +28,7 @@ import java.util.regex.Pattern;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class PoiCreationScreen extends Screen implements TextboxScreen {
@@ -71,7 +70,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
     private boolean firstSetup = false;
 
     private PoiCreationScreen(MainMapScreen oldMapScreen) {
-        super(new TextComponent("Poi Creation Screen"));
+        super(Component.literal("Poi Creation Screen"));
         this.oldMapScreen = oldMapScreen;
 
         this.firstSetup = true;
@@ -185,7 +184,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
 
         // region Icon
         this.addRenderableWidget(
-                new Button(this.width / 2 - 100, this.height / 2 + 40, 20, 20, new TextComponent("<"), (button) -> {
+                new Button(this.width / 2 - 100, this.height / 2 + 40, 20, 20, Component.literal("<"), (button) -> {
                     if (selectedIconIndex - 1 < 0) {
                         selectedIconIndex = POI_ICONS.size() - 1;
                     } else {
@@ -193,7 +192,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
                     }
                 }));
         this.addRenderableWidget(
-                new Button(this.width / 2 - 40, this.height / 2 + 40, 20, 20, new TextComponent(">"), (button) -> {
+                new Button(this.width / 2 - 40, this.height / 2 + 40, 20, 20, Component.literal(">"), (button) -> {
                     if (selectedIconIndex + 1 >= POI_ICONS.size()) {
                         selectedIconIndex = 0;
                     } else {
@@ -238,13 +237,13 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
 
         // region Visibility
         this.addRenderableWidget(
-                new Button(this.width / 2 - 100, this.height / 2 + 90, 20, 20, new TextComponent("<"), (button) -> {
+                new Button(this.width / 2 - 100, this.height / 2 + 90, 20, 20, Component.literal("<"), (button) -> {
                     selectedVisiblity = CustomPoi.Visibility.values()[
                             (selectedVisiblity.ordinal() - 1 + CustomPoi.Visibility.values().length)
                                     % CustomPoi.Visibility.values().length];
                 }));
         this.addRenderableWidget(
-                new Button(this.width / 2 + 80, this.height / 2 + 90, 20, 20, new TextComponent(">"), (button) -> {
+                new Button(this.width / 2 + 80, this.height / 2 + 90, 20, 20, Component.literal(">"), (button) -> {
                     selectedVisiblity = CustomPoi.Visibility.values()[
                             (selectedVisiblity.ordinal() + 1 + CustomPoi.Visibility.values().length)
                                     % CustomPoi.Visibility.values().length];
@@ -261,7 +260,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
                         this.height / 2 + 140,
                         100,
                         20,
-                        new TranslatableComponent("screens.wynntils.poiCreation.save"),
+                        Component.translatable("screens.wynntils.poiCreation.save"),
                         (button) -> {
                             savePoi();
                             this.onClose();
@@ -272,7 +271,7 @@ public class PoiCreationScreen extends Screen implements TextboxScreen {
                 this.height / 2 + 140,
                 100,
                 20,
-                new TranslatableComponent("screens.wynntils.poiCreation.cancel"),
+                Component.translatable("screens.wynntils.poiCreation.cancel"),
                 (button) -> this.onClose()));
         // endregion
 

--- a/common/src/main/java/com/wynntils/gui/screens/overlays/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/overlays/OverlayManagementScreen.java
@@ -39,8 +39,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.phys.Vec2;
 import org.lwjgl.glfw.GLFW;
 
@@ -59,26 +57,26 @@ public class OverlayManagementScreen extends Screen {
     private static final int ANIMATION_LENGTH = 30;
 
     private static final List<Component> HELP_TOOLTIP_LINES = List.of(
-            new TextComponent("Resize the overlay by dragging the edges or corners."),
-            new TextComponent("Move it by dragging the center of the overlay."),
-            new TextComponent("By holding shift, you can disable alignment lines."),
-            new TextComponent("Use your arrows to change vertical"),
-            new TextComponent("and horizontal alignment."),
-            new TextComponent("The overlay name will render respecting"),
-            new TextComponent("the current overlay alignments."),
-            new TextComponent("Shift-Middle click on an overlay to reset it to it's original state.")
+            Component.literal("Resize the overlay by dragging the edges or corners."),
+            Component.literal("Move it by dragging the center of the overlay."),
+            Component.literal("By holding shift, you can disable alignment lines."),
+            Component.literal("Use your arrows to change vertical"),
+            Component.literal("and horizontal alignment."),
+            Component.literal("The overlay name will render respecting"),
+            Component.literal("the current overlay alignments."),
+            Component.literal("Shift-Middle click on an overlay to reset it to it's original state.")
                     .withStyle(ChatFormatting.RED));
 
     private static final List<Component> CLOSE_TOOLTIP_LINES =
-            List.of(new TextComponent("Click here to stop editing and reset changes."));
+            List.of(Component.literal("Click here to stop editing and reset changes."));
 
     private static final List<Component> TEST_TOOLTIP_LINES = List.of(
-            new TextComponent("Click here to toggle test mode."),
-            new TextComponent("In test mode, you can see how your overlay setup would look in-game,"),
-            new TextComponent("using preview render mode."));
+            Component.literal("Click here to toggle test mode."),
+            Component.literal("In test mode, you can see how your overlay setup would look in-game,"),
+            Component.literal("using preview render mode."));
 
     private static final List<Component> APPLY_TOOLTIP_LINES =
-            List.of(new TextComponent("Click here to apply changes to current overlay."));
+            List.of(Component.literal("Click here to apply changes to current overlay."));
 
     private final Set<Float> verticalAlignmentLinePositions = new HashSet<>();
     private final Set<Float> horizontalAlignmentLinePositions = new HashSet<>();
@@ -99,14 +97,14 @@ public class OverlayManagementScreen extends Screen {
     private int animationLengthRemaining;
 
     private OverlayManagementScreen(Overlay overlay) {
-        super(new TranslatableComponent("screens.wynntils.overlayManagement.name"));
+        super(Component.translatable("screens.wynntils.overlayManagement.name"));
         selectedOverlay = overlay;
         fixedSelection = true;
         animationLengthRemaining = ANIMATION_LENGTH;
     }
 
     private OverlayManagementScreen() {
-        super(new TranslatableComponent("screens.wynntils.overlayManagement.name"));
+        super(Component.translatable("screens.wynntils.overlayManagement.name"));
         selectedOverlay = null;
         fixedSelection = false;
         animationLengthRemaining = 0;
@@ -718,7 +716,7 @@ public class OverlayManagementScreen extends Screen {
                 this.height - 150,
                 BUTTON_WIDTH,
                 BUTTON_HEIGHT,
-                new TranslatableComponent("screens.wynntils.overlayManagement.closeSettingsScreen"),
+                Component.translatable("screens.wynntils.overlayManagement.closeSettingsScreen"),
                 button -> {
                     McUtils.mc().setScreen(OverlaySelectionScreen.create());
                     onClose();
@@ -736,7 +734,7 @@ public class OverlayManagementScreen extends Screen {
                 this.height - 150,
                 BUTTON_WIDTH,
                 BUTTON_HEIGHT,
-                new TranslatableComponent("screens.wynntils.overlayManagement.testSettings"),
+                Component.translatable("screens.wynntils.overlayManagement.testSettings"),
                 button -> testMode = !testMode,
                 (button, poseStack, renderX, renderY) -> RenderUtils.drawTooltipAt(
                         poseStack,
@@ -751,7 +749,7 @@ public class OverlayManagementScreen extends Screen {
                 this.height - 150,
                 BUTTON_WIDTH,
                 BUTTON_HEIGHT,
-                new TranslatableComponent("screens.wynntils.overlayManagement.applySettings"),
+                Component.translatable("screens.wynntils.overlayManagement.applySettings"),
                 button -> {
                     Managers.Config.saveConfig();
                     McUtils.mc().setScreen(OverlaySelectionScreen.create());

--- a/common/src/main/java/com/wynntils/gui/screens/overlays/OverlaySelectionScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/overlays/OverlaySelectionScreen.java
@@ -20,7 +20,7 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class OverlaySelectionScreen extends Screen {
@@ -30,7 +30,7 @@ public class OverlaySelectionScreen extends Screen {
     private OverlayList overlayList;
 
     private OverlaySelectionScreen() {
-        super(new TranslatableComponent("screens.wynntils.overlaySelection.name"));
+        super(Component.translatable("screens.wynntils.overlaySelection.name"));
     }
 
     public static Screen create() {
@@ -45,7 +45,7 @@ public class OverlaySelectionScreen extends Screen {
                 this.height / 10 + Texture.OVERLAY_SELECTION_GUI.height() + 20,
                 BUTTON_WIDTH,
                 BUTTON_HEIGHT,
-                new TranslatableComponent("screens.wynntils.overlaySelection.close"),
+                Component.translatable("screens.wynntils.overlaySelection.close"),
                 button -> McUtils.mc().setScreen(WynntilsMenuScreen.create())));
 
         this.addRenderableWidget(new Button(
@@ -53,7 +53,7 @@ public class OverlaySelectionScreen extends Screen {
                 this.height / 10 + Texture.OVERLAY_SELECTION_GUI.height() + 20,
                 BUTTON_WIDTH,
                 BUTTON_HEIGHT,
-                new TranslatableComponent("screens.wynntils.overlaySelection.freeMove"),
+                Component.translatable("screens.wynntils.overlaySelection.freeMove"),
                 button -> McUtils.mc().setScreen(OverlayManagementScreen.create())));
     }
 

--- a/common/src/main/java/com/wynntils/gui/screens/overlays/lists/OverlayList.java
+++ b/common/src/main/java/com/wynntils/gui/screens/overlays/lists/OverlayList.java
@@ -19,19 +19,18 @@ import java.util.Objects;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.ContainerObjectSelectionList;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 
 public class OverlayList extends ContainerObjectSelectionList<OverlayEntry> {
     private static final int ITEM_HEIGHT = 25;
     private static final int ROW_WIDTH = 161;
 
     private static final List<Component> HELP_TOOLTIP_LINES = List.of(
-            new TextComponent("Left click on the overlay to edit it."),
-            new TextComponent("Right click on the overlay to disable/enable it."));
+            Component.literal("Left click on the overlay to edit it."),
+            Component.literal("Right click on the overlay to disable/enable it."));
 
     private static final List<Component> DISABLED_PARENT_TOOLTIP_LINES = List.of(
-            new TextComponent("This overlay's parent feature is disabled.").withStyle(ChatFormatting.RED),
-            new TextComponent("Enable the feature to edit this overlay.").withStyle(ChatFormatting.RED));
+            Component.literal("This overlay's parent feature is disabled.").withStyle(ChatFormatting.RED),
+            Component.literal("Enable the feature to edit this overlay.").withStyle(ChatFormatting.RED));
 
     public OverlayList(OverlaySelectionScreen screen) {
         super(
@@ -63,8 +62,8 @@ public class OverlayList extends ContainerObjectSelectionList<OverlayEntry> {
         if (hovered != null) {
             if (!hovered.getOverlay().isParentEnabled()) {
                 List<Component> helpModified = new ArrayList<>(DISABLED_PARENT_TOOLTIP_LINES);
-                helpModified.add(new TextComponent(""));
-                helpModified.add(new TextComponent("Feature: "
+                helpModified.add(Component.literal(""));
+                helpModified.add(Component.literal("Feature: "
                         + Managers.Overlay.getOverlayParent(hovered.getOverlay())
                                 .getTranslatedName()));
 

--- a/common/src/main/java/com/wynntils/gui/screens/settings/WynntilsBookSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/settings/WynntilsBookSettingsScreen.java
@@ -41,7 +41,7 @@ import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class WynntilsBookSettingsScreen extends Screen implements TextboxScreen {
@@ -63,7 +63,7 @@ public class WynntilsBookSettingsScreen extends Screen implements TextboxScreen 
     private int configScrollOffset = 0;
 
     private WynntilsBookSettingsScreen() {
-        super(new TranslatableComponent("screens.wynntils.settingsScreen.name"));
+        super(Component.translatable("screens.wynntils.settingsScreen.name"));
 
         McUtils.mc().keyboardHandler.setSendRepeatsToGui(true);
 
@@ -92,12 +92,12 @@ public class WynntilsBookSettingsScreen extends Screen implements TextboxScreen 
                 Texture.SETTING_BACKGROUND.height() - 30,
                 35,
                 14,
-                new TranslatableComponent("screens.wynntils.settingsScreen.apply"),
+                Component.translatable("screens.wynntils.settingsScreen.apply"),
                 () -> {
                     Managers.Config.saveConfig();
                     this.onClose();
                 },
-                List.of(new TranslatableComponent("screens.wynntils.settingsScreen.apply.description")
+                List.of(Component.translatable("screens.wynntils.settingsScreen.apply.description")
                         .withStyle(ChatFormatting.GREEN))));
 
         this.addRenderableWidget(new GeneralSettingsButton(
@@ -105,9 +105,9 @@ public class WynntilsBookSettingsScreen extends Screen implements TextboxScreen 
                 Texture.SETTING_BACKGROUND.height() - 30,
                 35,
                 14,
-                new TranslatableComponent("screens.wynntils.settingsScreen.close"),
+                Component.translatable("screens.wynntils.settingsScreen.close"),
                 this::onClose,
-                List.of(new TranslatableComponent("screens.wynntils.settingsScreen.close.description")
+                List.of(Component.translatable("screens.wynntils.settingsScreen.close.description")
                         .withStyle(ChatFormatting.DARK_RED))));
     }
 

--- a/common/src/main/java/com/wynntils/gui/screens/settings/widgets/CategoryButton.java
+++ b/common/src/main/java/com/wynntils/gui/screens/settings/widgets/CategoryButton.java
@@ -12,13 +12,13 @@ import com.wynntils.mc.objects.CommonColors;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 
 public class CategoryButton extends AbstractButton {
     private final FeatureCategory featureCategory;
 
     public CategoryButton(int x, int y, int width, int height, FeatureCategory featureCategory) {
-        super(x, y, width, height, new TranslatableComponent(featureCategory.toString()));
+        super(x, y, width, height, Component.translatable(featureCategory.toString()));
         this.featureCategory = featureCategory;
     }
 

--- a/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ConfigButton.java
+++ b/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ConfigButton.java
@@ -25,8 +25,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 
 public class ConfigButton extends AbstractButton {
     private final WynntilsBookSettingsScreen settingsScreen;
@@ -37,7 +35,7 @@ public class ConfigButton extends AbstractButton {
 
     public ConfigButton(
             int x, int y, int width, int height, WynntilsBookSettingsScreen settingsScreen, ConfigHolder configHolder) {
-        super(x, y, width, height, new TextComponent(configHolder.getJsonName()));
+        super(x, y, width, height, Component.literal(configHolder.getJsonName()));
         this.settingsScreen = settingsScreen;
         this.configHolder = configHolder;
         this.resetButton = new GeneralSettingsButton(
@@ -45,12 +43,12 @@ public class ConfigButton extends AbstractButton {
                 this.y + 13,
                 35,
                 12,
-                new TranslatableComponent("screens.wynntils.settingsScreen.reset.name"),
+                Component.translatable("screens.wynntils.settingsScreen.reset.name"),
                 () -> {
                     configHolder.reset();
                     this.configOptionElement = getWidgetFromConfigHolder(configHolder);
                 },
-                List.of(new TranslatableComponent("screens.wynntils.settingsScreen.reset.description")));
+                List.of(Component.translatable("screens.wynntils.settingsScreen.reset.description")));
         this.configOptionElement = getWidgetFromConfigHolder(configHolder);
     }
 
@@ -100,7 +98,7 @@ public class ConfigButton extends AbstractButton {
             String description = configHolder.getDescription();
             String[] parts = StringUtils.wrapTextBySize(description, 200);
             List<Component> components = Arrays.stream(parts)
-                    .map(s -> (Component) new TextComponent(s))
+                    .map(s -> (Component) Component.literal(s))
                     .toList();
 
             RenderUtils.drawTooltipAt(

--- a/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ConfigurableButton.java
+++ b/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ConfigurableButton.java
@@ -19,13 +19,13 @@ import com.wynntils.mc.objects.CustomColor;
 import java.util.Optional;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class ConfigurableButton extends AbstractButton {
     private final Configurable configurable;
 
     public ConfigurableButton(int x, int y, int width, int height, Configurable configurable) {
-        super(x, y, width, height, new TextComponent(((Translatable) configurable).getTranslatedName()));
+        super(x, y, width, height, Component.literal(((Translatable) configurable).getTranslatedName()));
         this.configurable = configurable;
     }
 

--- a/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ScrollButton.java
+++ b/common/src/main/java/com/wynntils/gui/screens/settings/widgets/ScrollButton.java
@@ -12,7 +12,7 @@ import com.wynntils.utils.MathUtils;
 import java.util.function.Consumer;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class ScrollButton extends AbstractButton {
     private final Consumer<Integer> onScroll;
@@ -36,7 +36,7 @@ public class ScrollButton extends AbstractButton {
             int perScrollIncrement,
             Consumer<Integer> onScroll,
             CustomColor scrollAreaColor) {
-        super(x, y, width, height, new TextComponent("Scroll Button"));
+        super(x, y, width, height, Component.literal("Scroll Button"));
         this.y2 = y2;
         this.maxScroll = maxScroll;
         this.perScrollIncrement = perScrollIncrement;

--- a/common/src/main/java/com/wynntils/gui/widgets/BackButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/BackButton.java
@@ -11,13 +11,13 @@ import com.wynntils.mc.utils.McUtils;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class BackButton extends AbstractButton {
     private final Screen backTo;
 
     public BackButton(int x, int y, int width, int height, Screen backTo) {
-        super(x, y, width, height, new TextComponent("Back Button"));
+        super(x, y, width, height, Component.literal("Back Button"));
         this.backTo = backTo;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/BasicTexturedButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/BasicTexturedButton.java
@@ -14,7 +14,6 @@ import java.util.function.Consumer;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 
 public class BasicTexturedButton extends AbstractButton {
     private final Texture texture;
@@ -24,7 +23,7 @@ public class BasicTexturedButton extends AbstractButton {
 
     public BasicTexturedButton(
             int x, int y, int width, int height, Texture texture, Consumer<Integer> onClick, List<Component> tooltip) {
-        super(x, y, width, height, new TextComponent("Basic Button"));
+        super(x, y, width, height, Component.literal("Basic Button"));
         this.texture = texture;
         this.onClick = onClick;
         this.setTooltip(tooltip);

--- a/common/src/main/java/com/wynntils/gui/widgets/ChatTabAddButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ChatTabAddButton.java
@@ -14,11 +14,11 @@ import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.mc.utils.McUtils;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class ChatTabAddButton extends AbstractButton {
     public ChatTabAddButton(int x, int y, int width, int height) {
-        super(x, y, width, height, new TextComponent("Chat Tab Add Button"));
+        super(x, y, width, height, Component.literal("Chat Tab Add Button"));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/gui/widgets/ChatTabButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ChatTabButton.java
@@ -17,14 +17,14 @@ import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.mc.utils.McUtils;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class ChatTabButton extends AbstractButton {
     private final ChatTab tab;
 
     public ChatTabButton(int x, int y, int width, int height, ChatTab tab) {
-        super(x, y, width, height, new TextComponent("Chat Tab Button"));
+        super(x, y, width, height, Component.literal("Chat Tab Button"));
         this.tab = tab;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/ClassInfoButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ClassInfoButton.java
@@ -16,7 +16,7 @@ import com.wynntils.mc.objects.CommonColors;
 import com.wynntils.wynn.objects.ClassInfo;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class ClassInfoButton extends AbstractButton {
     private final ClassInfo classInfo;
@@ -24,7 +24,7 @@ public class ClassInfoButton extends AbstractButton {
 
     public ClassInfoButton(
             int x, int y, int width, int height, ClassInfo classInfo, CharacterSelectorScreen characterSelectorScreen) {
-        super(x, y, width, height, new TextComponent("Class Info Button"));
+        super(x, y, width, height, Component.literal("Class Info Button"));
         this.classInfo = classInfo;
         this.characterSelectorScreen = characterSelectorScreen;
     }

--- a/common/src/main/java/com/wynntils/gui/widgets/ClassSelectionAddButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ClassSelectionAddButton.java
@@ -15,24 +15,23 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 
 public class ClassSelectionAddButton extends AbstractButton {
     private static final List<Component> TOOLTIP_CANNOT_ADD = List.of(
-            new TranslatableComponent("screens.wynntils.characterSelection.cannotAdd.name")
+            Component.translatable("screens.wynntils.characterSelection.cannotAdd.name")
                     .withStyle(ChatFormatting.DARK_RED),
-            new TranslatableComponent("screens.wynntils.characterSelection.cannotAdd.discussion")
+            Component.translatable("screens.wynntils.characterSelection.cannotAdd.discussion")
                     .withStyle(ChatFormatting.GRAY));
     private static final List<Component> TOOLTIP_CAN_ADD = List.of(
-            new TranslatableComponent("screens.wynntils.characterSelection.add.name").withStyle(ChatFormatting.GREEN),
-            new TranslatableComponent("screens.wynntils.characterSelection.add.discussion")
+            Component.translatable("screens.wynntils.characterSelection.add.name")
+                    .withStyle(ChatFormatting.GREEN),
+            Component.translatable("screens.wynntils.characterSelection.add.discussion")
                     .withStyle(ChatFormatting.GRAY));
     private final CharacterSelectorScreen characterSelectorScreen;
 
     public ClassSelectionAddButton(
             int x, int y, int width, int height, CharacterSelectorScreen characterSelectorScreen) {
-        super(x, y, width, height, new TextComponent("Class Selection Delete Button"));
+        super(x, y, width, height, Component.literal("Class Selection Delete Button"));
         this.characterSelectorScreen = characterSelectorScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/ClassSelectionDeleteButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ClassSelectionDeleteButton.java
@@ -15,19 +15,18 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 
 public class ClassSelectionDeleteButton extends AbstractButton {
     private static final List<Component> TOOLTIP = List.of(
-            new TranslatableComponent("screens.wynntils.characterSelection.delete.name").withStyle(ChatFormatting.RED),
-            new TranslatableComponent("screens.wynntils.characterSelection.delete.discussion")
+            Component.translatable("screens.wynntils.characterSelection.delete.name")
+                    .withStyle(ChatFormatting.RED),
+            Component.translatable("screens.wynntils.characterSelection.delete.discussion")
                     .withStyle(ChatFormatting.GRAY));
     private final CharacterSelectorScreen characterSelectorScreen;
 
     public ClassSelectionDeleteButton(
             int x, int y, int width, int height, CharacterSelectorScreen characterSelectorScreen) {
-        super(x, y, width, height, new TextComponent("Class Selection Delete Button"));
+        super(x, y, width, height, Component.literal("Class Selection Delete Button"));
         this.characterSelectorScreen = characterSelectorScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/ClassSelectionEditButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ClassSelectionEditButton.java
@@ -15,20 +15,19 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 
 public class ClassSelectionEditButton extends AbstractButton {
     private static final List<Component> TOOLTIP = List.of(
-            new TranslatableComponent("screens.wynntils.characterSelection.edit.name").withStyle(ChatFormatting.YELLOW),
-            new TranslatableComponent("screens.wynntils.characterSelection.edit.discussion")
+            Component.translatable("screens.wynntils.characterSelection.edit.name")
+                    .withStyle(ChatFormatting.YELLOW),
+            Component.translatable("screens.wynntils.characterSelection.edit.discussion")
                     .withStyle(ChatFormatting.GRAY));
     private final CharacterSelectorScreen characterSelectorScreen;
 
     public ClassSelectionEditButton(
             int x, int y, int width, int height, CharacterSelectorScreen characterSelectorScreen) {
-        super(x, y, width, height, new TextComponent("Class Selection Edit Button"));
+        super(x, y, width, height, Component.literal("Class Selection Edit Button"));
         this.characterSelectorScreen = characterSelectorScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/DialogueHistoryButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/DialogueHistoryButton.java
@@ -11,11 +11,11 @@ import com.wynntils.gui.screens.WynntilsDialogueHistoryScreen;
 import com.wynntils.mc.utils.McUtils;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class DialogueHistoryButton extends AbstractButton {
     public DialogueHistoryButton(int x, int y, int width, int height) {
-        super(x, y, width, height, new TextComponent("Dialogue History Button"));
+        super(x, y, width, height, Component.literal("Dialogue History Button"));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/gui/widgets/DiscoveryButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/DiscoveryButton.java
@@ -23,7 +23,6 @@ import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import org.lwjgl.glfw.GLFW;
 
 public class DiscoveryButton extends AbstractButton {
@@ -33,7 +32,7 @@ public class DiscoveryButton extends AbstractButton {
     private final DiscoveryInfo discoveryInfo;
 
     public DiscoveryButton(int x, int y, int width, int height, DiscoveryInfo discoveryInfo) {
-        super(x, y, width, height, new TextComponent("Discovery Button"));
+        super(x, y, width, height, Component.literal("Discovery Button"));
         this.discoveryInfo = discoveryInfo;
     }
 
@@ -114,27 +113,27 @@ public class DiscoveryButton extends AbstractButton {
 
             if (!unmet.isEmpty()) {
                 lines.add(TextComponent.EMPTY);
-                lines.add(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.requirements")
+                lines.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.requirements")
                         .withStyle(ChatFormatting.DARK_AQUA));
-                unmet.forEach(requirement -> lines.add(new TextComponent(" - ")
+                unmet.forEach(requirement -> lines.add(Component.literal(" - ")
                         .withStyle(ChatFormatting.RED)
-                        .append(new TextComponent(requirement).withStyle(ChatFormatting.GRAY))));
+                        .append(Component.literal(requirement).withStyle(ChatFormatting.GRAY))));
             }
         }
 
         if (discoveryInfo.getType() == DiscoveryType.SECRET
                 || Managers.Territory.getTerritoryProfile(discoveryInfo.getName()) != null) {
             lines.add(TextComponent.EMPTY);
-            lines.add(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.leftClickToSetCompass")
+            lines.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.leftClickToSetCompass")
                     .withStyle(ChatFormatting.BOLD)
                     .withStyle(ChatFormatting.GREEN));
-            lines.add(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.middleClickToOpenOnMap")
+            lines.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.middleClickToOpenOnMap")
                     .withStyle(ChatFormatting.BOLD)
                     .withStyle(ChatFormatting.YELLOW));
         }
 
         if (discoveryInfo.getType() == DiscoveryType.SECRET) {
-            lines.add(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.rightClickToOpenWiki")
+            lines.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.rightClickToOpenWiki")
                     .withStyle(ChatFormatting.BOLD)
                     .withStyle(ChatFormatting.GOLD));
         }

--- a/common/src/main/java/com/wynntils/gui/widgets/DiscoveryFilterButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/DiscoveryFilterButton.java
@@ -15,8 +15,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 
 public class DiscoveryFilterButton extends AbstractButton {
     private static final CustomColor BUTTON_COLOR = new CustomColor(181, 174, 151);
@@ -39,7 +37,7 @@ public class DiscoveryFilterButton extends AbstractButton {
             List<Component> tooltipList,
             Runnable onPress,
             Supplier<Boolean> isEnabled) {
-        super(x, y, width, height, new TextComponent("Discovery Filter Button"));
+        super(x, y, width, height, Component.literal("Discovery Filter Button"));
 
         this.texture = texture;
         this.dynamicTexture = dynamicTexture;
@@ -113,10 +111,10 @@ public class DiscoveryFilterButton extends AbstractButton {
         List<Component> renderedTooltip = new ArrayList<>(tooltipList);
 
         if (isEnabled.get()) {
-            renderedTooltip.add(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.clickToHide")
+            renderedTooltip.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.clickToHide")
                     .withStyle(ChatFormatting.GRAY));
         } else {
-            renderedTooltip.add(new TranslatableComponent("screens.wynntils.wynntilsDiscoveries.clickToShow")
+            renderedTooltip.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.clickToShow")
                     .withStyle(ChatFormatting.GRAY));
         }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/DiscoveryProgressButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/DiscoveryProgressButton.java
@@ -9,13 +9,13 @@ import com.wynntils.gui.render.RenderUtils;
 import com.wynntils.gui.render.Texture;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class DiscoveryProgressButton extends AbstractButton {
     private final boolean isSecretDiscoveryButton;
 
     public DiscoveryProgressButton(int x, int y, int width, int height, boolean isSecretDiscoveryButton) {
-        super(x, y, width, height, new TextComponent("Discovery Progress Button"));
+        super(x, y, width, height, Component.literal("Discovery Progress Button"));
 
         this.isSecretDiscoveryButton = isSecretDiscoveryButton;
     }

--- a/common/src/main/java/com/wynntils/gui/widgets/GearItemButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/GearItemButton.java
@@ -9,7 +9,7 @@ import com.wynntils.gui.render.RenderUtils;
 import com.wynntils.gui.screens.GearViewerScreen;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
 public class GearItemButton extends AbstractButton {
@@ -17,7 +17,7 @@ public class GearItemButton extends AbstractButton {
     private final ItemStack itemStack;
 
     public GearItemButton(int x, int y, int width, int height, GearViewerScreen gearViewerScreen, ItemStack itemStack) {
-        super(x, y, width, height, new TextComponent("Gear Item Button"));
+        super(x, y, width, height, Component.literal("Gear Item Button"));
         this.gearViewerScreen = gearViewerScreen;
         this.itemStack = itemStack;
     }

--- a/common/src/main/java/com/wynntils/gui/widgets/GuidesButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/GuidesButton.java
@@ -17,7 +17,7 @@ import com.wynntils.utils.StringUtils;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class GuidesButton extends AbstractButton {
     private static final CustomColor BUTTON_COLOR = new CustomColor(181, 174, 151);
@@ -26,7 +26,7 @@ public class GuidesButton extends AbstractButton {
     private final Screen guideScreen;
 
     public GuidesButton(int x, int y, int width, int height, Screen guideScreen) {
-        super(x, y, width, height, new TextComponent("Guides Button"));
+        super(x, y, width, height, Component.literal("Guides Button"));
         this.guideScreen = guideScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/LootrunButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/LootrunButton.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import net.minecraft.Util;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.phys.Vec3;
 import org.lwjgl.glfw.GLFW;
 
@@ -38,7 +38,7 @@ public class LootrunButton extends AbstractButton {
 
     public LootrunButton(
             int x, int y, int width, int height, LootrunModel.LootrunInstance lootrun, WynntilsLootrunsScreen screen) {
-        super(x, y, width, height, new TextComponent("Lootrun Button"));
+        super(x, y, width, height, Component.literal("Lootrun Button"));
         this.lootrun = lootrun;
         this.screen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/widgets/PageSelectorButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/PageSelectorButton.java
@@ -10,7 +10,7 @@ import com.wynntils.gui.render.Texture;
 import com.wynntils.gui.screens.WynntilsMenuPagedScreenBase;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class PageSelectorButton extends AbstractButton {
     private final boolean forward;
@@ -18,7 +18,7 @@ public class PageSelectorButton extends AbstractButton {
 
     public PageSelectorButton(
             int x, int y, int width, int height, boolean forward, WynntilsMenuPagedScreenBase screen) {
-        super(x, y, width, height, new TextComponent("Page Selector Button"));
+        super(x, y, width, height, Component.literal("Page Selector Button"));
         this.forward = forward;
         this.screen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/widgets/PlayButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/PlayButton.java
@@ -16,19 +16,17 @@ import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 
 public class PlayButton extends AbstractButton {
     private static final List<Component> TOOLTIP = List.of(
-            new TranslatableComponent("screens.wynntils.characterSelection.playButton.play")
+            Component.translatable("screens.wynntils.characterSelection.playButton.play")
                     .withStyle(ChatFormatting.GREEN),
-            new TranslatableComponent("screens.wynntils.characterSelection.playButton.description")
+            Component.translatable("screens.wynntils.characterSelection.playButton.description")
                     .withStyle(ChatFormatting.GRAY));
     private final CharacterSelectorScreen characterSelectorScreen;
 
     public PlayButton(int x, int y, int width, int height, CharacterSelectorScreen characterSelectorScreen) {
-        super(x, y, width, height, new TextComponent("Play Button"));
+        super(x, y, width, height, Component.literal("Play Button"));
         this.characterSelectorScreen = characterSelectorScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/QuestButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/QuestButton.java
@@ -23,7 +23,7 @@ import com.wynntils.wynn.model.quests.QuestInfo;
 import java.util.Optional;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
@@ -38,7 +38,7 @@ public class QuestButton extends AbstractButton {
     private final WynntilsQuestBookScreen questBookScreen;
 
     public QuestButton(int x, int y, int width, int height, QuestInfo questInfo, WynntilsQuestBookScreen screen) {
-        super(x, y, width, height, new TextComponent("Quest Button"));
+        super(x, y, width, height, Component.literal("Quest Button"));
         this.questInfo = questInfo;
         this.questBookScreen = screen;
     }

--- a/common/src/main/java/com/wynntils/gui/widgets/QuestInfoButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/QuestInfoButton.java
@@ -10,13 +10,13 @@ import com.wynntils.gui.render.Texture;
 import com.wynntils.gui.screens.WynntilsQuestBookScreen;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class QuestInfoButton extends AbstractButton {
     private final WynntilsQuestBookScreen questBookScreen;
 
     public QuestInfoButton(int x, int y, int width, int height, WynntilsQuestBookScreen questBookScreen) {
-        super(x, y, width, height, new TextComponent("Quest Info / Mini Quest Toggle Button"));
+        super(x, y, width, height, Component.literal("Quest Info / Mini Quest Toggle Button"));
         this.questBookScreen = questBookScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/QuestsPageButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/QuestsPageButton.java
@@ -11,11 +11,11 @@ import com.wynntils.gui.screens.WynntilsQuestBookScreen;
 import com.wynntils.mc.utils.McUtils;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class QuestsPageButton extends AbstractButton {
     public QuestsPageButton(int x, int y, int width, int height) {
-        super(x, y, width, height, new TextComponent("Quests Page Button"));
+        super(x, y, width, height, Component.literal("Quests Page Button"));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/gui/widgets/ReloadButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ReloadButton.java
@@ -9,14 +9,14 @@ import com.wynntils.gui.render.RenderUtils;
 import com.wynntils.gui.render.Texture;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class ReloadButton extends AbstractButton {
 
     private final Runnable onClickRunnable;
 
     public ReloadButton(int x, int y, int width, int height, Runnable onClickRunnable) {
-        super(x, y, width, height, new TextComponent("Reload Button"));
+        super(x, y, width, height, Component.literal("Reload Button"));
         this.onClickRunnable = onClickRunnable;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/SearchWidget.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/SearchWidget.java
@@ -15,17 +15,15 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.sounds.SoundEvents;
 
 public class SearchWidget extends TextInputBoxWidget {
     protected static final Component DEFAULT_TEXT =
-            new TranslatableComponent("screens.wynntils.searchWidget.defaultSearchText");
+            Component.translatable("screens.wynntils.searchWidget.defaultSearchText");
 
     public SearchWidget(
             int x, int y, int width, int height, Consumer<String> onUpdateConsumer, TextboxScreen textboxScreen) {
-        super(x, y, width, height, new TextComponent("Search Box"), onUpdateConsumer, textboxScreen);
+        super(x, y, width, height, Component.literal("Search Box"), onUpdateConsumer, textboxScreen);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/gui/widgets/SortOrderWidget.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/SortOrderWidget.java
@@ -11,13 +11,13 @@ import com.wynntils.gui.screens.WynntilsQuestBookScreen;
 import com.wynntils.wynn.model.quests.QuestSortOrder;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 public class SortOrderWidget extends AbstractButton {
     private final WynntilsQuestBookScreen questBookScreen;
 
     public SortOrderWidget(int x, int y, int width, int height, WynntilsQuestBookScreen questBookScreen) {
-        super(x, y, width, height, new TextComponent("Sort Order Button"));
+        super(x, y, width, height, Component.literal("Sort Order Button"));
         this.questBookScreen = questBookScreen;
     }
 

--- a/common/src/main/java/com/wynntils/gui/widgets/ViewPlayerStatsButton.java
+++ b/common/src/main/java/com/wynntils/gui/widgets/ViewPlayerStatsButton.java
@@ -10,14 +10,14 @@ import com.wynntils.mc.utils.McUtils;
 import java.util.Map;
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 
 public class ViewPlayerStatsButton extends AbstractButton {
     private final String playerName;
 
     public ViewPlayerStatsButton(int x, int y, int width, int height, String playerName) {
-        super(x, y, width, height, new TextComponent("↵"));
+        super(x, y, width, height, Component.literal("↵"));
         this.playerName = playerName;
     }
 

--- a/common/src/main/java/com/wynntils/mc/utils/ComponentUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/ComponentUtils.java
@@ -18,7 +18,6 @@ import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
-import net.minecraft.network.chat.TextComponent;
 
 public final class ComponentUtils {
     private static final Pattern NEWLINE_PATTERN = Pattern.compile("\n");
@@ -175,10 +174,10 @@ public final class ComponentUtils {
     }
 
     public static Component formattedTextToComponent(FormattedText formattedText) {
-        MutableComponent component = new TextComponent("");
+        MutableComponent component = Component.literal("");
         formattedText.visit(
                 (style, string) -> {
-                    component.append(new TextComponent(string).withStyle(style));
+                    component.append(Component.literal(string).withStyle(style));
                     return Optional.empty();
                 },
                 Style.EMPTY);
@@ -211,21 +210,21 @@ public final class ComponentUtils {
         List<Component> split = McUtils.mc().font.getSplitter().splitLines(component, maxWidth, Style.EMPTY).stream()
                 .map(ComponentUtils::formattedTextToComponent)
                 .collect(Collectors.toList());
-        if (split.isEmpty()) split.add(new TextComponent(""));
+        if (split.isEmpty()) split.add(Component.literal(""));
         return split;
     }
 
     private static class ComponentListBuilder {
         private final List<Component> lines = new ArrayList<>();
-        private MutableComponent currentLine = new TextComponent("");
+        private MutableComponent currentLine = Component.literal("");
 
         protected void appendSegment(String segment, Style style) {
-            currentLine.append(new TextComponent(segment).withStyle(style));
+            currentLine.append(Component.literal(segment).withStyle(style));
         }
 
         protected void endLine() {
             lines.add(currentLine);
-            currentLine = new TextComponent("");
+            currentLine = Component.literal("");
         }
 
         protected List<Component> extractLines() {

--- a/common/src/main/java/com/wynntils/sockets/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/sockets/HadesClientHandler.java
@@ -39,7 +39,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
 
             if (Managers.WorldState.onServer()) {
                 McUtils.sendMessageToClient(
-                        new TextComponent("Could not connect to HadesServer because you are not logged in on Athena.")
+                        Component.literal("Could not connect to HadesServer because you are not logged in on Athena.")
                                 .withStyle(ChatFormatting.RED));
             }
 
@@ -55,7 +55,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
 
         if (Managers.WorldState.onServer()) {
             McUtils.sendMessageToClient(
-                    new TextComponent("Disconnected from HadesServer").withStyle(ChatFormatting.RED));
+                    Component.literal("Disconnected from HadesServer").withStyle(ChatFormatting.RED));
         }
 
         WynntilsMod.info("Disconnected from HadesServer.");
@@ -70,19 +70,19 @@ public class HadesClientHandler implements IHadesClientAdapter {
         switch (packet.getResponse()) {
             case SUCCESS -> {
                 WynntilsMod.info("Successfully connected to HadesServer: " + packet.getMessage());
-                userComponent =
-                        new TextComponent("Successfully connected to HadesServer").withStyle(ChatFormatting.GREEN);
+                userComponent = Component.literal("Successfully connected to HadesServer")
+                        .withStyle(ChatFormatting.GREEN);
                 WynntilsMod.postEvent(new SocketEvent.Authenticated());
             }
             case INVALID_TOKEN -> {
                 WynntilsMod.error("Got invalid token when trying to connect to HadesServer: " + packet.getMessage());
-                userComponent = new TextComponent("Got invalid token when connecting HadesServer")
+                userComponent = Component.literal("Got invalid token when connecting HadesServer")
                         .withStyle(ChatFormatting.RED);
             }
             case ERROR -> {
                 WynntilsMod.error("Got an error trying to connect to HadesServer: " + packet.getMessage());
-                userComponent =
-                        new TextComponent("Got error when connecting HadesServer").withStyle(ChatFormatting.RED);
+                userComponent = Component.literal("Got error when connecting HadesServer")
+                        .withStyle(ChatFormatting.RED);
             }
         }
 
@@ -124,7 +124,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
         WynntilsMod.info("Disconnected from HadesServer. Reason: " + packet.getReason());
 
         if (Managers.WorldState.onServer()) {
-            McUtils.sendMessageToClient(new TextComponent("[Wynntils/Artemis] Disconnected from HadesServer.")
+            McUtils.sendMessageToClient(Component.literal("[Wynntils/Artemis] Disconnected from HadesServer.")
                     .withStyle(ChatFormatting.YELLOW));
         }
 

--- a/common/src/main/java/com/wynntils/wynn/item/EmeraldPouchItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/EmeraldPouchItemStack.java
@@ -86,27 +86,27 @@ public class EmeraldPouchItemStack extends WynnItemStack {
         List<Component> itemLore = new ArrayList<>();
 
         itemLore.add(TextComponent.EMPTY);
-        itemLore.add(new TextComponent("Emerald Pouches allows the wearer to easily ")
+        itemLore.add(Component.literal("Emerald Pouches allows the wearer to easily ")
                 .withStyle(ChatFormatting.GRAY)
-                .append(new TextComponent("store ").withStyle(ChatFormatting.AQUA))
-                .append(new TextComponent("and ").withStyle(ChatFormatting.GRAY))
-                .append(new TextComponent("convert ").withStyle(ChatFormatting.AQUA))
-                .append(new TextComponent("picked emeralds without spending extra inventory slots.")
+                .append(Component.literal("store ").withStyle(ChatFormatting.AQUA))
+                .append(Component.literal("and ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("convert ").withStyle(ChatFormatting.AQUA))
+                .append(Component.literal("picked emeralds without spending extra inventory slots.")
                         .withStyle(ChatFormatting.GRAY)));
         itemLore.add(TextComponent.EMPTY);
-        itemLore.add(new TextComponent(" - " + rows + " Rows ")
+        itemLore.add(Component.literal(" - " + rows + " Rows ")
                 .withStyle(ChatFormatting.GRAY)
-                .append(new TextComponent("(" + totalString + " Total)"))
+                .append(Component.literal("(" + totalString + " Total)"))
                 .withStyle(ChatFormatting.DARK_GRAY));
 
         switch (upTo) {
-            case 0 -> itemLore.add(new TextComponent("No Auto-Conversions").withStyle(ChatFormatting.GRAY));
-            case 1 -> itemLore.add(new TextComponent("Converts up to")
+            case 0 -> itemLore.add(Component.literal("No Auto-Conversions").withStyle(ChatFormatting.GRAY));
+            case 1 -> itemLore.add(Component.literal("Converts up to")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(new TextComponent(" Emerald Blocks").withStyle(ChatFormatting.WHITE)));
-            default -> itemLore.add(new TextComponent("Converts up to")
+                    .append(Component.literal(" Emerald Blocks").withStyle(ChatFormatting.WHITE)));
+            default -> itemLore.add(Component.literal("Converts up to")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(new TextComponent(" Liquid Emeralds").withStyle(ChatFormatting.WHITE)));
+                    .append(Component.literal(" Liquid Emeralds").withStyle(ChatFormatting.WHITE)));
         }
 
         return itemLore;
@@ -115,9 +115,9 @@ public class EmeraldPouchItemStack extends WynnItemStack {
     @Override
     public Component getHoverName() {
         return generated
-                ? new TextComponent("Emerald Pouch ")
+                ? Component.literal("Emerald Pouch ")
                         .withStyle(ChatFormatting.GREEN)
-                        .append(new TextComponent("[Tier " + MathUtils.toRoman(tier) + "]")
+                        .append(Component.literal("[Tier " + MathUtils.toRoman(tier) + "]")
                                 .withStyle(ChatFormatting.DARK_GREEN))
                 : super.getHoverName();
     }

--- a/common/src/main/java/com/wynntils/wynn/item/GearItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/GearItemStack.java
@@ -34,7 +34,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -44,7 +43,7 @@ public class GearItemStack extends WynnItemStack {
     private static final Pattern ITEM_TIER =
             Pattern.compile("(?<Quality>Normal|Unique|Rare|Legendary|Fabled|Mythic|Set) Item(?: \\[(?<Rolls>\\d+)])?");
 
-    private static final Component ID_PLACEHOLDER = new TextComponent("ID_PLACEHOLDER");
+    private static final Component ID_PLACEHOLDER = Component.literal("ID_PLACEHOLDER");
 
     private ItemProfile itemProfile;
     private boolean isPerfect;
@@ -127,7 +126,7 @@ public class GearItemStack extends WynnItemStack {
             if (!hasIds) {
                 hasIds = true;
                 baseTooltip.add(ID_PLACEHOLDER);
-                baseTooltip.add(new TextComponent(""));
+                baseTooltip.add(Component.literal(""));
             }
 
             identifications.add(idContainer);
@@ -155,7 +154,7 @@ public class GearItemStack extends WynnItemStack {
             tag.putInt("color", itemProfile.getItemInfo().getArmorColorAsInt());
         this.setTag(tag);
 
-        customName = new TextComponent(itemProfile.getDisplayName())
+        customName = Component.literal(itemProfile.getDisplayName())
                 .withStyle(itemProfile.getTier().getChatFormatting());
 
         List<Component> baseTooltip = constructBaseTooltip();
@@ -183,7 +182,7 @@ public class GearItemStack extends WynnItemStack {
             tag.putInt("color", itemProfile.getItemInfo().getArmorColorAsInt());
         this.setTag(tag);
 
-        customName = new TextComponent(itemProfile.getDisplayName())
+        customName = Component.literal(itemProfile.getDisplayName())
                 .withStyle(itemProfile.getTier().getChatFormatting());
 
         parseIDs();
@@ -211,7 +210,7 @@ public class GearItemStack extends WynnItemStack {
             tag.putInt("color", itemProfile.getItemInfo().getArmorColorAsInt());
         this.setTag(tag);
 
-        customName = new TextComponent(itemProfile.getDisplayName())
+        customName = Component.literal(itemProfile.getDisplayName())
                 .withStyle(itemProfile.getTier().getChatFormatting());
 
         parseIDs();
@@ -257,7 +256,7 @@ public class GearItemStack extends WynnItemStack {
          * Avaritia Repo: https://github.com/Morpheus1101/Avaritia
          */
         if (ItemStatInfoFeature.INSTANCE.perfect && isPerfect) {
-            MutableComponent newName = new TextComponent("").withStyle(ChatFormatting.BOLD);
+            MutableComponent newName = Component.literal("").withStyle(ChatFormatting.BOLD);
 
             String name = "Perfect " + itemName;
 
@@ -270,14 +269,14 @@ public class GearItemStack extends WynnItemStack {
                         .withColor(Color.HSBtoRGB((hue / (float) cycle), 0.8F, 0.8F))
                         .withItalic(false);
 
-                newName.append(new TextComponent(String.valueOf(name.charAt(i))).setStyle(color));
+                newName.append(Component.literal(String.valueOf(name.charAt(i))).setStyle(color));
             }
 
             return newName;
         }
 
         if (ItemStatInfoFeature.INSTANCE.defective && isDefective) {
-            MutableComponent newName = new TextComponent("").withStyle(ChatFormatting.BOLD, ChatFormatting.DARK_RED);
+            MutableComponent newName = Component.literal("").withStyle(ChatFormatting.BOLD, ChatFormatting.DARK_RED);
             newName.setStyle(newName.getStyle().withItalic(false));
 
             String name = "Defective " + itemName;
@@ -294,12 +293,12 @@ public class GearItemStack extends WynnItemStack {
                         (i + 1) / (float) (name.length() - 1));
 
                 if (!obfuscated && Math.random() < chance) {
-                    newName.append(new TextComponent(current.toString()).withStyle(Style.EMPTY.withItalic(false)));
+                    newName.append(Component.literal(current.toString()).withStyle(Style.EMPTY.withItalic(false)));
                     current = new StringBuilder();
 
                     obfuscated = true;
                 } else if (obfuscated && Math.random() > chance) {
-                    newName.append(new TextComponent(current.toString())
+                    newName.append(Component.literal(current.toString())
                             .withStyle(Style.EMPTY.withObfuscated(true).withItalic(false)));
                     current = new StringBuilder();
 
@@ -310,10 +309,10 @@ public class GearItemStack extends WynnItemStack {
             current.append(name.charAt(name.length() - 1));
 
             if (obfuscated) {
-                newName.append(new TextComponent(current.toString())
+                newName.append(Component.literal(current.toString())
                         .withStyle(Style.EMPTY.withItalic(false).withObfuscated(true)));
             } else {
-                newName.append(new TextComponent(current.toString()).withStyle(Style.EMPTY.withItalic(false)));
+                newName.append(Component.literal(current.toString()).withStyle(Style.EMPTY.withItalic(false)));
             }
 
             return newName;
@@ -334,7 +333,7 @@ public class GearItemStack extends WynnItemStack {
         }
 
         if (isChatItem) {
-            tooltip.add(new TextComponent("From chat")
+            tooltip.add(Component.literal("From chat")
                     .withStyle(ChatFormatting.DARK_GRAY)
                     .withStyle(ChatFormatting.ITALIC));
 
@@ -365,13 +364,13 @@ public class GearItemStack extends WynnItemStack {
 
         MutableComponent name;
         if (customName == null) {
-            name = new TextComponent(WynnUtils.normalizeBadString(ComponentUtils.getCoded(getHoverName())));
+            name = Component.literal(WynnUtils.normalizeBadString(ComponentUtils.getCoded(getHoverName())));
         } else {
             name = customName.copy();
         }
 
         if (hasNew) {
-            name.append(new TextComponent(" [NEW]").withStyle(ChatFormatting.GOLD));
+            name.append(Component.literal(" [NEW]").withStyle(ChatFormatting.GOLD));
         } else if (idAmount > 0) {
             overallPercentage = percentTotal / idAmount;
 
@@ -432,17 +431,18 @@ public class GearItemStack extends WynnItemStack {
 
         // attack speed
         if (itemProfile.getAttackSpeed() != null)
-            baseTooltip.add(new TextComponent(itemProfile.getAttackSpeed().asLore()));
+            baseTooltip.add(Component.literal(itemProfile.getAttackSpeed().asLore()));
 
-        baseTooltip.add(new TextComponent(""));
+        baseTooltip.add(Component.literal(""));
 
         // elemental damages
         if (!itemProfile.getDamageTypes().isEmpty()) {
             Map<DamageType, String> damages = itemProfile.getDamages();
             for (Map.Entry<DamageType, String> entry : damages.entrySet()) {
                 DamageType type = entry.getKey();
-                MutableComponent damage = new TextComponent(type.getSymbol() + " " + type).withStyle(type.getColor());
-                damage.append(new TextComponent(" Damage: " + entry.getValue())
+                MutableComponent damage =
+                        Component.literal(type.getSymbol() + " " + type).withStyle(type.getColor());
+                damage.append(Component.literal(" Damage: " + entry.getValue())
                         .withStyle(
                                 type == DamageType.NEUTRAL
                                         ? type.getColor()
@@ -450,7 +450,7 @@ public class GearItemStack extends WynnItemStack {
                 baseTooltip.add(damage);
             }
 
-            baseTooltip.add(new TextComponent(""));
+            baseTooltip.add(Component.literal(""));
         }
 
         // elemental defenses
@@ -458,19 +458,21 @@ public class GearItemStack extends WynnItemStack {
             int health = itemProfile.getHealth();
             if (health != 0) {
                 MutableComponent healthComp =
-                        new TextComponent("❤ Health: " + health).withStyle(ChatFormatting.DARK_RED);
+                        Component.literal("❤ Health: " + health).withStyle(ChatFormatting.DARK_RED);
                 baseTooltip.add(healthComp);
             }
 
             Map<DamageType, Integer> defenses = itemProfile.getElementalDefenses();
             for (Map.Entry<DamageType, Integer> entry : defenses.entrySet()) {
                 DamageType type = entry.getKey();
-                MutableComponent defense = new TextComponent(type.getSymbol() + " " + type).withStyle(type.getColor());
-                defense.append(new TextComponent(" Defence: " + entry.getValue()).withStyle(ChatFormatting.GRAY));
+                MutableComponent defense =
+                        Component.literal(type.getSymbol() + " " + type).withStyle(type.getColor());
+                defense.append(
+                        Component.literal(" Defence: " + entry.getValue()).withStyle(ChatFormatting.GRAY));
                 baseTooltip.add(defense);
             }
 
-            baseTooltip.add(new TextComponent(""));
+            baseTooltip.add(Component.literal(""));
         }
 
         // requirements
@@ -478,46 +480,47 @@ public class GearItemStack extends WynnItemStack {
             Map<RequirementType, String> requirements = itemProfile.getRequirements();
             for (Map.Entry<RequirementType, String> entry : requirements.entrySet()) {
                 RequirementType type = entry.getKey();
-                MutableComponent requirement = new TextComponent("✔ ").withStyle(ChatFormatting.GREEN);
-                requirement.append(new TextComponent(type.asLore() + entry.getValue()).withStyle(ChatFormatting.GRAY));
+                MutableComponent requirement = Component.literal("✔ ").withStyle(ChatFormatting.GREEN);
+                requirement.append(
+                        Component.literal(type.asLore() + entry.getValue()).withStyle(ChatFormatting.GRAY));
                 baseTooltip.add(requirement);
             }
 
-            baseTooltip.add(new TextComponent(""));
+            baseTooltip.add(Component.literal(""));
         }
 
         // ids
         if (!itemProfile.getStatuses().isEmpty()) {
             baseTooltip.add(ID_PLACEHOLDER);
-            baseTooltip.add(new TextComponent(""));
+            baseTooltip.add(Component.literal(""));
         }
 
         // major ids
         if (itemProfile.getMajorIds() != null && !itemProfile.getMajorIds().isEmpty()) {
             for (MajorIdentification majorId : itemProfile.getMajorIds()) {
                 Stream.of(StringUtils.wrapTextBySize(majorId.asLore(), 150))
-                        .forEach(c -> baseTooltip.add(new TextComponent(c).withStyle(ChatFormatting.DARK_AQUA)));
+                        .forEach(c -> baseTooltip.add(Component.literal(c).withStyle(ChatFormatting.DARK_AQUA)));
             }
-            baseTooltip.add(new TextComponent(""));
+            baseTooltip.add(Component.literal(""));
         }
 
         // powder slots
         if (itemProfile.getPowderAmount() > 0) {
             if (isGuideStack || powders == null) {
-                baseTooltip.add(new TextComponent("[" + itemProfile.getPowderAmount() + " Powder Slots]")
+                baseTooltip.add(Component.literal("[" + itemProfile.getPowderAmount() + " Powder Slots]")
                         .withStyle(ChatFormatting.GRAY));
             } else {
-                MutableComponent powderLine = new TextComponent(
+                MutableComponent powderLine = Component.literal(
                                 "[" + powders.size() + "/" + itemProfile.getPowderAmount() + "] Powder Slots ")
                         .withStyle(ChatFormatting.GRAY);
                 if (!powders.isEmpty()) {
-                    MutableComponent powderList = new TextComponent("[");
+                    MutableComponent powderList = Component.literal("[");
                     for (Powder p : powders) {
                         String symbol = p.getColoredSymbol();
                         if (!powderList.getSiblings().isEmpty()) symbol = " " + symbol;
-                        powderList.append(new TextComponent(symbol));
+                        powderList.append(Component.literal(symbol));
                     }
-                    powderList.append(new TextComponent("]"));
+                    powderList.append(Component.literal("]"));
                     powderLine.append(powderList);
                 }
                 baseTooltip.add(powderLine);
@@ -533,7 +536,7 @@ public class GearItemStack extends WynnItemStack {
 
         // untradable
         if (itemProfile.getRestriction() != null) {
-            baseTooltip.add(new TextComponent(StringUtils.capitalizeFirst(itemProfile.getRestriction() + " Item"))
+            baseTooltip.add(Component.literal(StringUtils.capitalizeFirst(itemProfile.getRestriction() + " Item"))
                     .withStyle(ChatFormatting.RED));
         }
 

--- a/common/src/main/java/com/wynntils/wynn/item/IdentificationOrderer.java
+++ b/common/src/main/java/com/wynntils/wynn/item/IdentificationOrderer.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 
 public class IdentificationOrderer {
     public static IdentificationOrderer INSTANCE = new IdentificationOrderer(null, null, null);
@@ -76,7 +75,7 @@ public class IdentificationOrderer {
 
                 if (currentGroup != lastGroup)
                     result.add(ItemUtils.toLoreStringTag(
-                            new TextComponent(" "))); // adds a space before if the group is different
+                            Component.literal(" "))); // adds a space before if the group is different
 
                 result.add(keys.getValue());
                 lastGroup = currentGroup;
@@ -111,7 +110,7 @@ public class IdentificationOrderer {
                 int currentGroup = getGroup(keys.getKey()); // next key group
 
                 if (currentGroup != lastGroup)
-                    result.add(new TextComponent(" ")); // adds a space before if the group is different
+                    result.add(Component.literal(" ")); // adds a space before if the group is different
 
                 result.add(keys.getValue());
                 lastGroup = currentGroup;

--- a/common/src/main/java/com/wynntils/wynn/item/IngredientItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/IngredientItemStack.java
@@ -73,9 +73,9 @@ public class IngredientItemStack extends WynnItemStack {
     @Override
     public Component getHoverName() {
         if (isGuideStack) {
-            return new TextComponent(ingredientProfile.getDisplayName())
+            return Component.literal(ingredientProfile.getDisplayName())
                     .withStyle(ChatFormatting.GRAY)
-                    .append(new TextComponent(" " + ingredientProfile.getTier().getTierString()));
+                    .append(Component.literal(" " + ingredientProfile.getTier().getTierString()));
         }
 
         return super.getHoverName();
@@ -84,7 +84,7 @@ public class IngredientItemStack extends WynnItemStack {
     private List<Component> generateGuideTooltip() {
         List<Component> itemLore = new ArrayList<>();
 
-        itemLore.add(new TextComponent("Crafting Ingredient").withStyle(ChatFormatting.DARK_GRAY));
+        itemLore.add(Component.literal("Crafting Ingredient").withStyle(ChatFormatting.DARK_GRAY));
         itemLore.add(TextComponent.EMPTY);
 
         Map<String, IngredientIdentificationContainer> statuses = ingredientProfile.getStatuses();
@@ -93,36 +93,36 @@ public class IngredientItemStack extends WynnItemStack {
             IngredientIdentificationContainer identificationContainer = statuses.get(status);
             if (identificationContainer.hasConstantValue()) {
                 if (identificationContainer.getMin() >= 0) {
-                    itemLore.add(new TextComponent("+" + identificationContainer.getMin()
+                    itemLore.add(Component.literal("+" + identificationContainer.getMin()
                                     + identificationContainer.getType().getInGame(status))
                             .withStyle(ChatFormatting.GREEN)
-                            .append(new TextComponent(" " + IdentificationProfile.getAsLongName(status))
+                            .append(Component.literal(" " + IdentificationProfile.getAsLongName(status))
                                     .withStyle(ChatFormatting.GRAY)));
                 } else {
-                    itemLore.add(new TextComponent(identificationContainer.getMin()
+                    itemLore.add(Component.literal(identificationContainer.getMin()
                                     + identificationContainer.getType().getInGame(status))
                             .withStyle(ChatFormatting.RED)
-                            .append(new TextComponent(" " + IdentificationProfile.getAsLongName(status))
+                            .append(Component.literal(" " + IdentificationProfile.getAsLongName(status))
                                     .withStyle(ChatFormatting.GRAY)));
                 }
             } else {
                 if (identificationContainer.getMin() >= 0) {
-                    itemLore.add(new TextComponent("+" + identificationContainer.getMin())
+                    itemLore.add(Component.literal("+" + identificationContainer.getMin())
                             .withStyle(ChatFormatting.GREEN)
-                            .append(new TextComponent(" to ").withStyle(ChatFormatting.DARK_GREEN))
-                            .append(new TextComponent(identificationContainer.getMax()
+                            .append(Component.literal(" to ").withStyle(ChatFormatting.DARK_GREEN))
+                            .append(Component.literal(identificationContainer.getMax()
                                             + identificationContainer.getType().getInGame(status))
                                     .withStyle(ChatFormatting.GREEN))
-                            .append(new TextComponent(" " + IdentificationProfile.getAsLongName(status))
+                            .append(Component.literal(" " + IdentificationProfile.getAsLongName(status))
                                     .withStyle(ChatFormatting.GRAY)));
                 } else {
-                    itemLore.add(new TextComponent(String.valueOf(identificationContainer.getMin()))
+                    itemLore.add(Component.literal(String.valueOf(identificationContainer.getMin()))
                             .withStyle(ChatFormatting.RED)
-                            .append(new TextComponent(" to ").withStyle(ChatFormatting.DARK_RED))
-                            .append(new TextComponent(identificationContainer.getMax()
+                            .append(Component.literal(" to ").withStyle(ChatFormatting.DARK_RED))
+                            .append(Component.literal(identificationContainer.getMax()
                                             + identificationContainer.getType().getInGame(status))
                                     .withStyle(ChatFormatting.RED))
-                            .append(new TextComponent(" " + IdentificationProfile.getAsLongName(status))
+                            .append(Component.literal(" " + IdentificationProfile.getAsLongName(status))
                                     .withStyle(ChatFormatting.GRAY)));
                 }
             }
@@ -147,14 +147,14 @@ public class IngredientItemStack extends WynnItemStack {
         }
 
         if (ingredientProfile.isUntradeable())
-            itemLore.add(new TextComponent("Untradable Item").withStyle(ChatFormatting.RED));
+            itemLore.add(Component.literal("Untradable Item").withStyle(ChatFormatting.RED));
 
-        itemLore.add(
-                new TextComponent("Crafting Lv. Min: " + ingredientProfile.getLevel()).withStyle(ChatFormatting.GRAY));
+        itemLore.add(Component.literal("Crafting Lv. Min: " + ingredientProfile.getLevel())
+                .withStyle(ChatFormatting.GRAY));
 
         for (ProfessionType profession : ingredientProfile.getProfessions()) {
-            itemLore.add(new TextComponent("  " + profession.getProfessionIconChar() + " ")
-                    .append(new TextComponent(profession.getDisplayName()).withStyle(ChatFormatting.GRAY)));
+            itemLore.add(Component.literal("  " + profession.getProfessionIconChar() + " ")
+                    .append(Component.literal(profession.getDisplayName()).withStyle(ChatFormatting.GRAY)));
         }
 
         return itemLore;

--- a/common/src/main/java/com/wynntils/wynn/item/IntelligenceSkillPointsItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/IntelligenceSkillPointsItemStack.java
@@ -14,7 +14,6 @@ import java.util.LinkedList;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -44,7 +43,7 @@ public class IntelligenceSkillPointsItemStack extends WynnItemStack {
 
     private List<Component> getTooltipExtension() {
         List<Component> tooltipExtension = new ArrayList<>();
-        tooltipExtension.add(new TextComponent(""));
+        tooltipExtension.add(Component.literal(""));
         tooltipExtension.addAll(getManaTables());
         return tooltipExtension;
     }
@@ -76,12 +75,12 @@ public class IntelligenceSkillPointsItemStack extends WynnItemStack {
                     spellInfo += ChatFormatting.GRAY + " (-" + (manaCost - 1) + " ✺ in "
                             + remainingLevelsDescription(nextUpgrade - intelligencePoints) + ")";
                 }
-                newLore.add(new TextComponent(spellInfo));
+                newLore.add(Component.literal(spellInfo));
             }
         }
 
         if (closestUpgradeLevel < Integer.MAX_VALUE) {
-            newLore.addFirst(new TextComponent(ChatFormatting.GRAY + "Next upgrade: At " + ChatFormatting.WHITE
+            newLore.addFirst(Component.literal(ChatFormatting.GRAY + "Next upgrade: At " + ChatFormatting.WHITE
                     + closestUpgradeLevel + ChatFormatting.GRAY + " points (in "
                     + remainingLevelsDescription(closestUpgradeLevel - intelligencePoints) + ")"));
         }

--- a/common/src/main/java/com/wynntils/wynn/item/PowderItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/PowderItemStack.java
@@ -59,7 +59,7 @@ public class PowderItemStack extends WynnItemStack {
     @Override
     public Component getHoverName() {
         return generated
-                ? new TextComponent(
+                ? Component.literal(
                                 element.getSymbol() + " " + element.getName() + " Powder " + MathUtils.toRoman(tier))
                         .withStyle(element.getLightColor())
                 : super.getHoverName();
@@ -89,35 +89,35 @@ public class PowderItemStack extends WynnItemStack {
         String name = element.getName();
         Powder opposingElement = element.getOpposingElement();
 
-        itemLore.add(new TextComponent("Tier " + tier + " [")
+        itemLore.add(Component.literal("Tier " + tier + " [")
                 .withStyle(ChatFormatting.GRAY)
-                .append(new TextComponent(tierStringBuilder))
-                .append(new TextComponent("]").withStyle(ChatFormatting.GRAY)));
+                .append(Component.literal(tierStringBuilder))
+                .append(Component.literal("]").withStyle(ChatFormatting.GRAY)));
         itemLore.add(TextComponent.EMPTY);
-        itemLore.add(new TextComponent("Effect on Weapons:").withStyle(element.getDarkColor()));
-        itemLore.add(new TextComponent(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+" + powderProfile.min()
+        itemLore.add(Component.literal("Effect on Weapons:").withStyle(element.getDarkColor()));
+        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+" + powderProfile.min()
                 + "-" + powderProfile.max() + " " + element.getLightColor() + element.getSymbol() + " " + name + " "
                 + ChatFormatting.GRAY + "Damage"));
-        itemLore.add(new TextComponent(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
+        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
                 + powderProfile.convertedFromNeutral() + "% " + ChatFormatting.GOLD + "✣ Neutral" + ChatFormatting.GRAY
                 + " to " + element.getLightColor() + element.getSymbol() + " " + name));
         itemLore.add(TextComponent.EMPTY);
-        itemLore.add(new TextComponent("Effect on Armour:").withStyle(element.getDarkColor()));
-        itemLore.add(new TextComponent(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
+        itemLore.add(Component.literal("Effect on Armour:").withStyle(element.getDarkColor()));
+        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
                 + powderProfile.addedDefence() + " " + element.getLightColor() + element.getSymbol() + " " + name + " "
                 + ChatFormatting.GRAY + "Defence"));
-        itemLore.add(new TextComponent(element.getDarkColor() + "— " + ChatFormatting.GRAY + "-"
+        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "-"
                 + powderProfile.removedDefence() + " " + opposingElement.getLightColor() + opposingElement.getSymbol()
                 + " " + StringUtils.capitalizeFirst(opposingElement.name().toLowerCase(Locale.ROOT)) + " "
                 + ChatFormatting.GRAY + "Defence"));
         itemLore.add(TextComponent.EMPTY);
-        itemLore.add(new TextComponent(
+        itemLore.add(Component.literal(
                         "Add this powder to your items by visiting a Powder Master or use it as an ingredient when crafting.")
                 .withStyle(ChatFormatting.DARK_GRAY));
 
         if (tier > 3) {
             itemLore.add(TextComponent.EMPTY);
-            itemLore.add(new TextComponent(
+            itemLore.add(Component.literal(
                             "Adding 2 powders of tier 4-6 at the powder master will unlock a special attack/effect.")
                     .withStyle(ChatFormatting.DARK_GRAY));
         }

--- a/common/src/main/java/com/wynntils/wynn/item/ServerItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/ServerItemStack.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -45,9 +44,9 @@ public class ServerItemStack extends WynnItemStack {
         ServerProfile serverProfile = Models.ServerList.getServer(serverId);
         String uptimeString = serverProfile == null ? "Unknown" : serverProfile.getUptime();
 
-        newTooltip.add(new TextComponent("Uptime: ")
+        newTooltip.add(Component.literal("Uptime: ")
                 .withStyle(ChatFormatting.DARK_GREEN)
-                .append(new TextComponent(uptimeString).withStyle(ChatFormatting.GREEN)));
+                .append(Component.literal(uptimeString).withStyle(ChatFormatting.GREEN)));
         tooltip = newTooltip;
     }
 

--- a/common/src/main/java/com/wynntils/wynn/item/SoulPointItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/SoulPointItemStack.java
@@ -11,8 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -31,13 +29,13 @@ public class SoulPointItemStack extends WynnItemStack {
         if (SoulPointTimerFeature.INSTANCE.isEnabled()) {
             List<Component> copy = new ArrayList<>(tooltip);
 
-            copy.add(new TextComponent(" "));
+            copy.add(Component.literal(" "));
 
             int rawSecondsUntilSoulPoint = Managers.Character.getCharacterInfo().getTicksToNextSoulPoint() / 20;
             int minutesUntilSoulPoint = rawSecondsUntilSoulPoint / 60;
             int secondsUntilSoulPoint = rawSecondsUntilSoulPoint % 60;
 
-            copy.add(new TranslatableComponent(
+            copy.add(Component.translatable(
                             "feature.wynntils.soulPointTimer.lore",
                             ChatFormatting.WHITE
                                     + String.format("%d:%02d", minutesUntilSoulPoint, secondsUntilSoulPoint))

--- a/common/src/main/java/com/wynntils/wynn/item/UnidentifiedItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/UnidentifiedItemStack.java
@@ -22,8 +22,6 @@ import java.util.TreeMap;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -75,7 +73,7 @@ public class UnidentifiedItemStack extends WynnItemStack {
         itemPossibilities = rarityMap.get(itemTier);
         if (itemPossibilities == null || itemPossibilities.isEmpty()) return;
 
-        tooltip.add(new TranslatableComponent("feature.wynntils.itemGuess.possibilities"));
+        tooltip.add(Component.translatable("feature.wynntils.itemGuess.possibilities"));
 
         Map<Integer, List<MutableComponent>> levelToItems = new TreeMap<>();
 
@@ -84,7 +82,7 @@ public class UnidentifiedItemStack extends WynnItemStack {
 
             int level = (profile != null) ? profile.getLevelRequirement() : -1;
 
-            MutableComponent itemDesc = new TextComponent(item).withStyle(itemTier.getChatFormatting());
+            MutableComponent itemDesc = Component.literal(item).withStyle(itemTier.getChatFormatting());
 
             if (ItemFavoriteFeature.INSTANCE.favoriteItems.contains(item)) {
                 itemDesc.withStyle(ChatFormatting.UNDERLINE);
@@ -97,24 +95,23 @@ public class UnidentifiedItemStack extends WynnItemStack {
             int level = entry.getKey();
             List<MutableComponent> itemsForLevel = entry.getValue();
 
-            MutableComponent guesses = new TextComponent("    ");
+            MutableComponent guesses = Component.literal("    ");
 
-            guesses.append(
-                    new TranslatableComponent("feature.wynntils.itemGuess.levelLine", level == -1 ? "?" : level));
+            guesses.append(Component.translatable("feature.wynntils.itemGuess.levelLine", level == -1 ? "?" : level));
 
             if (ItemGuessFeature.INSTANCE.showGuessesPrice && level != -1) {
-                guesses.append(new TextComponent(" [")
-                        .append(new TextComponent(
+                guesses.append(Component.literal(" [")
+                        .append(Component.literal(
                                         (itemTier.getItemIdentificationCost(level) + " " + EmeraldSymbols.E_STRING))
                                 .withStyle(ChatFormatting.GREEN))
-                        .append(new TextComponent("]"))
+                        .append(Component.literal("]"))
                         .withStyle(ChatFormatting.GRAY));
             }
 
             guesses.append("§7: ");
 
             Optional<MutableComponent> itemsComponent = itemsForLevel.stream()
-                    .reduce((i, j) -> i.append(new TextComponent(", ").withStyle(ChatFormatting.GRAY))
+                    .reduce((i, j) -> i.append(Component.literal(", ").withStyle(ChatFormatting.GRAY))
                             .append(j));
 
             if (itemsComponent.isPresent()) {

--- a/common/src/main/java/com/wynntils/wynn/model/ActionBarModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ActionBarModel.java
@@ -16,7 +16,6 @@ import java.util.regex.Pattern;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class ActionBarModel extends Model {
@@ -74,7 +73,7 @@ public final class ActionBarModel extends Model {
         WynntilsMod.postEvent(healthText);
         WynntilsMod.postEvent(manaText);
 
-        MutableComponent modified = new TextComponent(healthText.getMessage())
+        MutableComponent modified = Component.literal(healthText.getMessage())
                 .append("    ")
                 .append(actionText.getMessage())
                 .append("    ")

--- a/common/src/main/java/com/wynntils/wynn/model/ChatItemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ChatItemModel.java
@@ -28,7 +28,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 import org.apache.commons.lang3.ArrayUtils;
 
 public final class ChatItemModel extends Model {
@@ -227,7 +226,7 @@ public final class ChatItemModel extends Model {
                 message.getSiblings().stream().map(Component::copy).collect(Collectors.toList());
         components.add(0, message.plainCopy().withStyle(message.getStyle()));
 
-        MutableComponent temp = new TextComponent("");
+        MutableComponent temp = Component.literal("");
 
         for (Component comp : components) {
             Matcher m = ENCODED_PATTERN.matcher(ComponentUtils.getCoded(comp));
@@ -247,7 +246,7 @@ public final class ChatItemModel extends Model {
                     continue;
                 }
 
-                MutableComponent preText = new TextComponent(text.substring(0, m.start()));
+                MutableComponent preText = Component.literal(text.substring(0, m.start()));
                 preText.withStyle(style);
                 temp.append(preText);
 
@@ -255,7 +254,7 @@ public final class ChatItemModel extends Model {
                 Component itemComponent = createItemComponent(item);
                 temp.append(itemComponent);
 
-                comp = new TextComponent(ComponentUtils.getLastPartCodes(ComponentUtils.getCoded(preText))
+                comp = Component.literal(ComponentUtils.getLastPartCodes(ComponentUtils.getCoded(preText))
                                 + text.substring(m.end()))
                         .withStyle(style);
                 m = ENCODED_PATTERN.matcher(ComponentUtils.getCoded(comp)); // recreate matcher for new substring
@@ -268,7 +267,7 @@ public final class ChatItemModel extends Model {
     }
 
     private Component createItemComponent(GearItemStack item) {
-        MutableComponent itemComponent = new TextComponent(item.getItemProfile().getDisplayName())
+        MutableComponent itemComponent = Component.literal(item.getItemProfile().getDisplayName())
                 .withStyle(ChatFormatting.UNDERLINE)
                 .withStyle(item.getItemProfile().getTier().getChatFormatting());
 

--- a/common/src/main/java/com/wynntils/wynn/model/discoveries/DiscoveryContainerQueries.java
+++ b/common/src/main/java/com/wynntils/wynn/model/discoveries/DiscoveryContainerQueries.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
@@ -104,7 +104,7 @@ public class DiscoveryContainerQueries {
                 .onError(msg -> {
                     WynntilsMod.warn("Problem querying discoveries: " + msg);
                     McUtils.sendMessageToClient(
-                            new TextComponent("Error updating discoveries.").withStyle(ChatFormatting.RED));
+                            Component.literal("Error updating discoveries.").withStyle(ChatFormatting.RED));
                 })
                 .useItemInHotbar(InventoryUtils.QUEST_BOOK_SLOT_NUM)
                 .matchTitle(Managers.Quest.getQuestBookTitle(1))

--- a/common/src/main/java/com/wynntils/wynn/model/discoveries/DiscoveryManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/discoveries/DiscoveryManager.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -134,7 +133,7 @@ public final class DiscoveryManager extends Manager {
         ApiResponse apiResponse = Managers.Net.callApi(UrlId.API_WIKI_DISCOVERY_QUERY, Map.of("name", name));
         apiResponse.handleJsonObject(json -> {
             if (json.has("error")) { // Returns error if page does not exist
-                McUtils.sendMessageToClient(new TextComponent(
+                McUtils.sendMessageToClient(Component.literal(
                         ChatFormatting.RED + "Unable to find discovery coordinates. (Wiki page not found)"));
                 return;
             }
@@ -161,13 +160,13 @@ public final class DiscoveryManager extends Manager {
                 x = Integer.parseInt(xLocation.substring(12, xEnd));
                 z = Integer.parseInt(zLocation.substring(12, zEnd));
             } catch (NumberFormatException e) {
-                McUtils.sendMessageToClient(new TextComponent(
+                McUtils.sendMessageToClient(Component.literal(
                         ChatFormatting.RED + "Unable to find discovery coordinates. (Wiki template not located)"));
                 return;
             }
 
             if (x == 0 && z == 0) {
-                McUtils.sendMessageToClient(new TextComponent(
+                McUtils.sendMessageToClient(Component.literal(
                         ChatFormatting.RED + "Unable to find discovery coordinates. (Wiki coordinates not located)"));
                 return;
             }

--- a/common/src/main/java/com/wynntils/wynn/model/discoveries/objects/DiscoveryInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/discoveries/objects/DiscoveryInfo.java
@@ -76,34 +76,34 @@ public class DiscoveryInfo {
     private List<Component> generateLore() {
         displayLore = new ArrayList<>();
 
-        displayLore.add(new TextComponent(name).withStyle(type.getColor()).withStyle(ChatFormatting.BOLD));
+        displayLore.add(Component.literal(name).withStyle(type.getColor()).withStyle(ChatFormatting.BOLD));
 
         if (Managers.Character.getCharacterInfo().getLevel() >= minLevel) {
-            displayLore.add(new TextComponent("✔")
+            displayLore.add(Component.literal("✔")
                     .withStyle(ChatFormatting.GREEN)
-                    .append(new TextComponent(" Combat Lv. Min: ")
+                    .append(Component.literal(" Combat Lv. Min: ")
                             .withStyle(ChatFormatting.GRAY)
-                            .append(new TextComponent(String.valueOf(minLevel)).withStyle(ChatFormatting.WHITE))));
+                            .append(Component.literal(String.valueOf(minLevel)).withStyle(ChatFormatting.WHITE))));
         } else {
-            displayLore.add(new TextComponent("✘")
+            displayLore.add(Component.literal("✘")
                     .withStyle(ChatFormatting.RED)
-                    .append(new TextComponent(" Combat Lv. Min: ")
+                    .append(Component.literal(" Combat Lv. Min: ")
                             .withStyle(ChatFormatting.GRAY)
-                            .append(new TextComponent(String.valueOf(minLevel)).withStyle(ChatFormatting.WHITE))));
+                            .append(Component.literal(String.valueOf(minLevel)).withStyle(ChatFormatting.WHITE))));
         }
 
         displayLore.add(TextComponent.EMPTY);
 
         if (discovered) {
-            displayLore.add(new TextComponent("Discovered").withStyle(ChatFormatting.GREEN));
+            displayLore.add(Component.literal("Discovered").withStyle(ChatFormatting.GREEN));
         } else {
-            displayLore.add(new TextComponent("Not Discovered").withStyle(ChatFormatting.RED));
+            displayLore.add(Component.literal("Not Discovered").withStyle(ChatFormatting.RED));
         }
 
         if (!description.isEmpty()) {
             displayLore.add(TextComponent.EMPTY);
             displayLore.addAll(ComponentUtils.wrapTooltips(
-                    List.of(new TextComponent(description).withStyle(ChatFormatting.GRAY)), 300));
+                    List.of(Component.literal(description).withStyle(ChatFormatting.GRAY)), 300));
         }
 
         return displayLore;

--- a/common/src/main/java/com/wynntils/wynn/model/map/TerritoryDefenseFilterType.java
+++ b/common/src/main/java/com/wynntils/wynn/model/map/TerritoryDefenseFilterType.java
@@ -6,7 +6,6 @@ package com.wynntils.wynn.model.map;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 
 public enum TerritoryDefenseFilterType {
     DEFAULT(""),
@@ -20,6 +19,6 @@ public enum TerritoryDefenseFilterType {
     }
 
     public Component asComponent() {
-        return new TextComponent(asString).withStyle(ChatFormatting.WHITE);
+        return Component.literal(asString).withStyle(ChatFormatting.WHITE);
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestContainerQueries.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestContainerQueries.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import org.lwjgl.glfw.GLFW;
@@ -37,7 +37,7 @@ public class QuestContainerQueries {
                 .onError(msg -> {
                     WynntilsMod.warn("Problem querying Quest Book: " + msg);
                     McUtils.sendMessageToClient(
-                            new TextComponent("Error updating quest book.").withStyle(ChatFormatting.RED));
+                            Component.literal("Error updating quest book.").withStyle(ChatFormatting.RED));
                 })
                 .useItemInHotbar(InventoryUtils.QUEST_BOOK_SLOT_NUM)
                 .matchTitle(Managers.Quest.getQuestBookTitle(1))
@@ -93,7 +93,7 @@ public class QuestContainerQueries {
                 .onError(msg -> {
                     WynntilsMod.warn("Problem querying Quest Book for mini quests: " + msg);
                     McUtils.sendMessageToClient(
-                            new TextComponent("Error updating quest book.").withStyle(ChatFormatting.RED));
+                            Component.literal("Error updating quest book.").withStyle(ChatFormatting.RED));
                 })
                 .useItemInHotbar(InventoryUtils.QUEST_BOOK_SLOT_NUM)
                 .matchTitle(Managers.Quest.getQuestBookTitle(1))

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestInfo.java
@@ -20,7 +20,6 @@ import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 public class QuestInfo {
     private static final int NEXT_TASK_MAX_WIDTH = 200;
@@ -154,18 +153,19 @@ public class QuestInfo {
     public static List<Component> generateTooltipForQuest(QuestInfo questInfo) {
         List<Component> tooltipLines = new ArrayList<>();
 
-        tooltipLines.add(new TextComponent(questInfo.getName())
+        tooltipLines.add(Component.literal(questInfo.getName())
                 .withStyle(ChatFormatting.BOLD)
                 .withStyle(ChatFormatting.WHITE));
         tooltipLines.add(questInfo.getStatus().getQuestBookComponent());
-        tooltipLines.add(new TextComponent(""));
+        tooltipLines.add(Component.literal(""));
         // We always parse level as one, so check if this mini-quest does not have a min combat level
         if (!questInfo.isMiniQuest || questInfo.additionalRequirements.isEmpty()) {
             tooltipLines.add((Managers.Character.getCharacterInfo().getLevel() >= questInfo.getLevel()
-                            ? new TextComponent("✔").withStyle(ChatFormatting.GREEN)
-                            : new TextComponent("✖").withStyle(ChatFormatting.RED))
-                    .append(new TextComponent(" Combat Lv. Min: ").withStyle(ChatFormatting.GRAY))
-                    .append(new TextComponent(String.valueOf(questInfo.getLevel())).withStyle(ChatFormatting.WHITE)));
+                            ? Component.literal("✔").withStyle(ChatFormatting.GREEN)
+                            : Component.literal("✖").withStyle(ChatFormatting.RED))
+                    .append(Component.literal(" Combat Lv. Min: ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(String.valueOf(questInfo.getLevel()))
+                            .withStyle(ChatFormatting.WHITE)));
         }
 
         for (Pair<String, Integer> additionalRequirement : questInfo.getAdditionalRequirements()) {
@@ -173,29 +173,29 @@ public class QuestInfo {
                                     .getProfessionInfo()
                                     .getLevel(ProfessionType.fromString(additionalRequirement.a()))
                             >= additionalRequirement.b()
-                    ? new TextComponent("✔ ").withStyle(ChatFormatting.GREEN)
-                    : new TextComponent("✖ ").withStyle(ChatFormatting.RED);
+                    ? Component.literal("✔ ").withStyle(ChatFormatting.GREEN)
+                    : Component.literal("✖ ").withStyle(ChatFormatting.RED);
 
-            tooltipLines.add(base.append(new TextComponent(additionalRequirement.a() + " Lv. Min: ")
+            tooltipLines.add(base.append(Component.literal(additionalRequirement.a() + " Lv. Min: ")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(new TextComponent(String.valueOf(additionalRequirement.b()))
+                    .append(Component.literal(String.valueOf(additionalRequirement.b()))
                             .withStyle(ChatFormatting.WHITE))));
         }
 
-        tooltipLines.add(new TextComponent("-")
+        tooltipLines.add(Component.literal("-")
                 .withStyle(ChatFormatting.GREEN)
-                .append(new TextComponent(" Length: ").withStyle(ChatFormatting.GRAY))
-                .append(new TextComponent(StringUtils.capitalizeFirst(
+                .append(Component.literal(" Length: ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(StringUtils.capitalizeFirst(
                                 questInfo.getLength().toString().toLowerCase(Locale.ROOT)))
                         .withStyle(ChatFormatting.WHITE)));
 
         if (questInfo.getStatus() != QuestStatus.COMPLETED) {
-            tooltipLines.add(new TextComponent(""));
+            tooltipLines.add(Component.literal(""));
             String nextTask = questInfo.getNextTask();
             String[] lines = StringUtils.wrapTextBySize(nextTask, NEXT_TASK_MAX_WIDTH);
 
             for (String line : lines) {
-                tooltipLines.add(new TextComponent(line).withStyle(ChatFormatting.GRAY));
+                tooltipLines.add(Component.literal(line).withStyle(ChatFormatting.GRAY));
             }
         }
 

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestStatus.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestStatus.java
@@ -8,13 +8,12 @@ import com.wynntils.gui.screens.WynntilsQuestBookScreen;
 import java.util.Locale;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 
 public enum QuestStatus {
-    STARTED(new TextComponent("Started...").withStyle(ChatFormatting.YELLOW)),
-    CAN_START(new TextComponent("Can start...").withStyle(ChatFormatting.YELLOW)),
-    CANNOT_START(new TextComponent("Cannot start...").withStyle(ChatFormatting.RED)),
-    COMPLETED(new TextComponent("Completed!").withStyle(ChatFormatting.GREEN));
+    STARTED(Component.literal("Started...").withStyle(ChatFormatting.YELLOW)),
+    CAN_START(Component.literal("Can start...").withStyle(ChatFormatting.YELLOW)),
+    CANNOT_START(Component.literal("Cannot start...").withStyle(ChatFormatting.RED)),
+    COMPLETED(Component.literal("Completed!").withStyle(ChatFormatting.GREEN));
 
     /** This component is used to reconstruct quest tooltip in {@link WynntilsQuestBookScreen}.
      */

--- a/common/src/main/java/com/wynntils/wynn/model/scoreboard/ScoreboardModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/scoreboard/ScoreboardModel.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.ServerScoreboard;
 import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.PlayerTeam;
@@ -203,7 +203,7 @@ public final class ScoreboardModel extends Model {
                 objective = scoreboard.addObjective(
                         objectiveName,
                         ObjectiveCriteria.DUMMY,
-                        new TextComponent(" play.wynncraft.com")
+                        Component.literal(" play.wynncraft.com")
                                 .withStyle(ChatFormatting.GOLD)
                                 .withStyle(ChatFormatting.BOLD),
                         ObjectiveCriteria.RenderType.INTEGER);

--- a/common/src/main/java/com/wynntils/wynn/objects/account/AccountType.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/account/AccountType.java
@@ -5,16 +5,16 @@
 package com.wynntils.wynn.objects.account;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 public enum AccountType {
     NORMAL(null),
     BANNED(null),
-    DONATOR(new TextComponent("Wynntils Donator").withStyle(ChatFormatting.LIGHT_PURPLE)),
-    CONTENT_TEAM(new TextComponent("Wynntils CT").withStyle(ChatFormatting.DARK_AQUA)),
-    HELPER(new TextComponent("Wynntils Helper").withStyle(ChatFormatting.GREEN)),
-    MODERATOR(new TextComponent("Wynntils Developer")
+    DONATOR(Component.literal("Wynntils Donator").withStyle(ChatFormatting.LIGHT_PURPLE)),
+    CONTENT_TEAM(Component.literal("Wynntils CT").withStyle(ChatFormatting.DARK_AQUA)),
+    HELPER(Component.literal("Wynntils Helper").withStyle(ChatFormatting.GREEN)),
+    MODERATOR(Component.literal("Wynntils Developer")
             .withStyle(ChatFormatting.GOLD)
             .withStyle(ChatFormatting.BOLD));
 

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/item/ItemTier.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/item/ItemTier.java
@@ -13,7 +13,6 @@ import java.util.Locale;
 import java.util.concurrent.Callable;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 
 public enum ItemTier {
     NORMAL(
@@ -133,7 +132,7 @@ public enum ItemTier {
     }
 
     public Component asLore() {
-        return new TextComponent(this + " Item").withStyle(chatFormatting);
+        return Component.literal(this + " Item").withStyle(chatFormatting);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
@@ -39,7 +39,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
@@ -98,21 +97,21 @@ public final class WynnItemUtils {
                 idProfile != null ? idProfile.getType() : IdentificationProfile.getTypeFromName(shortIdName);
         if (type == null) return null; // not a valid id
 
-        MutableComponent percentLine = new TextComponent("");
+        MutableComponent percentLine = Component.literal("");
 
-        MutableComponent statInfo = new TextComponent((value > 0 ? "+" : "") + value + type.getInGame(shortIdName));
+        MutableComponent statInfo = Component.literal((value > 0 ? "+" : "") + value + type.getInGame(shortIdName));
         statInfo.setStyle(Style.EMPTY.withColor(isInverted ^ (value > 0) ? ChatFormatting.GREEN : ChatFormatting.RED));
 
         percentLine.append(statInfo);
 
         if (ItemStatInfoFeature.INSTANCE.showStars)
-            percentLine.append(new TextComponent("***".substring(3 - starCount)).withStyle(ChatFormatting.DARK_GREEN));
+            percentLine.append(Component.literal("***".substring(3 - starCount)).withStyle(ChatFormatting.DARK_GREEN));
 
-        percentLine.append(new TextComponent(" " + idName).withStyle(ChatFormatting.GRAY));
+        percentLine.append(Component.literal(" " + idName).withStyle(ChatFormatting.GRAY));
 
         boolean isNew = idProfile == null || idProfile.isInvalidValue(value);
 
-        if (isNew) percentLine.append(new TextComponent(" [NEW]").withStyle(ChatFormatting.GOLD));
+        if (isNew) percentLine.append(Component.literal(" [NEW]").withStyle(ChatFormatting.GOLD));
 
         MutableComponent rangeLine = percentLine.copy();
         MutableComponent rerollLine = percentLine.copy();
@@ -171,7 +170,7 @@ public final class WynnItemUtils {
             boolean inverted = idProfile.isInverted();
             if (idProfile.hasConstantValue()) {
                 int value = idProfile.getBaseValue();
-                line = new TextComponent((value > 0 ? "+" : "") + value + type.getInGame(idName));
+                line = Component.literal((value > 0 ? "+" : "") + value + type.getInGame(idName));
                 line.setStyle(
                         Style.EMPTY.withColor(inverted ^ (value > 0) ? ChatFormatting.GREEN : ChatFormatting.RED));
             } else {
@@ -179,13 +178,13 @@ public final class WynnItemUtils {
                 int max = idProfile.getMax();
                 ChatFormatting mainColor = inverted ^ (min > 0) ? ChatFormatting.GREEN : ChatFormatting.RED;
                 ChatFormatting textColor = inverted ^ (min > 0) ? ChatFormatting.DARK_GREEN : ChatFormatting.DARK_RED;
-                line = new TextComponent((min > 0 ? "+" : "") + min).withStyle(mainColor);
-                line.append(new TextComponent(" to ").withStyle(textColor));
-                line.append(
-                        new TextComponent((max > 0 ? "+" : "") + max + type.getInGame(idName)).withStyle(mainColor));
+                line = Component.literal((min > 0 ? "+" : "") + min).withStyle(mainColor);
+                line.append(Component.literal(" to ").withStyle(textColor));
+                line.append(Component.literal((max > 0 ? "+" : "") + max + type.getInGame(idName))
+                        .withStyle(mainColor));
             }
 
-            line.append(new TextComponent(" " + IdentificationProfile.getAsLongName(idName))
+            line.append(Component.literal(" " + IdentificationProfile.getAsLongName(idName))
                     .withStyle(ChatFormatting.GRAY));
 
             ItemIdentificationContainer id =
@@ -212,7 +211,7 @@ public final class WynnItemUtils {
         String percentString = new BigDecimal(percentage)
                 .setScale(ItemStatInfoFeature.INSTANCE.decimalPlaces, RoundingMode.DOWN)
                 .toPlainString();
-        return new TextComponent(" [" + percentString + "%]").withStyle(color);
+        return Component.literal(" [" + percentString + "%]").withStyle(color);
     }
 
     /**
@@ -223,8 +222,8 @@ public final class WynnItemUtils {
      * @return the styled ID range text component
      */
     public static MutableComponent getRangeTextComponent(int min, int max) {
-        return new TextComponent(" [")
-                .append(new TextComponent(min + ", " + max).withStyle(ChatFormatting.GREEN))
+        return Component.literal(" [")
+                .append(Component.literal(min + ", " + max).withStyle(ChatFormatting.GREEN))
                 .append("]")
                 .withStyle(ChatFormatting.DARK_GREEN);
     }
@@ -238,11 +237,11 @@ public final class WynnItemUtils {
      * @return the styled reroll chance text component
      */
     public static MutableComponent getRerollChancesComponent(double perfect, double increase, double decrease) {
-        return new TextComponent(String.format(Utils.getGameLocale(), " \u2605%.2f%%", perfect * 100))
+        return Component.literal(String.format(Utils.getGameLocale(), " \u2605%.2f%%", perfect * 100))
                 .withStyle(ChatFormatting.AQUA)
-                .append(new TextComponent(String.format(Utils.getGameLocale(), " \u21E7%.1f%%", increase * 100))
+                .append(Component.literal(String.format(Utils.getGameLocale(), " \u21E7%.1f%%", increase * 100))
                         .withStyle(ChatFormatting.GREEN))
-                .append(new TextComponent(String.format(Utils.getGameLocale(), " \u21E9%.1f%%", decrease * 100))
+                .append(Component.literal(String.format(Utils.getGameLocale(), " \u21E9%.1f%%", decrease * 100))
                         .withStyle(ChatFormatting.RED));
     }
 
@@ -326,7 +325,7 @@ public final class WynnItemUtils {
 
         // can't create lore on crafted items
         if (itemName.startsWith("Crafted")) {
-            itemStack.setHoverName(new TextComponent(itemName).withStyle(ChatFormatting.DARK_AQUA));
+            itemStack.setHoverName(Component.literal(itemName).withStyle(ChatFormatting.DARK_AQUA));
             return itemStack;
         }
 
@@ -334,7 +333,7 @@ public final class WynnItemUtils {
         if (itemStack.getItem() == Items.STONE_SHOVEL
                 && itemStack.getDamageValue() >= 1
                 && itemStack.getDamageValue() <= 6) {
-            itemStack.setHoverName(new TextComponent("Unidentified Item")
+            itemStack.setHoverName(Component.literal("Unidentified Item")
                     .withStyle(
                             ItemTier.fromBoxDamage(itemStack.getDamageValue()).getChatFormatting()));
             return itemStack;

--- a/common/src/main/java/net/minecraft/network/chat/Component.java
+++ b/common/src/main/java/net/minecraft/network/chat/Component.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package net.minecraft.network.chat;
+
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.stream.JsonReader;
+import com.mojang.brigadier.Message;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
+import net.minecraft.Util;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.FormattedCharSequence;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.LowerCaseEnumTypeAdapterFactory;
+
+public interface Component extends Message, FormattedText {
+    static TextComponent literal(String s) {
+        return new TextComponent(s);
+    }
+
+    static TranslatableComponent translatable(String string) {
+        return new TranslatableComponent(string);
+    }
+
+    static TranslatableComponent translatable(String string, Object... objects) {
+        return new TranslatableComponent(string, objects);
+    }
+
+    /**
+     * Gets the style of this component.
+     */
+    Style getStyle();
+
+    /**
+     * Gets the raw content of this component if possible. For special components (like {@link TranslatableComponent} this usually returns the empty string.
+     */
+    String getContents();
+
+    @Override
+    default String getString() {
+        return FormattedText.super.getString();
+    }
+
+    /**
+     * Get the plain text of this FormattedText, without any styling or formatting codes, limited to {@code maxLength} characters.
+     */
+    default String getString(int maxLength) {
+        StringBuilder stringBuilder = new StringBuilder();
+        this.visit(string -> {
+            int j = maxLength - stringBuilder.length();
+            if (j <= 0) {
+                return STOP_ITERATION;
+            } else {
+                stringBuilder.append(string.length() <= j ? string : string.substring(0, j));
+                return Optional.empty();
+            }
+        });
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Gets the sibling components of this one.
+     */
+    List<Component> getSiblings();
+
+    /**
+     * Creates a copy of this component, losing any style or siblings.
+     */
+    MutableComponent plainCopy();
+
+    /**
+     * Creates a copy of this component and also copies the style and siblings. Note that the siblings are copied shallowly, meaning the siblings themselves are not copied.
+     */
+    MutableComponent copy();
+
+    FormattedCharSequence getVisualOrderText();
+
+    @Override
+    default <T> Optional<T> visit(StyledContentConsumer<T> acceptor, Style style) {
+        Style style2 = this.getStyle().applyTo(style);
+        Optional<T> optional = this.visitSelf(acceptor, style2);
+        if (optional.isPresent()) {
+            return optional;
+        } else {
+            for (Component component : this.getSiblings()) {
+                Optional<T> optional2 = component.visit(acceptor, style2);
+                if (optional2.isPresent()) {
+                    return optional2;
+                }
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    default <T> Optional<T> visit(ContentConsumer<T> acceptor) {
+        Optional<T> optional = this.visitSelf(acceptor);
+        if (optional.isPresent()) {
+            return optional;
+        } else {
+            for (Component component : this.getSiblings()) {
+                Optional<T> optional2 = component.visit(acceptor);
+                if (optional2.isPresent()) {
+                    return optional2;
+                }
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    default <T> Optional<T> visitSelf(StyledContentConsumer<T> consumer, Style style) {
+        return consumer.accept(style, this.getContents());
+    }
+
+    default <T> Optional<T> visitSelf(ContentConsumer<T> consumer) {
+        return consumer.accept(this.getContents());
+    }
+
+    default List<Component> toFlatList(Style style) {
+        List<Component> list = Lists.<Component>newArrayList();
+        this.visit(
+                (stylex, string) -> {
+                    if (!string.isEmpty()) {
+                        list.add(literal(string).withStyle(stylex));
+                    }
+
+                    return Optional.empty();
+                },
+                style);
+        return list;
+    }
+
+    static Component nullToEmpty(String text) {
+        return (Component) (text != null ? literal(text) : TextComponent.EMPTY);
+    }
+
+    public static class Serializer implements JsonDeserializer<MutableComponent>, JsonSerializer<Component> {
+        private static final Gson GSON = Util.make(() -> {
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            gsonBuilder.disableHtmlEscaping();
+            gsonBuilder.registerTypeHierarchyAdapter(Component.class, new Serializer());
+            gsonBuilder.registerTypeHierarchyAdapter(Style.class, new Style.Serializer());
+            gsonBuilder.registerTypeAdapterFactory(new LowerCaseEnumTypeAdapterFactory());
+            return gsonBuilder.create();
+        });
+        private static final Field JSON_READER_POS = Util.make(() -> {
+            try {
+                new JsonReader(new StringReader(""));
+                Field field = JsonReader.class.getDeclaredField("pos");
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException var1) {
+                throw new IllegalStateException("Couldn't get field 'pos' for JsonReader", var1);
+            }
+        });
+        private static final Field JSON_READER_LINESTART = Util.make(() -> {
+            try {
+                new JsonReader(new StringReader(""));
+                Field field = JsonReader.class.getDeclaredField("lineStart");
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException var1) {
+                throw new IllegalStateException("Couldn't get field 'lineStart' for JsonReader", var1);
+            }
+        });
+
+        public MutableComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            if (json.isJsonPrimitive()) {
+                return literal(json.getAsString());
+            } else if (!json.isJsonObject()) {
+                if (json.isJsonArray()) {
+                    JsonArray jsonArray3 = json.getAsJsonArray();
+                    MutableComponent mutableComponent = null;
+
+                    for (JsonElement jsonElement : jsonArray3) {
+                        MutableComponent mutableComponent2 =
+                                this.deserialize(jsonElement, jsonElement.getClass(), context);
+                        if (mutableComponent == null) {
+                            mutableComponent = mutableComponent2;
+                        } else {
+                            mutableComponent.append(mutableComponent2);
+                        }
+                    }
+
+                    return mutableComponent;
+                } else {
+                    throw new JsonParseException("Don't know how to turn " + json + " into a Component");
+                }
+            } else {
+                JsonObject jsonObject = json.getAsJsonObject();
+                MutableComponent mutableComponent;
+                if (jsonObject.has("text")) {
+                    mutableComponent = literal(GsonHelper.getAsString(jsonObject, "text"));
+                } else if (jsonObject.has("translate")) {
+                    String string = GsonHelper.getAsString(jsonObject, "translate");
+                    if (jsonObject.has("with")) {
+                        JsonArray jsonArray = GsonHelper.getAsJsonArray(jsonObject, "with");
+                        Object[] objects = new Object[jsonArray.size()];
+
+                        for (int i = 0; i < objects.length; ++i) {
+                            objects[i] = this.deserialize(jsonArray.get(i), typeOfT, context);
+                            if (objects[i] instanceof TextComponent textComponent
+                                    && textComponent.getStyle().isEmpty()
+                                    && textComponent.getSiblings().isEmpty()) {
+                                objects[i] = textComponent.getText();
+                            }
+                        }
+
+                        mutableComponent = translatable(string, objects);
+                    } else {
+                        mutableComponent = translatable(string);
+                    }
+                } else if (jsonObject.has("score")) {
+                    JsonObject jsonObject2 = GsonHelper.getAsJsonObject(jsonObject, "score");
+                    if (!jsonObject2.has("name") || !jsonObject2.has("objective")) {
+                        throw new JsonParseException("A score component needs a least a name and an objective");
+                    }
+
+                    mutableComponent = new ScoreComponent(
+                            GsonHelper.getAsString(jsonObject2, "name"),
+                            GsonHelper.getAsString(jsonObject2, "objective"));
+                } else if (jsonObject.has("selector")) {
+                    Optional<Component> optional = this.parseSeparator(typeOfT, context, jsonObject);
+                    mutableComponent = new SelectorComponent(GsonHelper.getAsString(jsonObject, "selector"), optional);
+                } else if (jsonObject.has("keybind")) {
+                    mutableComponent = new KeybindComponent(GsonHelper.getAsString(jsonObject, "keybind"));
+                } else {
+                    if (!jsonObject.has("nbt")) {
+                        throw new JsonParseException("Don't know how to turn " + json + " into a Component");
+                    }
+
+                    String string = GsonHelper.getAsString(jsonObject, "nbt");
+                    Optional<Component> optional2 = this.parseSeparator(typeOfT, context, jsonObject);
+                    boolean bl = GsonHelper.getAsBoolean(jsonObject, "interpret", false);
+                    if (jsonObject.has("block")) {
+                        mutableComponent = new NbtComponent.BlockNbtComponent(
+                                string, bl, GsonHelper.getAsString(jsonObject, "block"), optional2);
+                    } else if (jsonObject.has("entity")) {
+                        mutableComponent = new NbtComponent.EntityNbtComponent(
+                                string, bl, GsonHelper.getAsString(jsonObject, "entity"), optional2);
+                    } else {
+                        if (!jsonObject.has("storage")) {
+                            throw new JsonParseException("Don't know how to turn " + json + " into a Component");
+                        }
+
+                        mutableComponent = new NbtComponent.StorageNbtComponent(
+                                string,
+                                bl,
+                                new ResourceLocation(GsonHelper.getAsString(jsonObject, "storage")),
+                                optional2);
+                    }
+                }
+
+                if (jsonObject.has("extra")) {
+                    JsonArray jsonArray2 = GsonHelper.getAsJsonArray(jsonObject, "extra");
+                    if (jsonArray2.size() <= 0) {
+                        throw new JsonParseException("Unexpected empty array of components");
+                    }
+
+                    for (int j = 0; j < jsonArray2.size(); ++j) {
+                        mutableComponent.append(this.deserialize(jsonArray2.get(j), typeOfT, context));
+                    }
+                }
+
+                mutableComponent.setStyle(context.deserialize(json, Style.class));
+                return mutableComponent;
+            }
+        }
+
+        private Optional<Component> parseSeparator(
+                Type type, JsonDeserializationContext jsonContext, JsonObject jsonObject) {
+            return jsonObject.has("separator")
+                    ? Optional.of(this.deserialize(jsonObject.get("separator"), type, jsonContext))
+                    : Optional.empty();
+        }
+
+        private void serializeStyle(Style style, JsonObject object, JsonSerializationContext ctx) {
+            JsonElement jsonElement = ctx.serialize(style);
+            if (jsonElement.isJsonObject()) {
+                JsonObject jsonObject = (JsonObject) jsonElement;
+
+                for (Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+                    object.add((String) entry.getKey(), (JsonElement) entry.getValue());
+                }
+            }
+        }
+
+        public JsonElement serialize(Component src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject jsonObject = new JsonObject();
+            if (!src.getStyle().isEmpty()) {
+                this.serializeStyle(src.getStyle(), jsonObject, context);
+            }
+
+            if (!src.getSiblings().isEmpty()) {
+                JsonArray jsonArray = new JsonArray();
+
+                for (Component component : src.getSiblings()) {
+                    jsonArray.add(this.serialize(component, component.getClass(), context));
+                }
+
+                jsonObject.add("extra", jsonArray);
+            }
+
+            if (src instanceof TextComponent) {
+                jsonObject.addProperty("text", ((TextComponent) src).getText());
+            } else if (src instanceof TranslatableComponent translatableComponent) {
+                jsonObject.addProperty("translate", translatableComponent.getKey());
+                if (translatableComponent.getArgs() != null && translatableComponent.getArgs().length > 0) {
+                    JsonArray jsonArray2 = new JsonArray();
+
+                    for (Object object : translatableComponent.getArgs()) {
+                        if (object instanceof Component) {
+                            jsonArray2.add(this.serialize((Component) object, object.getClass(), context));
+                        } else {
+                            jsonArray2.add(new JsonPrimitive(String.valueOf(object)));
+                        }
+                    }
+
+                    jsonObject.add("with", jsonArray2);
+                }
+            } else if (src instanceof ScoreComponent scoreComponent) {
+                JsonObject jsonObject2 = new JsonObject();
+                jsonObject2.addProperty("name", scoreComponent.getName());
+                jsonObject2.addProperty("objective", scoreComponent.getObjective());
+                jsonObject.add("score", jsonObject2);
+            } else if (src instanceof SelectorComponent selectorComponent) {
+                jsonObject.addProperty("selector", selectorComponent.getPattern());
+                this.serializeSeparator(context, jsonObject, selectorComponent.getSeparator());
+            } else if (src instanceof KeybindComponent keybindComponent) {
+                jsonObject.addProperty("keybind", keybindComponent.getName());
+            } else {
+                if (!(src instanceof NbtComponent)) {
+                    throw new IllegalArgumentException("Don't know how to serialize " + src + " as a Component");
+                }
+
+                NbtComponent nbtComponent = (NbtComponent) src;
+                jsonObject.addProperty("nbt", nbtComponent.getNbtPath());
+                jsonObject.addProperty("interpret", nbtComponent.isInterpreting());
+                this.serializeSeparator(context, jsonObject, nbtComponent.separator);
+                if (src instanceof NbtComponent.BlockNbtComponent blockNbtComponent) {
+                    jsonObject.addProperty("block", blockNbtComponent.getPos());
+                } else if (src instanceof NbtComponent.EntityNbtComponent entityNbtComponent) {
+                    jsonObject.addProperty("entity", entityNbtComponent.getSelector());
+                } else {
+                    if (!(src instanceof NbtComponent.StorageNbtComponent)) {
+                        throw new IllegalArgumentException("Don't know how to serialize " + src + " as a Component");
+                    }
+
+                    NbtComponent.StorageNbtComponent storageNbtComponent = (NbtComponent.StorageNbtComponent) src;
+                    jsonObject.addProperty(
+                            "storage", storageNbtComponent.getId().toString());
+                }
+            }
+
+            return jsonObject;
+        }
+
+        private void serializeSeparator(
+                JsonSerializationContext context, JsonObject json, Optional<Component> separator) {
+            separator.ifPresent(
+                    component -> json.add("separator", this.serialize(component, component.getClass(), context)));
+        }
+
+        /**
+         * Serializes a component into JSON.
+         */
+        public static String toJson(Component component) {
+            return GSON.toJson(component);
+        }
+
+        public static JsonElement toJsonTree(Component component) {
+            return GSON.toJsonTree(component);
+        }
+
+        public static MutableComponent fromJson(String json) {
+            return GsonHelper.fromJson(GSON, json, MutableComponent.class, false);
+        }
+
+        public static MutableComponent fromJson(JsonElement json) {
+            return GSON.fromJson(json, MutableComponent.class);
+        }
+
+        public static MutableComponent fromJsonLenient(String json) {
+            return GsonHelper.fromJson(GSON, json, MutableComponent.class, true);
+        }
+
+        public static MutableComponent fromJson(com.mojang.brigadier.StringReader reader) {
+            try {
+                JsonReader jsonReader = new JsonReader(new StringReader(reader.getRemaining()));
+                jsonReader.setLenient(false);
+                MutableComponent mutableComponent = GSON.<MutableComponent>getAdapter(MutableComponent.class)
+                        .read(jsonReader);
+                reader.setCursor(reader.getCursor() + getPos(jsonReader));
+                return mutableComponent;
+            } catch (StackOverflowError | IOException var3) {
+                throw new JsonParseException(var3);
+            }
+        }
+
+        private static int getPos(JsonReader reader) {
+            try {
+                return JSON_READER_POS.getInt(reader) - JSON_READER_LINESTART.getInt(reader) + 1;
+            } catch (IllegalAccessException var2) {
+                throw new IllegalStateException("Couldn't read position of JsonReader", var2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I figured out a way to prepare for the 1.19 port. By adding a (temporary) local copy of the Component class, with the new 1.19 style factory methods implemented in a way that is suitable for 1.18, we can create sort of a "hybrid" code base, which is 1.18 and runs on 1.18, but where all the Component constructions are made like we will need to do in 1.19.

By integrating this now, the diff between main and the 1.19 port will shrink about an order of magnitude.