### PR TITLE
refactor: In preparation for 1.19.3, break out sendCommand()

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/CustomCommandKeybindsFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CustomCommandKeybindsFeature.java
@@ -110,7 +110,7 @@ public class CustomCommandKeybindsFeature extends UserFeature {
 
     private void executeKeybind(String keybindCommand, CommandType commandType) {
         switch (commandType) {
-            case EXECUTE -> McUtils.player().chat(keybindCommand);
+            case EXECUTE -> McUtils.sendCommand(keybindCommand.isEmpty() ? "" : keybindCommand.substring(1));
             case SUGGEST -> {
                 McUtils.mc().setScreen(new ChatScreen(keybindCommand));
             }

--- a/common/src/main/java/com/wynntils/features/user/TerritoryDefenseMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TerritoryDefenseMessageFeature.java
@@ -32,7 +32,7 @@ public class TerritoryDefenseMessageFeature extends UserFeature {
             String unformatted = ComponentUtils.getUnformatted(tooltipLine);
             Matcher matcher = TERRITORY_DEFENSE_PATTERN.matcher(unformatted);
             if (matcher.matches()) {
-                McUtils.player().chat("/g %s defense is %s".formatted(titleMatcher.group(1), matcher.group(1)));
+                McUtils.sendCommand("g %s defense is %s".formatted(titleMatcher.group(1), matcher.group(1)));
                 return;
             }
         }

--- a/common/src/main/java/com/wynntils/features/user/WynncraftPauseScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/WynncraftPauseScreenFeature.java
@@ -45,7 +45,7 @@ public class WynncraftPauseScreenFeature extends UserFeature {
                 (button) -> {
                     McUtils.mc().setScreen(null);
                     McUtils.mc().mouseHandler.grabMouse();
-                    McUtils.player().chat("/class");
+                    McUtils.sendCommand("class");
                 });
 
         renderables.set(3, classSelection);
@@ -56,7 +56,7 @@ public class WynncraftPauseScreenFeature extends UserFeature {
                 (button) -> {
                     McUtils.mc().setScreen(null);
                     McUtils.mc().mouseHandler.grabMouse();
-                    McUtils.player().chat("/hub");
+                    McUtils.sendCommand("hub");
                 });
 
         renderables.set(4, hub);

--- a/common/src/main/java/com/wynntils/gui/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/gui/screens/maps/GuildMapScreen.java
@@ -217,7 +217,7 @@ public class GuildMapScreen extends AbstractMapScreen {
         if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT
                 && KeyboardUtils.isShiftDown()
                 && hovered instanceof TerritoryPoi territoryPoi) {
-            McUtils.player().chat("/gu territory " + territoryPoi.getName());
+            McUtils.sendCommand("gu territory " + territoryPoi.getName());
         }
 
         return super.mouseClicked(mouseX, mouseY, button);

--- a/common/src/main/java/com/wynntils/mc/utils/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/LocationUtils.java
@@ -52,11 +52,11 @@ public class LocationUtils {
 
     private static void sendShareMessage(String target, String locationString) {
         if (target.equals("guild")) {
-            McUtils.player().chat("/g " + locationString);
+            McUtils.sendCommand("g " + locationString);
         } else if (target.equals("party")) {
-            McUtils.player().chat("/p " + locationString);
+            McUtils.sendCommand("p " + locationString);
         } else {
-            McUtils.player().chat("/msg " + target + " " + locationString);
+            McUtils.sendCommand("msg " + target + " " + locationString);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/utils/McUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/McUtils.java
@@ -71,4 +71,8 @@ public final class McUtils {
     public static void sendPacket(Packet<?> packet) {
         mc().getConnection().send(packet);
     }
+
+    public static void sendCommand(String command) {
+        player().chat("/" + command);
+    }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/PlayerRelationsModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/PlayerRelationsModel.java
@@ -270,7 +270,7 @@ public final class PlayerRelationsModel extends Model {
         if (McUtils.player() == null) return;
 
         expectingFriendMessage = true;
-        McUtils.player().chat("/friend list");
+        McUtils.sendCommand("friend list");
         WynntilsMod.info("Requested friend list from Wynncraft.");
     }
 
@@ -278,7 +278,7 @@ public final class PlayerRelationsModel extends Model {
         if (McUtils.player() == null) return;
 
         expectingPartyMessage = true;
-        McUtils.player().chat("/party list");
+        McUtils.sendCommand("party list");
         WynntilsMod.info("Requested party list from Wynncraft.");
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/QuestManager.java
@@ -108,7 +108,7 @@ public final class QuestManager extends Manager {
     }
 
     public void stopTracking() {
-        McUtils.player().chat("/tracking");
+        McUtils.sendCommand("tracking");
     }
 
     public void openQuestOnWiki(QuestInfo questInfo) {


### PR DESCRIPTION
In 1.19, we need to use a special vanilla method to send commands, not just send a chat starting with "/". By creating this method already, we minimize the merge problems with the 1.19.3 port, since we then only has to update the implementation of this method.