### PR TITLE
fix: Require a newer version of FML (to match Forge version req)

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[40,)"
+loaderVersion = "[40.1.84,)"
 #issueTrackerURL = ""
 license = "GNU AGPL 3"
 


### PR DESCRIPTION
The version requirement for Forge Mod Loader is the same as Forge now. This is needed so users get notified they are using an old Forge before they crash (older Forge versions don't load the game, and people think it is our fault).