### PR TITLE
refactor: Stop differentiating between SYSTEM and NORMAL messages

### DIFF
--- a/common/src/main/java/com/wynntils/core/chat/ChatModel.java
+++ b/common/src/main/java/com/wynntils/core/chat/ChatModel.java
@@ -27,11 +27,9 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
  * The responsibility of this class is to act as the first gateway for incoming
  * chat messages from Wynncraft. Chat messages in vanilla comes in three types,
  * CHAT, SYSTEM and GAME_INFO. The latter is the "action bar", and is handled
- * elsewhere. The difference between CHAT and SYSTEM is almost academic; it looks
- * the same to users, but Wynntils put different messages in different categories.
- * Most are CHAT, but a few are SYSTEM. When we pass on the messages, we use the
- * term "NORMAL" instead of "CHAT".
- * <p>
+ * elsewhere. However, starting with Minecraft 1.19, Wynncraft will send all chat
+ * messages as SYSTEM, so we will ignore the CHAT type.
+ *
  * Using the regexp patterns in RecipientType, we classify the incoming messages
  * according to if they are sent to the guild, party, global chat, etc. Messages
  * that do not match any of these categories are called "info" messages, and are
@@ -88,8 +86,7 @@ public final class ChatModel extends Model {
         // make it a multiline message
         if (!codedMessage.contains("\n") || codedMessage.indexOf('\n') == (codedMessage.length() - 1)) {
             saveLastChat(message);
-            MessageType messageType = e.getType() == ChatType.SYSTEM ? MessageType.SYSTEM : MessageType.NORMAL;
-            Component updatedMessage = handleChatLine(message, codedMessage, messageType);
+            Component updatedMessage = handleChatLine(message, codedMessage, MessageType.FOREGROUND);
             if (updatedMessage == null) {
                 e.setCanceled(true);
             } else if (!updatedMessage.equals(message)) {
@@ -211,17 +208,9 @@ public final class ChatModel extends Model {
         String msg = ComponentUtils.getCoded(message);
 
         // Check if message match a recipient category
-        if (messageType == MessageType.SYSTEM) {
-            // System type messages can only be shouts or "info" messages
-            // We call this MessageType.NORMAL anyway...
-            if (RecipientType.SHOUT.matchPattern(msg, MessageType.NORMAL)) {
-                return RecipientType.SHOUT;
-            }
-        } else {
-            for (RecipientType recipientType : RecipientType.values()) {
-                if (recipientType.matchPattern(msg, messageType)) {
-                    return recipientType;
-                }
+        for (RecipientType recipientType : RecipientType.values()) {
+            if (recipientType.matchPattern(msg, messageType)) {
+                return recipientType;
             }
         }
 

--- a/common/src/main/java/com/wynntils/core/chat/MessageType.java
+++ b/common/src/main/java/com/wynntils/core/chat/MessageType.java
@@ -5,7 +5,6 @@
 package com.wynntils.core.chat;
 
 public enum MessageType {
-    NORMAL,
-    SYSTEM,
+    FOREGROUND,
     BACKGROUND
 }

--- a/common/src/main/java/com/wynntils/core/chat/RecipientType.java
+++ b/common/src/main/java/com/wynntils/core/chat/RecipientType.java
@@ -22,20 +22,19 @@ public enum RecipientType {
     PRIVATE("^§7\\[.* ➤ .*\\] §r§f.*$", "^(§r§8)?\\[.* ➤ .*\\] §r§7.*$", "Private"),
     SHOUT("^§3.* \\[[A-Z0-9]+\\] shouts: §r§b.*$", "^(§r§8)?.* \\[[A-Z0-9]+\\] shouts: §r§7.*$", "Shout");
 
-    private final Pattern normalPattern;
+    private final Pattern foregroundPattern;
     private final Pattern backgroundPattern;
     private final String name;
 
-    RecipientType(String normalPattern, String backgroundPattern, String name) {
-        this.normalPattern = (normalPattern == null ? null : Pattern.compile(normalPattern));
+    RecipientType(String foregroundPattern, String backgroundPattern, String name) {
+        this.foregroundPattern = (foregroundPattern == null ? null : Pattern.compile(foregroundPattern));
         this.backgroundPattern = (backgroundPattern == null ? null : Pattern.compile(backgroundPattern));
 
         this.name = name;
     }
 
     public boolean matchPattern(String msg, MessageType messageType) {
-        assert (messageType == MessageType.NORMAL || messageType == MessageType.BACKGROUND);
-        Pattern pattern = (messageType == MessageType.NORMAL ? normalPattern : backgroundPattern);
+        Pattern pattern = (messageType == MessageType.FOREGROUND ? foregroundPattern : backgroundPattern);
         if (pattern == null) return false;
         return pattern.matcher(msg).find();
     }

--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -57,7 +57,7 @@ public class InfoMessageFilterFeature extends UserFeature {
         String msg = e.getOriginalCodedMessage();
         MessageType messageType = e.getMessageType();
 
-        if (messageType == MessageType.NORMAL) {
+        if (messageType == MessageType.FOREGROUND) {
             if (hideSystemInfo) {
                 if (SYSTEM_INFO.matcher(msg).find()) {
                     e.setCanceled(true);
@@ -71,7 +71,6 @@ public class InfoMessageFilterFeature extends UserFeature {
                     return;
                 }
             }
-        } else if (messageType == MessageType.SYSTEM) {
             if (hideLevelUp) {
                 if (LEVEL_UP_1.matcher(msg).find() || LEVEL_UP_2.matcher(msg).find()) {
                     e.setCanceled(true);

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -116,8 +116,8 @@ public class ChatRedirectFeature extends UserFeature {
             Matcher matcher;
             Pattern pattern = redirector.getPattern(messageType);
             // Ideally we will get rid of those "uncolored" patterns
-            Pattern uncoloredPattern = redirector.getUncoloredSystemPattern();
-            if (messageType == MessageType.SYSTEM && uncoloredPattern != null) {
+            Pattern uncoloredPattern = redirector.getUncoloredForegroundPattern();
+            if (messageType == MessageType.FOREGROUND && uncoloredPattern != null) {
                 matcher = uncoloredPattern.matcher(ComponentUtils.stripFormatting(message));
             } else {
                 if (pattern == null) continue;
@@ -147,7 +147,7 @@ public class ChatRedirectFeature extends UserFeature {
         // This is a bit of a hack to support patterns without
         // color coding.
         @Deprecated
-        default Pattern getUncoloredSystemPattern() {
+        default Pattern getUncoloredForegroundPattern() {
             return null;
         }
 
@@ -160,17 +160,12 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         public Pattern getPattern(MessageType messageType) {
             return switch (messageType) {
-                case NORMAL -> getNormalPattern();
+                case FOREGROUND -> getForegroundPattern();
                 case BACKGROUND -> getBackgroundPattern();
-                case SYSTEM -> getSystemPattern();
             };
         }
 
-        protected Pattern getSystemPattern() {
-            return null;
-        }
-
-        protected Pattern getNormalPattern() {
+        protected Pattern getForegroundPattern() {
             return null;
         }
 
@@ -187,12 +182,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class CraftedDurabilityRedirector extends SimpleRedirector {
-        private static final Pattern UNCOLORED_SYSTEM_PATTERN = Pattern.compile(
+        private static final Pattern UNCOLORED_FOREGROUND_PATTERN = Pattern.compile(
                 "^Your items are damaged and have become less effective. Bring them to a Blacksmith to repair them.$");
 
         @Override
-        public Pattern getUncoloredSystemPattern() {
-            return UNCOLORED_SYSTEM_PATTERN;
+        public Pattern getUncoloredForegroundPattern() {
+            return UNCOLORED_FOREGROUND_PATTERN;
         }
 
         @Override
@@ -207,14 +202,14 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class FriendJoinRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile(
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile(
                 "§a(§o)?(?<name>.+)§r§2 has logged into server §r§a(?<server>.+)§r§2 as §r§aan? (?<class>.+)");
         private static final Pattern BACKGROUND_PATTERN = Pattern.compile(
                 "§r§7(§o)?(?<name>.+)§r§8(§o)? has logged into server §r§7(§o)?(?<server>.+)§r§8(§o)? as §r§7(§o)?an? (?<class>.+)");
 
         @Override
-        protected Pattern getNormalPattern() {
-            return NORMAL_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -241,12 +236,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class FriendLeaveRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("§a(?<name>.+) left the game.");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("§a(?<name>.+) left the game.");
         private static final Pattern BACKGROUND_PATTERN = Pattern.compile("§r§7(?<name>.+) left the game.");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -268,11 +263,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class HealRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("^§c\\[\\+(\\d+) ❤\\]$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("^§c\\[\\+(\\d+) ❤\\]$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -289,12 +284,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class HealedByOtherRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile("^.+ gave you §r§c\\[\\+(\\d+) ❤\\]$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("^.+ gave you §r§c\\[\\+(\\d+) ❤\\]$");
         private static final Pattern BACKGROUND_PATTERN = Pattern.compile("^.+ gave you §r§7§o\\[\\+(\\d+) ❤\\]$");
 
         @Override
-        protected Pattern getNormalPattern() {
-            return NORMAL_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -316,12 +311,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class HorseDespawnedRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("§dSince you interacted with your inventory, your horse has despawned.");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -336,12 +331,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class HorseScaredRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("§dYour horse is scared to come out right now, too many mobs are nearby.");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -356,11 +351,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class HorseSpawnFailRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("§4There is no room for a horse.");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("§4There is no room for a horse.");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -375,12 +370,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class IngredientPouchSellRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("§dYou have sold §r§7(.+)§r§d ingredients for a total of §r§a(.+)§r§d\\.$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -402,14 +397,14 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class LoginRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("^§.\\[§r§.([A-Z+]+)§r§.\\] §r§.(.*)§r§. has just logged in!$");
         private static final Pattern BACKGROUND_PATTERN =
                 Pattern.compile("^(?:§r§8)?\\[§r§7([A-Z+]+)§r§8\\] §r§7(.*)§r§8 has just logged in!$");
 
         @Override
-        protected Pattern getNormalPattern() {
-            return NORMAL_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -432,12 +427,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class MageTeleportationFailRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("^§cSorry, you can't teleport... Try moving away from blocks.$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -452,12 +447,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class ManaDeficitRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("^§4You don't have enough mana to cast that spell!$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -472,11 +467,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class NoTotemRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("§4You have no active totems near you$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("§4You have no active totems near you$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -491,11 +486,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class PotionAlreadyActiveRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("^§cYou already have that potion active...$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("^§cYou already have that potion active...$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -510,12 +505,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class PotionsMaxRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("§4You already are holding the maximum amount of potions allowed.");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -530,12 +525,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class PotionsMovedRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile(
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile(
                 "^§7You already are holding the maximum amount of potions allowed so your crafting result was moved to your bank.$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -550,12 +545,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class PotionsReplacedRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("§7One less powerful potion was replaced to open space for the added one.");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -570,11 +565,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class ScrollTeleportationFailRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("§cThere are aggressive mobs nearby...$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("§cThere are aggressive mobs nearby...$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -589,7 +584,7 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class SoulPointGainDiscarder implements Redirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("^§5As the sun rises, you feel a little bit safer...$");
         private static final Pattern BACKGROUND_PATTERN =
                 Pattern.compile("^(§r§8)?As the sun rises, you feel a little bit safer...$");
@@ -598,7 +593,7 @@ public class ChatRedirectFeature extends UserFeature {
         public Pattern getPattern(MessageType messageType) {
             return switch (messageType) {
                 case BACKGROUND -> BACKGROUND_PATTERN;
-                case SYSTEM -> SYSTEM_PATTERN;
+                case FOREGROUND -> FOREGROUND_PATTERN;
                 default -> null;
             };
         }
@@ -618,11 +613,11 @@ public class ChatRedirectFeature extends UserFeature {
 
     private class SoulPointGainRedirector extends SimpleRedirector {
         private static final Pattern BACKGROUND_PATTERN = Pattern.compile("^§r§7\\[(\\+\\d+ Soul Points?)\\]$");
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile("^§d\\[(\\+\\d+ Soul Points?)\\]$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("^§d\\[(\\+\\d+ Soul Points?)\\]$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -643,12 +638,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class SoulPointLossRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN =
+        private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("^§[47](\\d+) soul points? (has|have) been lost...$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -672,11 +667,11 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class SpeedBoostRedirector extends SimpleRedirector {
-        private static final Pattern NORMAL_PATTERN = Pattern.compile("^§b\\+([23]) minutes§r§7 speed boost.$");
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("^§b\\+([23]) minutes§r§7 speed boost.$");
 
         @Override
-        protected Pattern getNormalPattern() {
-            return NORMAL_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -692,12 +687,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class ToolDurabilityRedirector extends SimpleRedirector {
-        private static final Pattern UNCOLORED_SYSTEM_PATTERN = Pattern.compile(
+        private static final Pattern UNCOLORED_FOREGROUND_PATTERN = Pattern.compile(
                 "^Your tool has 0 durability left! You will not receive any new resources until you repair it at a Blacksmith.$");
 
         @Override
-        public Pattern getUncoloredSystemPattern() {
-            return UNCOLORED_SYSTEM_PATTERN;
+        public Pattern getUncoloredForegroundPattern() {
+            return UNCOLORED_FOREGROUND_PATTERN;
         }
 
         @Override
@@ -712,12 +707,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class UnusedAbilityPointsRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile(
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile(
                 "^§4You have §r§b§l(\\d+) unused Ability Points?! §r§4Right-Click while holding your compass to use them$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override
@@ -739,13 +734,13 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class UnusedSkillAndAbilityPointsRedirector implements Redirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile(
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile(
                 "^§4You have §r§c§l(\\d+) unused Skill Points?§r§4 and §r§b§l(\\d+) unused Ability Points?! §r§4Right-Click while holding your compass to use them$");
 
         @Override
         public Pattern getPattern(MessageType messageType) {
-            if (messageType == MessageType.SYSTEM) {
-                return SYSTEM_PATTERN;
+            if (messageType == MessageType.FOREGROUND) {
+                return FOREGROUND_PATTERN;
             } else {
                 return null;
             }
@@ -768,12 +763,12 @@ public class ChatRedirectFeature extends UserFeature {
     }
 
     private class UnusedSkillPointsRedirector extends SimpleRedirector {
-        private static final Pattern SYSTEM_PATTERN = Pattern.compile(
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile(
                 "^§4You have §r§c§l(\\d+) unused Skill Points?! §r§4Right-Click while holding your compass to use them$");
 
         @Override
-        protected Pattern getSystemPattern() {
-            return SYSTEM_PATTERN;
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/wynn/model/PlayerRelationsModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/PlayerRelationsModel.java
@@ -85,7 +85,7 @@ public final class PlayerRelationsModel extends Model {
 
     @SubscribeEvent
     public void onChatReceived(ChatMessageReceivedEvent event) {
-        if (event.getMessageType() != MessageType.SYSTEM) return;
+        if (event.getMessageType() != MessageType.FOREGROUND) return;
 
         String coded = event.getOriginalCodedMessage();
         String unformatted = ComponentUtils.stripFormatting(coded);


### PR DESCRIPTION
This is in preparation of the 1.19 port. In 1.19, Wynncraft only sends SYSTEM messages (probably to avoid problems with chat signing), so we can't use the difference between "NORMAL" and "SYSTEM" anymore.