### PR TITLE
feat: Redirects "Housing Teleport" messages to Overlay

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -82,6 +82,7 @@ public class ChatRedirectFeature extends UserFeature {
         register(new HorseScaredRedirector());
         register(new HorseSpawnFailRedirector());
         register(new HousingTeleportArrivalRedirector());
+        register(new HousingTeleportCooldownRedirector());
         register(new HousingTeleportDepartureRedirector());
         register(new IngredientPouchSellRedirector());
         register(new LoginRedirector());
@@ -391,6 +392,26 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         protected String getNotification(Matcher matcher) {
             return ChatFormatting.GRAY + "→ Housing Island";
+        }
+    }
+
+    private class HousingTeleportCooldownRedirector extends SimpleRedirector {
+        private static final Pattern FOREGROUND_PATTERN =
+                Pattern.compile("^§cYou need to wait a bit before leaving a house.$");
+
+        @Override
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return housingTeleport;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            return ChatFormatting.DARK_RED + "Housing teleport is on cooldown!";
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -82,8 +82,9 @@ public class ChatRedirectFeature extends UserFeature {
         register(new HorseScaredRedirector());
         register(new HorseSpawnFailRedirector());
         register(new HousingTeleportArrivalRedirector());
-        register(new HousingTeleportCooldownRedirector());
+        register(new HousingTeleportArrivalCooldownRedirector());
         register(new HousingTeleportDepartureRedirector());
+        register(new HousingTeleportDepartureCooldownRedirector());
         register(new IngredientPouchSellRedirector());
         register(new LoginRedirector());
         register(new MageTeleportationFailRedirector());
@@ -395,9 +396,9 @@ public class ChatRedirectFeature extends UserFeature {
         }
     }
 
-    private class HousingTeleportCooldownRedirector extends SimpleRedirector {
+    private class HousingTeleportArrivalCooldownRedirector extends SimpleRedirector {
         private static final Pattern FOREGROUND_PATTERN =
-                Pattern.compile("^§cYou need to wait a bit before leaving a house.$");
+                Pattern.compile("^§cYou need to wait a bit before joining another house.$");
 
         @Override
         protected Pattern getForegroundPattern() {
@@ -432,6 +433,26 @@ public class ChatRedirectFeature extends UserFeature {
         @Override
         protected String getNotification(Matcher matcher) {
             return ChatFormatting.GRAY + "← Housing Island";
+        }
+    }
+
+    private class HousingTeleportDepartureCooldownRedirector extends SimpleRedirector {
+        private static final Pattern FOREGROUND_PATTERN =
+                Pattern.compile("^§cYou need to wait a bit before leaving a house.$");
+
+        @Override
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return housingTeleport;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            return ChatFormatting.DARK_RED + "Housing teleport is on cooldown!";
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/redirects/ChatRedirectFeature.java
@@ -35,6 +35,9 @@ public class ChatRedirectFeature extends UserFeature {
     public RedirectAction horse = RedirectAction.REDIRECT;
 
     @Config
+    public RedirectAction housingTeleport = RedirectAction.REDIRECT;
+
+    @Config
     public RedirectAction ingredientPouch = RedirectAction.REDIRECT;
 
     @Config
@@ -78,6 +81,8 @@ public class ChatRedirectFeature extends UserFeature {
         register(new HorseDespawnedRedirector());
         register(new HorseScaredRedirector());
         register(new HorseSpawnFailRedirector());
+        register(new HousingTeleportArrivalRedirector());
+        register(new HousingTeleportDepartureRedirector());
         register(new IngredientPouchSellRedirector());
         register(new LoginRedirector());
         register(new MageTeleportationFailRedirector());
@@ -87,7 +92,8 @@ public class ChatRedirectFeature extends UserFeature {
         register(new PotionsMaxRedirector());
         register(new PotionsMovedRedirector());
         register(new PotionsReplacedRedirector());
-        register(new ScrollTeleportationFailRedirector());
+        register(new ScrollTeleportationHousingFailRedirector());
+        register(new ScrollTeleportationMobFailRedirector());
         register(new SoulPointGainDiscarder());
         register(new SoulPointGainRedirector());
         register(new SoulPointLossRedirector());
@@ -369,6 +375,45 @@ public class ChatRedirectFeature extends UserFeature {
         }
     }
 
+    private class HousingTeleportArrivalRedirector extends SimpleRedirector {
+        private static final Pattern FOREGROUND_PATTERN = Pattern.compile("^§aYou have flown to your housing island.$");
+
+        @Override
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return housingTeleport;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            return ChatFormatting.GRAY + "→ Housing Island";
+        }
+    }
+
+    private class HousingTeleportDepartureRedirector extends SimpleRedirector {
+        private static final Pattern FOREGROUND_PATTERN =
+                Pattern.compile("^§aYou have flown to your original position.$");
+
+        @Override
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return housingTeleport;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            return ChatFormatting.GRAY + "← Housing Island";
+        }
+    }
+
     private class IngredientPouchSellRedirector extends SimpleRedirector {
         private static final Pattern FOREGROUND_PATTERN =
                 Pattern.compile("§dYou have sold §r§7(.+)§r§d ingredients for a total of §r§a(.+)§r§d\\.$");
@@ -564,7 +609,27 @@ public class ChatRedirectFeature extends UserFeature {
         }
     }
 
-    private class ScrollTeleportationFailRedirector extends SimpleRedirector {
+    private class ScrollTeleportationHousingFailRedirector extends SimpleRedirector {
+        private static final Pattern FOREGROUND_PATTERN =
+                Pattern.compile("^§cYou can not teleport while inside a house...$");
+
+        @Override
+        protected Pattern getForegroundPattern() {
+            return FOREGROUND_PATTERN;
+        }
+
+        @Override
+        public RedirectAction getAction() {
+            return scrollTeleport;
+        }
+
+        @Override
+        protected String getNotification(Matcher matcher) {
+            return ChatFormatting.DARK_RED + "Can't teleport on a housing island!";
+        }
+    }
+
+    private class ScrollTeleportationMobFailRedirector extends SimpleRedirector {
         private static final Pattern FOREGROUND_PATTERN = Pattern.compile("§cThere are aggressive mobs nearby...$");
 
         @Override

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -40,6 +40,8 @@
   "feature.wynntils.chatRedirect.heal.name": "Heal Message Filtering",
   "feature.wynntils.chatRedirect.horse.description": "How should messages relating to your horse appear?",
   "feature.wynntils.chatRedirect.horse.name": "Horse Message Filtering",
+  "feature.wynntils.chatRedirect.housingTeleport.description": "How should messages about teleporting to a housing plot appear?",
+  "feature.wynntils.chatRedirect.housingTeleport.name": "Housing Teleport Message Filtering",
   "feature.wynntils.chatRedirect.ingredientPouch.description": "How should messages about selling the contents of your ingredient pouch appear?",
   "feature.wynntils.chatRedirect.ingredientPouch.name": "Ingredient Pouch Sale Message Filtering",
   "feature.wynntils.chatRedirect.loginAnnouncements.description": "How should login messages appear?",


### PR DESCRIPTION
Adds redirect matchers for flying to and from a housing island. I also found an edge-case scrollTeleportation failure message that triggers when you try and use a scroll on a housing island, so I added that in this PR as well (required to rename another redirector to ensure differentiation).

![image](https://user-images.githubusercontent.com/34697715/208565377-3085838e-1341-4763-a183-c39d78a47eab.png)