### PR TITLE
fix: Strict Coordinate Pattern now matches on five-digit long coords

### DIFF
--- a/common/src/main/java/com/wynntils/mc/utils/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/mc/utils/LocationUtils.java
@@ -14,7 +14,7 @@ public class LocationUtils {
             Pattern.compile("(?<x>[-+]?\\d+)([^0-9+-]{1,5}(?<y>[-+]?\\d+))?[^0-9+-]{1,5}(?<z>[-+]?\\d+)");
 
     private static final Pattern STRICT_COORDINATE_PATTERN =
-            Pattern.compile("([-+]?\\d{1,4})([,\\s]{1,2}([-+]?\\d{1,4}))?[,\\s]{1,2}([-+]?\\d{1,4})");
+            Pattern.compile("([-+]?\\d{1,5})([,\\s]{1,2}([-+]?\\d{1,4}))?[,\\s]{1,2}([-+]?\\d{1,5})");
 
     public static Optional<Location> parseFromString(String locString) {
         Matcher matcher = COORDINATE_PATTERN.matcher(locString);


### PR DESCRIPTION
This was an issue for both TNA and TCC, where both of those locations are really out there coordinate-wise and you needed to communicate locations (i.e. where is the portal in TCC, a dead player telling the rest of their party where the shadowling is in TNA), so let's loosen it up to prevent weird splitting. It also qualifies for cases when you're out on your housing plot.

![image](https://user-images.githubusercontent.com/34697715/208588477-5ae23625-a758-4a4a-a11b-19ace7705cc0.png)
