### PR TITLE
fix: Lootrun screen loading is now async, and is cached

### DIFF
--- a/common/src/main/java/com/wynntils/wynn/event/LootrunCacheRefreshEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/LootrunCacheRefreshEvent.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class LootrunCacheRefreshEvent extends Event {}

--- a/common/src/main/java/com/wynntils/wynn/model/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/LootrunModel.java
@@ -15,6 +15,7 @@ import com.wynntils.core.managers.Model;
 import com.wynntils.features.statemanaged.LootrunFeature;
 import com.wynntils.gui.render.CustomRenderType;
 import com.wynntils.mc.utils.McUtils;
+import com.wynntils.wynn.event.LootrunCacheRefreshEvent;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.io.File;
@@ -65,6 +66,8 @@ public final class LootrunModel extends Model {
             ChatFormatting.BLUE.getColor(),
             0x3f00ff,
             ChatFormatting.DARK_PURPLE.getColor());
+
+    private static List<LootrunInstance> LOOTRUN_INSTANCE_CACHE = new ArrayList<>();
 
     private LootrunState state = LootrunState.DISABLED;
 
@@ -584,6 +587,10 @@ public final class LootrunModel extends Model {
     }
 
     public List<LootrunInstance> getLootruns() {
+        return LOOTRUN_INSTANCE_CACHE;
+    }
+
+    public void refreshLootrunCache() {
         List<LootrunInstance> lootruns = new ArrayList<>();
 
         File[] files = LOOTRUNS.listFiles();
@@ -600,7 +607,8 @@ public final class LootrunModel extends Model {
             }
         }
 
-        return lootruns;
+        LOOTRUN_INSTANCE_CACHE = lootruns;
+        WynntilsMod.postEvent(new LootrunCacheRefreshEvent());
     }
 
     public boolean tryLoadFile(String fileName) {

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -855,7 +855,7 @@
   "screens.wynntils.lootruns.lootrunButton.unload": "Left click to unload this lootrun",
   "screens.wynntils.lootruns.lootrunButton.viewInFolder": "Middle click to open lootrun in folder",
   "screens.wynntils.lootruns.name": "Lootruns",
-  "screens.wynntils.lootruns.noLootruns": "No lootruns were found! Try changing your search term.",
+  "screens.wynntils.lootruns.noLootruns": "No lootruns were found! Try changing your search term or reloading lootruns by pressing the button in the top right corner..",
   "screens.wynntils.lootruns.notes": "Notes",
   "screens.wynntils.lootruns.start": "Start point",
   "screens.wynntils.map.focus.description1": "Left click here to center around the waypoint.",


### PR DESCRIPTION
Old version reloaded every lootrun on every search / screen init, and it caused game pauses for seconds. This fixes these issues. 