### PR TITLE
fix: Do not do number formatting on info variables

### DIFF
--- a/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/functions/FunctionManager.java
@@ -15,7 +15,6 @@ import com.wynntils.functions.MinecraftFunctions;
 import com.wynntils.functions.WorldFunction;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wynn.objects.EmeraldSymbols;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -158,11 +157,6 @@ public final class FunctionManager extends Manager {
     }
 
     private String format(Object value) {
-        if (value instanceof Number number) {
-            // French locale has NBSP
-            // https://stackoverflow.com/questions/34156585/java-decimal-format-parsing-issue
-            return NumberFormat.getInstance().format(number).replaceAll("\u00A0", " ");
-        }
         return value.toString();
     }
 


### PR DESCRIPTION
Number formatting is pretty weird in some locales, and there are multiple cases, where we don't want number functions formatted. I think we should remove this for now, and add is back, when the tokenizer allows us to specify these kinds of properties. 