### PR TITLE
fix: Powder Special charge bar should only be reset when coordinates are shown

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -84,8 +84,10 @@ public final class ActionBarHandler extends Handler {
                             lastSegment.removed();
                         }
                         lastSegments.put(pos, segment);
+                        segment.appeared(m);
+                    } else {
+                        segment.update(m);
                     }
-                    segment.handleMatch(m);
                 }
             }
         });

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarSegment.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarSegment.java
@@ -8,13 +8,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public interface ActionBarSegment {
-    Pattern getPattern();
-
-    void handleMatch(Matcher matcher);
-
+    // What the segment tells the handler
     ActionBarPosition getPosition();
 
-    default void removed() {}
+    Pattern getPattern();
 
     boolean isHidden();
+
+    // What the handler tells the segment
+    void appeared(Matcher matcher);
+
+    void update(Matcher matcher);
+
+    default void removed() {}
 }

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/ActionBarModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/ActionBarModel.java
@@ -6,7 +6,9 @@ package com.wynntils.wynn.model.actionbar;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
+import com.wynntils.wynn.model.actionbar.event.CenterSegmentClearedEvent;
 import com.wynntils.wynn.objects.Powder;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class ActionBarModel extends Model {
     private final CoordinatesSegment coordinatesSegment = new CoordinatesSegment();
@@ -66,5 +68,10 @@ public final class ActionBarModel extends Model {
 
     public void hideMana(boolean shouldHide) {
         manaSegment.setHidden(shouldHide);
+    }
+
+    @SubscribeEvent
+    public void onCenterSegmentCleared(CenterSegmentClearedEvent event) {
+        powderSpecialSegment.replaced();
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/CoordinatesSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/CoordinatesSegment.java
@@ -4,8 +4,10 @@
  */
 package com.wynntils.wynn.model.actionbar;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.handlers.actionbar.ActionBarPosition;
 import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.wynn.model.actionbar.event.CenterSegmentClearedEvent;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +33,9 @@ public class CoordinatesSegment implements ActionBarSegment {
     @Override
     public void appeared(Matcher matcher) {
         // Currently we don't care about the actual matches,
-        // but we need to signal that other special center segment has been cleared
+        // but we need to signal that other special center segment has been cleared,
+        // since coordinate segment is the default/fallback segment
+        WynntilsMod.postEvent(new CenterSegmentClearedEvent());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/CoordinatesSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/CoordinatesSegment.java
@@ -18,7 +18,7 @@ public class CoordinatesSegment implements ActionBarSegment {
     }
 
     @Override
-    public void handleMatch(Matcher matcher) {
+    public void update(Matcher matcher) {
         /* Currently we don't care about the actual matches.
         String leftPad = matcher.group(1);
         String xCoord = matcher.group(2);
@@ -26,6 +26,12 @@ public class CoordinatesSegment implements ActionBarSegment {
         String yCoord = matcher.group(4);
         String rightPad = matcher.group(5);
          */
+    }
+
+    @Override
+    public void appeared(Matcher matcher) {
+        // Currently we don't care about the actual matches,
+        // but we need to signal that other special center segment has been cleared
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/HealthSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/HealthSegment.java
@@ -23,7 +23,16 @@ public class HealthSegment implements ActionBarSegment {
     }
 
     @Override
-    public void handleMatch(Matcher matcher) {
+    public void update(Matcher matcher) {
+        updateHealth(matcher);
+    }
+
+    @Override
+    public void appeared(Matcher matcher) {
+        updateHealth(matcher);
+    }
+
+    private void updateHealth(Matcher matcher) {
         currentHealth = Integer.parseInt(matcher.group(1));
         maxHealth = Integer.parseInt(matcher.group(2));
     }

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/ManaSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/ManaSegment.java
@@ -23,7 +23,16 @@ public class ManaSegment implements ActionBarSegment {
     }
 
     @Override
-    public void handleMatch(Matcher matcher) {
+    public void update(Matcher matcher) {
+        updateMana(matcher);
+    }
+
+    @Override
+    public void appeared(Matcher matcher) {
+        updateMana(matcher);
+    }
+
+    private void updateMana(Matcher matcher) {
         currentMana = Integer.parseInt(matcher.group(1));
         maxMana = Integer.parseInt(matcher.group(2));
     }

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/PowderSpecialSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/PowderSpecialSegment.java
@@ -24,7 +24,16 @@ public class PowderSpecialSegment implements ActionBarSegment {
     }
 
     @Override
-    public void handleMatch(Matcher matcher) {
+    public void update(Matcher matcher) {
+        updatePowderSpecial(matcher);
+    }
+
+    @Override
+    public void appeared(Matcher matcher) {
+        updatePowderSpecial(matcher);
+    }
+
+    private void updatePowderSpecial(Matcher matcher) {
         powderSpecialType = Powder.getFromSymbol(matcher.group(1).charAt(0));
         powderSpecialCharge = Integer.parseInt(matcher.group(2));
     }

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/PowderSpecialSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/PowderSpecialSegment.java
@@ -45,8 +45,8 @@ public class PowderSpecialSegment implements ActionBarSegment {
 
     @Override
     public void removed() {
-        powderSpecialType = null;
-        powderSpecialCharge = 0;
+        // This can mean that it is just temporarily replaced by e.g.
+        // a spell, so assume it does not change
     }
 
     public float getPowderSpecialCharge() {
@@ -63,5 +63,11 @@ public class PowderSpecialSegment implements ActionBarSegment {
 
     public void setHidden(boolean hidden) {
         this.hidden = hidden;
+    }
+
+    public void replaced() {
+        // We have been replaced by the coordinate segment, so we know the charge is gone
+        powderSpecialType = null;
+        powderSpecialCharge = 0;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/SpellSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/SpellSegment.java
@@ -21,7 +21,16 @@ public class SpellSegment implements ActionBarSegment {
     }
 
     @Override
-    public void handleMatch(Matcher matcher) {
+    public void update(Matcher matcher) {
+        updateSpell(matcher);
+    }
+
+    @Override
+    public void appeared(Matcher matcher) {
+        updateSpell(matcher);
+    }
+
+    private void updateSpell(Matcher matcher) {
         WynntilsMod.postEvent(new SpellSegmentUpdateEvent(matcher));
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/SprintSegment.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/SprintSegment.java
@@ -21,7 +21,16 @@ public class SprintSegment implements ActionBarSegment {
     }
 
     @Override
-    public void handleMatch(Matcher matcher) {
+    public void update(Matcher matcher) {
+        updateSprint(matcher);
+    }
+
+    @Override
+    public void appeared(Matcher matcher) {
+        updateSprint(matcher);
+    }
+
+    private void updateSprint(Matcher matcher) {
         // Expamples:
         // "§2[§a|||Sprint|||§2]" -- max
         // "§2[§a|||Spr§8int|||§2]"  -- partial

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/event/CenterSegmentClearedEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/event/CenterSegmentClearedEvent.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.model.actionbar.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class CenterSegmentClearedEvent extends Event {}


### PR DESCRIPTION
Fixes #930. This was a regression due to the action bar refactoring.