### PR TITLE
chore: Shorten the dev version string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def usingHotswapAgent = project.hasProperty('wynntils.hotswap') ? project.getPro
 
 // On the release branches, this string will be automatically updated by the bots
 // Do not change this in the main branch!
-version = "0.0.1-main-dev-SNAPSHOT"
+version = "0.0.2-SNAPSHOT"
 
 subprojects {
     apply plugin: "dev.architectury.loom"


### PR DESCRIPTION
This is an alternative approach to #920 to solve the ugliness in the wynntils menu.