### PR TITLE
Combat Level info variable auto updating

### DIFF
--- a/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
@@ -291,7 +291,7 @@ public class CharacterFunctions {
     public static class LevelFunction extends Function<Integer> {
         @Override
         public Integer getValue(String argument) {
-            return Managers.Character.getCharacterInfo().getLevel();
+            return Managers.Character.getCharacterInfo().getXpLevel();
         }
 
         @Override


### PR DESCRIPTION
Change from:
return Managers.Character.getCharacterInfo().getLevel(); to
return Managers.Character.getCharacterInfo().getXpLevel(); 
in order to make the variable update when you level up.