### PR TITLE
feat: Add ItemHandler, Annotators and WynnItem models

### DIFF
--- a/common/src/main/java/com/wynntils/core/components/Handlers.java
+++ b/common/src/main/java/com/wynntils/core/components/Handlers.java
@@ -9,6 +9,7 @@ import com.wynntils.handlers.actionbar.ActionBarHandler;
 import com.wynntils.handlers.bossbar.BossBarHandler;
 import com.wynntils.handlers.chat.ChatHandler;
 import com.wynntils.handlers.container.ContainerQueryHandler;
+import com.wynntils.handlers.item.ItemHandler;
 import com.wynntils.handlers.scoreboard.ScoreboardHandler;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
@@ -17,6 +18,7 @@ public final class Handlers {
     public static final BossBarHandler BossBar = new BossBarHandler();
     public static final ChatHandler Chat = new ChatHandler();
     public static final ContainerQueryHandler ContainerQuery = new ContainerQueryHandler();
+    public static final ItemHandler Item = new ItemHandler();
     public static final ScoreboardHandler Scoreboard = new ScoreboardHandler();
 
     public static void init() {

--- a/common/src/main/java/com/wynntils/core/components/Models.java
+++ b/common/src/main/java/com/wynntils/core/components/Models.java
@@ -8,6 +8,7 @@ import com.wynntils.core.chat.tabs.ChatTabModel;
 import com.wynntils.core.net.hades.model.HadesModel;
 import com.wynntils.core.net.hades.model.HadesUserModel;
 import com.wynntils.core.services.TranslationModel;
+import com.wynntils.wynn.handleditems.ItemModel;
 import com.wynntils.wynn.model.BombBellModel;
 import com.wynntils.wynn.model.ChatItemModel;
 import com.wynntils.wynn.model.CompassModel;
@@ -77,6 +78,7 @@ public final class Models {
     public static final IngredientPropertyModel IngredientProperty = new IngredientPropertyModel();
     public static final IntelligenceSkillPointsItemStackModel IntelligenceSkillPointsItemStack =
             new IntelligenceSkillPointsItemStackModel();
+    public static final ItemModel Item = new ItemModel();
     public static final ItemTierPropertyModel ItemTierProperty = new ItemTierPropertyModel();
     public static final LootChestModel LootChest = new LootChestModel();
     public static final LootrunModel Lootrun = new LootrunModel();

--- a/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureRegistry.java
@@ -12,6 +12,7 @@ import com.wynntils.core.features.properties.RegisterKeyBind;
 import com.wynntils.core.features.properties.StartDisabled;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.features.debug.ConnectionProgressFeature;
+import com.wynntils.features.debug.ItemDebugTooltipsFeature;
 import com.wynntils.features.debug.LogItemInfoFeature;
 import com.wynntils.features.debug.PacketDebuggerFeature;
 import com.wynntils.features.statemanaged.DataStorageFeature;
@@ -114,6 +115,7 @@ public final class FeatureRegistry {
     public static void init() {
         // debug
         registerFeature(new ConnectionProgressFeature());
+        registerFeature(new ItemDebugTooltipsFeature());
         registerFeature(new LogItemInfoFeature());
         registerFeature(new PacketDebuggerFeature());
 

--- a/common/src/main/java/com/wynntils/features/debug/ItemDebugTooltipsFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ItemDebugTooltipsFeature.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.debug;
+
+import com.wynntils.core.features.DebugFeature;
+import com.wynntils.mc.event.ItemTooltipRenderEvent;
+import com.wynntils.utils.KeyboardUtils;
+import com.wynntils.utils.StringUtils;
+import com.wynntils.wynn.handleditems.ItemModel;
+import com.wynntils.wynn.handleditems.WynnItem;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.lwjgl.glfw.GLFW;
+
+public class ItemDebugTooltipsFeature extends DebugFeature {
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onTooltipPre(ItemTooltipRenderEvent.Pre event) {
+        Optional<WynnItem> wynnItemOpt = ItemModel.getWynnItem(event.getItemStack());
+        if (wynnItemOpt.isEmpty()) return;
+        WynnItem wynnItem = wynnItemOpt.get();
+
+        List<Component> tooltips = new ArrayList<>(event.getTooltips());
+        tooltips.addAll(getTooltipAddon(wynnItem));
+        event.setTooltips(tooltips);
+    }
+
+    private List<Component> getTooltipAddon(WynnItem wynnItem) {
+        List<Component> addon = new ArrayList<>();
+
+        addon.add(Component.literal("Wynn Item Type: ").withStyle(ChatFormatting.GREEN));
+
+        List<String> wrappedDescription = Arrays.stream(StringUtils.wrapTextBySize(wynnItem.toString(), 150))
+                .toList();
+        if (!KeyboardUtils.isKeyDown(GLFW.GLFW_KEY_RIGHT_SHIFT) && wrappedDescription.size() > 4) {
+            wrappedDescription = new ArrayList<>(wrappedDescription.subList(0, 3));
+            wrappedDescription.add("...");
+            wrappedDescription.add("Press Right Shift for all");
+        }
+
+        for (String line : wrappedDescription) {
+            addon.add(Component.literal(line).withStyle(ChatFormatting.DARK_GREEN));
+        }
+
+        return addon;
+    }
+}

--- a/common/src/main/java/com/wynntils/features/debug/ItemDebugTooltipsFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ItemDebugTooltipsFeature.java
@@ -35,7 +35,7 @@ public class ItemDebugTooltipsFeature extends DebugFeature {
     private List<Component> getTooltipAddon(WynnItem wynnItem) {
         List<Component> addon = new ArrayList<>();
 
-        addon.add(Component.literal("Wynn Item Type: ").withStyle(ChatFormatting.GREEN));
+        addon.add(Component.literal("Wynn Item Type:").withStyle(ChatFormatting.GREEN));
 
         List<String> wrappedDescription = Arrays.stream(StringUtils.wrapTextBySize(wynnItem.toString(), 150))
                 .toList();

--- a/common/src/main/java/com/wynntils/features/debug/ItemDebugTooltipsFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ItemDebugTooltipsFeature.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.features.debug;
 
+import com.wynntils.core.components.Models;
 import com.wynntils.core.features.DebugFeature;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.utils.KeyboardUtils;
 import com.wynntils.utils.StringUtils;
-import com.wynntils.wynn.handleditems.ItemModel;
 import com.wynntils.wynn.handleditems.WynnItem;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,7 +23,7 @@ import org.lwjgl.glfw.GLFW;
 public class ItemDebugTooltipsFeature extends DebugFeature {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onTooltipPre(ItemTooltipRenderEvent.Pre event) {
-        Optional<WynnItem> wynnItemOpt = ItemModel.getWynnItem(event.getItemStack());
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(event.getItemStack());
         if (wynnItemOpt.isEmpty()) return;
         WynnItem wynnItem = wynnItemOpt.get();
 

--- a/common/src/main/java/com/wynntils/handlers/item/AnnotatedItemStack.java
+++ b/common/src/main/java/com/wynntils/handlers/item/AnnotatedItemStack.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.item;
+
+public interface AnnotatedItemStack {
+    ItemAnnotation getAnnotation();
+
+    void setAnnotation(ItemAnnotation annotation);
+}

--- a/common/src/main/java/com/wynntils/handlers/item/ItemAnnotation.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemAnnotation.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.item;
+
+public interface ItemAnnotation {}

--- a/common/src/main/java/com/wynntils/handlers/item/ItemAnnotator.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemAnnotator.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.item;
+
+import net.minecraft.world.item.ItemStack;
+
+@FunctionalInterface
+public interface ItemAnnotator {
+    ItemAnnotation getAnnotation(ItemStack itemStack);
+}

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.item;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Handler;
+import com.wynntils.mc.event.ContainerSetContentEvent;
+import com.wynntils.mc.event.SetSlotEvent;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.mc.utils.McUtils;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class ItemHandler extends Handler {
+    private final List<ItemAnnotator> annotators = new ArrayList<>();
+
+    public static Optional<ItemAnnotation> getItemStackAnnotation(ItemStack item) {
+        ItemAnnotation annotation = ((AnnotatedItemStack) item).getAnnotation();
+        return Optional.ofNullable(annotation);
+    }
+
+    public void registerAnnotator(ItemAnnotator annotator) {
+        annotators.add(annotator);
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onSetSlot(SetSlotEvent.Pre event) {
+        annotate(event.getItem());
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onContainerSetContent(ContainerSetContentEvent.Pre event) {
+        event.getItems().forEach(this::annotate);
+    }
+
+    private void annotate(ItemStack item) {
+        ItemAnnotation annotation = ((AnnotatedItemStack) item).getAnnotation();
+        // Don't redo if we already have an annotation
+        if (annotation != null) return;
+
+        List<ItemAnnotator> crashedAnnotators = new LinkedList<>();
+        for (ItemAnnotator annotator : annotators) {
+            try {
+                annotation = annotator.getAnnotation(item);
+                if (annotation != null) {
+                    break;
+                }
+            } catch (Throwable t) {
+                String annotatorName = annotator.getClass().getSimpleName();
+                WynntilsMod.error("Exception when processing item annotator " + annotatorName, t);
+                WynntilsMod.warn("This annotator will be disabled");
+                WynntilsMod.warn("Problematic item:" + item);
+                WynntilsMod.warn("Problematic item name:" + ComponentUtils.getCoded(item.getHoverName()));
+                WynntilsMod.warn("Problematic item tags:" + item.getTag());
+                McUtils.sendMessageToClient(Component.literal("Wynntils error: Item Annotator '" + annotatorName
+                                + "' has crashed and will be disabled. Not all items will be properly parsed.")
+                        .withStyle(ChatFormatting.RED));
+                // We can't disable it right away since that will cause ConcurrentModificationException
+                crashedAnnotators.add(annotator);
+            }
+        }
+
+        // Hopefully we have none :)
+        for (ItemAnnotator annotator : crashedAnnotators) {
+            annotators.remove(annotator);
+        }
+
+        if (annotation == null) return;
+
+        ((AnnotatedItemStack) item).setAnnotation(annotation);
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
@@ -34,11 +34,13 @@ public abstract class ItemStackMixin implements AnnotatedItemStack {
     }
 
     @Override
+    @Unique
     public ItemAnnotation getAnnotation() {
         return wynntilsAnnotation;
     }
 
     @Override
+    @Unique
     public void setAnnotation(ItemAnnotation annotation) {
         this.wynntilsAnnotation = annotation;
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
@@ -4,16 +4,22 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.wynntils.handlers.item.AnnotatedItemStack;
+import com.wynntils.handlers.item.ItemAnnotation;
 import com.wynntils.mc.EventFactory;
 import com.wynntils.mc.event.ItemTooltipHoveredNameEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ItemStack.class)
-public abstract class ItemStackMixin {
+public abstract class ItemStackMixin implements AnnotatedItemStack {
+    @Unique
+    private ItemAnnotation wynntilsAnnotation;
+
     @Redirect(
             method =
                     "getTooltipLines(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/TooltipFlag;)Ljava/util/List;",
@@ -25,5 +31,15 @@ public abstract class ItemStackMixin {
     private Component redirectGetHoveredName(ItemStack instance) {
         ItemTooltipHoveredNameEvent event = EventFactory.onGetHoverName(instance.getHoverName(), instance);
         return event.getHoveredName();
+    }
+
+    @Override
+    public ItemAnnotation getAnnotation() {
+        return wynntilsAnnotation;
+    }
+
+    @Override
+    public void setAnnotation(ItemAnnotation annotation) {
+        this.wynntilsAnnotation = annotation;
     }
 }

--- a/common/src/main/java/com/wynntils/utils/CappedValue.java
+++ b/common/src/main/java/com/wynntils/utils/CappedValue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils;
+
+import java.util.Objects;
+
+public class CappedValue {
+    public static final CappedValue EMPTY = new CappedValue(0, 0);
+    private int current;
+    private int max;
+
+    public CappedValue(int current, int max) {
+        this.current = current;
+        this.max = max;
+    }
+
+    public int getCurrent() {
+        return current;
+    }
+
+    public void setCurrent(int current) {
+        this.current = current;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public void setMax(int max) {
+        this.max = max;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + current + "/" + max + ']';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CappedValue that = (CappedValue) o;
+        return current == that.current && max == that.max;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(current, max);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems;
+
+import com.wynntils.core.components.Handlers;
+import com.wynntils.core.components.Model;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.handlers.item.ItemHandler;
+import com.wynntils.wynn.handleditems.annotators.game.AmplifierAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.CraftedConsumableAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.CraftedGearAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.DungeonKeyAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.EmeraldPouchAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.GatheringToolAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.GearAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.GearBoxAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.HealthPotionAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.HorseAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.IngredientAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.ManaPotionAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.MaterialAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.PowderAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.SkillPotionAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.TeleportScrollAnnotator;
+import com.wynntils.wynn.handleditems.annotators.game.XpPotionAnnotator;
+import com.wynntils.wynn.handleditems.annotators.gui.CosmeticTierAnnotator;
+import com.wynntils.wynn.handleditems.annotators.gui.DailyRewardMultiplierAnnotator;
+import com.wynntils.wynn.handleditems.annotators.gui.ServerAnnotator;
+import com.wynntils.wynn.handleditems.annotators.gui.SkillPointAnnotator;
+import com.wynntils.wynn.handleditems.annotators.gui.SoulPointAnnotator;
+import java.util.Optional;
+import net.minecraft.world.item.ItemStack;
+
+public class ItemModel extends Model {
+    @Override
+    public void init() {
+        // For efficiency, register these annotator first
+        Handlers.Item.registerAnnotator(new GearAnnotator());
+        Handlers.Item.registerAnnotator(new GearBoxAnnotator());
+        Handlers.Item.registerAnnotator(new IngredientAnnotator());
+        Handlers.Item.registerAnnotator(new MaterialAnnotator());
+
+        // Then alphabetically
+        Handlers.Item.registerAnnotator(new AmplifierAnnotator());
+        Handlers.Item.registerAnnotator(new CraftedConsumableAnnotator());
+        Handlers.Item.registerAnnotator(new CraftedGearAnnotator());
+        Handlers.Item.registerAnnotator(new DungeonKeyAnnotator());
+        Handlers.Item.registerAnnotator(new EmeraldPouchAnnotator());
+        Handlers.Item.registerAnnotator(new GatheringToolAnnotator());
+        Handlers.Item.registerAnnotator(new HealthPotionAnnotator());
+        Handlers.Item.registerAnnotator(new HorseAnnotator());
+        Handlers.Item.registerAnnotator(new ManaPotionAnnotator());
+        Handlers.Item.registerAnnotator(new PowderAnnotator());
+        Handlers.Item.registerAnnotator(new SkillPotionAnnotator());
+        Handlers.Item.registerAnnotator(new TeleportScrollAnnotator());
+        Handlers.Item.registerAnnotator(new XpPotionAnnotator());
+
+        // GUI handlers
+        Handlers.Item.registerAnnotator(new CosmeticTierAnnotator());
+        Handlers.Item.registerAnnotator(new DailyRewardMultiplierAnnotator());
+        Handlers.Item.registerAnnotator(new ServerAnnotator());
+        Handlers.Item.registerAnnotator(new SkillPointAnnotator());
+        Handlers.Item.registerAnnotator(new SoulPointAnnotator());
+
+        // This must be done last
+        Handlers.Item.registerAnnotator(new FallbackAnnotator());
+    }
+
+    public static Optional<WynnItem> getWynnItem(ItemStack itemStack) {
+        var annotationOpt = ItemHandler.getItemStackAnnotation(itemStack);
+        if (annotationOpt.isEmpty()) return Optional.empty();
+        if (!(annotationOpt.get() instanceof WynnItem wynnItem)) return Optional.empty();
+
+        return Optional.of(wynnItem);
+    }
+
+    public static final class FallbackAnnotator implements ItemAnnotator {
+        @Override
+        public ItemAnnotation getAnnotation(ItemStack itemStack) {
+            return new WynnItem();
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
@@ -37,7 +37,7 @@ import net.minecraft.world.item.ItemStack;
 public class ItemModel extends Model {
     @Override
     public void init() {
-        // For efficiency, register these annotator first
+        // For efficiency, register these annotators first
         Handlers.Item.registerAnnotator(new GearAnnotator());
         Handlers.Item.registerAnnotator(new GearBoxAnnotator());
         Handlers.Item.registerAnnotator(new IngredientAnnotator());

--- a/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
@@ -70,7 +70,7 @@ public class ItemModel extends Model {
     }
 
     public static Optional<WynnItem> getWynnItem(ItemStack itemStack) {
-        var annotationOpt = ItemHandler.getItemStackAnnotation(itemStack);
+        Optional<ItemAnnotation> annotationOpt = ItemHandler.getItemStackAnnotation(itemStack);
         if (annotationOpt.isEmpty()) return Optional.empty();
         if (!(annotationOpt.get() instanceof WynnItem wynnItem)) return Optional.empty();
 

--- a/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/ItemModel.java
@@ -69,12 +69,21 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new FallbackAnnotator());
     }
 
-    public static Optional<WynnItem> getWynnItem(ItemStack itemStack) {
+    public Optional<WynnItem> getWynnItem(ItemStack itemStack) {
         Optional<ItemAnnotation> annotationOpt = ItemHandler.getItemStackAnnotation(itemStack);
         if (annotationOpt.isEmpty()) return Optional.empty();
         if (!(annotationOpt.get() instanceof WynnItem wynnItem)) return Optional.empty();
 
         return Optional.of(wynnItem);
+    }
+
+    public <T extends WynnItem> Optional<T> asWynnItem(ItemStack itemStack, Class<T> clazz) {
+        var annotationOpt = ItemHandler.getItemStackAnnotation(itemStack);
+        if (annotationOpt.isEmpty()) return Optional.empty();
+        if (!(annotationOpt.get() instanceof WynnItem wynnItem)) return Optional.empty();
+        if (wynnItem.getClass() != clazz) return Optional.empty();
+
+        return Optional.of((T) wynnItem);
     }
 
     public static final class FallbackAnnotator implements ItemAnnotator {

--- a/common/src/main/java/com/wynntils/wynn/handleditems/WynnItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/WynnItem.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WynnItem implements ItemAnnotation {
+    private Map<Class<?>, Object> cache = new HashMap<>();
+    private boolean searched = false;
+
+    public <T> T getCached(Class<T> clazz) {
+        return (T) cache.get(clazz);
+    }
+
+    public <T> void storeInCache(T obj) {
+        cache.put(obj.getClass(), obj);
+    }
+
+    public void setSearched(boolean searched) {
+        this.searched = searched;
+    }
+
+    public boolean isSearched() {
+        return searched;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/AmplifierAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/AmplifierAnnotator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.utils.MathUtils;
+import com.wynntils.wynn.handleditems.items.game.AmplifierItem;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+public final class AmplifierAnnotator implements ItemAnnotator {
+    private static final Pattern AMPLIFIER_PATTERN = Pattern.compile("§bCorkian Amplifier (I{1,3})");
+
+    public static Matcher amplifierNameMatcher(Component text) {
+        return AMPLIFIER_PATTERN.matcher(WynnUtils.normalizeBadString(text.getString()));
+    }
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        Matcher ampMatcher = amplifierNameMatcher(itemStack.getHoverName());
+        if (!ampMatcher.matches()) return null;
+
+        int tier = MathUtils.integerFromRoman(ampMatcher.group(1));
+
+        return new AmplifierItem(tier);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedConsumableAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedConsumableAnnotator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.CraftedConsumableItem;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class CraftedConsumableAnnotator implements ItemAnnotator {
+    private static final Pattern CRAFTED_CONSUMABLE_PATTERN = Pattern.compile("^§3(.*)§b \\[(\\d+)/(\\d+)\\]À$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = CRAFTED_CONSUMABLE_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        String craftedName = matcher.group(1);
+        int uses = Integer.parseInt(matcher.group(2));
+        int maxUses = Integer.parseInt(matcher.group(3));
+
+        return new CraftedConsumableItem(craftedName, new CappedValue(uses, maxUses));
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
@@ -37,6 +37,10 @@ public final class CraftedGearAnnotator implements ItemAnnotator {
 
         // Parse lore for identifications and powders
         List<Component> lore = ComponentUtils.stripDuplicateBlank(itemStack.getTooltipLines(null, TooltipFlag.NORMAL));
+        if (lore.size() <= 1) {
+            // We should always have the item name as the first line, unless some other mod interacts badly...
+            return null;
+        }
         lore.remove(0); // remove item name
 
         for (Component loreLine : lore) {

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
@@ -54,6 +54,7 @@ public final class CraftedGearAnnotator implements ItemAnnotator {
             }
 
             // Look for identifications
+            // FIXME: This pattern is likely to fail, needs fixing
             Matcher identificationMatcher = GearAnnotator.ITEM_IDENTIFICATION_PATTERN.matcher(unformattedLoreLine);
             if (identificationMatcher.find()) {
                 String idName = WynnItemMatchers.getShortIdentificationName(

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.CraftedGearItem;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import com.wynntils.wynn.objects.Powder;
+import com.wynntils.wynn.objects.profiles.item.GearIdentification;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+
+public final class CraftedGearAnnotator implements ItemAnnotator {
+    private static final Pattern CRAFTED_GEAR_PATTERN = Pattern.compile("^§3(.*)§b \\[100%\\]À$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = CRAFTED_GEAR_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        CappedValue durability = WynnItemMatchers.getDurability(itemStack);
+
+        List<GearIdentification> identifications = new ArrayList<>();
+        List<Powder> powders = List.of();
+
+        // Parse lore for identifications and powders
+        List<Component> lore = ComponentUtils.stripDuplicateBlank(itemStack.getTooltipLines(null, TooltipFlag.NORMAL));
+        lore.remove(0); // remove item name
+
+        for (Component loreLine : lore) {
+            // FIXME: This is partially shared with GearAnnotator
+            String unformattedLoreLine = WynnUtils.normalizeBadString(loreLine.getString());
+
+            // Look for Powder
+            if (unformattedLoreLine.contains("] Powder Slots")) {
+                powders = Powder.findPowders(unformattedLoreLine);
+                continue;
+            }
+
+            // Look for identifications
+            Matcher identificationMatcher = GearAnnotator.ITEM_IDENTIFICATION_PATTERN.matcher(unformattedLoreLine);
+            if (identificationMatcher.find()) {
+                String idName = WynnItemMatchers.getShortIdentificationName(
+                        identificationMatcher.group("ID"), identificationMatcher.group("Suffix") == null);
+                int value = Integer.parseInt(identificationMatcher.group("Value"));
+                int stars = identificationMatcher.group("Stars").length();
+                identifications.add(new GearIdentification(idName, value, stars));
+            }
+        }
+
+        // FIXME: Missing requirements and damages
+        return new CraftedGearItem(List.of(), List.of(), identifications, powders, durability);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/DungeonKeyAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/DungeonKeyAnnotator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.wynn.handleditems.items.game.DungeonKeyItem;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+public final class DungeonKeyAnnotator implements ItemAnnotator {
+    private static final Pattern DUNGEON_KEY_PATTERN = Pattern.compile("(?:§.)*(?:Broken )?(?:Corrupted )?(.+) Key");
+
+    public static Matcher dungeonKeyNameMatcher(Component text) {
+        return DUNGEON_KEY_PATTERN.matcher(WynnUtils.normalizeBadString(text.getString()));
+    }
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        Matcher keyMatcher = dungeonKeyNameMatcher(itemStack.getHoverName());
+        if (!keyMatcher.matches()) return null;
+
+        if (!verifyDungeonKey(itemStack)) return null;
+
+        String name = keyMatcher.group();
+
+        String dungeon = Arrays.stream(keyMatcher.group(1).split(" ", 2))
+                .map(s -> s.substring(0, 1))
+                .collect(Collectors.joining());
+
+        boolean corrupted = name.contains("Corrupted") || name.contains("Broken");
+
+        return new DungeonKeyItem(dungeon, corrupted);
+    }
+
+    private boolean verifyDungeonKey(ItemStack itemStack) {
+        for (Component line : ItemUtils.getTooltipLines(itemStack)) {
+            // check lore to avoid matching misc. key items
+            if (line.getString().contains("Dungeon Info")) return true;
+            if (line.getString().contains("Corrupted Dungeon Key")) return true;
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/EmeraldPouchAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/EmeraldPouchAnnotator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.utils.MathUtils;
+import com.wynntils.wynn.handleditems.items.game.EmeraldPouchItem;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import java.util.regex.Matcher;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public final class EmeraldPouchAnnotator implements ItemAnnotator {
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        // Checks for normal emerald pouch (diamond axe) and emerald pouch pickup texture (gold shovel)
+        if (itemStack.getItem() != Items.DIAMOND_AXE && itemStack.getItem() != Items.GOLDEN_SHOVEL) return null;
+
+        Matcher matcher = WynnItemMatchers.emeraldPouchTierMatcher(itemStack.getHoverName());
+        if (!matcher.matches()) return null;
+
+        int tier = MathUtils.integerFromRoman(matcher.group(1));
+        return new EmeraldPouchItem(tier);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GatheringToolAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GatheringToolAnnotator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.GatheringToolItem;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import com.wynntils.wynn.objects.profiles.ToolProfile;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class GatheringToolAnnotator implements ItemAnnotator {
+    private static final Pattern GATHERING_TOOL_PATTERN =
+            Pattern.compile("[ⒸⒷⓀⒿ] Gathering (Axe|Rod|Scythe|Pickaxe) T(\\d+)");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        Matcher matcher = GATHERING_TOOL_PATTERN.matcher(
+                WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(itemStack.getHoverName())));
+        if (!matcher.matches()) return null;
+
+        String toolType = matcher.group(1);
+        int tier = Integer.parseInt(matcher.group(2));
+
+        ToolProfile toolProfile = ToolProfile.fromString(toolType, tier);
+        if (toolProfile == null) return null;
+
+        CappedValue durability = WynnItemMatchers.getDurability(itemStack);
+
+        return new GatheringToolItem(toolProfile, durability);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GearAnnotator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.core.components.Managers;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.handleditems.items.game.GearItem;
+import com.wynntils.wynn.item.GearItemStack;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import com.wynntils.wynn.objects.Powder;
+import com.wynntils.wynn.objects.profiles.item.GearIdentification;
+import com.wynntils.wynn.objects.profiles.item.ItemProfile;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+
+public final class GearAnnotator implements ItemAnnotator {
+    private static final Pattern ITEM_TIER =
+            Pattern.compile("(?<Quality>Normal|Unique|Rare|Legendary|Fabled|Mythic|Set) Item(?: \\[(?<Rolls>\\d+)])?");
+    public static final Pattern ITEM_IDENTIFICATION_PATTERN =
+            Pattern.compile("(^\\+?(?<Value>-?\\d+)(?: to \\+?(?<UpperValue>-?\\d+))?(?<Suffix>%|/\\ds|"
+                    + " tier)?(?<Stars>\\*{0,3}) (?<ID>[a-zA-Z 0-9]+))");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        ItemProfile itemProfile;
+        List<GearIdentification> identifications = new ArrayList<>();
+        List<Powder> powders = List.of();
+        int rerolls = 0;
+        List<Component> setBonus = new ArrayList<>();
+
+        // Lookup Gear Profile
+        String name = itemStack.getHoverName().getString();
+
+        // FIXME: Temporary workaround awaiting full merge
+        if (!(itemStack instanceof GearItemStack gearItemStack)) return null;
+        name = gearItemStack.getOriginalHoverName().getString();
+
+        String strippedName = WynnUtils.normalizeBadString(ComponentUtils.stripFormatting(name));
+        itemProfile = Managers.ItemProfiles.getItemsProfile(strippedName);
+        if (itemProfile == null) return null;
+
+        // Verify that rarity matches
+        if (!name.startsWith(itemProfile.getTier().getChatFormatting().toString())) return null;
+
+        // Parse lore for identifications, powders and rerolls
+        List<Component> lore = ComponentUtils.stripDuplicateBlank(itemStack.getTooltipLines(null, TooltipFlag.NORMAL));
+        lore.remove(0); // remove item name
+
+        boolean collectingSetBonus = false;
+        for (Component loreLine : lore) {
+            String unformattedLoreLine = WynnUtils.normalizeBadString(loreLine.getString());
+
+            // Look for Set Bonus
+            if (unformattedLoreLine.equals("Set Bonus:")) {
+                collectingSetBonus = true;
+                continue;
+            }
+            if (collectingSetBonus) {
+                setBonus.add(loreLine);
+
+                if (unformattedLoreLine.isBlank()) {
+                    collectingSetBonus = false;
+                }
+                continue;
+            }
+
+            // Look for Powder
+            if (unformattedLoreLine.contains("] Powder Slots")) {
+                powders = Powder.findPowders(unformattedLoreLine);
+                continue;
+            }
+
+            // Look for Rerolls
+            Matcher rerollMatcher = ITEM_TIER.matcher(unformattedLoreLine);
+            if (rerollMatcher.find()) {
+                if (rerollMatcher.group("Rolls") == null) continue;
+                rerolls = Integer.parseInt(rerollMatcher.group("Rolls"));
+                continue;
+            }
+
+            // Look for identifications
+            Matcher identificationMatcher = ITEM_IDENTIFICATION_PATTERN.matcher(unformattedLoreLine);
+            if (identificationMatcher.find()) {
+                String idName = WynnItemMatchers.getShortIdentificationName(
+                        identificationMatcher.group("ID"), identificationMatcher.group("Suffix") == null);
+                int value = Integer.parseInt(identificationMatcher.group("Value"));
+                int stars = identificationMatcher.group("Stars").length();
+                identifications.add(new GearIdentification(idName, value, stars));
+            }
+        }
+
+        return new GearItem(itemProfile, identifications, powders, rerolls, setBonus);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GearAnnotator.java
@@ -11,9 +11,11 @@ import com.wynntils.mc.utils.ComponentUtils;
 import com.wynntils.wynn.handleditems.items.game.GearItem;
 import com.wynntils.wynn.item.GearItemStack;
 import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import com.wynntils.wynn.objects.ItemIdentificationContainer;
 import com.wynntils.wynn.objects.Powder;
 import com.wynntils.wynn.objects.profiles.item.GearIdentification;
 import com.wynntils.wynn.objects.profiles.item.ItemProfile;
+import com.wynntils.wynn.utils.WynnItemUtils;
 import com.wynntils.wynn.utils.WynnUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +36,7 @@ public final class GearAnnotator implements ItemAnnotator {
     public ItemAnnotation getAnnotation(ItemStack itemStack) {
         ItemProfile itemProfile;
         List<GearIdentification> identifications = new ArrayList<>();
+        List<ItemIdentificationContainer> idContainers = new ArrayList<>();
         List<Powder> powders = List.of();
         int rerolls = 0;
         List<Component> setBonus = new ArrayList<>();
@@ -96,9 +99,13 @@ public final class GearAnnotator implements ItemAnnotator {
                 int value = Integer.parseInt(identificationMatcher.group("Value"));
                 int stars = identificationMatcher.group("Stars").length();
                 identifications.add(new GearIdentification(idName, value, stars));
+
+                // This is partially overlapping with GearIdentification, sort this out later
+                ItemIdentificationContainer idContainer = WynnItemUtils.identificationFromLore(loreLine, itemProfile);
+                idContainers.add(idContainer);
             }
         }
 
-        return new GearItem(itemProfile, identifications, powders, rerolls, setBonus);
+        return new GearItem(itemProfile, identifications, idContainers, powders, rerolls, setBonus);
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GearBoxAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/GearBoxAnnotator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.handleditems.items.game.GearBoxItem;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
+import com.wynntils.wynn.objects.profiles.item.ItemType;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.Optional;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+
+public final class GearBoxAnnotator implements ItemAnnotator {
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        if (!WynnItemMatchers.isUnidentified(itemStack)) return null;
+
+        String name = itemStack.getHoverName().getString();
+
+        ItemType itemType = getItemType(name);
+        ItemTier itemTier = ItemTier.fromString(name);
+        String levelRange = getLevelRange(itemStack);
+
+        if (itemType == null || itemTier == null || levelRange == null) return null;
+
+        return new GearBoxItem(itemType, itemTier, levelRange);
+    }
+
+    private static ItemType getItemType(String name) {
+        String itemName = WynnUtils.normalizeBadString(ComponentUtils.stripFormatting(name));
+
+        // FIXME: This is dangerous and can crash! Should use regex instead.
+        String itemTypeStr = itemName.split(" ", 2)[1];
+        if (itemTypeStr == null) return null;
+
+        Optional<ItemType> itemType = ItemType.fromString(itemTypeStr);
+        return itemType.orElse(null);
+    }
+
+    private static String getLevelRange(ItemStack itemStack) {
+        for (Component tooltipLine : itemStack.getTooltipLines(null, TooltipFlag.NORMAL)) {
+            String line = WynnUtils.normalizeBadString(tooltipLine.getString());
+            if (line.contains("Lv. Range")) {
+                return line.replace("- Lv. Range: ", "");
+            }
+        }
+        return null;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/HealthPotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/HealthPotionAnnotator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.HealthPotionItem;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class HealthPotionAnnotator implements ItemAnnotator {
+    private static final Pattern HEALTH_POTION_PATTERN =
+            Pattern.compile("^§c\\[\\+(\\d+) ❤\\] §dPotions of Healing §4\\[(\\d+)/(\\d+)\\]$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = HEALTH_POTION_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        int hearts = Integer.parseInt(matcher.group(1));
+        int uses = Integer.parseInt(matcher.group(2));
+        int maxUses = Integer.parseInt(matcher.group(3));
+
+        return new HealthPotionItem(hearts, new CappedValue(uses, maxUses));
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/HorseAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/HorseAnnotator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.HorseItem;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public final class HorseAnnotator implements ItemAnnotator {
+    private static final Pattern HORSE_PATTERN = Pattern.compile(
+            "§7Tier (\\d)§6Speed: (\\d+)/(\\d+)§6Jump: \\d+/\\d+§5Armour: None§bXp: (\\d+)/100(?:§cUntradable Item)?(:?§7Name: (.+))?");
+
+    private static boolean isHorse(ItemStack itemStack) {
+        return itemStack.getItem() == Items.SADDLE
+                && itemStack.getHoverName().getString().contains("Horse");
+    }
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        if (!isHorse(itemStack)) return null;
+
+        String lore = ItemUtils.getStringLore(itemStack);
+        Matcher m = HORSE_PATTERN.matcher(lore);
+
+        if (!m.matches()) return null;
+
+        int tier = Integer.parseInt(m.group(1));
+        int level = Integer.parseInt(m.group(2));
+        int maxLevel = Integer.parseInt(m.group(3));
+        int xp = Integer.parseInt(m.group(4));
+        String name = m.group(5);
+
+        return new HorseItem(tier, new CappedValue(level, maxLevel), xp, name);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/IngredientAnnotator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Managers;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.handleditems.items.game.IngredientItem;
+import com.wynntils.wynn.objects.profiles.ingredient.IngredientProfile;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.item.ItemStack;
+
+public final class IngredientAnnotator implements ItemAnnotator {
+    private static final Pattern INGREDIENT_PATTERN =
+            Pattern.compile("^§7(.*)§[3567] \\[§([8bde])✫(§8)?✫(§8)?✫§[3567]\\]$");
+    private static final Map<ChatFormatting, Integer> LEVEL_COLORS = Map.of(
+            ChatFormatting.DARK_GRAY, 0,
+            ChatFormatting.YELLOW, 1,
+            ChatFormatting.LIGHT_PURPLE, 2,
+            ChatFormatting.AQUA, 3);
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = INGREDIENT_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        String ingredientName = matcher.group(1);
+        String tierColor = matcher.group(2);
+        int tier = getTierFromColorCode(tierColor);
+
+        IngredientProfile ingredientProfile = Managers.ItemProfiles.getIngredient(ingredientName);
+        if (ingredientProfile == null) return null;
+        if (ingredientProfile.getTier().getTierInt() != tier) {
+            WynntilsMod.warn("Incorrect tier in ingredient database: " + ingredientName + " is " + tier);
+            return null;
+        }
+
+        return new IngredientItem(ingredientProfile);
+    }
+
+    private int getTierFromColorCode(String tierColor) {
+        return LEVEL_COLORS.getOrDefault(ChatFormatting.getByCode(tierColor.charAt(0)), 0);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/ManaPotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/ManaPotionAnnotator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.ManaPotionItem;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class ManaPotionAnnotator implements ItemAnnotator {
+    private static final Pattern MANA_POTION_PATTERN = Pattern.compile("^§bPotion of Mana§3 \\[(\\d+)/(\\d+)\\]$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = MANA_POTION_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        int uses = Integer.parseInt(matcher.group(1));
+        int maxUses = Integer.parseInt(matcher.group(2));
+
+        return new ManaPotionItem(new CappedValue(uses, maxUses));
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/MaterialAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/MaterialAnnotator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.handleditems.items.game.MaterialItem;
+import com.wynntils.wynn.objects.profiles.material.MaterialProfile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class MaterialAnnotator implements ItemAnnotator {
+    private static final Pattern MATERIAL_PATTERN = Pattern.compile("§f(.*) ([^ ]+)§6 \\[§e✫((?:§8)?✫(?:§8)?)✫§6\\]");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+
+        Matcher matcher = MATERIAL_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        String materialSource = matcher.group(1);
+        String resourceType = matcher.group(2);
+        String tierIndicator = matcher.group(3);
+        int tier =
+                switch (tierIndicator) {
+                    case "§8✫" -> 1;
+                    case "✫§8" -> 2;
+                    case "✫" -> 3;
+                    default -> {
+                        WynntilsMod.warn("Cannot parse tier from material: " + name);
+                        yield 1;
+                    }
+                };
+
+        MaterialProfile materialProfile = MaterialProfile.lookup(materialSource, resourceType, tier);
+        if (materialProfile == null) return null;
+
+        return new MaterialItem(materialProfile);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/PowderAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/PowderAnnotator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.utils.MathUtils;
+import com.wynntils.wynn.handleditems.items.game.PowderItem;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import com.wynntils.wynn.objects.Powder;
+import com.wynntils.wynn.objects.profiles.PowderProfile;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import net.minecraft.world.item.ItemStack;
+
+public final class PowderAnnotator implements ItemAnnotator {
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        Matcher matcher = WynnItemMatchers.powderNameMatcher(itemStack.getHoverName());
+
+        if (!matcher.matches()) return null;
+
+        Powder element = Powder.valueOf(matcher.group(1).toUpperCase(Locale.ROOT));
+        int tier = MathUtils.integerFromRoman(matcher.group(2));
+
+        PowderProfile powderProfile = PowderProfile.getPowderProfile(element, tier);
+
+        return new PowderItem(powderProfile);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/SkillPotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/SkillPotionAnnotator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.items.game.SkillPotionItem;
+import com.wynntils.wynn.objects.Skill;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class SkillPotionAnnotator implements ItemAnnotator {
+    private static final Pattern SKILL_POTION_PATTERN =
+            Pattern.compile("^§aPotion of §[2ebcf][✤✦❉✹❋] (.*)§a \\[(\\d+)/(\\d+)\\]$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = SKILL_POTION_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        String skillName = matcher.group(1);
+        int uses = Integer.parseInt(matcher.group(2));
+        int maxUses = Integer.parseInt(matcher.group(3));
+        Skill skill = Skill.fromString(skillName);
+
+        return new SkillPotionItem(skill, new CappedValue(uses, maxUses));
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/TeleportScrollAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/TeleportScrollAnnotator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.handleditems.items.game.TeleportScrollItem;
+import com.wynntils.wynn.utils.WynnUtils;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+
+public final class TeleportScrollAnnotator implements ItemAnnotator {
+    private static final Pattern TELEPORT_SCROLL_PATTERN = Pattern.compile(".*§b(.*) Teleport Scroll");
+    private static final Pattern TELEPORT_LOCATION_PATTERN = Pattern.compile("- Teleports to: (.*)");
+
+    public static Matcher teleportScrollNameMatcher(Component text) {
+        return TELEPORT_SCROLL_PATTERN.matcher(WynnUtils.normalizeBadString(ComponentUtils.getCoded(text)));
+    }
+
+    public static Matcher teleportScrollLocationMatcher(Component text) {
+        return TELEPORT_LOCATION_PATTERN.matcher(WynnUtils.normalizeBadString(text.getString()));
+    }
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        boolean dungeon = false;
+        String destination = "";
+
+        Component itemName = itemStack.getHoverName();
+        Matcher nameMatcher = teleportScrollNameMatcher(itemName);
+        if (!nameMatcher.matches()) return null;
+
+        String scrollName = ComponentUtils.stripFormatting(nameMatcher.group(1));
+
+        if (scrollName.equals("Dungeon")) {
+            dungeon = true;
+            for (Component line : itemStack.getTooltipLines(null, TooltipFlag.NORMAL)) {
+                Matcher locationMatcher = teleportScrollLocationMatcher(line);
+                if (!locationMatcher.matches()) continue;
+
+                // remove "the" to properly represent forgery scrolls
+                destination =
+                        WynnUtils.normalizeBadString(locationMatcher.group(1)).replace("the ", "");
+
+                destination = Arrays.stream(destination.split(" ", 2))
+                        .map(s -> s.substring(0, 1))
+                        .collect(Collectors.joining())
+                        .toUpperCase(Locale.ROOT);
+
+                break;
+            }
+        } else {
+            destination = scrollName.substring(0, 2);
+        }
+
+        return new TeleportScrollItem(destination, dungeon);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/XpPotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/XpPotionAnnotator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.game;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.wynn.handleditems.items.game.XpPotionItem;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class XpPotionAnnotator implements ItemAnnotator {
+    private static final Pattern XP_POTION_PATTERN = Pattern.compile("^§6Potion of Wisdom$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+        Matcher matcher = XP_POTION_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        return new XpPotionItem();
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/CosmeticTierAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/CosmeticTierAnnotator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.gui;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.objects.CustomColor;
+import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.wynn.handleditems.items.gui.CosmeticItem;
+import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+public final class CosmeticTierAnnotator implements ItemAnnotator {
+    private static final Pattern COSMETIC_PATTERN =
+            Pattern.compile("(Common|Rare|Epic|Godly|\\|\\|\\| Black Market \\|\\|\\|) Reward");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        if (!isCosmetic(itemStack)) return null;
+
+        ChatFormatting chatColor =
+                ChatFormatting.getByCode(itemStack.getHoverName().getString().charAt(1));
+        if (chatColor == null) chatColor = ChatFormatting.WHITE;
+
+        CustomColor highlightColor = CustomColor.fromChatFormatting(chatColor);
+        return new CosmeticItem(highlightColor);
+    }
+
+    public static boolean isCosmetic(ItemStack itemStack) {
+        for (Component c : ItemUtils.getTooltipLines(itemStack)) {
+            if (COSMETIC_PATTERN.matcher(c.getString()).matches()) return true;
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/DailyRewardMultiplierAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/DailyRewardMultiplierAnnotator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.gui;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.wynn.handleditems.items.gui.DailyRewardItem;
+import net.minecraft.world.item.ItemStack;
+
+public final class DailyRewardMultiplierAnnotator implements ItemAnnotator {
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        if (!itemStack.getHoverName().getString().contains("Daily Reward")) return null;
+
+        try {
+            // Multiplier line is always on index 3
+            String loreLine =
+                    ComponentUtils.stripFormatting(ItemUtils.getLore(itemStack).get(3));
+            String value = String.valueOf(loreLine.charAt(loreLine.indexOf("Streak Multiplier: ") + 19));
+            int count = Integer.parseInt(value);
+            return new DailyRewardItem(count);
+        } catch (IndexOutOfBoundsException ignored) {
+            return null;
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/ServerAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/ServerAnnotator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.gui;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.wynn.handleditems.items.gui.ServerItem;
+import com.wynntils.wynn.item.parsers.WynnItemMatchers;
+import java.util.regex.Matcher;
+import net.minecraft.world.item.ItemStack;
+
+public final class ServerAnnotator implements ItemAnnotator {
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        Matcher matcher = WynnItemMatchers.serverItemMatcher(itemStack.getHoverName());
+
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        int serverId = Integer.parseInt(matcher.group(1));
+
+        return new ServerItem(serverId);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/SkillPointAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/SkillPointAnnotator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.gui;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.mc.utils.ComponentUtils;
+import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.wynn.handleditems.items.gui.SkillPointItem;
+import com.wynntils.wynn.objects.Skill;
+import java.util.LinkedList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public final class SkillPointAnnotator implements ItemAnnotator {
+    private static final Pattern SKILL_POINT_PATTERN = Pattern.compile("^§dUpgrade your §[2ebcf][✤✦❉✹❋] (.*)§d skill$");
+    private static final Pattern POINT_PATTERN = Pattern.compile("^§7[ À]+(\\d+) points?[ À]+§r§6\\d+ points$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        String name = ComponentUtils.getCoded(itemStack.getHoverName());
+
+        Matcher matcher = SKILL_POINT_PATTERN.matcher(name);
+        if (!matcher.matches()) return null;
+
+        String skillName = matcher.group(1);
+        Skill skill = Skill.fromString(skillName);
+
+        int skillPoints = -1;
+        LinkedList<String> a = ItemUtils.getLore(itemStack);
+        for (String lore : ItemUtils.getLore(itemStack)) {
+            Matcher m = POINT_PATTERN.matcher(lore);
+            if (m.find()) {
+                String points = m.group(1);
+                skillPoints = Integer.parseInt(points);
+                break;
+            }
+        }
+
+        if (skillPoints == -1) return null;
+
+        return new SkillPointItem(skill, skillPoints);
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/SoulPointAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/gui/SoulPointAnnotator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.annotators.gui;
+
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.handlers.item.ItemAnnotator;
+import com.wynntils.wynn.handleditems.items.gui.SoulPointItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public final class SoulPointAnnotator implements ItemAnnotator {
+    private static boolean isSoulPoint(ItemStack itemStack) {
+        return !itemStack.isEmpty()
+                && (itemStack.getItem() == Items.NETHER_STAR || itemStack.getItem() == Items.SNOW)
+                && itemStack.getDisplayName().getString().contains("Soul Point");
+    }
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack) {
+        if (!isSoulPoint(itemStack)) return null;
+
+        return new SoulPointItem();
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/AmplifierItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/AmplifierItem.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.NumberedTierItemProperty;
+
+public class AmplifierItem extends GameItem implements NumberedTierItemProperty {
+    private final int tier;
+
+    public AmplifierItem(int tier) {
+        this.tier = tier;
+    }
+
+    public int getTier() {
+        return tier;
+    }
+
+    @Override
+    public String toString() {
+        return "AmplifierItem{" + "tier=" + tier + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/ConsumableItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/ConsumableItem.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.UsesItemPropery;
+
+public class ConsumableItem extends GameItem implements UsesItemPropery {
+    private final CappedValue uses;
+
+    public ConsumableItem(CappedValue uses) {
+        this.uses = uses;
+    }
+
+    public CappedValue getUses() {
+        return uses;
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumableItem{" + "uses=" + uses + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/CraftedConsumableItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/CraftedConsumableItem.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.UsesItemPropery;
+
+public class CraftedConsumableItem extends GameItem implements UsesItemPropery {
+    private final String name;
+    private final CappedValue uses;
+
+    public CraftedConsumableItem(String name, CappedValue uses) {
+        this.name = name;
+        this.uses = uses;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public CappedValue getUses() {
+        return uses;
+    }
+
+    @Override
+    public String toString() {
+        return "CraftedConsumableItem{" + "name='" + name + '\'' + ", uses=" + uses + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/CraftedGearItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/CraftedGearItem.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.DurableItemProperty;
+import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
+import com.wynntils.wynn.objects.Powder;
+import com.wynntils.wynn.objects.profiles.item.GearIdentification;
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
+import java.util.List;
+
+public class CraftedGearItem extends GameItem implements GearTierItemProperty, DurableItemProperty {
+    // FIXME: Better types than strings...
+    private final List<String> damages;
+    private final List<String> requirements;
+    private final List<GearIdentification> identifications;
+    private final List<Powder> powders;
+    private final CappedValue durability;
+
+    public CraftedGearItem(
+            List<String> damages,
+            List<String> requirements,
+            List<GearIdentification> identifications,
+            List<Powder> powders,
+            CappedValue durability) {
+        this.damages = damages;
+        this.requirements = requirements;
+        this.identifications = identifications;
+        this.powders = powders;
+        this.durability = durability;
+    }
+
+    public List<GearIdentification> getIdentifications() {
+        return identifications;
+    }
+
+    public List<Powder> getPowders() {
+        return powders;
+    }
+
+    public List<String> getDamages() {
+        return damages;
+    }
+
+    public List<String> getRequirements() {
+        return requirements;
+    }
+
+    public CappedValue getDurability() {
+        return durability;
+    }
+
+    @Override
+    public ItemTier getGearTier() {
+        return ItemTier.CRAFTED;
+    }
+
+    @Override
+    public String toString() {
+        return "CraftedGearItem{" + "damages="
+                + damages + ", requirements="
+                + requirements + ", identifications="
+                + identifications + ", powders="
+                + powders + ", durability="
+                + durability + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/DungeonKeyItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/DungeonKeyItem.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.TargetedItemProperty;
+
+public class DungeonKeyItem extends GameItem implements TargetedItemProperty {
+    private final String dungeon;
+    private final boolean corrupted;
+
+    public DungeonKeyItem(String dungeon, boolean corrupted) {
+        this.dungeon = dungeon;
+        this.corrupted = corrupted;
+    }
+
+    public String getDungeon() {
+        return dungeon;
+    }
+
+    public boolean isCorrupted() {
+        return corrupted;
+    }
+
+    public String getTarget() {
+        return dungeon;
+    }
+
+    @Override
+    public String toString() {
+        return "DungeonKeyItem{" + "dungeon='" + dungeon + '\'' + ", corrupted=" + corrupted + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/EmeraldPouchItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/EmeraldPouchItem.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.NumberedTierItemProperty;
+
+public class EmeraldPouchItem extends GameItem implements NumberedTierItemProperty {
+    private final int tier;
+
+    public EmeraldPouchItem(int tier) {
+        this.tier = tier;
+    }
+
+    public int getTier() {
+        return tier;
+    }
+
+    @Override
+    public String toString() {
+        return "EmeraldPouchItem{" + "tier=" + tier + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GameItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GameItem.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.WynnItem;
+
+public class GameItem extends WynnItem {}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GatheringToolItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GatheringToolItem.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.DurableItemProperty;
+import com.wynntils.wynn.handleditems.properties.NumberedTierItemProperty;
+import com.wynntils.wynn.objects.profiles.ToolProfile;
+
+public class GatheringToolItem extends GameItem implements NumberedTierItemProperty, DurableItemProperty {
+    private final ToolProfile toolProfile;
+    private final CappedValue durability;
+
+    public GatheringToolItem(ToolProfile toolProfile, CappedValue durability) {
+        this.toolProfile = toolProfile;
+        this.durability = durability;
+    }
+
+    public ToolProfile getToolProfile() {
+        return toolProfile;
+    }
+
+    public CappedValue getDurability() {
+        return durability;
+    }
+
+    public int getTier() {
+        return toolProfile.getTier();
+    }
+
+    @Override
+    public String toString() {
+        return "GatheringToolItem{" + "toolProfile=" + toolProfile + ", durability=" + durability + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GearBoxItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GearBoxItem.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.core.components.Managers;
+import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
+import com.wynntils.wynn.objects.profiles.ItemGuessProfile;
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
+import com.wynntils.wynn.objects.profiles.item.ItemType;
+import java.util.List;
+import java.util.Map;
+
+public class GearBoxItem extends GameItem implements GearTierItemProperty {
+    private final ItemType itemType;
+    private final ItemTier itemTier;
+    private final String levelRange;
+
+    public GearBoxItem(ItemType itemType, ItemTier itemTier, String levelRange) {
+        this.itemType = itemType;
+        this.itemTier = itemTier;
+        this.levelRange = levelRange;
+    }
+
+    public ItemType getItemType() {
+        return itemType;
+    }
+
+    public ItemTier getItemTier() {
+        return itemTier;
+    }
+
+    public String getLevelRange() {
+        return levelRange;
+    }
+
+    public List<String> getItemPossibilities() {
+        ItemGuessProfile guessProfile = Managers.ItemProfiles.getItemGuess(levelRange);
+        if (guessProfile == null) return List.of();
+
+        Map<ItemTier, List<String>> rarityMap = guessProfile.getItems().get(itemType);
+        if (rarityMap == null) return List.of();
+
+        List<String> itemPossibilities = rarityMap.get(itemTier);
+        return itemPossibilities;
+    }
+
+    @Override
+    public ItemTier getGearTier() {
+        return itemTier;
+    }
+
+    @Override
+    public String toString() {
+        return "GearBoxItem{" + "itemType="
+                + itemType + ", itemTier="
+                + itemTier + ", levelRange='"
+                + levelRange + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GearItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GearItem.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
+import com.wynntils.wynn.objects.Powder;
+import com.wynntils.wynn.objects.profiles.item.GearIdentification;
+import com.wynntils.wynn.objects.profiles.item.ItemProfile;
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
+import java.util.List;
+import net.minecraft.network.chat.Component;
+
+public class GearItem extends GameItem implements GearTierItemProperty {
+    private final ItemProfile itemProfile;
+    private final List<GearIdentification> identifications;
+    private final List<Powder> powders;
+    private final int rerolls;
+    private final List<Component> setBonus;
+
+    public GearItem(
+            ItemProfile itemProfile,
+            List<GearIdentification> identifications,
+            List<Powder> powders,
+            int rerolls,
+            List<Component> setBonus) {
+        this.itemProfile = itemProfile;
+        this.identifications = identifications;
+        this.powders = powders;
+        this.rerolls = rerolls;
+        this.setBonus = setBonus;
+    }
+
+    public ItemProfile getItemProfile() {
+        return itemProfile;
+    }
+
+    public List<GearIdentification> getIdentifications() {
+        return identifications;
+    }
+
+    public List<Powder> getPowders() {
+        return powders;
+    }
+
+    public int getRerolls() {
+        return rerolls;
+    }
+
+    public List<Component> getSetBonus() {
+        return setBonus;
+    }
+
+    @Override
+    public ItemTier getGearTier() {
+        return itemProfile.getTier();
+    }
+
+    @Override
+    public String toString() {
+        return "GearItem{" + "itemProfile="
+                + itemProfile + ", identifications="
+                + identifications + ", powders="
+                + powders + ", rerolls="
+                + rerolls + ", setBonus="
+                + setBonus + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GearItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/GearItem.java
@@ -5,6 +5,7 @@
 package com.wynntils.wynn.handleditems.items.game;
 
 import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
+import com.wynntils.wynn.objects.ItemIdentificationContainer;
 import com.wynntils.wynn.objects.Powder;
 import com.wynntils.wynn.objects.profiles.item.GearIdentification;
 import com.wynntils.wynn.objects.profiles.item.ItemProfile;
@@ -15,6 +16,7 @@ import net.minecraft.network.chat.Component;
 public class GearItem extends GameItem implements GearTierItemProperty {
     private final ItemProfile itemProfile;
     private final List<GearIdentification> identifications;
+    private final List<ItemIdentificationContainer> idContainers;
     private final List<Powder> powders;
     private final int rerolls;
     private final List<Component> setBonus;
@@ -22,11 +24,13 @@ public class GearItem extends GameItem implements GearTierItemProperty {
     public GearItem(
             ItemProfile itemProfile,
             List<GearIdentification> identifications,
+            List<ItemIdentificationContainer> idContainers,
             List<Powder> powders,
             int rerolls,
             List<Component> setBonus) {
         this.itemProfile = itemProfile;
         this.identifications = identifications;
+        this.idContainers = idContainers;
         this.powders = powders;
         this.rerolls = rerolls;
         this.setBonus = setBonus;
@@ -38,6 +42,10 @@ public class GearItem extends GameItem implements GearTierItemProperty {
 
     public List<GearIdentification> getIdentifications() {
         return identifications;
+    }
+
+    public List<ItemIdentificationContainer> getIdContainers() {
+        return idContainers;
     }
 
     public List<Powder> getPowders() {

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/HealthPotionItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/HealthPotionItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.UsesItemPropery;
+
+public class HealthPotionItem extends GameItem implements UsesItemPropery {
+    private final int hearts;
+    private final CappedValue uses;
+
+    public HealthPotionItem(int hearts, CappedValue uses) {
+        this.hearts = hearts;
+        this.uses = uses;
+    }
+
+    public int getHearts() {
+        return hearts;
+    }
+
+    @Override
+    public CappedValue getUses() {
+        return uses;
+    }
+
+    @Override
+    public String toString() {
+        return "HealthPotionItem{" + "hearts=" + hearts + ", uses=" + uses + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/HorseItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/HorseItem.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+
+public class HorseItem extends GameItem {
+    private final int tier;
+    private final CappedValue level;
+    private final int xp;
+    private final String name;
+
+    public HorseItem(int tier, CappedValue level, int xp, String name) {
+        this.tier = tier;
+        this.level = level;
+        this.xp = xp;
+        this.name = name;
+    }
+
+    public int getTier() {
+        return tier;
+    }
+
+    public CappedValue getLevel() {
+        return level;
+    }
+
+    public int getXp() {
+        return xp;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "HorseItem{" + "tier=" + tier + ", level=" + level + ", xp=" + xp + ", name='" + name + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/IngredientItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/IngredientItem.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.QualityTierItemProperty;
+import com.wynntils.wynn.objects.profiles.ingredient.IngredientProfile;
+
+public class IngredientItem extends GameItem implements QualityTierItemProperty {
+    private final IngredientProfile ingredientProfile;
+
+    public IngredientItem(IngredientProfile ingredientProfile) {
+        this.ingredientProfile = ingredientProfile;
+    }
+
+    public IngredientProfile getIngredientProfile() {
+        return ingredientProfile;
+    }
+
+    public int getQualityTier() {
+        return ingredientProfile.getTier().getTierInt();
+    }
+
+    @Override
+    public String toString() {
+        return "IngredientItem{" + "ingredientProfile=" + ingredientProfile + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/ManaPotionItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/ManaPotionItem.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.UsesItemPropery;
+
+public class ManaPotionItem extends GameItem implements UsesItemPropery {
+    private final CappedValue uses;
+
+    public ManaPotionItem(CappedValue uses) {
+        this.uses = uses;
+    }
+
+    @Override
+    public CappedValue getUses() {
+        return uses;
+    }
+
+    @Override
+    public String toString() {
+        return "ManaPotionItem{" + "uses=" + uses + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/MaterialItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/MaterialItem.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.QualityTierItemProperty;
+import com.wynntils.wynn.objects.profiles.material.MaterialProfile;
+
+public class MaterialItem extends GameItem implements QualityTierItemProperty {
+    private final MaterialProfile materialProfile;
+
+    public MaterialItem(MaterialProfile ingredientProfile) {
+        this.materialProfile = ingredientProfile;
+    }
+
+    public MaterialProfile getMaterialProfile() {
+        return materialProfile;
+    }
+
+    public int getQualityTier() {
+        return materialProfile.getTier();
+    }
+
+    @Override
+    public String toString() {
+        return "MaterialItem{" + "materialProfile=" + materialProfile + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/PowderItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/PowderItem.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.NumberedTierItemProperty;
+import com.wynntils.wynn.objects.profiles.PowderProfile;
+
+public class PowderItem extends GameItem implements NumberedTierItemProperty {
+    private final PowderProfile powderProfile;
+
+    public PowderItem(PowderProfile powderProfile) {
+        this.powderProfile = powderProfile;
+    }
+
+    public PowderProfile getPowderProfile() {
+        return powderProfile;
+    }
+
+    @Override
+    public int getTier() {
+        return powderProfile.tier();
+    }
+
+    @Override
+    public String toString() {
+        return "PowderItem{" + "powderProfile=" + powderProfile + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/SkillPotionItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/SkillPotionItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.UsesItemPropery;
+import com.wynntils.wynn.objects.Skill;
+
+public class SkillPotionItem extends GameItem implements UsesItemPropery {
+    private final Skill skill;
+    private final CappedValue uses;
+
+    public SkillPotionItem(Skill skill, CappedValue uses) {
+        this.skill = skill;
+        this.uses = uses;
+    }
+
+    public Skill getSkill() {
+        return skill;
+    }
+
+    public CappedValue getUses() {
+        return uses;
+    }
+
+    @Override
+    public String toString() {
+        return "SkillPotionItem{" + "skill=" + skill + ", uses=" + uses + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/TeleportScrollItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/TeleportScrollItem.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+import com.wynntils.wynn.handleditems.properties.TargetedItemProperty;
+
+public class TeleportScrollItem extends GameItem implements TargetedItemProperty {
+    private final String destination;
+    private final boolean dungeon;
+
+    public TeleportScrollItem(String destination, boolean dungeon) {
+        this.destination = destination;
+        this.dungeon = dungeon;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public boolean isDungeon() {
+        return dungeon;
+    }
+
+    @Override
+    public String getTarget() {
+        return destination;
+    }
+
+    @Override
+    public String toString() {
+        return "TeleportScrollItem{" + "destination='" + destination + '\'' + ", dungeon=" + dungeon + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/XpPotionItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/XpPotionItem.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.game;
+
+public class XpPotionItem extends GameItem {
+    @Override
+    public String toString() {
+        return "XpPotionItem{}";
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/CosmeticItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/CosmeticItem.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.gui;
+
+import com.wynntils.mc.objects.CustomColor;
+
+public class CosmeticItem extends GuiItem {
+    private final CustomColor highlightColor;
+
+    public CosmeticItem(CustomColor highlightColor) {
+        this.highlightColor = highlightColor;
+    }
+
+    public CustomColor getHighlightColor() {
+        return highlightColor;
+    }
+
+    @Override
+    public String toString() {
+        return "CosmeticItem{" + "highlightColor=" + highlightColor + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/DailyRewardItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/DailyRewardItem.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.gui;
+
+import com.wynntils.wynn.handleditems.properties.CountedItemProperty;
+
+public class DailyRewardItem extends GuiItem implements CountedItemProperty {
+    private final int count;
+
+    public DailyRewardItem(int count) {
+        this.count = count;
+    }
+
+    @Override
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public String toString() {
+        return "DailyRewardItem{" + "count=" + count + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/GuiItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/GuiItem.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.gui;
+
+import com.wynntils.wynn.handleditems.WynnItem;
+
+public class GuiItem extends WynnItem {}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/ServerItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/ServerItem.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.gui;
+
+import com.wynntils.wynn.handleditems.properties.CountedItemProperty;
+
+public class ServerItem extends GuiItem implements CountedItemProperty {
+    private final int serverId;
+
+    public ServerItem(int serverId) {
+        this.serverId = serverId;
+    }
+
+    public int getServerId() {
+        return serverId;
+    }
+
+    @Override
+    public int getCount() {
+        return serverId;
+    }
+
+    @Override
+    public String toString() {
+        return "ServerItem{" + "serverId=" + serverId + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/SkillPointItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/SkillPointItem.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.gui;
+
+import com.wynntils.wynn.handleditems.properties.CountedItemProperty;
+import com.wynntils.wynn.objects.Skill;
+
+public class SkillPointItem extends GuiItem implements CountedItemProperty {
+    private final Skill skill;
+    private final int skillPoints;
+
+    public SkillPointItem(Skill skill, int skillPoints) {
+        this.skill = skill;
+        this.skillPoints = skillPoints;
+    }
+
+    public Skill getSkill() {
+        return skill;
+    }
+
+    public int getSkillPoints() {
+        return skillPoints;
+    }
+
+    @Override
+    public int getCount() {
+        return skillPoints;
+    }
+
+    @Override
+    public String toString() {
+        return "SkillPointItem{" + "skill=" + skill + ", skillPoints=" + skillPoints + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/SoulPointItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/SoulPointItem.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.items.gui;
+
+public class SoulPointItem extends GuiItem {
+    @Override
+    public String toString() {
+        return "SoulPointItem{}";
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/CountedItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/CountedItemProperty.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+public interface CountedItemProperty {
+    int getCount();
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/DurableItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/DurableItemProperty.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+import com.wynntils.utils.CappedValue;
+
+public interface DurableItemProperty {
+    CappedValue getDurability();
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/GearTierItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/GearTierItemProperty.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
+
+public interface GearTierItemProperty {
+    ItemTier getGearTier();
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/NumberedTierItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/NumberedTierItemProperty.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+public interface NumberedTierItemProperty {
+    int getTier();
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/QualityTierItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/QualityTierItemProperty.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+public interface QualityTierItemProperty {
+    int getQualityTier();
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/TargetedItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/TargetedItemProperty.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+public interface TargetedItemProperty {
+    String getTarget();
+}

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/UsesItemPropery.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/UsesItemPropery.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.handleditems.properties;
+
+import com.wynntils.utils.CappedValue;
+
+public interface UsesItemPropery extends CountedItemProperty {
+    CappedValue getUses();
+
+    default int getCount() {
+        return getUses().getCurrent();
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/item/GearItemStack.java
+++ b/common/src/main/java/com/wynntils/wynn/item/GearItemStack.java
@@ -245,6 +245,10 @@ public class GearItemStack extends WynnItemStack {
         return rerolls;
     }
 
+    public Component getOriginalHoverName() {
+        return super.getHoverName();
+    }
+
     @Override
     public Component getHoverName() {
         if (isGuideStack || isChatItem) return customName;

--- a/common/src/main/java/com/wynntils/wynn/item/parsers/WynnItemMatchers.java
+++ b/common/src/main/java/com/wynntils/wynn/item/parsers/WynnItemMatchers.java
@@ -7,12 +7,16 @@ package com.wynntils.wynn.item.parsers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.mc.utils.ComponentUtils;
 import com.wynntils.mc.utils.ItemUtils;
+import com.wynntils.utils.CappedValue;
 import com.wynntils.wynn.item.EmeraldPouchItemStack;
 import com.wynntils.wynn.item.GearItemStack;
 import com.wynntils.wynn.item.IngredientItemStack;
 import com.wynntils.wynn.item.PowderItemStack;
+import com.wynntils.wynn.objects.SpellType;
+import com.wynntils.wynn.objects.profiles.item.IdentificationProfile;
 import com.wynntils.wynn.objects.profiles.item.ItemProfile;
 import com.wynntils.wynn.utils.WynnUtils;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
@@ -21,6 +25,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.TooltipFlag;
 
 /** Tests if an item is a certain wynncraft item */
 public final class WynnItemMatchers {
@@ -321,5 +326,28 @@ public final class WynnItemMatchers {
 
     public static Matcher gatheringToolMatcher(Component text) {
         return GATHERING_TOOL_PATTERN.matcher(WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(text)));
+    }
+
+    public static CappedValue getDurability(ItemStack itemStack) {
+        List<Component> lore = itemStack.getTooltipLines(null, TooltipFlag.NORMAL);
+        for (Component line : lore) {
+            Matcher durabilityMatcher = durabilityLineMatcher(line);
+            if (!durabilityMatcher.find()) continue;
+
+            var currentDurability = Integer.parseInt(durabilityMatcher.group(1));
+            var maxDurability = Integer.parseInt(durabilityMatcher.group(2));
+            return new CappedValue(currentDurability, maxDurability);
+        }
+
+        return CappedValue.EMPTY;
+    }
+
+    public static String getShortIdentificationName(String fullIdName, boolean isRaw) {
+        SpellType spell = SpellType.fromName(fullIdName);
+        if (spell != null) {
+            return spell.getShortIdName(isRaw);
+        }
+
+        return IdentificationProfile.getAsShortName(fullIdName, isRaw);
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/item/ItemManager.java
+++ b/common/src/main/java/com/wynntils/wynn/model/item/ItemManager.java
@@ -4,8 +4,10 @@
  */
 package com.wynntils.wynn.model.item;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Manager;
 import com.wynntils.core.components.Managers;
+import com.wynntils.core.components.Models;
 import com.wynntils.wynn.item.GearItemStack;
 import com.wynntils.wynn.item.IngredientItemStack;
 import com.wynntils.wynn.model.ItemProfilesManager;
@@ -18,6 +20,10 @@ public class ItemManager extends Manager {
 
     public ItemManager(ItemProfilesManager itemProfilesManager) {
         super(List.of(itemProfilesManager));
+
+        // This is slightly hacky, awaiting the full refactoring
+        WynntilsMod.registerEventListener(Models.Item);
+        Models.Item.init();
     }
 
     public List<IngredientItemStack> getAllIngredientItems() {

--- a/common/src/main/java/com/wynntils/wynn/objects/Skill.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/Skill.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.objects;
+
+import java.util.Locale;
+import net.minecraft.ChatFormatting;
+
+public enum Skill {
+    STRENGTH("✤", ChatFormatting.DARK_GREEN),
+    DEXTERITY("✦", ChatFormatting.YELLOW),
+    INTELLIGENCE("✽", ChatFormatting.AQUA),
+    DEFENCE("✹", ChatFormatting.RED), // Note! Must be spelled with "C" to match in-game
+    AGILITY("❋", ChatFormatting.WHITE);
+
+    private final String symbol;
+    private final ChatFormatting color;
+
+    Skill(String symbol, ChatFormatting color) {
+        this.symbol = symbol;
+        this.color = color;
+    }
+
+    public static Skill fromString(String str) {
+        try {
+            return Skill.valueOf(str.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public ChatFormatting getColor() {
+        return color;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/PowderProfile.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/PowderProfile.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.objects.profiles;
+
+import com.wynntils.wynn.objects.Powder;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record PowderProfile(
+        Powder element, int tier, int min, int max, int convertedFromNeutral, int addedDefence, int removedDefence) {
+    public static final Map<Powder, List<PowderProfile>> powderProfileMap = new HashMap<>();
+
+    static {
+        PowderProfile.powderProfileMap.put(
+                Powder.WATER,
+                Arrays.asList(
+                        new PowderProfile(Powder.WATER, 1, 3, 4, 13, 3, 1),
+                        new PowderProfile(Powder.WATER, 2, 4, 6, 15, 6, 1),
+                        new PowderProfile(Powder.WATER, 3, 5, 8, 17, 11, 2),
+                        new PowderProfile(Powder.WATER, 4, 6, 8, 21, 18, 4),
+                        new PowderProfile(Powder.WATER, 5, 7, 10, 26, 28, 7),
+                        new PowderProfile(Powder.WATER, 6, 9, 11, 32, 40, 10)));
+        PowderProfile.powderProfileMap.put(
+                Powder.FIRE,
+                Arrays.asList(
+                        new PowderProfile(Powder.FIRE, 1, 2, 5, 14, 3, 1),
+                        new PowderProfile(Powder.FIRE, 2, 4, 8, 16, 5, 2),
+                        new PowderProfile(Powder.FIRE, 3, 5, 9, 19, 9, 3),
+                        new PowderProfile(Powder.FIRE, 4, 6, 9, 24, 16, 5),
+                        new PowderProfile(Powder.FIRE, 5, 8, 10, 30, 25, 9),
+                        new PowderProfile(Powder.FIRE, 6, 10, 12, 37, 36, 13)));
+        PowderProfile.powderProfileMap.put(
+                Powder.AIR,
+                Arrays.asList(
+                        new PowderProfile(Powder.AIR, 1, 2, 6, 11, 3, 1),
+                        new PowderProfile(Powder.AIR, 2, 3, 10, 14, 6, 2),
+                        new PowderProfile(Powder.AIR, 3, 4, 11, 17, 10, 3),
+                        new PowderProfile(Powder.AIR, 4, 5, 11, 22, 16, 5),
+                        new PowderProfile(Powder.AIR, 5, 7, 12, 28, 24, 9),
+                        new PowderProfile(Powder.AIR, 6, 8, 14, 35, 34, 13)));
+        PowderProfile.powderProfileMap.put(
+                Powder.EARTH,
+                Arrays.asList(
+                        new PowderProfile(Powder.EARTH, 1, 3, 6, 17, 2, 1),
+                        new PowderProfile(Powder.EARTH, 2, 5, 8, 21, 4, 2),
+                        new PowderProfile(Powder.EARTH, 3, 6, 10, 25, 8, 3),
+                        new PowderProfile(Powder.EARTH, 4, 7, 10, 31, 14, 5),
+                        new PowderProfile(Powder.EARTH, 5, 9, 11, 38, 22, 9),
+                        new PowderProfile(Powder.EARTH, 6, 11, 13, 46, 30, 13)));
+        PowderProfile.powderProfileMap.put(
+                Powder.THUNDER,
+                Arrays.asList(
+                        new PowderProfile(Powder.THUNDER, 1, 1, 8, 9, 3, 1),
+                        new PowderProfile(Powder.THUNDER, 2, 1, 12, 11, 5, 1),
+                        new PowderProfile(Powder.THUNDER, 3, 2, 15, 13, 9, 2),
+                        new PowderProfile(Powder.THUNDER, 4, 3, 15, 17, 14, 4),
+                        new PowderProfile(Powder.THUNDER, 5, 4, 17, 22, 20, 7),
+                        new PowderProfile(Powder.THUNDER, 6, 5, 20, 28, 28, 10)));
+    }
+
+    public static List<PowderProfile> getAllPowderProfiles() {
+        return powderProfileMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+
+    public static PowderProfile getPowderProfile(Powder element, int tier) {
+        return powderProfileMap.get(element).get(tier - 1);
+    }
+
+    @Override
+    public String toString() {
+        return "PowderProfile{" + "element=" + element + ", tier=" + tier + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/ToolProfile.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/ToolProfile.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.objects.profiles;
+
+import com.wynntils.wynn.objects.profiles.ingredient.ProfessionType;
+import java.util.Locale;
+
+public class ToolProfile {
+    private final ToolType toolType;
+    private final int tier;
+
+    public ToolProfile(ToolType toolType, int tier) {
+        this.toolType = toolType;
+        this.tier = tier;
+    }
+
+    public static ToolProfile fromString(String toolTypeName, int tier) {
+        ToolType toolType = ToolType.fromString(toolTypeName);
+        if (toolType == null) return null;
+
+        return new ToolProfile(toolType, tier);
+    }
+
+    public ToolType getToolType() {
+        return toolType;
+    }
+
+    public int getTier() {
+        return tier;
+    }
+
+    public enum ToolType {
+        PICKAXE(ProfessionType.MINING),
+        AXE(ProfessionType.WOODCUTTING),
+        SCYTHE(ProfessionType.FARMING),
+        ROD(ProfessionType.FISHING);
+
+        private final ProfessionType professionType;
+
+        ToolType(ProfessionType professionType) {
+            this.professionType = professionType;
+        }
+
+        public static ToolType fromString(String str) {
+            try {
+                return ToolType.valueOf(str.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ToolProfile{" + "toolType=" + toolType + ", tier=" + tier + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/ingredient/IngredientProfile.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/ingredient/IngredientProfile.java
@@ -113,4 +113,19 @@ public class IngredientProfile {
 
         return itemStack;
     }
+
+    @Override
+    public String toString() {
+        return "IngredientProfile{" + "name='"
+                + name + '\'' + ", ingredientTier="
+                + ingredientTier + ", untradeable="
+                + untradeable + ", level="
+                + level + ", material='"
+                + material + '\'' + ", professions="
+                + professions + ", statuses="
+                + statuses + ", itemModifiers="
+                + itemModifiers + ", ingredientModifiers="
+                + ingredientModifiers + ", ingredientInfo="
+                + ingredientInfo + '}';
+    }
 }

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/item/GearIdentification.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/item/GearIdentification.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.objects.profiles.item;
+
+public class GearIdentification {
+    private final String idName;
+    private final int value;
+    private final int stars;
+
+    public GearIdentification(String idName, int value, int stars) {
+        this.idName = idName;
+        this.value = value;
+        this.stars = stars;
+    }
+
+    public String getIdName() {
+        return idName;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public int getStars() {
+        return stars;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/item/ItemProfile.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/item/ItemProfile.java
@@ -223,4 +223,21 @@ public class ItemProfile {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "ItemProfile{" + "displayName='"
+                + displayName + '\'' + ", tier="
+                + tier + ", powderAmount="
+                + powderAmount + ", attackSpeed="
+                + attackSpeed + ", itemInfo="
+                + itemInfo + ", requirements="
+                + requirements + ", damageTypes="
+                + damageTypes + ", defenseTypes="
+                + defenseTypes + ", statuses="
+                + statuses + ", restriction='"
+                + restriction + '\'' + ", lore='"
+                + lore + '\'' + ", majorIdentifications="
+                + majorIdentifications + '}';
+    }
 }

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/item/ItemTier.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/item/ItemTier.java
@@ -105,6 +105,14 @@ public enum ItemTier {
         }
     }
 
+    public static ItemTier fromString(String name) {
+        if (name.charAt(0) == '§') {
+            return fromChatFormatting(ChatFormatting.getByCode(name.charAt(1)));
+        }
+
+        return null;
+    }
+
     public static ItemTier fromComponent(Component component) {
         String name = component.getString();
 

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/item/RequirementType.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/item/RequirementType.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.wynn.objects.profiles.item;
 
+import com.wynntils.wynn.objects.Skill;
+
 public enum RequirementType {
     QUEST("Quest Req: "),
     CLASSTYPE("Class Req: "),
@@ -22,5 +24,16 @@ public enum RequirementType {
 
     public String asLore() {
         return lore;
+    }
+
+    public Skill getSkill() {
+        return switch (this) {
+            case STRENGTH -> Skill.STRENGTH;
+            case DEXTERITY -> Skill.DEXTERITY;
+            case INTELLIGENCE -> Skill.INTELLIGENCE;
+            case DEFENSE -> Skill.DEFENCE;
+            case AGILITY -> Skill.AGILITY;
+            default -> null;
+        };
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/material/MaterialProfile.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/material/MaterialProfile.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.wynn.objects.profiles.material;
+
+import com.wynntils.wynn.objects.profiles.ingredient.ProfessionType;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class MaterialProfile {
+    public static final Map<MaterialType, List<SourceMaterial>> SOURCE_MATERIALS = Map.of(
+            MaterialType.ORE,
+            List.of(
+                    new SourceMaterial("Copper", 1),
+                    new SourceMaterial("Granite", 10),
+                    new SourceMaterial("Gold", 20),
+                    new SourceMaterial("Sandstone", 30),
+                    new SourceMaterial("Iron", 40),
+                    new SourceMaterial("Silver", 50),
+                    new SourceMaterial("Cobalt", 60),
+                    new SourceMaterial("Kanderstone", 70),
+                    new SourceMaterial("Diamond", 80),
+                    new SourceMaterial("Molten", 90),
+                    new SourceMaterial("Voidstone", 100),
+                    new SourceMaterial("Dernic", 110)),
+            MaterialType.LOG,
+            List.of(
+                    new SourceMaterial("Oak", 1),
+                    new SourceMaterial("Birch", 10),
+                    new SourceMaterial("Willow", 20),
+                    new SourceMaterial("Acacia", 30),
+                    new SourceMaterial("Spruce", 40),
+                    new SourceMaterial("Jungle", 50),
+                    new SourceMaterial("Dark", 60),
+                    new SourceMaterial("Light", 70),
+                    new SourceMaterial("Pine", 80),
+                    new SourceMaterial("Avo", 90),
+                    new SourceMaterial("Sky", 100),
+                    new SourceMaterial("Dernic", 110)),
+            MaterialType.CROP,
+            List.of(
+                    new SourceMaterial("Wheat", 1),
+                    new SourceMaterial("Barley", 10),
+                    new SourceMaterial("Oat", 20),
+                    new SourceMaterial("Malt", 30),
+                    new SourceMaterial("Hops", 40),
+                    new SourceMaterial("Rye", 50),
+                    new SourceMaterial("Millet", 60),
+                    new SourceMaterial("Decay Roots", 70),
+                    new SourceMaterial("Rice", 80),
+                    new SourceMaterial("Sorghum", 90),
+                    new SourceMaterial("Hemp", 100),
+                    new SourceMaterial("Dernic Seed", 110)),
+            MaterialType.FISH,
+            List.of(
+                    new SourceMaterial("Gudgeon", 1),
+                    new SourceMaterial("Trout", 10),
+                    new SourceMaterial("Salmon", 20),
+                    new SourceMaterial("Carp", 30),
+                    new SourceMaterial("Icefish", 40),
+                    new SourceMaterial("Piranha", 50),
+                    new SourceMaterial("Koi", 60),
+                    new SourceMaterial("Gylia Fish", 70),
+                    new SourceMaterial("Bass", 80),
+                    new SourceMaterial("Molten Eel", 90),
+                    new SourceMaterial("Starfish", 100),
+                    new SourceMaterial("Dernic Fish", 110)));
+
+    private final ResourceType resourceType;
+    private final SourceMaterial sourceMaterial;
+    private final int tier;
+
+    private MaterialProfile(ResourceType resourceType, SourceMaterial sourceMaterial, int tier) {
+        this.resourceType = resourceType;
+        this.sourceMaterial = sourceMaterial;
+        this.tier = tier;
+    }
+
+    public static MaterialProfile lookup(String sourceMaterialName, String resourceTypeName, int tier) {
+        SourceMaterial sourceMaterial = SOURCE_MATERIALS.values().stream()
+                .flatMap(list -> list.stream())
+                .filter(material -> material.name().equals(sourceMaterialName))
+                .findFirst()
+                .orElseGet(null);
+        if (sourceMaterial == null) return null;
+
+        ResourceType resourceType = ResourceType.fromString(resourceTypeName);
+        if (resourceType == null) return null;
+
+        return new MaterialProfile(resourceType, sourceMaterial, tier);
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public SourceMaterial getSourceMaterial() {
+        return sourceMaterial;
+    }
+
+    public int getTier() {
+        return tier;
+    }
+
+    public enum MaterialType {
+        ORE(ProfessionType.MINING),
+        LOG(ProfessionType.WOODCUTTING),
+        CROP(ProfessionType.FARMING),
+        FISH(ProfessionType.FISHING);
+
+        private final ProfessionType professionType;
+
+        MaterialType(ProfessionType professionType) {
+            this.professionType = professionType;
+        }
+    }
+
+    public enum ResourceType {
+        INGOT(MaterialType.ORE),
+        GEM(MaterialType.ORE),
+        WOOD(MaterialType.LOG),
+        PAPER(MaterialType.LOG),
+        STRING(MaterialType.CROP),
+        GRAIN(MaterialType.CROP),
+        OIL(MaterialType.FISH),
+        MEAT(MaterialType.FISH);
+
+        private final MaterialType materialType;
+
+        ResourceType(MaterialType materialType) {
+            this.materialType = materialType;
+        }
+
+        public static ResourceType fromString(String str) {
+            try {
+                return ResourceType.valueOf(str.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MaterialProfile{" + "resourceType="
+                + resourceType + ", sourceMaterial="
+                + sourceMaterial + ", tier="
+                + tier + '}';
+    }
+
+    public record SourceMaterial(String name, int level) {}
+}

--- a/common/src/main/java/com/wynntils/wynn/objects/profiles/material/MaterialProfile.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/profiles/material/MaterialProfile.java
@@ -5,11 +5,12 @@
 package com.wynntils.wynn.objects.profiles.material;
 
 import com.wynntils.wynn.objects.profiles.ingredient.ProfessionType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-public class MaterialProfile {
+public final class MaterialProfile {
     public static final Map<MaterialType, List<SourceMaterial>> SOURCE_MATERIALS = Map.of(
             MaterialType.ORE,
             List.of(
@@ -80,7 +81,7 @@ public class MaterialProfile {
 
     public static MaterialProfile lookup(String sourceMaterialName, String resourceTypeName, int tier) {
         SourceMaterial sourceMaterial = SOURCE_MATERIALS.values().stream()
-                .flatMap(list -> list.stream())
+                .flatMap(Collection::stream)
                 .filter(material -> material.name().equals(sourceMaterialName))
                 .findFirst()
                 .orElseGet(null);

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -243,6 +243,7 @@
   "feature.wynntils.inventoryRedirect.redirectPotionStack.description": "Should messages about potions being added to your inventory be redirected to the game update ticker?",
   "feature.wynntils.inventoryRedirect.redirectPotionStack.name": "Redirect Potion Stack Messages",
   "feature.wynntils.itemCompare.name": "Item Compare",
+  "feature.wynntils.itemDebugTooltips.name": "Item Debug Tooltips",
   "feature.wynntils.itemFavorite.closingBlocked": "You cannot close this chest as it has a favorited item inside!",
   "feature.wynntils.itemFavorite.favoriteItems.description": "Favorite Items Set",
   "feature.wynntils.itemFavorite.favoriteItems.name": "Favorite Items",


### PR DESCRIPTION
First part of the item handler rewrite.

This part only adds the new functionality. It is not used anywhere, except in the new debug feature, just so it can be demonstrated. 

The debug feature will append information to the tooltips with what Wynntils knows about the item.

The main design of the system is as follows:

Each ItemStack has an additional field injected, called an "annotation". In that we store what we know about the item. The ItemHandler is responsible for registering "annotators", which will examine a new item stack in order until it is recognized, and an annotation can be produced.

The ItemModel has a registry of annotators. Since we always end up using the FallbackAnnotator, at least, we will always annotate all items, so we will never have to do this twice for any item.

The annotators extract relevant information from the item stack and construct a model-relevant representation of the item, which are subclasses of WynnItem. There are two major groups, GameItems which is basically everything you can throw on the ground in the game, and GuiItems, which is everything else.