### PR TITLE
fix: Search overlay now works for all users

### DIFF
--- a/common/src/main/java/com/wynntils/wynn/objects/SearchableContainerType.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/SearchableContainerType.java
@@ -7,7 +7,7 @@ package com.wynntils.wynn.objects;
 import java.util.regex.Pattern;
 
 public enum SearchableContainerType {
-    BANK(Pattern.compile("§0\\[Pg. (\\d+)\\] §8(.*)'s§0 Bank"), Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>"), 8),
+    BANK(Pattern.compile("§0\\[Pg. (\\d+)\\] §8(.*)'s?§0 Bank"), Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>"), 8),
     GUILD_BANK(Pattern.compile(".+: Bank \\(.+\\)"), null, -1),
     MEMBER_LIST(Pattern.compile(".+: Members"), Pattern.compile("§a§lNext Page"), 28);
 


### PR DESCRIPTION
When a user's name ends with 's', the name of the bank is like `mag_icus' Bank`, not `mag_icus's Bank`.