### PR TITLE
fix: Better handling of item screenshot on macOS

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -18,6 +18,7 @@ import com.wynntils.gui.render.FontRenderer;
 import com.wynntils.gui.render.RenderUtils;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.utils.McUtils;
+import com.wynntils.utils.Utils;
 import com.wynntils.wynn.item.GearItemStack;
 import com.wynntils.wynn.utils.WynnItemUtils;
 import com.wynntils.wynn.utils.WynnUtils;
@@ -59,10 +60,17 @@ public class ItemScreenshotFeature extends UserFeature {
 
         // has to be called during a render period
         takeScreenshot(screen, screenshotSlot);
+        makeChatPrompt(screenshotSlot);
         screenshotSlot = null;
     }
 
     private static void takeScreenshot(Screen screen, Slot hoveredSlot) {
+        if (Utils.isMac()) {
+            McUtils.sendMessageToClient(Component.translatable("feature.wynntils.itemScreenshot.mac")
+                    .withStyle(ChatFormatting.GRAY));
+            return;
+        }
+
         ItemStack stack = hoveredSlot.getItem();
         List<Component> tooltip = stack.getTooltipLines(null, TooltipFlag.NORMAL);
         WynnItemUtils.removeLoreTooltipLines(tooltip);
@@ -116,8 +124,11 @@ public class ItemScreenshotFeature extends UserFeature {
                     Component.translatable("feature.wynntils.itemScreenshot.error", stack.getHoverName())
                             .withStyle(ChatFormatting.RED));
         }
+    }
 
+    private static void makeChatPrompt(Slot hoveredSlot) {
         // chat item prompt
+        ItemStack stack = hoveredSlot.getItem();
         if (stack instanceof GearItemStack gearItem) {
             String encoded = Models.ChatItem.encodeItem(gearItem);
 

--- a/common/src/main/java/com/wynntils/mc/mixin/MainMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MainMixin.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.wynntils.utils.Utils;
 import java.awt.HeadlessException;
 import java.awt.Toolkit;
-import java.util.Locale;
 import net.minecraft.client.main.Main;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,7 +28,7 @@ public abstract class MainMixin {
 
         // This uses a Mixin because this must be done as early as possible - before other mods load that use AWT
         // see https://github.com/BuiltBrokenModding/SBM-SheepMetal/issues/2
-        if (!System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac")) {
+        if (!Utils.isMac()) {
             // Do NOT use logger here. If we reference the WynntilsMod class, we will crash.
             System.out.println("[Wynntils/Artemis] Setting java.awt.headless to false");
             System.setProperty("java.awt.headless", "false");

--- a/common/src/main/java/com/wynntils/utils/Utils.java
+++ b/common/src/main/java/com/wynntils/utils/Utils.java
@@ -22,4 +22,8 @@ public final class Utils {
     public static Random getRandom() {
         return random;
     }
+
+    public static boolean isMac() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac");
+    }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -336,6 +336,7 @@
   "feature.wynntils.itemScreenshot.chatItemMessage": "Click here to copy the item for chat!",
   "feature.wynntils.itemScreenshot.chatItemTooltip": "Paste this text in chat to display your item to other Wynntils users",
   "feature.wynntils.itemScreenshot.error": "Error while taking screenshot: %s",
+  "feature.wynntils.itemScreenshot.mac": "Item screenshot does not work on macOS",
   "feature.wynntils.itemScreenshot.message": "Copied %s to clipboard!",
   "feature.wynntils.itemScreenshot.name": "Item Screenshot",
   "feature.wynntils.itemStatInfo.colorLerp.description": "Should the colored percentage for item ID vary smoothly instead of between fixed levels?",


### PR DESCRIPTION
Due to AWT issues, we will never be able to make item screenshots on macOS. So give the user a better message about this.