### PR TITLE
fix: Replaces References To Deprecated "Reload" Command

### DIFF
--- a/common/src/main/java/com/wynntils/commands/TokenCommand.java
+++ b/common/src/main/java/com/wynntils/commands/TokenCommand.java
@@ -30,10 +30,10 @@ public class TokenCommand extends CommandBase {
             MutableComponent failed = Component.literal(
                             "Either setting up your Wynntils account or accessing the token failed. To try to set up the Wynntils account again, run ")
                     .withStyle(ChatFormatting.GREEN);
-            failed.append(Component.literal("/wynntils reload")
+            failed.append(Component.literal("/wynntils reauth")
                     .withStyle(Style.EMPTY
                             .withColor(ChatFormatting.AQUA)
-                            .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reload"))));
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reauth"))));
             context.getSource().sendFailure(failed);
             return 1;
         }

--- a/common/src/main/java/com/wynntils/core/net/athena/WynntilsAccountManager.java
+++ b/common/src/main/java/com/wynntils/core/net/athena/WynntilsAccountManager.java
@@ -63,7 +63,7 @@ public final class WynntilsAccountManager extends Manager {
             failed.append(Component.literal("/wynntils reauth")
                     .withStyle(Style.EMPTY
                             .withColor(ChatFormatting.AQUA)
-                            .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reload"))));
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reauth"))));
 
             McUtils.sendMessageToClient(failed);
         }

--- a/common/src/main/java/com/wynntils/core/net/hades/model/HadesModel.java
+++ b/common/src/main/java/com/wynntils/core/net/hades/model/HadesModel.java
@@ -136,13 +136,12 @@ public final class HadesModel extends Model {
     public void onWorldStateChange(WorldStateEvent event) {
         if (event.isFirstJoinWorld()) {
             if (!isConnected()) {
-                // FIXME: Use the proper reload command here, once they are reworked
                 MutableComponent failed = Component.literal("Welps! Trying to connect to Hades failed.")
                         .withStyle(ChatFormatting.GREEN);
-                failed.append(Component.literal("/wynntils reload")
+                failed.append(Component.literal("/wynntils reauth")
                         .withStyle(Style.EMPTY
                                 .withColor(ChatFormatting.AQUA)
-                                .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reload"))));
+                                .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils reauth"))));
 
                 McUtils.sendMessageToClient(failed);
 


### PR DESCRIPTION
This was changed back in #916, but the error messages were never updated to reflect this. I believe `reauth` is the correct one for all of these, but my knowledge in Athena is quite sparse- please do correct me if my assertion is incorrrect.