### PR TITLE
fix: add back highlights for crafted items, amplifiers, and emerald pouches

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ItemHighlightFeature.java
@@ -17,12 +17,14 @@ import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.wynn.handleditems.WynnItem;
 import com.wynntils.wynn.handleditems.WynnItemCache;
+import com.wynntils.wynn.handleditems.items.game.EmeraldPouchItem;
 import com.wynntils.wynn.handleditems.items.game.IngredientItem;
 import com.wynntils.wynn.handleditems.items.game.MaterialItem;
 import com.wynntils.wynn.handleditems.items.game.PowderItem;
 import com.wynntils.wynn.handleditems.items.gui.CosmeticItem;
 import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
 import java.util.Optional;
+import net.minecraft.ChatFormatting;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -199,6 +201,9 @@ public class ItemHighlightFeature extends UserFeature {
         if (wynnItem instanceof PowderItem powderItem) {
             return new PowderHighlight(powderItem);
         }
+        if (wynnItem instanceof EmeraldPouchItem emeraldPouchItem) {
+            return new EmeraldPouchHighlight(emeraldPouchItem);
+        }
 
         return null;
     }
@@ -244,6 +249,7 @@ public class ItemHighlightFeature extends UserFeature {
                 case LEGENDARY -> legendaryHighlightEnabled;
                 case FABLED -> fabledHighlightEnabled;
                 case MYTHIC -> mythicHighlightEnabled;
+                case CRAFTED -> craftedHighlightEnabled;
                 default -> false;
             };
         }
@@ -258,6 +264,7 @@ public class ItemHighlightFeature extends UserFeature {
                 case LEGENDARY -> legendaryHighlightColor;
                 case FABLED -> fabledHighlightColor;
                 case MYTHIC -> mythicHighlightColor;
+                case CRAFTED -> craftedHighlightColor;
                 default -> CustomColor.NONE;
             };
         }
@@ -336,6 +343,24 @@ public class ItemHighlightFeature extends UserFeature {
         @Override
         public CustomColor getHighlightColor() {
             return item.getPowderProfile().element().getColor();
+        }
+    }
+
+    private class EmeraldPouchHighlight implements HighlightInfo {
+        private final EmeraldPouchItem item;
+
+        private EmeraldPouchHighlight(EmeraldPouchItem item) {
+            this.item = item;
+        }
+
+        @Override
+        public boolean isHighlightEnabled() {
+            return emeraldPouchHighlightEnabled;
+        }
+
+        @Override
+        public CustomColor getHighlightColor() {
+            return CustomColor.fromChatFormatting(ChatFormatting.GREEN);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/annotators/game/CraftedGearAnnotator.java
@@ -22,7 +22,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 
 public final class CraftedGearAnnotator implements ItemAnnotator {
-    private static final Pattern CRAFTED_GEAR_PATTERN = Pattern.compile("^§3(.*)§b \\[100%\\]$");
+    private static final Pattern CRAFTED_GEAR_PATTERN = Pattern.compile("^§3(.*)§b \\[\\d{1,3}%\\]$");
     private static final Pattern ITEM_IDENTIFICATION_PATTERN =
             Pattern.compile("(^\\+?(?<Value>-?\\d+)(?: to \\+?(?<UpperValue>-?\\d+))?(?<Suffix>%|/\\ds|"
                     + " tier)?(?<Stars>\\*{0,3}) (?<ID>[a-zA-Z 0-9]+))");

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/AmplifierItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/AmplifierItem.java
@@ -4,9 +4,11 @@
  */
 package com.wynntils.wynn.handleditems.items.game;
 
+import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
 import com.wynntils.wynn.handleditems.properties.NumberedTierItemProperty;
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
 
-public class AmplifierItem extends GameItem implements NumberedTierItemProperty {
+public class AmplifierItem extends GameItem implements NumberedTierItemProperty, GearTierItemProperty {
     private final int tier;
 
     public AmplifierItem(int tier) {
@@ -15,6 +17,10 @@ public class AmplifierItem extends GameItem implements NumberedTierItemProperty 
 
     public int getTier() {
         return tier;
+    }
+
+    public ItemTier getGearTier() {
+        return ItemTier.LEGENDARY;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/game/CraftedConsumableItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/game/CraftedConsumableItem.java
@@ -5,9 +5,11 @@
 package com.wynntils.wynn.handleditems.items.game;
 
 import com.wynntils.utils.CappedValue;
+import com.wynntils.wynn.handleditems.properties.GearTierItemProperty;
 import com.wynntils.wynn.handleditems.properties.UsesItemPropery;
+import com.wynntils.wynn.objects.profiles.item.ItemTier;
 
-public class CraftedConsumableItem extends GameItem implements UsesItemPropery {
+public class CraftedConsumableItem extends GameItem implements UsesItemPropery, GearTierItemProperty {
     private final String name;
     private final CappedValue uses;
 
@@ -22,6 +24,10 @@ public class CraftedConsumableItem extends GameItem implements UsesItemPropery {
 
     public CappedValue getUses() {
         return uses;
+    }
+
+    public ItemTier getGearTier() {
+        return ItemTier.CRAFTED;
     }
 
     @Override


### PR DESCRIPTION
Had to add switch cases for the `CRAFTED` item tier, and fix the crafted annotator to match item percents other than 100%

Small aside: I can't say I'm a huge fan of how the `HighlightInfo` stuff works right now, but the alternative would be to fragment the feature functionality and settings away from the feature class so I'm not sure how it could be improved.