### PR TITLE
feat: add color to skill point counts

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ExtendedItemCountFeature.java
@@ -55,8 +55,11 @@ public class ExtendedItemCountFeature extends UserFeature {
         // with mixins...
         item.setCount(1);
 
-        TextRenderTask task = new TextRenderTask(
-                Integer.toString(count), TextRenderSetting.DEFAULT.withHorizontalAlignment(HorizontalAlignment.Right));
+        TextRenderSetting style = TextRenderSetting.DEFAULT
+                .withCustomColor(countedItem.getCountColor())
+                .withHorizontalAlignment(HorizontalAlignment.Right);
+
+        TextRenderTask task = new TextRenderTask(Integer.toString(count), style);
 
         PoseStack poseStack = new PoseStack();
         poseStack.translate(0, 0, 300); // items are drawn at z300, so text has to be as well

--- a/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/SkillPointItem.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/items/gui/SkillPointItem.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.wynn.handleditems.items.gui;
 
+import com.wynntils.mc.objects.CustomColor;
 import com.wynntils.wynn.handleditems.properties.CountedItemProperty;
 import com.wynntils.wynn.objects.Skill;
 
@@ -27,6 +28,11 @@ public class SkillPointItem extends GuiItem implements CountedItemProperty {
     @Override
     public int getCount() {
         return skillPoints;
+    }
+
+    @Override
+    public CustomColor getCountColor() {
+        return CustomColor.fromChatFormatting(skill.getColor());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/wynn/handleditems/properties/CountedItemProperty.java
+++ b/common/src/main/java/com/wynntils/wynn/handleditems/properties/CountedItemProperty.java
@@ -4,10 +4,17 @@
  */
 package com.wynntils.wynn.handleditems.properties;
 
+import com.wynntils.mc.objects.CommonColors;
+import com.wynntils.mc.objects.CustomColor;
+
 public interface CountedItemProperty {
     int getCount();
 
     default boolean hasCount() {
         return true;
+    }
+
+    default CustomColor getCountColor() {
+        return CommonColors.WHITE;
     }
 }


### PR DESCRIPTION
Restores the functionality of the text overlay feature from before the item overhaul. This code supports colors for any `CountedItemProperty`, but for now the only use is skill points.