### PR TITLE
fix: Item screenshot scaling issue

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -58,8 +58,8 @@ public class ItemScreenshotFeature extends UserFeature {
         screenshotSlot = hoveredSlot;
     }
 
-    // All other features must be able to update the tooltip first
-    @SubscribeEvent(priority = EventPriority.LOWEST)
+    // All other features (besides scaling) must be able to update the tooltip first
+    @SubscribeEvent(priority = EventPriority.LOW)
     public void render(ItemTooltipRenderEvent.Pre e) {
         if (!WynnUtils.onWorld()) return;
         if (screenshotSlot == null || !screenshotSlot.hasItem()) return;

--- a/common/src/main/java/com/wynntils/features/user/tooltips/TooltipFittingFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/tooltips/TooltipFittingFeature.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @FeatureInfo(stability = Stability.STABLE, category = FeatureCategory.TOOLTIPS)
@@ -35,7 +36,8 @@ public class TooltipFittingFeature extends UserFeature {
     private int oldWidth = -1;
     private int oldHeight = -1;
 
-    @SubscribeEvent
+    // scaling should only happen after every other feature has updated tooltip
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onTooltipPre(ItemTooltipRenderEvent.Pre e) {
         currentScreen = McUtils.mc().screen;
         if (currentScreen == null) return; // shouldn't be possible
@@ -80,7 +82,8 @@ public class TooltipFittingFeature extends UserFeature {
         scaledLast = true;
     }
 
-    @SubscribeEvent
+    // highest priority to reset pose before other features start rendering
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onTooltipPost(ItemTooltipRenderEvent.Post e) {
         if (!scaledLast) return;
 

--- a/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/wynn/utils/WynnItemUtils.java
@@ -67,18 +67,19 @@ public final class WynnItemUtils {
     }
 
     public static void removeLoreTooltipLines(List<Component> tooltip) {
-        List<Component> toRemove = new ArrayList<>();
-        boolean lore = false;
-        for (Component c : tooltip) {
+        int loreStart = -1;
+        for (int i = 0; i < tooltip.size(); i++) {
             // only remove text after the item type indicator
-            if (!lore && WynnItemMatchers.rarityLineMatcher(c).find()) {
-                lore = true;
-                continue;
+            if (WynnItemMatchers.rarityLineMatcher(tooltip.get(i)).find()) {
+                loreStart = i + 1;
+                break;
             }
-
-            if (lore) toRemove.add(c);
         }
-        tooltip.removeAll(toRemove);
+
+        // type indicator was found
+        if (loreStart != -1) {
+            tooltip.subList(loreStart, tooltip.size()).clear();
+        }
     }
 
     public static String getTranslatedName(ItemStack itemStack) {


### PR DESCRIPTION
Ensures the tooltip scaling code will always execute after all other features. Also fixes a small bug in the item lore remover used by the screenshot feature.