### PR TITLE
feat: Make the scale of custom nametag lines configurable

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
@@ -36,6 +36,9 @@ public class CustomNametagRendererFeature extends UserFeature {
     @Config
     public boolean showGearOnHover = true;
 
+    @Config
+    public float customNametagScale = 0.5f;
+
     private Player hitPlayerCache = null;
 
     @SubscribeEvent
@@ -56,6 +59,8 @@ public class CustomNametagRendererFeature extends UserFeature {
         }
 
         addAccountTypeNametag(event);
+
+        event.setInjectedLinesScale(customNametagScale);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/mc/event/NametagRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/NametagRenderEvent.java
@@ -21,7 +21,9 @@ public class NametagRenderEvent extends Event {
     private final PoseStack poseStack;
     private final MultiBufferSource buffer;
     private final int packedLight;
+
     private final List<MutableComponent> injectedLines;
+    private float injectedLinesScale;
 
     public NametagRenderEvent(
             AbstractClientPlayer entity,
@@ -35,6 +37,7 @@ public class NametagRenderEvent extends Event {
         this.buffer = buffer;
         this.packedLight = packedLight;
         this.injectedLines = new ArrayList<>();
+        this.injectedLinesScale = 1f;
     }
 
     public AbstractClientPlayer getEntity() {
@@ -61,7 +64,15 @@ public class NametagRenderEvent extends Event {
         return injectedLines;
     }
 
+    public float getInjectedLinesScale() {
+        return injectedLinesScale;
+    }
+
     public void addInjectedLine(MutableComponent component) {
         injectedLines.add(component);
+    }
+
+    public void setInjectedLinesScale(float scale) {
+        injectedLinesScale = scale;
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -140,6 +140,8 @@
   "feature.wynntils.customCommandKeybinds.keybindCommand6.description": "What command should be executed when pressing the sixth custom command keybind?",
   "feature.wynntils.customCommandKeybinds.keybindCommand6.name": "Sixth Custom Command Keybind",
   "feature.wynntils.customCommandKeybinds.name": "Custom Command Keybinds",
+  "feature.wynntils.customNametagRenderer.customNametagScale.description": "How large should the extra nametag lines be?",
+  "feature.wynntils.customNametagRenderer.customNametagScale.name": "Custom Nametag Scale",
   "feature.wynntils.customNametagRenderer.hideAllNametags.description": "Should all player nametags be hidden?",
   "feature.wynntils.customNametagRenderer.hideAllNametags.name": "Hide All Player Nametags",
   "feature.wynntils.customNametagRenderer.name": "Nametag Rendering",


### PR DESCRIPTION
Scale defaults to `0.5`, which matches how this feature worked in legacy. This should make the nametag gear display less confusing and disruptive.

The mixin is rather messy now due to the added scaling & transformation code, unfortunately. If desired, I can move our custom nametag rendering to a `RenderUtils` method instead.

![image](https://user-images.githubusercontent.com/3767283/211692729-a589f724-6ad3-444f-818a-618fea976752.png)
