### PR TITLE
fix: apply correct ID color value on exact thresholds

### DIFF
--- a/common/src/main/java/com/wynntils/utils/ColorUtils.java
+++ b/common/src/main/java/com/wynntils/utils/ColorUtils.java
@@ -81,6 +81,6 @@ public final class ColorUtils {
     }
 
     private static TextColor getFlatPercentageColor(float percentage) {
-        return FLAT_MAP.ceilingEntry(percentage).getValue();
+        return FLAT_MAP.higherEntry(percentage).getValue();
     }
 }


### PR DESCRIPTION
changes `ceilingEntry` to `higherEntry`, which searches for values strictly greater than as opposed to greater than or equal to