### PR TITLE
fix: Flag events as "posted" if they are processed

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -10,6 +10,7 @@ import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.ModelRegistry;
 import com.wynntils.core.events.EventBusWrapper;
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.core.features.Feature;
 import com.wynntils.core.features.FeatureRegistry;
 import com.wynntils.core.features.UserFeature;
@@ -55,8 +56,9 @@ public final class WynntilsMod {
         eventBus.register(object);
     }
 
-    public static boolean postEvent(Event event) {
+    public static boolean postEvent(WynntilsEvent event) {
         try {
+            event.setPosted();
             return eventBus.post(event);
         } catch (Throwable t) {
             handleExceptionInEventListener(t, event);

--- a/common/src/main/java/com/wynntils/core/events/WynntilsEvent.java
+++ b/common/src/main/java/com/wynntils/core/events/WynntilsEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.events;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class WynntilsEvent extends Event {
+    private boolean posted = false;
+
+    public boolean wasPosted() {
+        return posted;
+    }
+
+    // doesn't take an argument because you can't "unpost" an event
+    public void setPosted() {
+        posted = true;
+    }
+}

--- a/common/src/main/java/com/wynntils/core/events/WynntilsGenericEvent.java
+++ b/common/src/main/java/com/wynntils/core/events/WynntilsGenericEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.events;
+
+import java.lang.reflect.Type;
+import net.minecraftforge.eventbus.api.IGenericEvent;
+
+public class WynntilsGenericEvent<T> extends WynntilsEvent implements IGenericEvent<T> {
+    private Class<T> type;
+
+    protected WynntilsGenericEvent(Class<T> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type getGenericType() {
+        return type;
+    }
+}

--- a/common/src/main/java/com/wynntils/core/net/athena/event/AthenaLoginEvent.java
+++ b/common/src/main/java/com/wynntils/core/net/athena/event/AthenaLoginEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.core.net.athena.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class AthenaLoginEvent extends Event {}
+public class AthenaLoginEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/core/net/hades/event/HadesEvent.java
+++ b/common/src/main/java/com/wynntils/core/net/hades/event/HadesEvent.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.core.net.hades.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public abstract class HadesEvent extends Event {
+public abstract class HadesEvent extends WynntilsEvent {
     public static class Authenticated extends HadesEvent {}
 
     public static class Disconnected extends HadesEvent {}

--- a/common/src/main/java/com/wynntils/core/notifications/event/NotificationEvent.java
+++ b/common/src/main/java/com/wynntils/core/notifications/event/NotificationEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.core.notifications.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.core.notifications.MessageContainer;
-import net.minecraftforge.eventbus.api.Event;
 
-public class NotificationEvent extends Event {
+public class NotificationEvent extends WynntilsEvent {
     private final MessageContainer messageContainer;
 
     private NotificationEvent(MessageContainer messageContainer) {

--- a/common/src/main/java/com/wynntils/handlers/bossbar/event/BossBarAddedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/bossbar/event/BossBarAddedEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.handlers.bossbar.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.handlers.bossbar.TrackedBar;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class BossBarAddedEvent extends Event {
+public class BossBarAddedEvent extends WynntilsEvent {
     private final TrackedBar trackedBar;
 
     public BossBarAddedEvent(TrackedBar trackedBar) {

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
@@ -4,15 +4,15 @@
  */
 package com.wynntils.handlers.chat.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.handlers.chat.MessageType;
 import com.wynntils.handlers.chat.RecipientType;
 import com.wynntils.mc.utils.ComponentUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ChatMessageReceivedEvent extends Event {
+public class ChatMessageReceivedEvent extends WynntilsEvent {
     // These are used to keep the original message so different features don't have to fight over it.
     private final Component originalMessage;
     private final String originalCodedMessage;

--- a/common/src/main/java/com/wynntils/handlers/chat/event/NpcDialogEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/NpcDialogEvent.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.handlers.chat.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.handlers.chat.NpcDialogueType;
 import java.util.List;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class NpcDialogEvent extends Event {
+public class NpcDialogEvent extends WynntilsEvent {
     private final List<Component> chatMessage;
     private final NpcDialogueType type;
     private final boolean isProtected;

--- a/common/src/main/java/com/wynntils/handlers/scoreboard/event/ScoreboardSegmentAdditionEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/event/ScoreboardSegmentAdditionEvent.java
@@ -5,13 +5,13 @@
 package com.wynntils.handlers.scoreboard.event;
 
 import com.wynntils.core.events.EventThread;
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.handlers.scoreboard.Segment;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
 @EventThread(EventThread.Type.WORKER)
-public class ScoreboardSegmentAdditionEvent extends Event {
+public class ScoreboardSegmentAdditionEvent extends WynntilsEvent {
     private final Segment segment;
 
     public ScoreboardSegmentAdditionEvent(Segment segment) {

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.brigadier.tree.RootCommandNode;
 import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.mc.event.AddEntityLookupEvent;
 import com.wynntils.mc.event.AdvancementUpdateEvent;
 import com.wynntils.mc.event.ArmSwingEvent;
@@ -144,7 +145,7 @@ import org.joml.Matrix4f;
 
 /** Creates events from mixins and platform dependent hooks */
 public final class EventFactory {
-    private static <T extends Event> T post(T event) {
+    private static <T extends WynntilsEvent> T post(T event) {
         if (WynnUtils.onServer()) {
             WynntilsMod.postEvent(event);
         }
@@ -154,7 +155,7 @@ public final class EventFactory {
     /**
      * Post event without checking if we are connected to a Wynncraft server
      */
-    private static <T extends Event> T postAlways(T event) {
+    private static <T extends WynntilsEvent> T postAlways(T event) {
         WynntilsMod.postEvent(event);
         return event;
     }

--- a/common/src/main/java/com/wynntils/mc/event/AddEntityLookupEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/AddEntityLookupEvent.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.Map;
 import java.util.UUID;
 import net.minecraft.world.level.entity.EntityAccess;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class AddEntityLookupEvent extends Event {
+public class AddEntityLookupEvent extends WynntilsEvent {
     private final UUID uuid;
     private final Map<UUID, EntityAccess> entityMap;
 

--- a/common/src/main/java/com/wynntils/mc/event/AdvancementUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/AdvancementUpdateEvent.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.Map;
 import java.util.Set;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Event;
 
-public class AdvancementUpdateEvent extends Event {
+public class AdvancementUpdateEvent extends WynntilsEvent {
     private final boolean reset;
     private final Map<ResourceLocation, Advancement.Builder> added;
     private final Set<ResourceLocation> removed;

--- a/common/src/main/java/com/wynntils/mc/event/ArmSwingEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ArmSwingEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ArmSwingEvent extends Event {
+public class ArmSwingEvent extends WynntilsEvent {
 
     private final ArmSwingContext actionContext;
 

--- a/common/src/main/java/com/wynntils/mc/event/BossHealthUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/BossHealthUpdateEvent.java
@@ -4,15 +4,15 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.Map;
 import java.util.UUID;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class BossHealthUpdateEvent extends Event {
+public class BossHealthUpdateEvent extends WynntilsEvent {
     private final ClientboundBossEventPacket packet;
     private final Map<UUID, LerpingBossEvent> bossEvents;
 

--- a/common/src/main/java/com/wynntils/mc/event/ChatPacketReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatPacketReceivedEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public abstract class ChatPacketReceivedEvent extends Event {
+public abstract class ChatPacketReceivedEvent extends WynntilsEvent {
     private Component message;
 
     protected ChatPacketReceivedEvent(Component message) {

--- a/common/src/main/java/com/wynntils/mc/event/ChatScreenKeyTypedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatScreenKeyTypedEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ChatScreenKeyTypedEvent extends Event {
+public class ChatScreenKeyTypedEvent extends WynntilsEvent {
     private final int keyCode;
     private final int scanCode;
     private final int modifiers;

--- a/common/src/main/java/com/wynntils/mc/event/ChatSentEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatSentEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ChatSentEvent extends Event {
+public class ChatSentEvent extends WynntilsEvent {
     private final String message;
 
     public ChatSentEvent(String message) {

--- a/common/src/main/java/com/wynntils/mc/event/ChestMenuQuickMoveEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChestMenuQuickMoveEvent.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class ChestMenuQuickMoveEvent extends Event {
+public class ChestMenuQuickMoveEvent extends WynntilsEvent {
     private final int containerId;
 
     public ChestMenuQuickMoveEvent(int containerId) {

--- a/common/src/main/java/com/wynntils/mc/event/ClientsideMessageEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ClientsideMessageEvent.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.mc.utils.ComponentUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 // Fired when a message is sent to the local chat.
 @Cancelable
-public class ClientsideMessageEvent extends Event {
+public class ClientsideMessageEvent extends WynntilsEvent {
     private final Component originalComponent;
     private final String originalCodedMessage;
 

--- a/common/src/main/java/com/wynntils/mc/event/CommandSentEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandSentEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class CommandSentEvent extends Event {
+public class CommandSentEvent extends WynntilsEvent {
     private final String command;
     private final boolean signed;
 

--- a/common/src/main/java/com/wynntils/mc/event/CommandsPacketEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandsPacketEvent.java
@@ -5,10 +5,10 @@
 package com.wynntils.mc.event;
 
 import com.mojang.brigadier.tree.RootCommandNode;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.commands.SharedSuggestionProvider;
-import net.minecraftforge.eventbus.api.Event;
 
-public class CommandsPacketEvent extends Event {
+public class CommandsPacketEvent extends WynntilsEvent {
     private RootCommandNode<SharedSuggestionProvider> root;
 
     public CommandsPacketEvent(RootCommandNode<SharedSuggestionProvider> root) {

--- a/common/src/main/java/com/wynntils/mc/event/ConnectionEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ConnectionEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
 /** Fired on connection to a server */
-public abstract class ConnectionEvent extends Event {
+public abstract class ConnectionEvent extends WynntilsEvent {
     public static class ConnectedEvent extends ConnectionEvent {
         private final String host;
         private final int port;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerClickEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerClickEvent.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired on click in a container */
 @Cancelable
-public class ContainerClickEvent extends Event {
+public class ContainerClickEvent extends WynntilsEvent {
     private final int containerId;
     private final int slotNum;
     private final ItemStack itemStack;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerCloseEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerCloseEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class ContainerCloseEvent extends Event {
+public abstract class ContainerCloseEvent extends WynntilsEvent {
     @Cancelable
     public static class Pre extends ContainerCloseEvent {}
 

--- a/common/src/main/java/com/wynntils/mc/event/ContainerRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerRenderEvent.java
@@ -5,12 +5,12 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.inventory.Slot;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired on inventory render */
-public class ContainerRenderEvent extends Event {
+public class ContainerRenderEvent extends WynntilsEvent {
     private final AbstractContainerScreen<?> screen;
     private final PoseStack poseStack;
     private final int mouseX;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerSetContentEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerSetContentEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.List;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class ContainerSetContentEvent extends Event {
+public abstract class ContainerSetContentEvent extends WynntilsEvent {
     protected List<ItemStack> items;
     private final ItemStack carriedItem;
     private final int containerId;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerSetSlotEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerSetSlotEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Event;
 
-public class ContainerSetSlotEvent extends Event {
+public class ContainerSetSlotEvent extends WynntilsEvent {
     private final int containerId;
     private final int stateId;
     private final int slot;

--- a/common/src/main/java/com/wynntils/mc/event/DisplayResizeEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DisplayResizeEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class DisplayResizeEvent extends Event {}
+public class DisplayResizeEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/mc/event/DrawPotionGlintEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DrawPotionGlintEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.item.PotionItem;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class DrawPotionGlintEvent extends Event {
+public class DrawPotionGlintEvent extends WynntilsEvent {
     private final PotionItem item;
 
     public DrawPotionGlintEvent(PotionItem item) {

--- a/common/src/main/java/com/wynntils/mc/event/DropHeldItemEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DropHeldItemEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class DropHeldItemEvent extends Event {
+public class DropHeldItemEvent extends WynntilsEvent {
     private final boolean fullStack;
 
     public DropHeldItemEvent(boolean fullStack) {

--- a/common/src/main/java/com/wynntils/mc/event/EntityEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/EntityEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class EntityEvent extends Event {
+public abstract class EntityEvent extends WynntilsEvent {
     private final Entity entity;
 
     protected EntityEvent(Entity entity) {

--- a/common/src/main/java/com/wynntils/mc/event/GroundItemEntityTransformEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/GroundItemEntityTransformEvent.java
@@ -5,10 +5,10 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Event;
 
-public class GroundItemEntityTransformEvent extends Event {
+public class GroundItemEntityTransformEvent extends WynntilsEvent {
 
     private final PoseStack poseStack;
     private final ItemStack itemStack;

--- a/common/src/main/java/com/wynntils/mc/event/HotbarSlotRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/HotbarSlotRenderEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class HotbarSlotRenderEvent extends Event {
+public abstract class HotbarSlotRenderEvent extends WynntilsEvent {
     private final ItemStack stack;
     private final int x;
     private final int y;

--- a/common/src/main/java/com/wynntils/mc/event/InventoryKeyPressEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/InventoryKeyPressEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.inventory.Slot;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class InventoryKeyPressEvent extends Event {
+public class InventoryKeyPressEvent extends WynntilsEvent {
     private final int keyCode;
     private final int scanCode;
     private final int modifiers;

--- a/common/src/main/java/com/wynntils/mc/event/InventoryMouseClickedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/InventoryMouseClickedEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.inventory.Slot;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class InventoryMouseClickedEvent extends Event {
+public class InventoryMouseClickedEvent extends WynntilsEvent {
     private final double mouseX;
     private final double mouseY;
     private final int button;

--- a/common/src/main/java/com/wynntils/mc/event/ItemTooltipFlags.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemTooltipFlags.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class ItemTooltipFlags extends Event {
+public abstract class ItemTooltipFlags extends WynntilsEvent {
     private final ItemStack itemStack;
 
     protected ItemTooltipFlags(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/mc/event/ItemTooltipHoveredNameEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemTooltipHoveredNameEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Event;
 
-public class ItemTooltipHoveredNameEvent extends Event {
+public class ItemTooltipHoveredNameEvent extends WynntilsEvent {
     private Component hoveredName;
     private final ItemStack stack;
 

--- a/common/src/main/java/com/wynntils/mc/event/ItemTooltipRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemTooltipRenderEvent.java
@@ -5,14 +5,14 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.Collections;
 import java.util.List;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class ItemTooltipRenderEvent extends Event {
+public abstract class ItemTooltipRenderEvent extends WynntilsEvent {
     private final PoseStack poseStack;
     private ItemStack itemStack;
     private int mouseX;

--- a/common/src/main/java/com/wynntils/mc/event/KeyInputEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/KeyInputEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class KeyInputEvent extends Event {
+public class KeyInputEvent extends WynntilsEvent {
     private final int action;
     private final int key;
     private final int modifiers;

--- a/common/src/main/java/com/wynntils/mc/event/LivingEntityRenderTranslucentCheckEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/LivingEntityRenderTranslucentCheckEvent.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Fired when {@link net.minecraft.client.renderer.entity.LivingEntityRenderer} checks whether an
  * entity should be rendered translucent or not
  */
-public class LivingEntityRenderTranslucentCheckEvent extends Event {
+public class LivingEntityRenderTranslucentCheckEvent extends WynntilsEvent {
     private boolean translucent;
     private final LivingEntity entity;
     private float translucence;

--- a/common/src/main/java/com/wynntils/mc/event/MenuEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/MenuEvent.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired for Menu events */
-public abstract class MenuEvent extends Event {
+public abstract class MenuEvent extends WynntilsEvent {
     /** Fired for Menu opened events */
     @Cancelable
     public static class MenuOpenedEvent extends MenuEvent {

--- a/common/src/main/java/com/wynntils/mc/event/MobEffectEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/MobEffectEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class MobEffectEvent extends Event {
+public abstract class MobEffectEvent extends WynntilsEvent {
     private final Entity entity;
     private final MobEffect effect;
 

--- a/common/src/main/java/com/wynntils/mc/event/MouseScrollEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/MouseScrollEvent.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class MouseScrollEvent extends Event {
+public class MouseScrollEvent extends WynntilsEvent {
 
     private final double windowPointer;
     private final double xOffset;

--- a/common/src/main/java/com/wynntils/mc/event/NametagRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/NametagRenderEvent.java
@@ -5,16 +5,16 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class NametagRenderEvent extends Event {
+public class NametagRenderEvent extends WynntilsEvent {
     private final AbstractClientPlayer entity;
     private final Component displayName;
     private final PoseStack poseStack;

--- a/common/src/main/java/com/wynntils/mc/event/PacketEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PacketEvent.java
@@ -5,9 +5,9 @@
 package com.wynntils.mc.event;
 
 import com.wynntils.core.events.EventThread;
+import com.wynntils.core.events.WynntilsGenericEvent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.GenericEvent;
 
 /**
  * Fires on packet sending or recieving
@@ -15,7 +15,7 @@ import net.minecraftforge.eventbus.api.GenericEvent;
  * <p>Please do not misuse this class by looking for specific packet classes; instead create a
  * unique Event class in mc.event and add a mixin for the handler in ClientPacketListenerMixin.
  */
-public abstract class PacketEvent<T extends Packet<?>> extends GenericEvent<T> {
+public abstract class PacketEvent<T extends Packet<?>> extends WynntilsGenericEvent<T> {
     private final T packet;
 
     protected PacketEvent(T packet) {

--- a/common/src/main/java/com/wynntils/mc/event/PauseMenuInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PauseMenuInitEvent.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.function.Consumer;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.PauseScreen;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired on initialization of {@link PauseScreen} */
-public class PauseMenuInitEvent extends Event {
+public class PauseMenuInitEvent extends WynntilsEvent {
     private final PauseScreen pauseScreen;
     private final Consumer<AbstractWidget> addButton;
 

--- a/common/src/main/java/com/wynntils/mc/event/PlayerArmorRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerArmorRenderEvent.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class PlayerArmorRenderEvent extends Event {
+public class PlayerArmorRenderEvent extends WynntilsEvent {
     private final Player player;
     private final EquipmentSlot slot;
 

--- a/common/src/main/java/com/wynntils/mc/event/PlayerInfoEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerInfoEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.UUID;
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fires for changes in player info in scoreboard */
-public abstract class PlayerInfoEvent extends Event {
+public abstract class PlayerInfoEvent extends WynntilsEvent {
     private final UUID id;
 
     protected PlayerInfoEvent(UUID id) {

--- a/common/src/main/java/com/wynntils/mc/event/PlayerInfoFooterChangedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerInfoFooterChangedEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
 /** Fires on change to footer of scoreboard */
-public class PlayerInfoFooterChangedEvent extends Event {
+public class PlayerInfoFooterChangedEvent extends WynntilsEvent {
     private final String footer;
 
     public String getFooter() {

--- a/common/src/main/java/com/wynntils/mc/event/PlayerJoinedWorldEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerJoinedWorldEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.UUID;
 import net.minecraft.client.multiplayer.PlayerInfo;
-import net.minecraftforge.eventbus.api.Event;
 
-public class PlayerJoinedWorldEvent extends Event {
+public class PlayerJoinedWorldEvent extends WynntilsEvent {
     private final int entityId;
     private final UUID playerId;
     private final double x;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerTeamEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerTeamEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public abstract class PlayerTeamEvent extends Event {
+public abstract class PlayerTeamEvent extends WynntilsEvent {
     private final String username;
     private final PlayerTeam playerTeam;
 

--- a/common/src/main/java/com/wynntils/mc/event/PlayerTeleportEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerTeleportEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.core.Position;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fires when player is teleported */
-public class PlayerTeleportEvent extends Event {
+public class PlayerTeleportEvent extends WynntilsEvent {
     private final Position newPosition;
 
     public PlayerTeleportEvent(Position newPosition) {

--- a/common/src/main/java/com/wynntils/mc/event/RenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/RenderEvent.java
@@ -6,10 +6,10 @@ package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class RenderEvent extends Event {
+public abstract class RenderEvent extends WynntilsEvent {
     private final PoseStack poseStack;
     private final float partialTicks;
     private final Window window;

--- a/common/src/main/java/com/wynntils/mc/event/RenderLevelEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/RenderLevelEvent.java
@@ -5,12 +5,12 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraftforge.eventbus.api.Event;
 import org.joml.Matrix4f;
 
-public abstract class RenderLevelEvent extends Event {
+public abstract class RenderLevelEvent extends WynntilsEvent {
     private final LevelRenderer levelRenderer;
     private final PoseStack poseStack;
     private final float partialTick;

--- a/common/src/main/java/com/wynntils/mc/event/RenderTileLevelLastEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/RenderTileLevelLastEvent.java
@@ -5,12 +5,12 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraftforge.eventbus.api.Event;
 import org.joml.Matrix4f;
 
-public class RenderTileLevelLastEvent extends Event {
+public class RenderTileLevelLastEvent extends WynntilsEvent {
     private final LevelRenderer levelRenderer;
     private final PoseStack poseStack;
     private final float partialTick;

--- a/common/src/main/java/com/wynntils/mc/event/ResourcePackClearEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ResourcePackClearEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ResourcePackClearEvent extends Event {
+public class ResourcePackClearEvent extends WynntilsEvent {
     private final String hash;
 
     public ResourcePackClearEvent(String hash) {

--- a/common/src/main/java/com/wynntils/mc/event/ResourcePackEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ResourcePackEvent.java
@@ -5,13 +5,13 @@
 package com.wynntils.mc.event;
 
 import com.wynntils.core.events.EventThread;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fires on receiving {@link net.minecraft.network.protocol.game.ClientboundResourcePackPacket} */
 @EventThread(EventThread.Type.IO)
 @Cancelable
-public class ResourcePackEvent extends Event {
+public class ResourcePackEvent extends WynntilsEvent {
     private final String url;
     private final String hash;
     private final boolean required;

--- a/common/src/main/java/com/wynntils/mc/event/ScoreboardSetScoreEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScoreboardSetScoreEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.server.ServerScoreboard;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ScoreboardSetScoreEvent extends Event {
+public class ScoreboardSetScoreEvent extends WynntilsEvent {
     private final String owner;
     private final String objectiveName;
     private final int score;

--- a/common/src/main/java/com/wynntils/mc/event/ScreenClosedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenClosedEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class ScreenClosedEvent extends Event {}
+public class ScreenClosedEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/mc/event/ScreenInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenInitEvent.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Fired when a screen is re-inited. Use this to add widgets.
  */
-public class ScreenInitEvent extends Event {
+public class ScreenInitEvent extends WynntilsEvent {
     private final Screen screen;
 
     public ScreenInitEvent(Screen screen) {

--- a/common/src/main/java/com/wynntils/mc/event/ScreenOpenedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenOpenedEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired on setting the active screen */
-public class ScreenOpenedEvent extends Event {
+public class ScreenOpenedEvent extends WynntilsEvent {
     private final Screen screen;
 
     public ScreenOpenedEvent(Screen screen) {

--- a/common/src/main/java/com/wynntils/mc/event/ScreenRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenRenderEvent.java
@@ -5,10 +5,10 @@
 package com.wynntils.mc.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraftforge.eventbus.api.Event;
 
-public class ScreenRenderEvent extends Event {
+public class ScreenRenderEvent extends WynntilsEvent {
     private final Screen screen;
     private final PoseStack poseStack;
     private final int mouseX;

--- a/common/src/main/java/com/wynntils/mc/event/SetEntityPassengersEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetEntityPassengersEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class SetEntityPassengersEvent extends Event {
+public class SetEntityPassengersEvent extends WynntilsEvent {
     private final int vehicle;
 
     public SetEntityPassengersEvent(int vehicle) {

--- a/common/src/main/java/com/wynntils/mc/event/SetPlayerTeamEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetPlayerTeamEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class SetPlayerTeamEvent extends Event {
+public class SetPlayerTeamEvent extends WynntilsEvent {
     private final int method;
     private final String teamName;
 

--- a/common/src/main/java/com/wynntils/mc/event/SetSlotEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetSlotEvent.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired when an item is set in a slot */
-public abstract class SetSlotEvent extends Event {
+public abstract class SetSlotEvent extends WynntilsEvent {
     private final Container container;
     private final int slot;
     protected ItemStack item;

--- a/common/src/main/java/com/wynntils/mc/event/SetSpawnEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetSpawnEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class SetSpawnEvent extends Event {
+public class SetSpawnEvent extends WynntilsEvent {
     private final BlockPos spawnPos;
 
     public SetSpawnEvent(BlockPos spawnPos) {

--- a/common/src/main/java/com/wynntils/mc/event/SetXpEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetXpEvent.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class SetXpEvent extends Event {
+public class SetXpEvent extends WynntilsEvent {
     private final float experienceProgress;
     private final int totalExperience;
     private final int experienceLevel;

--- a/common/src/main/java/com/wynntils/mc/event/SlotRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SlotRenderEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.inventory.Slot;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class SlotRenderEvent extends Event {
+public abstract class SlotRenderEvent extends WynntilsEvent {
     private final Screen screen;
     private final Slot slot;
 

--- a/common/src/main/java/com/wynntils/mc/event/SubtitleSetTextEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SubtitleSetTextEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class SubtitleSetTextEvent extends Event {
+public class SubtitleSetTextEvent extends WynntilsEvent {
     private final Component component;
 
     public SubtitleSetTextEvent(Component component) {

--- a/common/src/main/java/com/wynntils/mc/event/TickEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/TickEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.mc.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public final class TickEvent extends Event {}
+public final class TickEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/mc/event/TitleScreenInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/TitleScreenInitEvent.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.function.Consumer;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.TitleScreen;
-import net.minecraftforge.eventbus.api.Event;
 
 /** Fired on initialization of {@link TitleScreen} */
-public abstract class TitleScreenInitEvent extends Event {
+public abstract class TitleScreenInitEvent extends WynntilsEvent {
     private final TitleScreen titleScreen;
     private final Consumer<AbstractWidget> addButton;
 

--- a/common/src/main/java/com/wynntils/mc/event/TitleSetTextEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/TitleSetTextEvent.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class TitleSetTextEvent extends Event {
+public class TitleSetTextEvent extends WynntilsEvent {
     private final Component component;
 
     public TitleSetTextEvent(Component component) {

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -118,6 +118,9 @@ public abstract class ClientPacketListenerMixin {
         RootCommandNode<SharedSuggestionProvider> root = this.commands.getRoot();
         CommandsPacketEvent event = EventFactory.onCommandsPacket(root);
 
+        // do not run mixin code if event wasn't posted
+        if (!event.wasPosted()) return;
+
         if (event.getRoot() != root) {
             // If we changed the root, replace the CommandDispatcher
             this.commands = new CommandDispatcher<>(event.getRoot());
@@ -194,6 +197,10 @@ public abstract class ClientPacketListenerMixin {
     private void handleContainerContentPre(ClientboundContainerSetContentPacket packet, CallbackInfo ci) {
         if (!isRenderThread()) return;
         ContainerSetContentEvent event = EventFactory.onContainerSetContentPre(packet);
+
+        // do not run mixin code if event wasn't posted
+        if (!event.wasPosted()) return;
+
         if (event.isCanceled()) {
             ci.cancel();
         }
@@ -304,6 +311,10 @@ public abstract class ClientPacketListenerMixin {
     private void handlePlayerChat(ClientboundPlayerChatPacket packet, CallbackInfo ci) {
         if (!isRenderThread()) return;
         ChatPacketReceivedEvent result = EventFactory.onPlayerChatReceived(packet.unsignedContent());
+
+        // do not run mixin code if event wasn't posted
+        if (!result.wasPosted()) return;
+
         if (result.isCanceled()) {
             ci.cancel();
             return;
@@ -353,13 +364,16 @@ public abstract class ClientPacketListenerMixin {
     private void handleSystemChat(ClientboundSystemChatPacket packet, CallbackInfo ci) {
         if (!isRenderThread()) return;
         ChatPacketReceivedEvent result = EventFactory.onSystemChatReceived(packet.content(), packet.overlay());
+
+        // do not run mixin code if event wasn't posted
+        if (!result.wasPosted()) return;
+
         if (result.isCanceled()) {
             ci.cancel();
             return;
         }
 
         if (!result.getMessage().equals(packet.content())) {
-
             this.minecraft.getChatListener().handleSystemMessage(result.getMessage(), packet.overlay());
             ci.cancel();
         }

--- a/common/src/main/java/com/wynntils/wynn/event/CharacterUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/CharacterUpdateEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.wynn.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class CharacterUpdateEvent extends Event {}
+public class CharacterUpdateEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/wynn/event/LootrunCacheRefreshEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/LootrunCacheRefreshEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.wynn.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class LootrunCacheRefreshEvent extends Event {}
+public class LootrunCacheRefreshEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/wynn/event/RelationsUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/RelationsUpdateEvent.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.hades.protocol.enums.PacketAction;
 import java.util.Set;
-import net.minecraftforge.eventbus.api.Event;
 
-public abstract class RelationsUpdateEvent extends Event {
+public abstract class RelationsUpdateEvent extends WynntilsEvent {
     private final Set<String> changedPlayers;
     private final ChangeType changeType;
 

--- a/common/src/main/java/com/wynntils/wynn/event/ShamanMaskTitlePacketEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/ShamanMaskTitlePacketEvent.java
@@ -4,8 +4,8 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class ShamanMaskTitlePacketEvent extends Event {}
+public class ShamanMaskTitlePacketEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/wynn/event/StatusEffectsChangedEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/StatusEffectsChangedEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.wynn.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class StatusEffectsChangedEvent extends Event {}
+public class StatusEffectsChangedEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/wynn/event/WorldStateEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/WorldStateEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.wynn.objects.WorldState;
-import net.minecraftforge.eventbus.api.Event;
 
-public class WorldStateEvent extends Event {
+public class WorldStateEvent extends WynntilsEvent {
     private final WorldState newState;
     private final WorldState oldState;
     private final String worldName;

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/event/CenterSegmentClearedEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/event/CenterSegmentClearedEvent.java
@@ -4,6 +4,6 @@
  */
 package com.wynntils.wynn.model.actionbar.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public class CenterSegmentClearedEvent extends Event {}
+public class CenterSegmentClearedEvent extends WynntilsEvent {}

--- a/common/src/main/java/com/wynntils/wynn/model/actionbar/event/SpellSegmentUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/model/actionbar/event/SpellSegmentUpdateEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.wynn.model.actionbar.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import java.util.regex.Matcher;
-import net.minecraftforge.eventbus.api.Event;
 
-public class SpellSegmentUpdateEvent extends Event {
+public class SpellSegmentUpdateEvent extends WynntilsEvent {
     private final Matcher matcher;
 
     public SpellSegmentUpdateEvent(Matcher matcher) {

--- a/common/src/main/java/com/wynntils/wynn/model/discoveries/event/DiscoveriesUpdatedEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/model/discoveries/event/DiscoveriesUpdatedEvent.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.wynn.model.discoveries.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public abstract class DiscoveriesUpdatedEvent extends Event {
+public abstract class DiscoveriesUpdatedEvent extends WynntilsEvent {
     public static class Normal extends DiscoveriesUpdatedEvent {}
 
     public static class Secret extends DiscoveriesUpdatedEvent {}

--- a/common/src/main/java/com/wynntils/wynn/model/quests/event/QuestBookReloadedEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/event/QuestBookReloadedEvent.java
@@ -4,9 +4,9 @@
  */
 package com.wynntils.wynn.model.quests.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import com.wynntils.core.events.WynntilsEvent;
 
-public abstract class QuestBookReloadedEvent extends Event {
+public abstract class QuestBookReloadedEvent extends WynntilsEvent {
     public static class QuestsReloaded extends QuestBookReloadedEvent {}
 
     public static class MiniQuestsReloaded extends QuestBookReloadedEvent {}

--- a/common/src/main/java/com/wynntils/wynn/model/quests/event/TrackedQuestUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/model/quests/event/TrackedQuestUpdateEvent.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.wynn.model.quests.event;
 
+import com.wynntils.core.events.WynntilsEvent;
 import com.wynntils.wynn.model.quests.QuestInfo;
-import net.minecraftforge.eventbus.api.Event;
 
-public class TrackedQuestUpdateEvent extends Event {
+public class TrackedQuestUpdateEvent extends WynntilsEvent {
     private final QuestInfo questInfo;
 
     public TrackedQuestUpdateEvent(QuestInfo questInfo) {


### PR DESCRIPTION
This PR adds a wrapper `WynntilsEvent` class for all our custom events, which lets us add a flag denoting whether the event was posted to the event bus or not. The purpose of this flag is to keep mixins from executing code that would otherwise run regardless of the event getting posted - or in other words, regardless of the player being online Wynncraft. This prevents the possibility of mixin code breaking unrelated, non-Wynncraft things. 