### PR TITLE
fix: Totem tracking improvements

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/overlays/ShamanTotemTrackingFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/overlays/ShamanTotemTrackingFeature.java
@@ -209,7 +209,7 @@ public class ShamanTotemTrackingFeature extends UserFeature {
                                 case NONE -> suffix = " (" + shamanTotem.getTime() + " s)";
                                 case COORDS -> {
                                     suffix = " (" + shamanTotem.getTime() + " s)";
-                                    detail = shamanTotem.getLocation().toString();
+                                    detail = " " + shamanTotem.getLocation().toString();
                                 }
                                 case DISTANCE -> suffix = " (" + shamanTotem.getTime() + " s, "
                                         + Math.round(McUtils.player()

--- a/common/src/main/java/com/wynntils/wynn/event/TotemEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/TotemEvent.java
@@ -20,11 +20,30 @@ public abstract class TotemEvent extends Event {
         return totemNumber;
     }
 
+    /**
+     * Fired when the totem's timer ArmorStand is bound to the visible totem
+     */
     public static class Activated extends TotemEvent {
+        private final Location location;
+
+        public Activated(int totemNumber, Location location) {
+            super(totemNumber);
+            this.location = location;
+        }
+
+        public Location getLocation() {
+            return location;
+        }
+    }
+
+    /**
+     * Fired when the totem's timer is updated (when it decreases by 1 sec)
+     */
+    public static class Updated extends TotemEvent {
         private final int time;
         private final Location location;
 
-        public Activated(int totemNumber, int time, Location location) {
+        public Updated(int totemNumber, int time, Location location) {
             super(totemNumber);
             this.time = time;
             this.location = location;
@@ -39,6 +58,9 @@ public abstract class TotemEvent extends Event {
         }
     }
 
+    /**
+     * Fired when a totem is removed in-game
+     */
     public static class Removed extends TotemEvent {
         private final ShamanTotem totem;
 
@@ -52,6 +74,9 @@ public abstract class TotemEvent extends Event {
         }
     }
 
+    /**
+     * Fired when totem is initially summoned by spell cast
+     */
     public static class Summoned extends TotemEvent {
         private final ArmorStand totemEntity;
 

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -131,6 +131,9 @@ public class ShamanTotemModel extends Model {
         Location parsedLocation = new Location(entity.position().x, entity.position().y, entity.position().z);
 
         if (getBoundTotem(entityId) == null && Math.abs(totemCastTimestamp - System.currentTimeMillis()) < 15000) {
+            // Don't unnecessarily check if we aren't even waiting for a totem
+            if (pendingTotem1Id == null && pendingTotem2Id == null && pendingTotem3Id == null) return;
+
             // Given timerId is not a totem, make a new totem (assuming regex matches and we are within 15s of casting)
             // First check if this is actually one casted by us
             List<ArmorStand> toCheck = McUtils.mc()
@@ -142,7 +145,7 @@ public class ShamanTotemModel extends Model {
                                     entity.position().y - 0.1,
                                     entity.position().z - 0.5,
                                     entity.position().x + 0.5,
-                                    entity.position().y + 0.1,
+                                    entity.position().y + 1.7,
                                     entity.position().z + 0.5));
 
             for (ArmorStand as : toCheck) {

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -80,6 +80,7 @@ public class ShamanTotemModel extends Model {
                     ShamanTotem newTotem = new ShamanTotem(
                             totemNumber,
                             -1,
+                            totemAS.getId(),
                             -1,
                             ShamanTotem.TotemState.SUMMONED,
                             new Location(totemAS.position().x, totemAS.position().y, totemAS.position().z));
@@ -119,7 +120,7 @@ public class ShamanTotemModel extends Model {
         Logic flow for the following bits:
         - First, the given entity is checked to see if it is a totem timer
         - If the given timerId (int entityId) is not already a totem, assign it to the lowest # totem slot
-          - Additionally, assign location, state, and time
+          - Additionally, assign location, state, and time, and keep the old visibleEntityId from when the spell was cast
         - If the given timerId is already a totem, update the time and location instead
           - Location is updated because there are now totems that can move
          */
@@ -146,15 +147,33 @@ public class ShamanTotemModel extends Model {
 
             for (ArmorStand as : toCheck) {
                 if (pendingTotem1Id != null && as.getId() == pendingTotem1Id) {
-                    totem1 = new ShamanTotem(1, entityId, parsedTime, ShamanTotem.TotemState.ACTIVE, parsedLocation);
+                    totem1 = new ShamanTotem(
+                            1,
+                            entityId,
+                            totem1.getVisibleEntityId(),
+                            parsedTime,
+                            ShamanTotem.TotemState.ACTIVE,
+                            parsedLocation);
                     WynntilsMod.postEvent(new TotemEvent.Activated(1, parsedTime, parsedLocation));
                     pendingTotem1Id = null;
                 } else if (pendingTotem2Id != null && as.getId() == pendingTotem2Id) {
-                    totem2 = new ShamanTotem(2, entityId, parsedTime, ShamanTotem.TotemState.ACTIVE, parsedLocation);
+                    totem2 = new ShamanTotem(
+                            2,
+                            entityId,
+                            totem2.getVisibleEntityId(),
+                            parsedTime,
+                            ShamanTotem.TotemState.ACTIVE,
+                            parsedLocation);
                     WynntilsMod.postEvent(new TotemEvent.Activated(2, parsedTime, parsedLocation));
                     pendingTotem2Id = null;
                 } else if (pendingTotem3Id != null && as.getId() == pendingTotem3Id) {
-                    totem3 = new ShamanTotem(3, entityId, parsedTime, ShamanTotem.TotemState.ACTIVE, parsedLocation);
+                    totem3 = new ShamanTotem(
+                            3,
+                            entityId,
+                            totem3.getVisibleEntityId(),
+                            parsedTime,
+                            ShamanTotem.TotemState.ACTIVE,
+                            parsedLocation);
                     WynntilsMod.postEvent(new TotemEvent.Activated(3, parsedTime, parsedLocation));
                     pendingTotem3Id = null;
                 } else {
@@ -183,13 +202,19 @@ public class ShamanTotemModel extends Model {
 
         List<Integer> destroyedEntities = e.getEntityIds();
 
-        if (totem1 != null && destroyedEntities.contains(totem1.getTimerId())) {
+        if (totem1 != null
+                && (destroyedEntities.contains(totem1.getTimerEntityId())
+                        || destroyedEntities.contains(totem1.getVisibleEntityId()))) {
             removeTotem(1);
         }
-        if (totem2 != null && destroyedEntities.contains(totem2.getTimerId())) {
+        if (totem2 != null
+                && (destroyedEntities.contains(totem2.getTimerEntityId())
+                        || destroyedEntities.contains(totem2.getVisibleEntityId()))) {
             removeTotem(2);
         }
-        if (totem3 != null && destroyedEntities.contains(totem3.getTimerId())) {
+        if (totem3 != null
+                && (destroyedEntities.contains(totem3.getTimerEntityId())
+                        || destroyedEntities.contains(totem3.getVisibleEntityId()))) {
             removeTotem(3);
         }
     }
@@ -285,9 +310,9 @@ public class ShamanTotemModel extends Model {
      * @return The totem bound to the given timerId, or null if no totem is bound
      */
     private ShamanTotem getBoundTotem(int timerId) {
-        if (totem1 != null && totem1.getTimerId() == timerId) return totem1;
-        if (totem2 != null && totem2.getTimerId() == timerId) return totem2;
-        if (totem3 != null && totem3.getTimerId() == timerId) return totem3;
+        if (totem1 != null && totem1.getTimerEntityId() == timerId) return totem1;
+        if (totem2 != null && totem2.getTimerEntityId() == timerId) return totem2;
+        if (totem3 != null && totem3.getTimerEntityId() == timerId) return totem3;
         return null;
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -119,8 +119,7 @@ public class ShamanTotemModel extends Model {
         Entity possibleTimer = getBufferedEntity(entityId);
         if (!(possibleTimer instanceof ArmorStand)) return;
 
-        // Given timerId is not a totem, make a new totem (assuming regex matches and we are within 15s of casting)
-        // First check if this is actually one casted by us
+        // Given timerId is not a totem, make a new totem
         List<ArmorStand> toCheck = McUtils.mc()
                 .level
                 .getEntitiesOfClass(

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -143,18 +143,21 @@ public class ShamanTotemModel extends Model {
             // Recreate location for each ArmorStand checked for most accurate coordinates
             Location parsedLocation = new Location(as.position().x, as.position().y, as.position().z);
             if (pendingTotem1VisibleId != null && as.getId() == pendingTotem1VisibleId) {
-                totem1 = new ShamanTotem(
-                        1, entityId, totem1.getVisibleEntityId(), -1, ShamanTotem.TotemState.ACTIVE, parsedLocation);
+                totem1.setTimerEntityId(entityId);
+                totem1.setLocation(parsedLocation);
+                totem1.setState(ShamanTotem.TotemState.ACTIVE);
                 WynntilsMod.postEvent(new TotemEvent.Activated(1, parsedLocation));
                 pendingTotem1VisibleId = null;
             } else if (pendingTotem2VisibleId != null && as.getId() == pendingTotem2VisibleId) {
-                totem2 = new ShamanTotem(
-                        2, entityId, totem2.getVisibleEntityId(), -1, ShamanTotem.TotemState.ACTIVE, parsedLocation);
+                totem2.setTimerEntityId(entityId);
+                totem2.setLocation(parsedLocation);
+                totem2.setState(ShamanTotem.TotemState.ACTIVE);
                 WynntilsMod.postEvent(new TotemEvent.Activated(2, parsedLocation));
                 pendingTotem2VisibleId = null;
             } else if (pendingTotem3VisibleId != null && as.getId() == pendingTotem3VisibleId) {
-                totem3 = new ShamanTotem(
-                        3, entityId, totem3.getVisibleEntityId(), -1, ShamanTotem.TotemState.ACTIVE, parsedLocation);
+                totem3.setTimerEntityId(entityId);
+                totem3.setLocation(parsedLocation);
+                totem3.setState(ShamanTotem.TotemState.ACTIVE);
                 WynntilsMod.postEvent(new TotemEvent.Activated(3, parsedLocation));
                 pendingTotem3VisibleId = null;
             } else {

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -106,6 +106,43 @@ public class ShamanTotemModel extends Model {
                 3);
     }
 
+    // TODO: remove debug/tests
+    @SubscribeEvent
+    public void onTimerSpawn(AddEntityEvent e) {
+        Entity possibleTimer = getBufferedEntity(e.getId());
+        if (!(possibleTimer instanceof ArmorStand as)) return;
+
+        Matcher m = SHAMAN_TOTEM_TIMER.matcher(as.getDisplayName().toString());
+        if (!m.find()) return;
+
+        System.out.println("an entity " + e.getId() + " passed totem timer checks");
+        if (pendingTotem1Id == null && pendingTotem2Id == null && pendingTotem3Id == null) return;
+
+        List<ArmorStand> nearbyVisibleTotems = McUtils.mc()
+                .level
+                .getEntitiesOfClass(
+                        ArmorStand.class,
+                        new AABB(
+                                as.position().x,
+                                as.position().y,
+                                as.position().z,
+                                as.position().x,
+                                as.position().y,
+                                as.position().z));
+
+        for (ArmorStand vt : nearbyVisibleTotems) {
+            if (pendingTotem1Id != null && vt.getId() == pendingTotem1Id) {
+                System.out.println("matched totem 1's visible entity");
+            } else if (pendingTotem2Id != null && vt.getId() == pendingTotem2Id) {
+                System.out.println("matched totem 2's visible entity");
+            } else if (pendingTotem3Id != null && vt.getId() == pendingTotem3Id) {
+                System.out.println("matched totem 3's visible entity");
+            } else {
+                System.out.println("ArmorStand " + vt.getId() + " detected, but did not match any totem");
+            }
+        }
+    }
+
     @SubscribeEvent
     public void onTotemRename(SetEntityDataEvent e) {
         if (!WynnUtils.onWorld()) return;

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -63,12 +63,9 @@ public class ShamanTotemModel extends Model {
         Entity entity = getBufferedEntity(e.getId());
         if (!(entity instanceof ArmorStand totemAS)) return;
 
-        // Checks to verify this is a totem
-        if (Math.abs(totemAS.getMyRidingOffset() - 0.10000000149011612f) > 0.00000000000012f) return;
-
         Managers.TickScheduler.scheduleLater(
                 () -> {
-                    // Continue checks to verify this is a totem
+                    // Checks to verify this is a totem
                     // This must be ran with a delay, as the totem spawns on the same tick as the spell cast, so we
                     // cannot immediately check the timestamp
                     if (Math.abs(totemCastTimestamp - System.currentTimeMillis()) > CAST_DELAY_MAX_MS) return;

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -55,7 +55,8 @@ public class ShamanTotemModel extends Model {
     public void onTotemSpellCast(SpellCastEvent e) {
         if (e.getSpell() != SpellType.TOTEM) return;
 
-        totemCastTimestamp = System.currentTimeMillis();
+        totemCastTimestamp = System.currentTimeMillis() - 40; // 40 == 2 ticks
+        // The -2 ticks is required so that the #onTotemSpawn event does not occasionally fail the cast timestamp check
     }
 
     @SubscribeEvent
@@ -63,13 +64,11 @@ public class ShamanTotemModel extends Model {
         Entity entity = getBufferedEntity(e.getId());
         if (!(entity instanceof ArmorStand totemAS)) return;
 
+        if (Math.abs(totemCastTimestamp - System.currentTimeMillis()) > CAST_DELAY_MAX_MS) return;
+
         Managers.TickScheduler.scheduleLater(
                 () -> {
                     // Checks to verify this is a totem
-                    // This must be ran with a delay, as the totem spawns on the same tick as the spell cast, so we
-                    // cannot immediately check the timestamp
-                    if (Math.abs(totemCastTimestamp - System.currentTimeMillis()) > CAST_DELAY_MAX_MS) return;
-
                     // These must be ran with a delay, as health and inventory contents
                     // are set a couple ticks after the totem actually spawns
                     if (Math.abs(totemAS.getHealth() - 1.0f) > 0.0001f) return;

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -48,6 +48,7 @@ public class ShamanTotemModel extends Model {
     private int nextTotemSlot = 1;
 
     private static final Pattern SHAMAN_TOTEM_TIMER = Pattern.compile("§c(\\d+)s");
+    private static final double TOTEM_SEARCH_RADIUS = 1.2;
 
     @SubscribeEvent
     public void onTotemSpellCast(SpellCastEvent e) {
@@ -141,12 +142,15 @@ public class ShamanTotemModel extends Model {
                     .getEntitiesOfClass(
                             ArmorStand.class,
                             new AABB(
-                                    entity.position().x - 0.5,
-                                    entity.position().y - 0.1,
-                                    entity.position().z - 0.5,
-                                    entity.position().x + 0.5,
-                                    entity.position().y + 1.7,
-                                    entity.position().z + 0.5));
+                                    entity.position().x - TOTEM_SEARCH_RADIUS,
+                                    entity.position().y
+                                            - 0.35, // Don't modify this unless you are certain it is causing issues
+                                    entity.position().z - TOTEM_SEARCH_RADIUS,
+                                    entity.position().x + TOTEM_SEARCH_RADIUS,
+                                    entity.position().y
+                                            + TOTEM_SEARCH_RADIUS
+                                            + 0.8, // More vertical radius required for totems casted off high places
+                                    entity.position().z + TOTEM_SEARCH_RADIUS));
 
             for (ArmorStand as : toCheck) {
                 if (pendingTotem1Id != null && as.getId() == pendingTotem1Id) {

--- a/common/src/main/java/com/wynntils/wynn/objects/ShamanTotem.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/ShamanTotem.java
@@ -8,14 +8,22 @@ import com.wynntils.mc.objects.Location;
 
 public class ShamanTotem {
     private final int totemNumber;
-    private int timerId;
+    private final int timerEntityId;
+    private final int visibleEntityId;
     private int time;
     private TotemState state;
     private Location location;
 
-    public ShamanTotem(int totemNumber, int timerId, int time, TotemState totemState, Location location) {
+    public ShamanTotem(
+            int totemNumber,
+            int timerEntityId,
+            int visibleEntityId,
+            int time,
+            TotemState totemState,
+            Location location) {
         this.totemNumber = totemNumber;
-        this.timerId = timerId;
+        this.timerEntityId = timerEntityId;
+        this.visibleEntityId = visibleEntityId;
         this.time = time;
         this.state = totemState;
         this.location = location;
@@ -25,12 +33,12 @@ public class ShamanTotem {
         return totemNumber;
     }
 
-    public int getTimerId() {
-        return timerId;
+    public int getTimerEntityId() {
+        return timerEntityId;
     }
 
-    public void setTimerId(int timerId) {
-        this.timerId = timerId;
+    public int getVisibleEntityId() {
+        return visibleEntityId;
     }
 
     public int getTime() {

--- a/common/src/main/java/com/wynntils/wynn/objects/ShamanTotem.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/ShamanTotem.java
@@ -8,8 +8,8 @@ import com.wynntils.mc.objects.Location;
 
 public class ShamanTotem {
     private final int totemNumber;
-    private final int timerEntityId;
     private final int visibleEntityId;
+    private int timerEntityId;
     private int time;
     private TotemState state;
     private Location location;
@@ -33,12 +33,16 @@ public class ShamanTotem {
         return totemNumber;
     }
 
+    public int getVisibleEntityId() {
+        return visibleEntityId;
+    }
+
     public int getTimerEntityId() {
         return timerEntityId;
     }
 
-    public int getVisibleEntityId() {
-        return visibleEntityId;
+    public void setTimerEntityId(int timerEntityId) {
+        this.timerEntityId = timerEntityId;
     }
 
     public int getTime() {


### PR DESCRIPTION
- Fixes flying totems that are destroyed not erasing the internal totem variable.
- Effectively eliminates chances of accidentally "capturing" someone else's totem timer.
  - This still has a very small chance to occur, if both yours and the other player's totems land in the same spot on the exact same tick, within 1 block of each other.
- Fixes totem timers not being "captured" when casting totems into a wall and they bounce
- Fixes totem timers not being "captured" when casting totems from very high locations (eg. from the top of Cinfras gate)
- Fixes missing space in COORDS option

"captured" refers to when the mod looks for and stores an ArmorStand entity that has the totem's time remaining as it's nametag.