### PR TITLE
fix: Fix HadesEvent$Authenticated errors

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/hades/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/core/net/hades/HadesClientHandler.java
@@ -71,7 +71,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
                 WynntilsMod.info("Successfully connected to HadesServer: " + packet.getMessage());
                 userComponent = Component.literal("Successfully connected to HadesServer")
                         .withStyle(ChatFormatting.GREEN);
-                WynntilsMod.postEvent(new HadesEvent.Authenticated());
+                Managers.TickScheduler.scheduleNextTick(() -> WynntilsMod.postEvent(new HadesEvent.Authenticated()));
             }
             case INVALID_TOKEN -> {
                 WynntilsMod.error("Got invalid token when trying to connect to HadesServer: " + packet.getMessage());

--- a/common/src/main/java/com/wynntils/core/net/hades/model/HadesModel.java
+++ b/common/src/main/java/com/wynntils/core/net/hades/model/HadesModel.java
@@ -97,6 +97,8 @@ public final class HadesModel extends Model {
 
     @SubscribeEvent
     public void onAuth(HadesEvent.Authenticated event) {
+        WynntilsMod.info("Starting Hades Ping Scheduler Task");
+
         pingScheduler = Executors.newSingleThreadScheduledExecutor();
         pingScheduler.scheduleAtFixedRate(this::sendPing, 0, MS_PER_PING, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
This fixes issues we've seen, sometimes. I always thought it had something to do with posting events from ForkJoinPool, this fix seems to have confirmed that. With this knowledge, we can transform Athena Login to be an event too, although, we might want to make it async, which is not possible with events.