### PR TITLE
refactor: integrate SpellModel with QuickCastFeature

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.features.user;
 
+import static com.wynntils.wynn.objects.SpellDirection.NO_SPELL;
+
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.FeatureInfo;
@@ -52,7 +54,6 @@ public class QuickCastFeature extends UserFeature {
             StringUtils.compileCCRegex("§([LR]|Right|Left)§-§([LR?]|Right|Left)§-§([LR?]|Right|Left)§");
     private static final Pattern INCORRECT_CLASS_PATTERN = StringUtils.compileCCRegex("§✖§ Class Req: (.+)");
     private static final Pattern LVL_MIN_NOT_REACHED_PATTERN = StringUtils.compileCCRegex("§✖§ (.+) Min: ([0-9]+)");
-    private static final SpellDirection[] NO_SPELL = new SpellDirection[0];
 
     private SpellDirection[] spellInProgress = NO_SPELL;
 

--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -146,7 +146,7 @@ public class QuickCastFeature extends UserFeature {
         if (!WynnUtils.onWorld()) return;
 
         // Clear spell after the 40 tick timeout period
-        if (spellCountdown > 0 && --spellCountdown <= 0) spellInProgress = NO_SPELL;
+        if (spellCountdown > 0 && --spellCountdown <= 0) spellInProgress = SpellDirection.NO_SPELL;
 
         if (SPELL_PACKET_QUEUE.isEmpty()) return;
         if (--packetCountdown > 0) return;
@@ -165,7 +165,7 @@ public class QuickCastFeature extends UserFeature {
     @SubscribeEvent
     public void onWorldChange(WorldStateEvent e) {
         SPELL_PACKET_QUEUE.clear();
-        spellInProgress = NO_SPELL;
+        spellInProgress = SpellDirection.NO_SPELL;
     }
 
     private static void sendCancelReason(MutableComponent reason) {

--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -9,14 +9,12 @@ import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.FeatureInfo;
 import com.wynntils.core.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
-import com.wynntils.mc.event.SubtitleSetTextEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.wynn.event.SpellProgressEvent;
 import com.wynntils.wynn.event.WorldStateEvent;
-import com.wynntils.wynn.model.actionbar.event.SpellSegmentUpdateEvent;
 import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.utils.WynnItemMatchers;
 import com.wynntils.wynn.utils.WynnUtils;
@@ -179,6 +177,4 @@ public class QuickCastFeature extends UserFeature {
         PRIMARY,
         SECONDARY
     }
-
-
 }

--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -14,8 +14,10 @@ import com.wynntils.mc.event.TickEvent;
 import com.wynntils.mc.utils.ItemUtils;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.utils.StringUtils;
+import com.wynntils.wynn.event.SpellProgressEvent;
 import com.wynntils.wynn.event.WorldStateEvent;
 import com.wynntils.wynn.model.actionbar.event.SpellSegmentUpdateEvent;
+import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.utils.WynnItemMatchers;
 import com.wynntils.wynn.utils.WynnUtils;
 import java.util.Arrays;
@@ -29,8 +31,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
-import net.minecraft.network.protocol.game.ServerboundSwingPacket;
-import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -65,22 +65,8 @@ public class QuickCastFeature extends UserFeature {
     private int lastSelectedSlot = 0;
 
     @SubscribeEvent
-    public void onSubtitleUpdate(SubtitleSetTextEvent e) {
-        // only actually used when player is still low-level
-        if (!WynnUtils.onWorld()) return;
-
-        Matcher matcher = SPELL_TITLE_PATTERN.matcher(e.getComponent().getString());
-        if (!matcher.matches()) return;
-
-        SpellDirection[] spell = getSpellFromMatcher(matcher);
-
-        updateSpell(spell);
-    }
-
-    @SubscribeEvent
-    public void updateSpellFromActionBar(SpellSegmentUpdateEvent event) {
-        SpellDirection[] spell = getSpellFromMatcher(event.getMatcher());
-        updateSpell(spell);
+    public void onSpellSequenceUpdate(SpellProgressEvent e) {
+        updateSpell(e.getSpellDirectionArray());
     }
 
     private void updateSpell(SpellDirection[] spell) {
@@ -92,20 +78,6 @@ public class QuickCastFeature extends UserFeature {
             spellInProgress = spell;
             spellCountdown = 40;
         }
-    }
-
-    private static SpellDirection[] getSpellFromMatcher(Matcher spellMatcher) {
-        int size = 1;
-        for (; size < 3; ++size) {
-            if (spellMatcher.group(size + 1).equals("?")) break;
-        }
-
-        SpellDirection[] spell = new SpellDirection[size];
-        for (int i = 0; i < size; ++i) {
-            spell[i] = spellMatcher.group(i + 1).charAt(0) == 'R' ? SpellDirection.RIGHT : SpellDirection.LEFT;
-        }
-
-        return spell;
     }
 
     private void castFirstSpell() {
@@ -208,18 +180,5 @@ public class QuickCastFeature extends UserFeature {
         SECONDARY
     }
 
-    private enum SpellDirection {
-        RIGHT(() -> McUtils.sendSequencedPacket(id -> new ServerboundUseItemPacket(InteractionHand.MAIN_HAND, id))),
-        LEFT(() -> McUtils.sendPacket(new ServerboundSwingPacket(InteractionHand.MAIN_HAND)));
 
-        private final Runnable sendPacketRunnable;
-
-        SpellDirection(Runnable sendPacketRunnable) {
-            this.sendPacketRunnable = sendPacketRunnable;
-        }
-
-        private Runnable getSendPacketRunnable() {
-            return sendPacketRunnable;
-        }
-    }
 }

--- a/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/QuickCastFeature.java
@@ -4,8 +4,6 @@
  */
 package com.wynntils.features.user;
 
-import static com.wynntils.wynn.objects.SpellDirection.NO_SPELL;
-
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.features.UserFeature;
 import com.wynntils.core.features.properties.FeatureInfo;
@@ -55,7 +53,7 @@ public class QuickCastFeature extends UserFeature {
     private static final Pattern INCORRECT_CLASS_PATTERN = StringUtils.compileCCRegex("§✖§ Class Req: (.+)");
     private static final Pattern LVL_MIN_NOT_REACHED_PATTERN = StringUtils.compileCCRegex("§✖§ (.+) Min: ([0-9]+)");
 
-    private SpellDirection[] spellInProgress = NO_SPELL;
+    private SpellDirection[] spellInProgress = SpellDirection.NO_SPELL;
 
     private static final Queue<Runnable> SPELL_PACKET_QUEUE = new LinkedList<>();
 
@@ -71,7 +69,7 @@ public class QuickCastFeature extends UserFeature {
     private void updateSpell(SpellDirection[] spell) {
         if (Arrays.equals(spellInProgress, spell)) return;
         if (spell.length == 3) {
-            spellInProgress = NO_SPELL;
+            spellInProgress = SpellDirection.NO_SPELL;
             spellCountdown = 0;
         } else {
             spellInProgress = spell;

--- a/common/src/main/java/com/wynntils/wynn/event/SpellCastEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellCastEvent.java
@@ -7,6 +7,11 @@ package com.wynntils.wynn.event;
 import com.wynntils.wynn.objects.SpellType;
 import net.minecraftforge.eventbus.api.Event;
 
+/**
+ * Fired upon successful, completed spell cast.
+ * FIXME: This event fires upon every three-click sequence, no matter if the spell was actually casted or not.
+ * FIXME: This event should be checking if the cast failed due to mana/unlock restrictions.
+ */
 public class SpellCastEvent extends Event {
 
     private final SpellType spell;

--- a/common/src/main/java/com/wynntils/wynn/event/SpellCastEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellCastEvent.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.objects.SpellType;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -12,11 +13,12 @@ import net.minecraftforge.eventbus.api.Event;
  * FIXME: This event fires upon every three-click sequence, no matter if the spell was actually casted or not.
  * FIXME: This event should be checking if the cast failed due to mana/unlock restrictions.
  */
-public class SpellCastEvent extends Event {
+public class SpellCastEvent extends SpellEvent {
 
     private final SpellType spell;
 
-    public SpellCastEvent(SpellType spell) {
+    public SpellCastEvent(SpellDirection[] spellDirectionArray, Source source, SpellType spell) {
+        super(spellDirectionArray, source);
         this.spell = spell;
     }
 

--- a/common/src/main/java/com/wynntils/wynn/event/SpellCastEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellCastEvent.java
@@ -6,7 +6,6 @@ package com.wynntils.wynn.event;
 
 import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.objects.SpellType;
-import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Fired upon successful, completed spell cast.

--- a/common/src/main/java/com/wynntils/wynn/event/SpellEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellEvent.java
@@ -1,7 +1,9 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.wynn.event;
 
 import net.minecraftforge.eventbus.api.Event;
 
-public abstract class SpellEvent extends Event {
-
-}
+public abstract class SpellEvent extends Event {}

--- a/common/src/main/java/com/wynntils/wynn/event/SpellEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellEvent.java
@@ -4,6 +4,29 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.wynn.objects.SpellDirection;
 import net.minecraftforge.eventbus.api.Event;
 
-public abstract class SpellEvent extends Event {}
+public abstract class SpellEvent extends Event {
+    private final SpellDirection[] spellDirectionArray;
+    private final Source source;
+
+    protected SpellEvent(SpellDirection[] spellDirectionArray, Source source) {
+        this.spellDirectionArray = spellDirectionArray;
+        this.source = source;
+    }
+
+    public SpellDirection[] getSpellDirectionArray() {
+        return spellDirectionArray.clone();
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public enum Source {
+        HOTBAR,
+        TITLE_LETTER,
+        TITLE_FULL;
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/event/SpellEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellEvent.java
@@ -1,0 +1,7 @@
+package com.wynntils.wynn.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public abstract class SpellEvent extends Event {
+
+}

--- a/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
@@ -1,5 +1,8 @@
 package com.wynntils.wynn.event;
 
+/**
+ * Fired upon user inputting the next click in a sequence to cast a spell.
+ */
 public class SpellProgressEvent extends SpellEvent {
-    
+
 }

--- a/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
@@ -1,5 +1,7 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.wynn.event;
 
-public class SpellProgressEvent extends SpellEvent {
-    
-}
+public class SpellProgressEvent extends SpellEvent {}

--- a/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
@@ -4,6 +4,14 @@
  */
 package com.wynntils.wynn.event;
 
+import com.wynntils.wynn.objects.SpellDirection;
+
+/**
+ * Fired upon user inputting the next click in a sequence to cast a spell.
+ */
 public class SpellProgressEvent extends SpellEvent {
-    
+
+    public SpellProgressEvent(SpellDirection[] spellDirectionArray, Source source) {
+        super(spellDirectionArray, source);
+    }
 }

--- a/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/SpellProgressEvent.java
@@ -1,0 +1,5 @@
+package com.wynntils.wynn.event;
+
+public class SpellProgressEvent extends SpellEvent {
+    
+}

--- a/common/src/main/java/com/wynntils/wynn/event/TrySpellCastEvent.java
+++ b/common/src/main/java/com/wynntils/wynn/event/TrySpellCastEvent.java
@@ -12,11 +12,11 @@ import com.wynntils.wynn.objects.SpellType;
  * FIXME: This event fires upon every three-click sequence, no matter if the spell was actually casted or not.
  * FIXME: This event should be checking if the cast failed due to mana/unlock restrictions.
  */
-public class SpellCastEvent extends SpellEvent {
+public class TrySpellCastEvent extends SpellEvent {
 
     private final SpellType spell;
 
-    public SpellCastEvent(SpellDirection[] spellDirectionArray, Source source, SpellType spell) {
+    public TrySpellCastEvent(SpellDirection[] spellDirectionArray, Source source, SpellType spell) {
         super(spellDirectionArray, source);
         this.spell = spell;
     }

--- a/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/ShamanTotemModel.java
@@ -14,8 +14,8 @@ import com.wynntils.mc.event.SetEntityDataEvent;
 import com.wynntils.mc.objects.Location;
 import com.wynntils.mc.utils.McUtils;
 import com.wynntils.wynn.event.CharacterUpdateEvent;
-import com.wynntils.wynn.event.SpellCastEvent;
 import com.wynntils.wynn.event.TotemEvent;
+import com.wynntils.wynn.event.TrySpellCastEvent;
 import com.wynntils.wynn.objects.ShamanTotem;
 import com.wynntils.wynn.objects.SpellType;
 import com.wynntils.wynn.utils.WynnUtils;
@@ -52,7 +52,7 @@ public class ShamanTotemModel extends Model {
     private static final int CAST_DELAY_MAX_MS = 450;
 
     @SubscribeEvent
-    public void onTotemSpellCast(SpellCastEvent e) {
+    public void onTotemSpellCast(TrySpellCastEvent e) {
         if (e.getSpell() != SpellType.TOTEM) return;
 
         totemCastTimestamp = System.currentTimeMillis() - 40; // 40 == 2 ticks

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -24,7 +24,7 @@ public class SpellModel extends Model {
     private static final Pattern SPELL_TITLE_PATTERN =
             StringUtils.compileCCRegex("§([LR]|Right|Left)§-§([LR?]|Right|Left)§-§([LR?]|Right|Left)§");
 
-    private SpellDirection[] lastSpell = new SpellDirection[3];
+    private SpellDirection[] lastSpell = SpellDirection.NO_SPELL;
 
     @SubscribeEvent
     public void onSpellSegmentUpdate(SpellSegmentUpdateEvent e) {

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -14,11 +14,9 @@ import com.wynntils.wynn.event.SpellProgressEvent;
 import com.wynntils.wynn.model.actionbar.event.SpellSegmentUpdateEvent;
 import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.objects.SpellType;
-
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class SpellModel extends Model {
@@ -35,7 +33,8 @@ public class SpellModel extends Model {
         WynntilsMod.postEvent(new SpellProgressEvent(spell, SpellEvent.Source.HOTBAR));
 
         if (!matcher.group(3).equals("?")) {
-            WynntilsMod.postEvent(new SpellCastEvent(spell, SpellEvent.Source.HOTBAR, SpellType.fromSpellDirectionArray(spell)));
+            WynntilsMod.postEvent(
+                    new SpellCastEvent(spell, SpellEvent.Source.HOTBAR, SpellType.fromSpellDirectionArray(spell)));
         }
     }
 
@@ -46,7 +45,8 @@ public class SpellModel extends Model {
 
         SpellDirection[] spell = getSpellFromMatcher(matcher);
         // This check looks for the "t" in Right and Left, that do not exist in L and R, to set the source
-        SpellEvent.Source source = (matcher.group(1).endsWith("t")) ? SpellEvent.Source.TITLE_FULL : SpellEvent.Source.TITLE_LETTER;
+        SpellEvent.Source source =
+                (matcher.group(1).endsWith("t")) ? SpellEvent.Source.TITLE_FULL : SpellEvent.Source.TITLE_LETTER;
 
         WynntilsMod.postEvent(new SpellProgressEvent(spell, source));
 

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -8,9 +8,9 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
 import com.wynntils.utils.StringUtils;
-import com.wynntils.wynn.event.SpellCastEvent;
 import com.wynntils.wynn.event.SpellEvent;
 import com.wynntils.wynn.event.SpellProgressEvent;
+import com.wynntils.wynn.event.TrySpellCastEvent;
 import com.wynntils.wynn.model.actionbar.event.SpellSegmentUpdateEvent;
 import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.objects.SpellType;
@@ -39,7 +39,7 @@ public class SpellModel extends Model {
 
         if (!matcher.group(3).equals("?")) {
             WynntilsMod.postEvent(
-                    new SpellCastEvent(spell, SpellEvent.Source.HOTBAR, SpellType.fromSpellDirectionArray(spell)));
+                    new TrySpellCastEvent(spell, SpellEvent.Source.HOTBAR, SpellType.fromSpellDirectionArray(spell)));
         }
     }
 
@@ -59,7 +59,7 @@ public class SpellModel extends Model {
         WynntilsMod.postEvent(new SpellProgressEvent(spell, source));
 
         if (!matcher.group(3).equals("?")) {
-            WynntilsMod.postEvent(new SpellCastEvent(spell, source, SpellType.fromSpellDirectionArray(spell)));
+            WynntilsMod.postEvent(new TrySpellCastEvent(spell, source, SpellType.fromSpellDirectionArray(spell)));
         }
     }
 

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class SpellModel extends Model {
-    // If you modify please test with
+    // If you modify please test with link below
     // If you pass the tests and it still doesn't work, please resync tests with the game and update the link here
     // https://regexr.com/76ijo
     private static final Pattern SPELL_TITLE_PATTERN = Pattern.compile(

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -5,49 +5,67 @@
 package com.wynntils.wynn.model;
 
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
+import com.wynntils.utils.StringUtils;
 import com.wynntils.wynn.event.SpellCastEvent;
+import com.wynntils.wynn.event.SpellEvent;
+import com.wynntils.wynn.event.SpellProgressEvent;
 import com.wynntils.wynn.model.actionbar.event.SpellSegmentUpdateEvent;
+import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.objects.SpellType;
+
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class SpellModel extends Model {
-    private static final Pattern LEVEL_1_SPELL_PATTERN =
-            Pattern.compile("§a(Left|Right|\\?)§7-§a(Left|Right|\\?)§7-§r§a(Left|Right|\\?)§r");
-    private static final Pattern LOW_LEVEL_SPELL_PATTERN = Pattern.compile("§a([LR?])§7-§a([LR?])§7-§r§a([LR?])§r");
+    private static final Pattern SPELL_TITLE_PATTERN =
+            StringUtils.compileCCRegex("§([LR]|Right|Left)§-§([LR?]|Right|Left)§-§([LR?]|Right|Left)§");
 
     @SubscribeEvent
     public void onSpellSegmentUpdate(SpellSegmentUpdateEvent e) {
         Matcher matcher = e.getMatcher();
         if (!matcher.matches()) return;
 
-        if (matcher.group(3) != null && !matcher.group(3).equals("?")) {
-            boolean[] lastSpell = new boolean[3];
-            lastSpell[0] = matcher.group(1).charAt(0) == 'R' ? SpellType.SPELL_RIGHT : SpellType.SPELL_LEFT;
-            lastSpell[1] = matcher.group(2).charAt(0) == 'R' ? SpellType.SPELL_RIGHT : SpellType.SPELL_LEFT;
-            lastSpell[2] = matcher.group(3).charAt(0) == 'R' ? SpellType.SPELL_RIGHT : SpellType.SPELL_LEFT;
-            SpellCastEvent spellCasted = new SpellCastEvent(SpellType.fromBooleanArray(lastSpell));
-            WynntilsMod.postEvent(spellCasted);
+        SpellDirection[] spell = getSpellFromMatcher(e.getMatcher());
+
+        WynntilsMod.postEvent(new SpellProgressEvent(spell, SpellEvent.Source.HOTBAR));
+
+        if (!matcher.group(3).equals("?")) {
+            WynntilsMod.postEvent(new SpellCastEvent(spell, SpellEvent.Source.HOTBAR, SpellType.fromSpellDirectionArray(spell)));
         }
     }
 
     @SubscribeEvent
     public void onSubtitleSetText(SubtitleSetTextEvent e) {
-        int level = Managers.Character.getXpLevel();
-        String right = (level == 1) ? "Right" : "R";
-        Matcher m = (level == 1 ? LEVEL_1_SPELL_PATTERN : LOW_LEVEL_SPELL_PATTERN)
-                .matcher(e.getComponent().getString());
-        if (!m.matches() || m.group(3).equals("?")) return;
+        Matcher matcher = SPELL_TITLE_PATTERN.matcher(e.getComponent().getString());
+        if (!matcher.matches()) return;
 
-        boolean[] spell = new boolean[3];
-        for (int i = 0; i < 3; i++) {
-            spell[i] = m.group(i + 1).equals(right) ? SpellType.SPELL_RIGHT : SpellType.SPELL_LEFT;
+        SpellDirection[] spell = getSpellFromMatcher(matcher);
+        // This check looks for the "t" in Right and Left, that do not exist in L and R, to set the source
+        SpellEvent.Source source = (matcher.group(1).endsWith("t")) ? SpellEvent.Source.TITLE_FULL : SpellEvent.Source.TITLE_LETTER;
+
+        WynntilsMod.postEvent(new SpellProgressEvent(spell, source));
+
+        if (!matcher.group(3).equals("?")) {
+            WynntilsMod.postEvent(new SpellCastEvent(spell, source, SpellType.fromSpellDirectionArray(spell)));
         }
-        SpellCastEvent spellCasted = new SpellCastEvent(SpellType.fromBooleanArray(spell));
-        WynntilsMod.postEvent(spellCasted);
+    }
+
+    private static SpellDirection[] getSpellFromMatcher(MatchResult spellMatcher) {
+        int size = 1;
+        for (; size < 3; ++size) {
+            if (spellMatcher.group(size + 1).equals("?")) break;
+        }
+
+        SpellDirection[] spell = new SpellDirection[size];
+        for (int i = 0; i < size; ++i) {
+            spell[i] = spellMatcher.group(i + 1).charAt(0) == 'R' ? SpellDirection.RIGHT : SpellDirection.LEFT;
+        }
+
+        return spell;
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -14,6 +14,7 @@ import com.wynntils.wynn.event.SpellProgressEvent;
 import com.wynntils.wynn.model.actionbar.event.SpellSegmentUpdateEvent;
 import com.wynntils.wynn.objects.SpellDirection;
 import com.wynntils.wynn.objects.SpellType;
+import java.util.Arrays;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,12 +24,16 @@ public class SpellModel extends Model {
     private static final Pattern SPELL_TITLE_PATTERN =
             StringUtils.compileCCRegex("§([LR]|Right|Left)§-§([LR?]|Right|Left)§-§([LR?]|Right|Left)§");
 
+    private SpellDirection[] lastSpell = new SpellDirection[3];
+
     @SubscribeEvent
     public void onSpellSegmentUpdate(SpellSegmentUpdateEvent e) {
         Matcher matcher = e.getMatcher();
         if (!matcher.matches()) return;
 
         SpellDirection[] spell = getSpellFromMatcher(e.getMatcher());
+        if (Arrays.equals(spell, lastSpell)) return; // Wynn sometimes sends duplicate packets, skip those
+        lastSpell = spell;
 
         WynntilsMod.postEvent(new SpellProgressEvent(spell, SpellEvent.Source.HOTBAR));
 
@@ -44,6 +49,9 @@ public class SpellModel extends Model {
         if (!matcher.matches()) return;
 
         SpellDirection[] spell = getSpellFromMatcher(matcher);
+        if (Arrays.equals(spell, lastSpell)) return; // Wynn sometimes sends duplicate packets, skip those
+        lastSpell = spell;
+
         // This check looks for the "t" in Right and Left, that do not exist in L and R, to set the source
         SpellEvent.Source source =
                 (matcher.group(1).endsWith("t")) ? SpellEvent.Source.TITLE_FULL : SpellEvent.Source.TITLE_LETTER;

--- a/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
+++ b/common/src/main/java/com/wynntils/wynn/model/SpellModel.java
@@ -7,7 +7,6 @@ package com.wynntils.wynn.model;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
-import com.wynntils.utils.StringUtils;
 import com.wynntils.wynn.event.SpellEvent;
 import com.wynntils.wynn.event.SpellProgressEvent;
 import com.wynntils.wynn.event.TrySpellCastEvent;
@@ -21,8 +20,11 @@ import java.util.regex.Pattern;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class SpellModel extends Model {
-    private static final Pattern SPELL_TITLE_PATTERN =
-            StringUtils.compileCCRegex("§([LR]|Right|Left)§-§([LR?]|Right|Left)§-§([LR?]|Right|Left)§");
+    // If you modify please test with
+    // If you pass the tests and it still doesn't work, please resync tests with the game and update the link here
+    // https://regexr.com/76ijo
+    private static final Pattern SPELL_TITLE_PATTERN = Pattern.compile(
+            "§a([LR]|Right|Left)§7-§[a7](?:§n)?([LR?]|Right|Left)§7-§r§[a7](?:§n)?([LR?]|Right|Left)§r");
 
     private SpellDirection[] lastSpell = SpellDirection.NO_SPELL;
 

--- a/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
@@ -16,6 +16,8 @@ public enum SpellDirection {
 
     private final Runnable sendPacketRunnable;
 
+    public static final SpellDirection[] NO_SPELL = new SpellDirection[0];
+
     SpellDirection(Runnable sendPacketRunnable) {
         this.sendPacketRunnable = sendPacketRunnable;
     }

--- a/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
@@ -1,11 +1,14 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.wynn.objects;
 
 import com.wynntils.mc.utils.McUtils;
+import java.util.Arrays;
 import net.minecraft.network.protocol.game.ServerboundSwingPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
 import net.minecraft.world.InteractionHand;
-
-import java.util.Arrays;
 
 public enum SpellDirection {
     RIGHT(() -> McUtils.sendSequencedPacket(id -> new ServerboundUseItemPacket(InteractionHand.MAIN_HAND, id))),

--- a/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
@@ -1,0 +1,27 @@
+package com.wynntils.wynn.objects;
+
+import com.wynntils.mc.utils.McUtils;
+import net.minecraft.network.protocol.game.ServerboundSwingPacket;
+import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
+import net.minecraft.world.InteractionHand;
+
+import java.util.Arrays;
+
+public enum SpellDirection {
+    RIGHT(() -> McUtils.sendSequencedPacket(id -> new ServerboundUseItemPacket(InteractionHand.MAIN_HAND, id))),
+    LEFT(() -> McUtils.sendPacket(new ServerboundSwingPacket(InteractionHand.MAIN_HAND)));
+
+    private final Runnable sendPacketRunnable;
+
+    SpellDirection(Runnable sendPacketRunnable) {
+        this.sendPacketRunnable = sendPacketRunnable;
+    }
+
+    public Runnable getSendPacketRunnable() {
+        return sendPacketRunnable;
+    }
+
+    public static SpellDirection[] invertArray(SpellDirection[] initial) {
+        return (SpellDirection[]) Arrays.stream(initial).map((x) -> (x == RIGHT) ? LEFT : RIGHT).toArray();
+    }
+}

--- a/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/SpellDirection.java
@@ -22,6 +22,6 @@ public enum SpellDirection {
     }
 
     public static SpellDirection[] invertArray(SpellDirection[] initial) {
-        return (SpellDirection[]) Arrays.stream(initial).map((x) -> (x == RIGHT) ? LEFT : RIGHT).toArray();
+        return Arrays.stream(initial).map((x) -> (x == RIGHT) ? LEFT : RIGHT).toArray(SpellDirection[]::new);
     }
 }

--- a/common/src/main/java/com/wynntils/wynn/objects/SpellType.java
+++ b/common/src/main/java/com/wynntils/wynn/objects/SpellType.java
@@ -40,18 +40,15 @@ public enum SpellType {
     THIRD_SPELL(ClassType.None, 3, "3rd Spell", 0, 0),
     FOURTH_SPELL(ClassType.None, 4, "4th Spell", 0, 0);
 
-    public static final boolean SPELL_RIGHT = true;
-    public static final boolean SPELL_LEFT = false;
-
-    private static final boolean[] RLR = {SPELL_RIGHT, SPELL_LEFT, SPELL_RIGHT};
-    private static final boolean[] RRR = {SPELL_RIGHT, SPELL_RIGHT, SPELL_RIGHT};
-    private static final boolean[] RLL = {SPELL_RIGHT, SPELL_LEFT, SPELL_LEFT};
-    private static final boolean[] RRL = {SPELL_RIGHT, SPELL_RIGHT, SPELL_LEFT};
+    private static final SpellDirection[] RLR = {SpellDirection.RIGHT, SpellDirection.LEFT, SpellDirection.RIGHT};
+    private static final SpellDirection[] RRR = {SpellDirection.RIGHT, SpellDirection.RIGHT, SpellDirection.RIGHT};
+    private static final SpellDirection[] RLL = {SpellDirection.RIGHT, SpellDirection.LEFT, SpellDirection.LEFT};
+    private static final SpellDirection[] RRL = {SpellDirection.RIGHT, SpellDirection.RIGHT, SpellDirection.LEFT};
     // Archer only
-    private static final boolean[] LRL = {SPELL_LEFT, SPELL_RIGHT, SPELL_LEFT};
-    private static final boolean[] LLL = {SPELL_LEFT, SPELL_LEFT, SPELL_LEFT};
-    private static final boolean[] LRR = {SPELL_LEFT, SPELL_RIGHT, SPELL_RIGHT};
-    private static final boolean[] LLR = {SPELL_LEFT, SPELL_LEFT, SPELL_RIGHT};
+    private static final SpellDirection[] LRL = SpellDirection.invertArray(RLR);
+    private static final SpellDirection[] LLL = SpellDirection.invertArray(RRR);
+    private static final SpellDirection[] LRR = SpellDirection.invertArray(RLL);
+    private static final SpellDirection[] LLR = SpellDirection.invertArray(RRL);
 
     private static final int[][] MANA_REDUCTION_LEVELS = {
         {},
@@ -143,7 +140,7 @@ public enum SpellType {
     public static SpellType fromName(String name) {
         for (SpellType spellType : values()) {
             // After the matching part, the string needs to be done, or a blank character
-            // must appaear
+            // must appear
             if (name.startsWith(spellType.name)
                     && (name.length() == spellType.name.length()
                             || String.valueOf(name.charAt(spellType.name.length()))
@@ -179,7 +176,7 @@ public enum SpellType {
         return IdentificationProfile.getAsShortName(getGenericName() + " Cost", isRaw);
     }
 
-    public static SpellType fromBooleanArray(boolean[] casted) {
+    public static SpellType fromSpellDirectionArray(SpellDirection[] casted) {
         int spellNumber = 4;
         if (Arrays.equals(casted, RLR) || Arrays.equals(casted, LRL)) {
             spellNumber = 1;


### PR DESCRIPTION
SpellProgressEvent and SpellCastEvent inherit from abstract SpellEvent, which allows those events to contain a SpellDirection[] array, as well as where the spell came from (for future use).

SpellProgressEvent is fired upon every user input to cast a spell.
SpellCastEvent is (incorrectly) fired upon every completed spell sequence. This should be fixed to only fire upon successful casts; but we don't really have a way of detecting this yet.

QuickCastFeature now relies on the singular SpellProgressEvent for it's purposes.

SpellDirection has been moved to it's own enum, and given an invert method for comparison later in SpellType.