### PR TITLE
Don't build on drafts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,11 @@ name: Spotless and Build
 on:
   workflow_dispatch:
   pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   format-and-build:
+    if: '! github.event.pull_request.draft'
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code


### PR DESCRIPTION
Stops building/formatting on draft commits. Instead, builds/formats when drafts are converted to normal.