### PR TITLE
feat: Prohibit rename on spell cast

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/features/FeatureManager.java
@@ -58,6 +58,7 @@ import com.wynntils.features.user.MythicBlockerFeature;
 import com.wynntils.features.user.MythicBoxScalerFeature;
 import com.wynntils.features.user.QuickCastFeature;
 import com.wynntils.features.user.SoulPointTimerFeature;
+import com.wynntils.features.user.SpellCastInfoFeature;
 import com.wynntils.features.user.TerritoryDefenseMessageFeature;
 import com.wynntils.features.user.TradeMarketAutoOpenChatFeature;
 import com.wynntils.features.user.TradeMarketPriceConversionFeature;
@@ -201,6 +202,7 @@ public final class FeatureManager extends Manager {
         registerFeature(new ShamanMasksOverlayFeature());
         registerFeature(new ShamanTotemTrackingFeature());
         registerFeature(new SoulPointTimerFeature());
+        registerFeature(new SpellCastInfoFeature());
         registerFeature(new StatusOverlayFeature());
         registerFeature(new TerritoryDefenseMessageFeature());
         registerFeature(new TerritoryMessageRedirectFeature());

--- a/common/src/main/java/com/wynntils/features/user/SpellCastInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/SpellCastInfoFeature.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © Wynntils 2022.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.user;
+
+import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.components.Models;
+import com.wynntils.core.features.UserFeature;
+import com.wynntils.handlers.item.event.ItemRenamedEvent;
+import com.wynntils.mc.event.RenderEvent;
+import com.wynntils.mc.event.TickEvent;
+import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.utils.mc.McUtils;
+import java.util.Optional;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class SpellCastInfoFeature extends UserFeature {
+    private static final int SHOW_TICKS = 40;
+
+    private int spellTimer;
+    private Component spellMessage;
+
+    @SubscribeEvent
+    public void onItemRename(ItemRenamedEvent event) {
+        ItemStack itemStack = event.getItemStack();
+        Optional<GearItem> gearItemOpt = Models.Item.asWynnItem(itemStack, GearItem.class);
+        if (gearItemOpt.isEmpty()) return;
+
+        GearItem gearItem = gearItemOpt.get();
+        if (!gearItem.getGearProfile().getGearInfo().getType().isWeapon()) return;
+
+        // Check that we are not just restoring the old name
+        if (event.getNewName().equals(gearItem.getGearProfile().getDisplayName())) return;
+
+        // This really is new info!
+        event.setCanceled(true);
+        spellTimer = SHOW_TICKS;
+        spellMessage = Component.literal(event.getNewName());
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent event) {
+        if (spellTimer <= 0) return;
+
+        spellTimer--;
+    }
+
+    @SubscribeEvent
+    public void onRender(RenderEvent.Post event) {
+        if (spellTimer <= 0) return;
+
+        // Render it the same way vanilla renders item changes
+        int alpha = (int) Math.min((float) spellTimer * 256.0F / 10.0F, 255.0F);
+        if (alpha <= 0) return;
+
+        Window window = McUtils.mc().getWindow();
+        var screenWidth = window.getGuiScaledWidth();
+        var screenHeight = window.getGuiScaledHeight();
+
+        int width = McUtils.mc().gui.getFont().width(spellMessage);
+        int x = (screenWidth - width) / 2;
+        int y = screenHeight - 59;
+
+        PoseStack poseStack = event.getPoseStack();
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        McUtils.mc().gui.getFont().drawShadow(poseStack, spellMessage, x, y, 0xFFFFFF + (alpha << 24));
+        RenderSystem.disableBlend();
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -101,7 +101,11 @@ public class ItemHandler extends Handler {
         Component existingName = existingItem.getHoverName();
         Component newName = newItem.getHoverName();
         if (!newName.equals(existingName)) {
-            WynntilsMod.postEvent(new ItemRenamedEvent(existingName.getString(), newName.getString()));
+            ItemRenamedEvent event = new ItemRenamedEvent(newItem, existingName.getString(), newName.getString());
+            WynntilsMod.postEvent(event);
+            if (event.isCanceled()) {
+                newItem.setHoverName(existingName);
+            }
         }
     }
 

--- a/common/src/main/java/com/wynntils/handlers/item/event/ItemRenamedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/item/event/ItemRenamedEvent.java
@@ -4,15 +4,24 @@
  */
 package com.wynntils.handlers.item.event;
 
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+@Cancelable
 public class ItemRenamedEvent extends Event {
+    private final ItemStack itemStack;
     private final String oldName;
     private final String newName;
 
-    public ItemRenamedEvent(String oldName, String newName) {
+    public ItemRenamedEvent(ItemStack itemStack, String oldName, String newName) {
+        this.itemStack = itemStack;
         this.oldName = oldName;
         this.newName = newName;
+    }
+
+    public ItemStack getItemStack() {
+        return itemStack;
     }
 
     public String getOldName() {

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -655,6 +655,7 @@
   "feature.wynntils.shamanTotemTracking.trackTotem.name": "Track Totem",
   "feature.wynntils.soulPointTimer.lore": "Time until next soul point: %s",
   "feature.wynntils.soulPointTimer.name": "Soul Point Timer",
+  "feature.wynntils.spellCastInfo.name": "Prohibit Rename on Spell Cast Info",
   "feature.wynntils.statusOverlay.name": "Statuses",
   "feature.wynntils.statusOverlay.overlay.status.name": "Status Overlay",
   "feature.wynntils.statusOverlay.overlay.status.textShadow.description": "What should the text shadow look like?",


### PR DESCRIPTION
Ideally, this should be an Overlay, but I'm not sure how to make an overlay that preserves the Vanilla layout as default. Hopefully someone can improve this later on.