### PR TITLE
fix: Mixed bag of fixes (gear rewrite preparation)

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -118,7 +118,7 @@ public final class WynntilsMod {
                             ClickEvent.Action.RUN_COMMAND, "/feature enable " + feature.getShortName())));
 
             McUtils.sendMessageToClient(Component.literal("Wynntils error: Feature '" + feature.getTranslatedName()
-                            + "' has crashed and will be disabled.")
+                            + "' has crashed and will be disabled. ")
                     .withStyle(ChatFormatting.RED)
                     .append(enableMessage));
         }

--- a/common/src/main/java/com/wynntils/core/features/Feature.java
+++ b/common/src/main/java/com/wynntils/core/features/Feature.java
@@ -173,9 +173,8 @@ public abstract class Feature extends AbstractConfigurable implements Translatab
     }
 
     public final void crash() {
-        state = FeatureState.CRASHED;
-
         disable();
+        state = FeatureState.CRASHED;
     }
 
     /** Whether a feature is enabled */

--- a/common/src/main/java/com/wynntils/features/user/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ItemTextOverlayFeature.java
@@ -310,7 +310,7 @@ public class ItemTextOverlayFeature extends UserFeature {
 
             String text = skill.getSymbol();
             TextRenderSetting style = TextRenderSetting.DEFAULT
-                    .withCustomColor(CustomColor.fromChatFormatting(skill.getColor()))
+                    .withCustomColor(CustomColor.fromChatFormatting(skill.getColorCode()))
                     .withTextShadow(skillIconShadow);
 
             return new TextOverlay(new TextRenderTask(text, style), -1, 1, 0.9f);
@@ -335,7 +335,7 @@ public class ItemTextOverlayFeature extends UserFeature {
 
             String text = skill.getSymbol();
             TextRenderSetting style = TextRenderSetting.DEFAULT
-                    .withCustomColor(CustomColor.fromChatFormatting(skill.getColor()))
+                    .withCustomColor(CustomColor.fromChatFormatting(skill.getColorCode()))
                     .withTextShadow(skillIconShadow);
 
             return new TextOverlay(new TextRenderTask(text, style), -1, 1, 0.9f);

--- a/common/src/main/java/com/wynntils/features/user/inventory/UnidentifiedItemIconFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/UnidentifiedItemIconFeature.java
@@ -16,12 +16,30 @@ import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.items.items.game.GearBoxItem;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.type.Pair;
+import java.util.Map;
 import java.util.Optional;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @FeatureInfo(category = FeatureCategory.INVENTORY)
 public class UnidentifiedItemIconFeature extends UserFeature {
+    private static final Map<GearType, Pair<Integer, Integer>> TEXTURE_COORDS = Map.ofEntries(
+            Map.entry(GearType.SPEAR, Pair.of(16 * 1, 16 * 1)),
+            Map.entry(GearType.WAND, Pair.of(16 * 0, 16 * 1)),
+            Map.entry(GearType.DAGGER, Pair.of(16 * 2, 16 * 1)),
+            Map.entry(GearType.BOW, Pair.of(16 * 3, 16 * 1)),
+            Map.entry(GearType.RELIK, Pair.of(16 * 0, 16 * 2)),
+            Map.entry(GearType.RING, Pair.of(16 * 1, 16 * 2)),
+            Map.entry(GearType.BRACELET, Pair.of(16 * 2, 16 * 2)),
+            Map.entry(GearType.NECKLACE, Pair.of(16 * 3, 16 * 2)),
+            Map.entry(GearType.HELMET, Pair.of(16 * 0, 16 * 0)),
+            Map.entry(GearType.CHESTPLATE, Pair.of(16 * 1, 16 * 0)),
+            Map.entry(GearType.LEGGINGS, Pair.of(16 * 2, 16 * 0)),
+            Map.entry(GearType.BOOTS, Pair.of(16 * 3, 16 * 0)),
+            Map.entry(GearType.MASTERY_TOME, Pair.of(16 * 0, 16 * 3)),
+            Map.entry(GearType.CHARM, Pair.of(16 * 1, 16 * 3)));
+
     @Config
     public UnidentifiedItemTextures texture = UnidentifiedItemTextures.Wynn;
 
@@ -41,6 +59,8 @@ public class UnidentifiedItemIconFeature extends UserFeature {
 
         GearType gearType = gearBoxItemOpt.get().getGearType();
 
+        int textureX = TEXTURE_COORDS.get(gearType).a();
+        int textureY = TEXTURE_COORDS.get(gearType).b();
         RenderUtils.drawTexturedRect(
                 new PoseStack(),
                 Texture.GEAR_ICONS.resource(),
@@ -49,8 +69,8 @@ public class UnidentifiedItemIconFeature extends UserFeature {
                 400,
                 12,
                 12,
-                gearType.getIconTextureX(),
-                gearType.getIconTextureY() + texture.getTextureYOffset(),
+                textureX,
+                textureY + texture.getTextureYOffset(),
                 16,
                 16,
                 Texture.GEAR_ICONS.width(),

--- a/common/src/main/java/com/wynntils/features/user/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/tooltips/ItemStatInfoFeature.java
@@ -14,13 +14,12 @@ import com.wynntils.core.features.properties.FeatureInfo.Stability;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.models.items.WynnItemCache;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.utils.MathUtils;
+import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.wynn.ColorScaleUtils;
 import com.wynntils.utils.wynn.GearTooltipBuilder;
 import com.wynntils.utils.wynn.WynnItemUtils;
-import java.awt.Color;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Optional;
@@ -28,7 +27,6 @@ import java.util.Set;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Style;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.lwjgl.glfw.GLFW;
 
@@ -130,69 +128,10 @@ public class ItemStatInfoFeature extends UserFeature {
     }
 
     private MutableComponent getPerfectName(String itemName) {
-        MutableComponent newName = Component.literal("").withStyle(ChatFormatting.BOLD);
-
-        String name = "Perfect " + itemName;
-
-        int cycle = 5000;
-
-        /*
-         * This math was originally based off Avaritia code.
-         * Special thanks for Morpheus1101 and SpitefulFox
-         * Avaritia Repo: https://github.com/Morpheus1101/Avaritia
-         */
-
-        int time = (int) (System.currentTimeMillis() % cycle);
-        for (int i = 0; i < name.length(); i++) {
-            int hue = (time + i * cycle / 7) % cycle;
-            Style color = Style.EMPTY
-                    .withColor(Color.HSBtoRGB((hue / (float) cycle), 0.8F, 0.8F))
-                    .withItalic(false);
-
-            newName.append(Component.literal(String.valueOf(name.charAt(i))).setStyle(color));
-        }
-
-        return newName;
+        return ComponentUtils.makeRainbowStyle("Perfect " + itemName);
     }
 
     private MutableComponent getDefectiveName(String itemName) {
-        MutableComponent newName = Component.literal("").withStyle(ChatFormatting.BOLD, ChatFormatting.DARK_RED);
-        newName.setStyle(newName.getStyle().withItalic(false));
-
-        String name = "Defective " + itemName;
-
-        boolean obfuscated = Math.random() < obfuscationChanceStart;
-        StringBuilder current = new StringBuilder();
-
-        for (int i = 0; i < name.length() - 1; i++) {
-            current.append(name.charAt(i));
-
-            float chance =
-                    MathUtils.lerp(obfuscationChanceStart, obfuscationChanceEnd, (i + 1) / (float) (name.length() - 1));
-
-            if (!obfuscated && Math.random() < chance) {
-                newName.append(Component.literal(current.toString()).withStyle(Style.EMPTY.withItalic(false)));
-                current = new StringBuilder();
-
-                obfuscated = true;
-            } else if (obfuscated && Math.random() > chance) {
-                newName.append(Component.literal(current.toString())
-                        .withStyle(Style.EMPTY.withObfuscated(true).withItalic(false)));
-                current = new StringBuilder();
-
-                obfuscated = false;
-            }
-        }
-
-        current.append(name.charAt(name.length() - 1));
-
-        if (obfuscated) {
-            newName.append(Component.literal(current.toString())
-                    .withStyle(Style.EMPTY.withItalic(false).withObfuscated(true)));
-        } else {
-            newName.append(Component.literal(current.toString()).withStyle(Style.EMPTY.withItalic(false)));
-        }
-
-        return newName;
+        return ComponentUtils.makeObfuscated("Defective " + itemName, obfuscationChanceStart, obfuscationChanceEnd);
     }
 }

--- a/common/src/main/java/com/wynntils/models/character/actionbar/PowderSpecialSegment.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/PowderSpecialSegment.java
@@ -34,7 +34,7 @@ public class PowderSpecialSegment implements ActionBarSegment {
     }
 
     private void updatePowderSpecial(Matcher matcher) {
-        powderSpecialType = Powder.getFromSymbol(matcher.group(1).charAt(0));
+        powderSpecialType = Powder.getFromSymbol(matcher.group(1));
         powderSpecialCharge = Integer.parseInt(matcher.group(2));
     }
 

--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -58,8 +58,12 @@ public enum ClassType {
         return isReskinned ? getReskinnedName() : getName();
     }
 
+    public String getFullName() {
+        return name + "/" + reskinnedName;
+    }
+
     @Override
     public String toString() {
-        return name + "/" + reskinnedName;
+        return getFullName();
     }
 }

--- a/common/src/main/java/com/wynntils/models/concepts/Element.java
+++ b/common/src/main/java/com/wynntils/models/concepts/Element.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.concepts;
+
+import com.wynntils.utils.StringUtils;
+import net.minecraft.ChatFormatting;
+
+public enum Element {
+    FIRE("✹", ChatFormatting.RED),
+    WATER("❉", ChatFormatting.AQUA),
+    AIR("❋", ChatFormatting.WHITE),
+    THUNDER("✦", ChatFormatting.YELLOW),
+    EARTH("✤", ChatFormatting.DARK_GREEN);
+
+    private final String symbol;
+    private final ChatFormatting colorCode;
+    private final String displayName;
+
+    Element(String symbol, ChatFormatting colorCode) {
+        this.symbol = symbol;
+        this.colorCode = colorCode;
+        this.displayName = StringUtils.capitalized(this.name());
+    }
+
+    public static Element fromSymbol(String symbol) {
+        for (Element element : Element.values()) {
+            if (element.symbol.equals(symbol)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public ChatFormatting getColorCode() {
+        return colorCode;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/concepts/Powder.java
+++ b/common/src/main/java/com/wynntils/models/concepts/Powder.java
@@ -14,36 +14,38 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 
 public enum Powder {
-    EARTH('✤', Items.LIME_DYE, Items.GREEN_DYE, ChatFormatting.DARK_GREEN, ChatFormatting.GREEN),
-    THUNDER('✦', Items.YELLOW_DYE, Items.ORANGE_DYE, ChatFormatting.YELLOW, ChatFormatting.GOLD),
-    WATER('❉', Items.LIGHT_BLUE_DYE, Items.CYAN_DYE, ChatFormatting.AQUA, ChatFormatting.DARK_AQUA),
-    FIRE('✹', Items.PINK_DYE, Items.RED_DYE, ChatFormatting.RED, ChatFormatting.DARK_RED),
-    AIR('❋', Items.GRAY_DYE, Items.LIGHT_GRAY_DYE, ChatFormatting.WHITE, ChatFormatting.GRAY);
+    EARTH(Element.EARTH, Items.LIME_DYE, Items.GREEN_DYE, ChatFormatting.DARK_GREEN, ChatFormatting.GREEN),
+    THUNDER(Element.THUNDER, Items.YELLOW_DYE, Items.ORANGE_DYE, ChatFormatting.YELLOW, ChatFormatting.GOLD),
+    WATER(Element.WATER, Items.LIGHT_BLUE_DYE, Items.CYAN_DYE, ChatFormatting.AQUA, ChatFormatting.DARK_AQUA),
+    FIRE(Element.FIRE, Items.PINK_DYE, Items.RED_DYE, ChatFormatting.RED, ChatFormatting.DARK_RED),
+    AIR(Element.AIR, Items.GRAY_DYE, Items.LIGHT_GRAY_DYE, ChatFormatting.WHITE, ChatFormatting.GRAY);
 
-    private final char symbol;
+    private final Element element;
     private final Item lowTierItem;
     private final Item highTierItem;
     private final ChatFormatting lightColor;
     private final ChatFormatting darkColor;
 
-    Powder(char symbol, Item lowTierItem, Item highTierItem, ChatFormatting lightColor, ChatFormatting darkColor) {
-        this.symbol = symbol;
+    Powder(Element element, Item lowTierItem, Item highTierItem, ChatFormatting lightColor, ChatFormatting darkColor) {
+        this.element = element;
         this.lowTierItem = lowTierItem;
         this.highTierItem = highTierItem;
         this.lightColor = lightColor;
         this.darkColor = darkColor;
     }
 
-    public char getSymbol() {
-        return symbol;
+    public static Powder fromElement(Element element) {
+        for (Powder powder : Powder.values()) {
+            if (powder.element.equals(element)) {
+                return powder;
+            }
+        }
+        return null;
     }
 
-    public CustomColor getColor() {
-        return CustomColor.fromInt(this.lightColor.getColor()).withAlpha(255);
-    }
-
-    public String getColoredSymbol() {
-        return lightColor.toString() + symbol;
+    public static Powder getFromSymbol(String symbol) {
+        Element element = Element.fromSymbol(symbol);
+        return fromElement(element);
     }
 
     public static List<Powder> findPowders(String input) {
@@ -57,6 +59,22 @@ public enum Powder {
         });
 
         return foundPowders;
+    }
+
+    public Element getElement() {
+        return element;
+    }
+
+    public char getSymbol() {
+        return element.getSymbol().charAt(0);
+    }
+
+    public CustomColor getColor() {
+        return CustomColor.fromInt(this.lightColor.getColor()).withAlpha(255);
+    }
+
+    public String getColoredSymbol() {
+        return lightColor.toString() + getSymbol();
     }
 
     public Item getLowTierItem() {
@@ -86,17 +104,6 @@ public enum Powder {
             case WATER -> Powder.THUNDER;
             case FIRE -> Powder.WATER;
             case AIR -> Powder.FIRE;
-        };
-    }
-
-    public static Powder getFromSymbol(char symbol) {
-        return switch (symbol) {
-            case '✤' -> EARTH;
-            case '✦' -> THUNDER;
-            case '❉' -> WATER;
-            case '✹' -> FIRE;
-            case '❋' -> AIR;
-            default -> null;
         };
     }
 }

--- a/common/src/main/java/com/wynntils/models/concepts/Skill.java
+++ b/common/src/main/java/com/wynntils/models/concepts/Skill.java
@@ -4,22 +4,32 @@
  */
 package com.wynntils.models.concepts;
 
+import com.wynntils.utils.StringUtils;
+import java.util.List;
 import java.util.Locale;
 import net.minecraft.ChatFormatting;
 
 public enum Skill {
-    STRENGTH("✤", ChatFormatting.DARK_GREEN),
-    DEXTERITY("✦", ChatFormatting.YELLOW),
-    INTELLIGENCE("✽", ChatFormatting.AQUA),
-    DEFENCE("✹", ChatFormatting.RED), // Note! Must be spelled with "C" to match in-game
-    AGILITY("❋", ChatFormatting.WHITE);
+    STRENGTH(Element.EARTH),
+    DEXTERITY(Element.THUNDER),
+    INTELLIGENCE(Element.WATER),
+    DEFENCE(Element.FIRE, "defense"), // Note! Must be spelled with "C" to match in-game
+    AGILITY(Element.AIR);
 
-    private final String symbol;
-    private final ChatFormatting color;
+    private final Element associatedElement;
+    private final String apiName;
+    private final String displayName;
 
-    Skill(String symbol, ChatFormatting color) {
-        this.symbol = symbol;
-        this.color = color;
+    Skill(Element associatedElement, String apiName) {
+        this.associatedElement = associatedElement;
+        this.apiName = apiName;
+        this.displayName = StringUtils.capitalized(this.name());
+    }
+
+    Skill(Element associatedElement) {
+        this.associatedElement = associatedElement;
+        this.apiName = this.name().toLowerCase(Locale.ROOT);
+        this.displayName = StringUtils.capitalized(this.name());
     }
 
     public static Skill fromString(String str) {
@@ -30,11 +40,36 @@ public enum Skill {
         }
     }
 
-    public String getSymbol() {
-        return symbol;
+    public static boolean isSkill(String idName) {
+        for (Skill skill : values()) {
+            if (idName.equals(skill.getDisplayName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    public ChatFormatting getColor() {
-        return color;
+    public static List<Skill> getGearSkillOrder() {
+        return List.of(Skill.STRENGTH, Skill.DEXTERITY, Skill.INTELLIGENCE, Skill.AGILITY, Skill.DEFENCE);
+    }
+
+    public Element getAssociatedElement() {
+        return associatedElement;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getApiName() {
+        return apiName;
+    }
+
+    public String getSymbol() {
+        return associatedElement.getSymbol();
+    }
+
+    public ChatFormatting getColorCode() {
+        return associatedElement.getColorCode();
     }
 }

--- a/common/src/main/java/com/wynntils/models/gear/GearItemModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearItemModel.java
@@ -6,8 +6,6 @@ package com.wynntils.models.gear;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.features.user.tooltips.ItemStatInfoFeature;
@@ -23,7 +21,6 @@ import com.wynntils.models.items.items.game.CharmItem;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.items.game.TomeItem;
 import com.wynntils.utils.MathUtils;
-import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.wynn.ColorScaleUtils;
@@ -357,14 +354,7 @@ public final class GearItemModel extends Model {
 
     public GearItem fromJsonLore(ItemStack itemStack, GearProfile gearProfile) {
         // attempt to parse item itemData
-        JsonObject itemData;
-        String rawLore = StringUtils.substringBeforeLast(LoreUtils.getStringLore(itemStack), "}")
-                + "}"; // remove extra unnecessary info
-        try {
-            itemData = JsonParser.parseString(rawLore).getAsJsonObject();
-        } catch (JsonSyntaxException e) {
-            itemData = new JsonObject(); // invalid or empty itemData on item
-        }
+        JsonObject itemData = LoreUtils.getJsonFromIngameLore(itemStack);
 
         List<GearIdentificationContainer> idContainers = new ArrayList<>();
         List<GearIdentification> identifications = new ArrayList<>();

--- a/common/src/main/java/com/wynntils/models/gear/type/GearType.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearType.java
@@ -11,45 +11,33 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 
 public enum GearType {
-    SPEAR(ClassType.Warrior, 16 * 1, 16 * 1, Items.IRON_SHOVEL, 0),
-    WAND(ClassType.Mage, 16 * 0, 16 * 1, Items.STICK, 0),
-    DAGGER(ClassType.Assassin, 16 * 2, 16 * 1, Items.SHEARS, 0),
-    BOW(ClassType.Archer, 16 * 3, 16 * 1, Items.BOW, 0),
-    RELIK(ClassType.Shaman, 16 * 0, 16 * 2, Items.STONE_SHOVEL, 7),
-    RING(null, 16 * 1, 16 * 2, Items.FLINT_AND_STEEL, 2),
-    BRACELET(null, 16 * 2, 16 * 2, Items.FLINT_AND_STEEL, 19),
-    NECKLACE(null, 16 * 3, 16 * 2, Items.FLINT_AND_STEEL, 36),
-    HELMET(null, 16 * 0, 16 * 0, Items.LEATHER_HELMET, 0),
-    CHESTPLATE(null, 16 * 1, 16 * 0, Items.LEATHER_CHESTPLATE, 0),
-    LEGGINGS(null, 16 * 2, 16 * 0, Items.LEATHER_LEGGINGS, 0),
-    BOOTS(null, 16 * 3, 16 * 0, Items.LEATHER_BOOTS, 0),
-    MASTERY_TOME(null, 16 * 0, 16 * 3, Items.ENCHANTED_BOOK, 0),
-    CHARM(null, 16 * 1, 16 * 3, Items.CLAY_BALL, 0);
+    SPEAR(ClassType.Warrior, Items.IRON_SHOVEL, 0),
+    WAND(ClassType.Mage, Items.STICK, 0),
+    DAGGER(ClassType.Assassin, Items.SHEARS, 0),
+    BOW(ClassType.Archer, Items.BOW, 0),
+    RELIK(ClassType.Shaman, Items.STONE_SHOVEL, 7),
+    RING(null, Items.FLINT_AND_STEEL, 2),
+    BRACELET(null, Items.FLINT_AND_STEEL, 19),
+    NECKLACE(null, Items.FLINT_AND_STEEL, 36),
+    HELMET(null, Items.LEATHER_HELMET, 0),
+    CHESTPLATE(null, Items.LEATHER_CHESTPLATE, 0),
+    LEGGINGS(null, Items.LEATHER_LEGGINGS, 0),
+    BOOTS(null, Items.LEATHER_BOOTS, 0),
+    MASTERY_TOME(null, Items.ENCHANTED_BOOK, 0),
+    CHARM(null, Items.CLAY_BALL, 0);
 
     private final ClassType classReq;
-    private final int iconTextureX;
-    private final int iconTextureY;
     private final Item defaultItem;
     private final int defaultDamage;
 
-    GearType(ClassType classReq, int iconTextureX, int iconTextureY, Item defaultItem, int defaultDamage) {
+    GearType(ClassType classReq, Item defaultItem, int defaultDamage) {
         this.classReq = classReq;
-        this.iconTextureX = iconTextureX;
-        this.iconTextureY = iconTextureY;
         this.defaultItem = defaultItem;
         this.defaultDamage = defaultDamage;
     }
 
     public ClassType getClassReq() {
         return classReq;
-    }
-
-    public int getIconTextureX() {
-        return iconTextureX;
-    }
-
-    public int getIconTextureY() {
-        return iconTextureY;
     }
 
     public int getDefaultDamage() {

--- a/common/src/main/java/com/wynntils/models/items/items/gui/SkillPointItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/SkillPointItem.java
@@ -32,7 +32,7 @@ public class SkillPointItem extends GuiItem implements CountedItemProperty {
 
     @Override
     public CustomColor getCountColor() {
-        return CustomColor.fromChatFormatting(skill.getColor());
+        return CustomColor.fromChatFormatting(skill.getColorCode());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/base/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/base/WynntilsScreen.java
@@ -18,8 +18,8 @@ public abstract class WynntilsScreen extends Screen {
 
     private void failure(String method, Throwable e) {
         WynntilsMod.error("Failure in " + this.getClass().getSimpleName() + "." + method + "()", e);
-        McUtils.sendMessageToClient(Component.literal("Wynntils: Failure in " + method + " in "
-                        + this.getClass().getSimpleName() + ". Screen forcefully closed.")
+        McUtils.sendMessageToClient(Component.literal("Wynntils: Failure in "
+                        + this.getClass().getSimpleName() + " during " + method + ". Screen forcefully closed.")
                 .withStyle(ChatFormatting.RED));
         McUtils.mc().setScreen(null);
     }

--- a/common/src/main/java/com/wynntils/utils/JsonUtils.java
+++ b/common/src/main/java/com/wynntils/utils/JsonUtils.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public final class JsonUtils {
+    public static String getNullableJsonString(JsonObject json, String key) {
+        JsonElement jsonElement = json.get(key);
+        if (jsonElement == null) return null;
+        if (jsonElement.isJsonNull()) return null;
+
+        return jsonElement.getAsString();
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/mc/ComponentUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/ComponentUtils.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.utils.mc;
 
+import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.wynn.WynnUtils;
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -20,6 +22,7 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
 
 public final class ComponentUtils {
+    private static final int RAINBOW_CYCLE_TIME = 5000;
     private static final Pattern NEWLINE_PATTERN = Pattern.compile("\n");
 
     // Text with formatting codes "§cTest §1Text"
@@ -212,6 +215,61 @@ public final class ComponentUtils {
                 .collect(Collectors.toList());
         if (split.isEmpty()) split.add(Component.literal(""));
         return split;
+    }
+
+    public static MutableComponent makeRainbowStyle(String name) {
+        MutableComponent newName = Component.literal("").withStyle(ChatFormatting.BOLD);
+
+        // This math was originally based off Avaritia code.
+        // Special thanks for Morpheus1101 and SpitefulFox
+        // Avaritia Repo: https://github.com/Morpheus1101/Avaritia
+        int time = (int) (System.currentTimeMillis() % RAINBOW_CYCLE_TIME);
+        for (int i = 0; i < name.length(); i++) {
+            int hue = (time + i * RAINBOW_CYCLE_TIME / 7) % RAINBOW_CYCLE_TIME;
+            Style color = Style.EMPTY
+                    .withColor(Color.HSBtoRGB((hue / (float) RAINBOW_CYCLE_TIME), 0.8F, 0.8F))
+                    .withItalic(false);
+
+            newName.append(Component.literal(String.valueOf(name.charAt(i))).setStyle(color));
+        }
+
+        return newName;
+    }
+
+    public static MutableComponent makeObfuscated(
+            String name, float obfuscationChanceStart, float obfuscationChanceEnd) {
+        MutableComponent newName = Component.literal("").withStyle(ChatFormatting.BOLD, ChatFormatting.DARK_RED);
+
+        boolean obfuscated = Math.random() < obfuscationChanceStart;
+        StringBuilder current = new StringBuilder();
+
+        for (int i = 0; i < name.length() - 1; i++) {
+            current.append(name.charAt(i));
+
+            float chance =
+                    MathUtils.lerp(obfuscationChanceStart, obfuscationChanceEnd, (i + 1) / (float) (name.length() - 1));
+
+            if (!obfuscated && Math.random() < chance) {
+                newName.append(Component.literal(current.toString()));
+                current = new StringBuilder();
+
+                obfuscated = true;
+            } else if (obfuscated && Math.random() > chance) {
+                newName.append(Component.literal(current.toString()).withStyle(Style.EMPTY.withObfuscated(true)));
+                current = new StringBuilder();
+
+                obfuscated = false;
+            }
+        }
+
+        current.append(name.charAt(name.length() - 1));
+
+        if (obfuscated) {
+            newName.append(Component.literal(current.toString()).withStyle(Style.EMPTY.withObfuscated(true)));
+        } else {
+            newName.append(Component.literal(current.toString()));
+        }
+        return newName;
     }
 
     private static class ComponentListBuilder {

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -6,6 +6,10 @@ package com.wynntils.utils.mc;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.wynntils.utils.StringUtils;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -236,5 +240,19 @@ public final class LoreUtils {
         String newLoreString = newLore.getAsString();
 
         return existingLoreString.equals(newLoreString);
+    }
+
+    /**
+     * This is used to extract the lore from an ingame item that is held by another player.
+     * This lore has a completely different format from the normal lore shown to the player
+     */
+    public static JsonObject getJsonFromIngameLore(ItemStack itemStack) {
+        String rawLore =
+                StringUtils.substringBeforeLast(getStringLore(itemStack), "}") + "}"; // remove extra unnecessary info
+        try {
+            return JsonParser.parseString(rawLore).getAsJsonObject();
+        } catch (JsonSyntaxException e) {
+            return new JsonObject(); // invalid or empty itemData on item
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/utils/type/Pair.java
+++ b/common/src/main/java/com/wynntils/utils/type/Pair.java
@@ -10,6 +10,14 @@ import java.util.Objects;
  * The Pair Type Holds 1 field of type T and 1 field of type J
  */
 public record Pair<T, J>(T a, J b) {
+    // Convenience aliases for typical usage
+    public T key() {
+        return a;
+    }
+
+    public J value() {
+        return b;
+    }
 
     @Override
     public String toString() {

--- a/common/src/main/java/com/wynntils/utils/type/RangedValue.java
+++ b/common/src/main/java/com/wynntils/utils/type/RangedValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.type;
+
+public record RangedValue(int low, int high) {
+    public static final RangedValue NONE = new RangedValue(0, 0);
+
+    public static RangedValue of(int low, int high) {
+        return new RangedValue(low, high);
+    }
+
+    public static RangedValue fromString(String range) {
+        String[] pair = range.split("-");
+        return new RangedValue(Integer.parseInt(pair[0]), Integer.parseInt(pair[1]));
+    }
+
+    public String asString() {
+        return low + "-" + high;
+    }
+
+    public boolean isFixed() {
+        return low == high;
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/wynn/WynnItemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/WynnItemUtils.java
@@ -66,22 +66,6 @@ public final class WynnItemUtils {
         return ids;
     }
 
-    public static void removeLoreTooltipLines(List<Component> tooltip) {
-        int loreStart = -1;
-        for (int i = 0; i < tooltip.size(); i++) {
-            // only remove text after the item type indicator
-            if (WynnItemMatchers.rarityLineMatcher(tooltip.get(i)).find()) {
-                loreStart = i + 1;
-                break;
-            }
-        }
-
-        // type indicator was found
-        if (loreStart != -1) {
-            tooltip.subList(loreStart, tooltip.size()).clear();
-        }
-    }
-
     public static String getTranslatedName(ItemStack itemStack) {
         String unformattedItemName = ComponentUtils.getUnformatted(itemStack.getHoverName());
         return Models.GearProfiles.getTranslatedReference(unformattedItemName).replace("֎", "");

--- a/common/src/main/java/com/wynntils/utils/wynn/WynnUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/WynnUtils.java
@@ -8,16 +8,15 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class WynnUtils {
     /**
-     * Removes the characters 'À' ('\u00c0') and '\u058e' that is sometimes added in Wynn APIs and
-     * replaces '\u2019' (RIGHT SINGLE QUOTATION MARK) with '\'' (And trims)
+     * Removes the characters 'À' ('\u00c0') and ֎ ('\u058e') that is sometimes added in Wynn APIs and
+     * replaces '’' ('\u2019') (RIGHT SINGLE QUOTATION MARK) with '\'' (And trims)
      *
      * @param input string
      * @return the string without these two chars
      */
     public static String normalizeBadString(String input) {
         if (input == null) return "";
-        return StringUtils.replaceEach(
-                        input, new String[] {"ÀÀÀ", "À", "\u058e", "\u2019"}, new String[] {" ", "", "", "'"})
+        return StringUtils.replaceEach(input, new String[] {"ÀÀÀ", "À", "֎", "’"}, new String[] {" ", "", "", "'"})
                 .trim();
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -353,6 +353,7 @@
   "feature.wynntils.itemLock.blockAllActionsOnLockedItems.description": "Should any click types be blocked on locked items?",
   "feature.wynntils.itemLock.blockAllActionsOnLockedItems.name": "Block All Actions on Locked Items",
   "feature.wynntils.itemLock.name": "Item Lock",
+  "feature.wynntils.itemScreenshot.chatItemError": "Cannot make chat link of unidentified gear!",
   "feature.wynntils.itemScreenshot.chatItemMessage": "Click here to copy the item for chat!",
   "feature.wynntils.itemScreenshot.chatItemTooltip": "Paste this text in chat to display your item to other Wynntils users",
   "feature.wynntils.itemScreenshot.copy.error": "Error while copying screenshot to clipboard",


### PR DESCRIPTION
* fix: Crashed Features were not properly disabled, leading to crash when trying to re-enable them
* fix: In ItemScreenshotFeature, we cannot make chat encoded message of unidentified gear. Prohibit and warn for this.
* fix: Formatting and wording of crash error messages
* refactor: Move texture position information out of GearType and into UnidentifiedItemIconFeature
* refactor: Move fancy formatting out from ItemStatInfoFeature
* refactor: Extract out some helper functions that will be needed soon
* feat: Create basic type Element, and use it in element-assocated types
* feat: Add utils that will be needed by upcoming gear rewrite