### PR TITLE
fix: Change hideLevelUp default value to false

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/InfoMessageFilterFeature.java
@@ -48,7 +48,7 @@ public class InfoMessageFilterFeature extends UserFeature {
     private boolean hideSystemInfo = true;
 
     @Config
-    private boolean hideLevelUp = true;
+    private boolean hideLevelUp = false;
 
     @SubscribeEvent
     public void onInfoMessage(ChatMessageReceivedEvent e) {


### PR DESCRIPTION
People enjoy knowing when people around them level up, whether it is during profession grinding or during grind parties.