### PR TITLE
fix: Use classloader workaround for all async netmanager code

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/NetResult.java
+++ b/common/src/main/java/com/wynntils/core/net/NetResult.java
@@ -49,6 +49,10 @@ public abstract class NetResult {
         handleReader(
                 reader -> {
                     try {
+                        // FIXME: This is needed for patching class loading issue with Forge EventBus:
+                        //        https://github.com/MinecraftForge/EventBus/issues/44
+                        Thread.currentThread().setContextClassLoader(WynntilsMod.class.getClassLoader());
+
                         handler.accept(JsonParser.parseReader(reader).getAsJsonObject());
                     } catch (Throwable t) {
                         WynntilsMod.warn("Failure in net manager [handleJsonObject], processing " + desc, t);

--- a/common/src/main/java/com/wynntils/core/net/athena/WynntilsAccountManager.java
+++ b/common/src/main/java/com/wynntils/core/net/athena/WynntilsAccountManager.java
@@ -102,10 +102,6 @@ public final class WynntilsAccountManager extends Manager {
 
             ApiResponse apiAuthResponse = Managers.Net.callApi(UrlId.API_ATHENA_AUTH_RESPONSE, arguments);
             apiAuthResponse.handleJsonObject(authJson -> {
-                // FIXME: This is needed for patching class loading issue with Forge EventBus:
-                //        https://github.com/MinecraftForge/EventBus/issues/44
-                Thread.currentThread().setContextClassLoader(WynntilsMod.class.getClassLoader());
-
                 token = authJson.get("authToken").getAsString(); /* md5 hashes*/
                 JsonObject hashes = authJson.getAsJsonObject("hashes");
                 hashes.entrySet()


### PR DESCRIPTION
Unfortunately this did not help resolve the deadlocks I've been seeing, but I think this is a safe and prudent move nevertheless.