### PR TITLE
fix: Properly resolve so fake item stacks keep their annotation

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -74,8 +74,8 @@ public class ItemHandler extends Handler {
     }
 
     private void updateAnnotation(ItemStack existingItem, ItemStack newItem) {
-        // These items will already have an annotation, no handling necessary
-        if (newItem instanceof FakeItemStack) return;
+        // For e.g. FakeItemStacks we will already have an annotation
+        if (((ItemStackExtension) newItem).getAnnotation() != null) return;
 
         ItemAnnotation annotation = ((ItemStackExtension) existingItem).getAnnotation();
         if (annotation == null) {

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -10,7 +10,6 @@ import com.wynntils.handlers.item.event.ItemRenamedEvent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.mc.event.SetSlotEvent;
 import com.wynntils.mc.extension.ItemStackExtension;
-import com.wynntils.models.items.FakeItemStack;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;


### PR DESCRIPTION
This is a follow-up on #1141.