### PR TITLE
fix: The cure for Cancer (and Necrosis)

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
@@ -18,7 +18,6 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.wynn.RaycastUtils;
 import com.wynntils.utils.wynn.WynnItemMatchers;
-import com.wynntils.utils.wynn.WynnUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/CustomNametagRendererFeature.java
@@ -100,7 +100,8 @@ public class CustomNametagRendererFeature extends UserFeature {
     private static MutableComponent getItemComponent(ItemStack itemStack) {
         if (itemStack == null || itemStack == ItemStack.EMPTY) return null;
 
-        String gearName = WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(itemStack.getHoverName()));
+        // This must specifically NOT be normalized; the ֎ is significant
+        String gearName = ComponentUtils.getUnformatted(itemStack.getHoverName());
         MutableComponent description = WynnItemMatchers.getNonGearDescription(itemStack, gearName);
         if (description != null) return description;
 

--- a/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
@@ -173,21 +173,31 @@ public class GearInfoRegistry {
                 throws JsonParseException {
             JsonObject json = jsonElement.getAsJsonObject();
 
-            String primaryName = WynnUtils.normalizeBadString(json.get("name").getAsString());
-            String secondaryName = WynnUtils.normalizeBadString(JsonUtils.getNullableJsonString(json, "displayName"));
+            // Wynncraft API has two fields: name and displayName. The former is the "api name", and is
+            // always present, the latter is only present if it differs from the api name.
+            // We want to store this the other way around: We always want a displayName (as the "name"),
+            // but if it the apiName is different, we want to store it separately
+            String primaryName = json.get("name").getAsString();
+            String secondaryName = JsonUtils.getNullableJsonString(json, "displayName");
 
-            // After normalization, we can end up with the same name. If so, treat this as not having
-            // a secondary name.
-            if (primaryName.equals(secondaryName)) {
-                secondaryName = "";
+            if (secondaryName == null) {
+                String normalizedApiName = WynnUtils.normalizeBadString(primaryName);
+                if (!normalizedApiName.equals(primaryName)) {
+                    // Normalization removed a ֎ from the name. This means we want to
+                    // treat the name as apiName and the normalized name as display name
+                    secondaryName = normalizedApiName;
+                }
             }
 
-            // The real name (display name) is the secondaryName if it exists, otherwise it is
-            // the primary name.
-            // If the secondary name exists, the primary name is the apiName. If the apiName
-            // does not exist, the api name is the same as the displayName.
-            String name = secondaryName.isEmpty() ? primaryName : secondaryName;
-            String apiName = secondaryName.isEmpty() ? null : primaryName;
+            String name;
+            String apiName;
+            if (secondaryName == null) {
+                name = primaryName;
+                apiName = null;
+            } else {
+                name = secondaryName;
+                apiName = primaryName;
+            }
 
             GearType type = parseType(json);
             GearTier tier = GearTier.fromString(json.get("tier").getAsString());

--- a/common/src/main/java/com/wynntils/models/gear/tooltip/GearTooltipIdentifications.java
+++ b/common/src/main/java/com/wynntils/models/gear/tooltip/GearTooltipIdentifications.java
@@ -70,7 +70,7 @@ public final class GearTooltipIdentifications {
             delimiterNeeded = true;
         }
 
-        if (identifications.get(identifications.size() - 1).getString().isEmpty()) {
+        if (!identifications.isEmpty() && identifications.get(identifications.size() - 1).getString().isEmpty()) {
             // Remove last line if it is a delimiter line
             identifications.remove(identifications.size() - 1);
         }

--- a/common/src/main/java/com/wynntils/models/gear/tooltip/GearTooltipIdentifications.java
+++ b/common/src/main/java/com/wynntils/models/gear/tooltip/GearTooltipIdentifications.java
@@ -70,7 +70,8 @@ public final class GearTooltipIdentifications {
             delimiterNeeded = true;
         }
 
-        if (!identifications.isEmpty() && identifications.get(identifications.size() - 1).getString().isEmpty()) {
+        if (!identifications.isEmpty()
+                && identifications.get(identifications.size() - 1).getString().isEmpty()) {
             // Remove last line if it is a delimiter line
             identifications.remove(identifications.size() - 1);
         }

--- a/common/src/main/java/com/wynntils/screens/gearviewer/GearViewerScreen.java
+++ b/common/src/main/java/com/wynntils/screens/gearviewer/GearViewerScreen.java
@@ -60,7 +60,8 @@ public final class GearViewerScreen extends WynntilsContainerScreen<GearViewerMe
             return itemStack;
         }
 
-        String gearName = WynnUtils.normalizeBadString(ComponentUtils.getUnformatted(itemStack.getHoverName()));
+        // This must specifically NOT be normalized; the ֎ is significant
+        String gearName = ComponentUtils.getUnformatted(itemStack.getHoverName());
         MutableComponent description = WynnItemMatchers.getNonGearDescription(itemStack, gearName);
         if (description != null) {
             itemStack.setHoverName(description);

--- a/common/src/main/java/com/wynntils/screens/gearviewer/GearViewerScreen.java
+++ b/common/src/main/java/com/wynntils/screens/gearviewer/GearViewerScreen.java
@@ -19,7 +19,6 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.wynn.WynnItemMatchers;
-import com.wynntils.utils.wynn.WynnUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Fixes a crash in gear view screen for some items where the apiname was the same as the displayname for another item (like Cancer and Necrosis).