### PR TITLE
fix: Fix parsing of weapons with gear skins

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -99,7 +99,7 @@ public class ItemHandler extends Handler {
         }
 
         // This might be just a name update. Check if lore matches:
-        if (!LoreUtils.loreSoftMatches(existingItem, newItem)) {
+        if (!LoreUtils.loreSoftMatches(existingItem, newItem, 3)) {
             // This could be a new item, or a crafted item losing in durability
             annotate(newItem);
             return;

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -13,7 +13,6 @@ import com.wynntils.mc.extension.ItemStackExtension;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.wynn.WynnItemMatchers;
 import com.wynntils.utils.wynn.WynnUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -89,17 +88,20 @@ public class ItemHandler extends Handler {
             return;
         }
 
+        // Check if item type, damage and count matches, if not, it's definitely a new item
+        if (!similarStack(existingItem, newItem)) {
+            annotate(newItem);
+            return;
+        }
+
         // This might be just a name update. Check if lore matches:
         ListTag existingLore = LoreUtils.getLoreTag(existingItem);
         ListTag newLore = LoreUtils.getLoreTag(newItem);
 
         if (!LoreUtils.isLoreEquals(existingLore, newLore)) {
-            // This could be a new item, a crafted item losing in durability, or a gear skin being applied
-            // If it is a gear skin, we should continue processing
-            if (!sameGearWithSkin(existingItem, newItem)) {
-                annotate(newItem);
-                return;
-            }
+            // This could be a new item, or a crafted item losing in durability
+            annotate(newItem);
+            return;
         }
 
         String originalName = ((ItemStackExtension) existingItem).getOriginalName();
@@ -147,22 +149,15 @@ public class ItemHandler extends Handler {
         return bracketIndex == -1 ? name : name.substring(0, bracketIndex);
     }
 
-    private boolean sameGearWithSkin(ItemStack existingItem, ItemStack newItem) {
-        if (WynnItemMatchers.isGearSkin(existingItem) || !WynnItemMatchers.isGearSkin(newItem)) return false;
+    private boolean similarStack(ItemStack firstItem, ItemStack secondItem) {
+        if (!firstItem.getItem().equals(secondItem.getItem())) return false;
 
-        // Old item doesn't have a skin and the new item does, so compare lore:
-        List<String> existingLines = LoreUtils.getLore(existingItem);
-        List<String> newLines = LoreUtils.getLore(newItem);
-
-        // If the new lore isn't longer, it can't be the same item but with a skin applied
-        if (newLines.size() <= existingLines.size()) return false;
-
-        for (int i = 0; i < existingLines.size(); i++) {
-            if (!existingLines.get(i).equals(newLines.get(i))) return false;
+        // We have to use the count field here to bypass the getCount method empty flag
+        if (firstItem.count != secondItem.count) {
+            return false;
         }
 
-        // The new item's lore is just the old item's, but with more lines: must be a gear skin
-        return true;
+        return firstItem.getDamageValue() == secondItem.getDamageValue();
     }
 
     private ItemAnnotation calculateAnnotation(ItemStack item, String name) {

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -246,11 +246,18 @@ public final class LoreUtils {
      * This checks if the lore of the second item contains the entirety of the first item's lore, or vice versa.
      * It might have additional lines added, but these are not checked.
      */
-    public static boolean loreSoftMatches(ItemStack firstItem, ItemStack secondItem) {
+    public static boolean loreSoftMatches(ItemStack firstItem, ItemStack secondItem, int tolerance) {
         List<String> firstLines = getLore(firstItem);
         List<String> secondLines = getLore(secondItem);
+        int firstLinesLen = firstLines.size();
+        int secondLinesLen = secondLines.size();
 
-        int linesToCheck = Math.min(firstLines.size(), secondLines.size());
+        // Only allow a maximum number of additional lines in the longer tooltip
+        if (Math.abs(firstLinesLen - secondLinesLen) > tolerance) return false;
+
+        int linesToCheck = Math.min(firstLinesLen, secondLinesLen);
+        // Prevent soft matching on tooltips that are very small
+        if (linesToCheck < 3 && firstLinesLen != secondLinesLen) return false;
 
         for (int i = 0; i < linesToCheck; i++) {
             if (!firstLines.get(i).equals(secondLines.get(i))) return false;

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -243,6 +243,25 @@ public final class LoreUtils {
     }
 
     /**
+     * This checks if the lore of the second item contains the entirety of the first item's lore.
+     * It might have additional lines added, but these are not checked.
+     */
+    public static boolean loreSoftMatches(ItemStack existingItem, ItemStack newItem) {
+        List<String> existingLines = getLore(existingItem);
+        List<String> newLines = getLore(newItem);
+
+        // If the new lore is shorter, it can't possibly match
+        if (newLines.size() < existingLines.size()) return false;
+
+        for (int i = 0; i < existingLines.size(); i++) {
+            if (!existingLines.get(i).equals(newLines.get(i))) return false;
+        }
+
+        // Every lore line from existingItem exists in newItem, we have a match
+        return true;
+    }
+
+    /**
      * This is used to extract the lore from an ingame item that is held by another player.
      * This lore has a completely different format from the normal lore shown to the player
      */

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -243,21 +243,20 @@ public final class LoreUtils {
     }
 
     /**
-     * This checks if the lore of the second item contains the entirety of the first item's lore.
+     * This checks if the lore of the second item contains the entirety of the first item's lore, or vice versa.
      * It might have additional lines added, but these are not checked.
      */
-    public static boolean loreSoftMatches(ItemStack existingItem, ItemStack newItem) {
-        List<String> existingLines = getLore(existingItem);
-        List<String> newLines = getLore(newItem);
+    public static boolean loreSoftMatches(ItemStack firstItem, ItemStack secondItem) {
+        List<String> firstLines = getLore(firstItem);
+        List<String> secondLines = getLore(secondItem);
 
-        // If the new lore is shorter, it can't possibly match
-        if (newLines.size() < existingLines.size()) return false;
+        int linesToCheck = Math.min(firstLines.size(), secondLines.size());
 
-        for (int i = 0; i < existingLines.size(); i++) {
-            if (!existingLines.get(i).equals(newLines.get(i))) return false;
+        for (int i = 0; i < linesToCheck; i++) {
+            if (!firstLines.get(i).equals(secondLines.get(i))) return false;
         }
 
-        // Every lore line from existingItem exists in newItem, we have a match
+        // Every lore line matches from the first to the second (or second to the first), so we have a match
         return true;
     }
 

--- a/common/src/main/java/com/wynntils/utils/wynn/WynnItemMatchers.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/WynnItemMatchers.java
@@ -26,8 +26,6 @@ public final class WynnItemMatchers {
     private static final Pattern ITEM_RARITY_PATTERN =
             Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic)( Raid)? (Item|Reward).*");
     private static final Pattern DURABILITY_PATTERN = Pattern.compile("\\[(\\d+)/(\\d+) Durability\\]");
-    private static final Pattern GEAR_SKIN_PATTERN =
-            Pattern.compile("\\[Active (?:Weapon|Helmet) Skin: ([\\w-' ]+)\\]");
 
     public static boolean isHealingPotion(ItemStack itemStack) {
         if (!isConsumable(itemStack)) return false;
@@ -100,13 +98,6 @@ public final class WynnItemMatchers {
         return itemStack.is(Items.STONE_SHOVEL) && itemStack.getDamageValue() == 6;
     }
 
-    public static boolean isGearSkin(ItemStack itemStack) {
-        for (Component line : LoreUtils.getTooltipLines(itemStack)) {
-            if (gearSkinLineMatcher(line).find()) return true;
-        }
-        return false;
-    }
-
     public static Matcher rarityLineMatcher(Component text) {
         return ITEM_RARITY_PATTERN.matcher(text.getString());
     }
@@ -117,10 +108,6 @@ public final class WynnItemMatchers {
 
     private static Matcher consumableNameMatcher(Component text) {
         return CONSUMABLE_PATTERN.matcher(WynnUtils.normalizeBadString(text.getString()));
-    }
-
-    private static Matcher gearSkinLineMatcher(Component text) {
-        return GEAR_SKIN_PATTERN.matcher(text.getString());
     }
 
     public static CappedValue getDurability(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/utils/wynn/WynnItemMatchers.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/WynnItemMatchers.java
@@ -26,6 +26,8 @@ public final class WynnItemMatchers {
     private static final Pattern ITEM_RARITY_PATTERN =
             Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic)( Raid)? (Item|Reward).*");
     private static final Pattern DURABILITY_PATTERN = Pattern.compile("\\[(\\d+)/(\\d+) Durability\\]");
+    private static final Pattern GEAR_SKIN_PATTERN =
+            Pattern.compile("\\[Active (?:Weapon|Helmet) Skin: ([\\w-' ]+)\\]");
 
     public static boolean isHealingPotion(ItemStack itemStack) {
         if (!isConsumable(itemStack)) return false;
@@ -98,6 +100,13 @@ public final class WynnItemMatchers {
         return itemStack.is(Items.STONE_SHOVEL) && itemStack.getDamageValue() == 6;
     }
 
+    public static boolean isGearSkin(ItemStack itemStack) {
+        for (Component line : LoreUtils.getTooltipLines(itemStack)) {
+            if (gearSkinLineMatcher(line).find()) return true;
+        }
+        return false;
+    }
+
     public static Matcher rarityLineMatcher(Component text) {
         return ITEM_RARITY_PATTERN.matcher(text.getString());
     }
@@ -108,6 +117,10 @@ public final class WynnItemMatchers {
 
     private static Matcher consumableNameMatcher(Component text) {
         return CONSUMABLE_PATTERN.matcher(WynnUtils.normalizeBadString(text.getString()));
+    }
+
+    private static Matcher gearSkinLineMatcher(Component text) {
+        return GEAR_SKIN_PATTERN.matcher(text.getString());
     }
 
     public static CappedValue getDurability(ItemStack itemStack) {


### PR DESCRIPTION
Weapons with skins would fail to parse if Wynncraft updated their skin at the same time a spell was cast - it would be detected as a new item, but not as a gear item because it would have the spell cast line as its name. On any further updates it would be detected as the same item and the annotation would never get updated.