### PR TITLE
fix: Clear item cache on item update

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemAnnotation.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemAnnotation.java
@@ -4,4 +4,8 @@
  */
 package com.wynntils.handlers.item;
 
-public interface ItemAnnotation {}
+import net.minecraft.world.item.ItemStack;
+
+public interface ItemAnnotation {
+    void onUpdate(ItemStack itemStack);
+}

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -52,6 +52,7 @@ public class ItemHandler extends Handler {
         ItemStackExtension itemStackExtension = (ItemStackExtension) itemStack;
         itemStackExtension.setAnnotation(annotation);
         itemStackExtension.setOriginalName(name);
+        annotation.onUpdate(itemStack);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/models/items/WynnItem.java
+++ b/common/src/main/java/com/wynntils/models/items/WynnItem.java
@@ -5,6 +5,7 @@
 package com.wynntils.models.items;
 
 import com.wynntils.handlers.item.ItemAnnotation;
+import net.minecraft.world.item.ItemStack;
 
 public class WynnItem implements ItemAnnotation {
     private final WynnItemCache cache = new WynnItemCache();
@@ -16,5 +17,10 @@ public class WynnItem implements ItemAnnotation {
     @Override
     public String toString() {
         return "WynnItem{}";
+    }
+
+    @Override
+    public void onUpdate(ItemStack itemStack) {
+        cache.clearAll();
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/WynnItemCache.java
+++ b/common/src/main/java/com/wynntils/models/items/WynnItemCache.java
@@ -38,4 +38,8 @@ public class WynnItemCache {
     public <T> void clear(String key) {
         cache.remove(key);
     }
+
+    public void clearAll() {
+        cache.clear();
+    }
 }


### PR DESCRIPTION
I could not actually provoke the wrong tooltip to display without this patch, but it is conceptually sound -- we should clear the cache if the item is refreshed.