### PR TITLE
fix: Add crash protection for a number of screens

### DIFF
--- a/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
@@ -10,6 +10,7 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.features.user.ChatTabsFeature;
 import com.wynntils.handlers.chat.RecipientType;
 import com.wynntils.screens.base.TextboxScreen;
+import com.wynntils.screens.base.WynntilsScreen;
 import com.wynntils.screens.base.widgets.TextInputBoxWidget;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.McUtils;
@@ -30,7 +31,7 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
-public final class ChatTabEditingScreen extends Screen implements TextboxScreen {
+public final class ChatTabEditingScreen extends WynntilsScreen implements TextboxScreen {
     private TextInputBoxWidget focusedTextInput;
 
     private TextInputBoxWidget nameInput;
@@ -66,7 +67,7 @@ public final class ChatTabEditingScreen extends Screen implements TextboxScreen 
     }
 
     @Override
-    protected void init() {
+    protected void doInit() {
         // region Name
         this.addRenderableWidget(
                 nameInput = new TextInputBoxWidget(
@@ -208,9 +209,9 @@ public final class ChatTabEditingScreen extends Screen implements TextboxScreen 
     }
 
     @Override
-    public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    public void doRender(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
         renderBackground(poseStack);
-        super.render(poseStack, mouseX, mouseY, partialTick);
+        super.doRender(poseStack, mouseX, mouseY, partialTick);
 
         // Name
         FontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -13,6 +13,7 @@ import com.wynntils.models.map.MapTexture;
 import com.wynntils.models.map.pois.IconPoi;
 import com.wynntils.models.map.pois.LabelPoi;
 import com.wynntils.models.map.pois.Poi;
+import com.wynntils.screens.base.WynntilsScreen;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
@@ -30,12 +31,11 @@ import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
-public abstract class AbstractMapScreen extends Screen {
+public abstract class AbstractMapScreen extends WynntilsScreen {
     protected static final float SCREEN_SIDE_OFFSET = 10;
     private static final float BORDER_OFFSET = 6;
 
@@ -81,7 +81,7 @@ public abstract class AbstractMapScreen extends Screen {
     }
 
     @Override
-    protected void init() {
+    protected void doInit() {
         // FIXME: Figure out a way to not need this.
         //        At the moment, this is needed for Minecraft not to forget we hold keys when we open the GUI...
         KeyMapping.set(

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -51,8 +51,8 @@ public final class GuildMapScreen extends AbstractMapScreen {
     }
 
     @Override
-    protected void init() {
-        super.init();
+    protected void doInit() {
+        super.doInit();
 
         // Buttons have to be added in reverse order (right to left) so they don't overlap
 
@@ -133,7 +133,7 @@ public final class GuildMapScreen extends AbstractMapScreen {
     }
 
     @Override
-    public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    public void doRender(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
         if (holdingMapKey
                 && !GuildMapFeature.INSTANCE.openGuildMapKeybind.getKeyMapping().isDown()) {
             this.onClose();

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -54,8 +54,8 @@ public final class MainMapScreen extends AbstractMapScreen {
     }
 
     @Override
-    protected void init() {
-        super.init();
+    protected void doInit() {
+        super.doInit();
 
         this.addRenderableWidget(new BasicTexturedButton(
                 width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20 * 6,
@@ -176,7 +176,7 @@ public final class MainMapScreen extends AbstractMapScreen {
     }
 
     @Override
-    public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    public void doRender(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
         if (holdingMapKey && !MapFeature.INSTANCE.openMapKeybind.getKeyMapping().isDown()) {
             this.onClose();
             return;

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -12,6 +12,7 @@ import com.wynntils.features.user.map.MapFeature;
 import com.wynntils.models.map.PoiLocation;
 import com.wynntils.models.map.pois.CustomPoi;
 import com.wynntils.screens.base.TextboxScreen;
+import com.wynntils.screens.base.WynntilsScreen;
 import com.wynntils.screens.base.widgets.TextInputBoxWidget;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
@@ -31,7 +32,7 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
-public final class PoiCreationScreen extends Screen implements TextboxScreen {
+public final class PoiCreationScreen extends WynntilsScreen implements TextboxScreen {
     private static final Pattern COORDINATE_PATTERN = Pattern.compile("[-+]?\\d+");
 
     private static final List<Texture> POI_ICONS = List.of(
@@ -103,8 +104,8 @@ public final class PoiCreationScreen extends Screen implements TextboxScreen {
     }
 
     @Override
-    protected void init() {
-        super.init();
+    protected void doInit() {
+        super.doInit();
 
         // region Name
         this.addRenderableWidget(
@@ -283,9 +284,9 @@ public final class PoiCreationScreen extends Screen implements TextboxScreen {
     }
 
     @Override
-    public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    public void doRender(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
         renderBackground(poseStack);
-        super.render(poseStack, mouseX, mouseY, partialTick);
+        super.doRender(poseStack, mouseX, mouseY, partialTick);
 
         FontRenderer.getInstance()
                 .renderText(

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -7,6 +7,7 @@ package com.wynntils.screens.partymanagement;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.TextboxScreen;
+import com.wynntils.screens.base.WynntilsScreen;
 import com.wynntils.screens.base.widgets.TextInputBoxWidget;
 import com.wynntils.screens.partymanagement.widgets.PartyMemberWidget;
 import com.wynntils.screens.partymanagement.widgets.SuggestionPlayerWidget;
@@ -30,7 +31,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 
-public final class PartyManagementScreen extends Screen implements TextboxScreen {
+public final class PartyManagementScreen extends WynntilsScreen implements TextboxScreen {
     private static final Pattern INVITE_REPLACER = Pattern.compile("[^\\w, ]+");
     private static final Pattern COMMA_REPLACER = Pattern.compile("[,; ]+");
 
@@ -57,7 +58,7 @@ public final class PartyManagementScreen extends Screen implements TextboxScreen
     }
 
     @Override
-    public void init() {
+    public void doInit() {
         refreshAll();
         // region Invite input and button
         this.addRenderableWidget(
@@ -108,7 +109,7 @@ public final class PartyManagementScreen extends Screen implements TextboxScreen
     }
 
     @Override
-    public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    public void doRender(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
         renderBackground(poseStack);
 
         boolean inParty = Models.Party.isInParty();
@@ -124,7 +125,7 @@ public final class PartyManagementScreen extends Screen implements TextboxScreen
                 .getTextBoxInput()
                 .isBlank(); // inParty check not required as button automatically makes new party if not in one
 
-        super.render(poseStack, mouseX, mouseY, partialTick);
+        super.doRender(poseStack, mouseX, mouseY, partialTick);
 
         // region Invite field header
         FontRenderer.getInstance()


### PR DESCRIPTION
For some reasons, these screens did not inherit WynntilsScreen, and thus caused the entire mod to crash if they had a failure in them. (I noticed this with the bug in #1208)