### PR TITLE
refactor: Consistently call ItemStack variables "itemStack"

### DIFF
--- a/common/src/main/java/com/wynntils/features/user/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ContainerSearchFeature.java
@@ -74,8 +74,8 @@ public class ContainerSearchFeature extends UserFeature {
 
     @SubscribeEvent
     public void onRenderSlot(SlotRenderEvent.Pre e) {
-        ItemStack item = e.getSlot().getItem();
-        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(item);
+        ItemStack itemStack = e.getSlot().getItem();
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
         if (wynnItemOpt.isEmpty()) return;
 
         Boolean result = wynnItemOpt.get().getCache().get(WynnItemCache.SEARCHED_KEY);
@@ -180,14 +180,15 @@ public class ContainerSearchFeature extends UserFeature {
         String search = searchStr.toLowerCase(Locale.ROOT);
 
         NonNullList<ItemStack> playerItems = McUtils.inventory().items;
-        for (ItemStack item : screen.getMenu().getItems()) {
-            Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(item);
+        for (ItemStack itemStack : screen.getMenu().getItems()) {
+            Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
             if (wynnItemOpt.isEmpty()) return;
-            if (playerItems.contains(item)) continue;
+            if (playerItems.contains(itemStack)) continue;
 
-            String name = ComponentUtils.getUnformatted(item.getHoverName()).toLowerCase(Locale.ROOT);
+            String name =
+                    ComponentUtils.getUnformatted(itemStack.getHoverName()).toLowerCase(Locale.ROOT);
 
-            boolean filtered = !search.isEmpty() && name.contains(search) && item.getItem() != Items.AIR;
+            boolean filtered = !search.isEmpty() && name.contains(search) && itemStack.getItem() != Items.AIR;
             wynnItemOpt.get().getCache().store(WynnItemCache.SEARCHED_KEY, filtered);
             if (filtered) {
                 autoSearching = false;

--- a/common/src/main/java/com/wynntils/features/user/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/HealthPotionBlockerFeature.java
@@ -43,8 +43,8 @@ public class HealthPotionBlockerFeature extends UserFeature {
     }
 
     private Component getBlockResponse() {
-        ItemStack stack = McUtils.inventory().getSelected();
-        if (!WynnItemMatchers.isHealingPotion(stack)) return null;
+        ItemStack itemStack = McUtils.inventory().getSelected();
+        if (!WynnItemMatchers.isHealingPotion(itemStack)) return null;
 
         if (Models.Character.getCurrentHealth() * 100 < Models.Character.getMaxHealth() * threshold) return null;
 

--- a/common/src/main/java/com/wynntils/features/user/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/HorseMountFeature.java
@@ -49,9 +49,9 @@ public class HorseMountFeature extends UserFeature {
     public void onUseItem(UseItemEvent event) {
         if (!guaranteedMount) return;
 
-        ItemStack item = McUtils.player().getMainHandItem();
+        ItemStack itemStack = McUtils.player().getMainHandItem();
 
-        Optional<WynnItem> wynnItem = Models.Item.getWynnItem(item);
+        Optional<WynnItem> wynnItem = Models.Item.getWynnItem(itemStack);
 
         if (wynnItem.isPresent() && wynnItem.get() instanceof HorseItem) {
             mountHorse();

--- a/common/src/main/java/com/wynntils/features/user/ItemFavoriteFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemFavoriteFeature.java
@@ -45,9 +45,9 @@ public class ItemFavoriteFeature extends UserFeature {
 
         NonNullList<ItemStack> items = ContainerUtils.getItems(McUtils.mc().screen);
         for (int i = 0; i < 27; i++) {
-            ItemStack stack = items.get(i);
+            ItemStack itemStack = items.get(i);
 
-            if (isFavorited(stack)) {
+            if (isFavorited(itemStack)) {
                 McUtils.sendMessageToClient(Component.translatable("feature.wynntils.itemFavorite.closingBlocked")
                         .withStyle(ChatFormatting.RED));
                 e.setCanceled(true);

--- a/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/ItemScreenshotFeature.java
@@ -77,7 +77,7 @@ public class ItemScreenshotFeature extends UserFeature {
     }
 
     private void takeScreenshot(Screen screen, Slot hoveredSlot, List<Component> itemTooltip) {
-        ItemStack stack = hoveredSlot.getItem();
+        ItemStack itemStack = hoveredSlot.getItem();
         List<Component> tooltip = new ArrayList<>(itemTooltip);
         removeLoreTooltipLines(tooltip);
 
@@ -123,8 +123,8 @@ public class ItemScreenshotFeature extends UserFeature {
 
         if (saveToDisk) {
             // First try to save it to disk
-            String itemNameForFile = WynnUtils.normalizeBadString(
-                            ComponentUtils.stripFormatting(stack.getHoverName().getString()))
+            String itemNameForFile = WynnUtils.normalizeBadString(ComponentUtils.stripFormatting(
+                            itemStack.getHoverName().getString()))
                     .replaceAll("[/ ]", "_");
             File screenshotDir = new File(McUtils.mc().gameDirectory, "screenshots");
             String filename = Util.getFilenameFormattedDateTime() + "-" + itemNameForFile + ".png";
@@ -134,7 +134,7 @@ public class ItemScreenshotFeature extends UserFeature {
 
                 McUtils.sendMessageToClient(Component.translatable(
                                 "feature.wynntils.itemScreenshot.save.message",
-                                stack.getHoverName(),
+                                itemStack.getHoverName(),
                                 Component.literal(outputfile.getName())
                                         .withStyle(ChatFormatting.UNDERLINE)
                                         .withStyle(style -> style.withClickEvent(new ClickEvent(
@@ -143,7 +143,7 @@ public class ItemScreenshotFeature extends UserFeature {
             } catch (IOException e) {
                 WynntilsMod.error("Failed to save image to disk", e);
                 McUtils.sendMessageToClient(Component.translatable(
-                                "feature.wynntils.itemScreenshot.save.error", stack.getHoverName(), filename)
+                                "feature.wynntils.itemScreenshot.save.error", itemStack.getHoverName(), filename)
                         .withStyle(ChatFormatting.RED));
             }
 

--- a/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/MythicBlockerFeature.java
@@ -27,8 +27,8 @@ public class MythicBlockerFeature extends UserFeature {
 
         NonNullList<ItemStack> items = ContainerUtils.getItems(McUtils.mc().screen);
         for (int i = 0; i < 27; i++) {
-            ItemStack stack = items.get(i);
-            if (WynnItemMatchers.isMythic(stack)) {
+            ItemStack itemStack = items.get(i);
+            if (WynnItemMatchers.isMythic(itemStack)) {
                 McUtils.sendMessageToClient(Component.translatable("feature.wynntils.mythicBlocker.closingBlocked")
                         .withStyle(ChatFormatting.RED));
                 e.setCanceled(true);

--- a/common/src/main/java/com/wynntils/features/user/TerritoryDefenseMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/TerritoryDefenseMessageFeature.java
@@ -26,9 +26,9 @@ public class TerritoryDefenseMessageFeature extends UserFeature {
                 ATTACK_SCREEN_TITLE.matcher(McUtils.mc().screen.getTitle().getString());
         if (!titleMatcher.matches()) return;
 
-        ItemStack item = event.getHoveredSlot().getItem();
+        ItemStack itemStack = event.getHoveredSlot().getItem();
 
-        for (Component tooltipLine : LoreUtils.getTooltipLines(item)) {
+        for (Component tooltipLine : LoreUtils.getTooltipLines(itemStack)) {
             String unformatted = ComponentUtils.getUnformatted(tooltipLine);
             Matcher matcher = TERRITORY_DEFENSE_PATTERN.matcher(unformatted);
             if (matcher.matches()) {

--- a/common/src/main/java/com/wynntils/features/user/inventory/DurabilityArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/DurabilityArcFeature.java
@@ -33,7 +33,7 @@ public class DurabilityArcFeature extends UserFeature {
     @SubscribeEvent
     public void onRenderHotbarSlot(HotbarSlotRenderEvent.Pre e) {
         if (!renderDurabilityArcHotbar) return;
-        drawDurabilityArc(e.getStack(), e.getX(), e.getY(), true);
+        drawDurabilityArc(e.getItemStack(), e.getX(), e.getY(), true);
     }
 
     @SubscribeEvent
@@ -42,8 +42,8 @@ public class DurabilityArcFeature extends UserFeature {
         drawDurabilityArc(e.getSlot().getItem(), e.getSlot().x, e.getSlot().y, false);
     }
 
-    private void drawDurabilityArc(ItemStack item, int slotX, int slotY, boolean hotbar) {
-        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(item);
+    private void drawDurabilityArc(ItemStack itemStack, int slotX, int slotY, boolean hotbar) {
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
         if (wynnItemOpt.isEmpty()) return;
         if (!(wynnItemOpt.get() instanceof DurableItemProperty durableItem)) return;
 

--- a/common/src/main/java/com/wynntils/features/user/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ExtendedItemCountFeature.java
@@ -41,11 +41,11 @@ public class ExtendedItemCountFeature extends UserFeature {
     public void onRenderHotbarSlot(HotbarSlotRenderEvent.Post e) {
         if (!hotbarTextOverlayEnabled) return;
 
-        drawTextOverlay(e.getStack(), e.getX(), e.getY());
+        drawTextOverlay(e.getItemStack(), e.getX(), e.getY());
     }
 
-    private void drawTextOverlay(ItemStack item, int slotX, int slotY) {
-        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(item);
+    private void drawTextOverlay(ItemStack itemStack, int slotX, int slotY) {
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
         if (wynnItemOpt.isEmpty()) return;
         if (!(wynnItemOpt.get() instanceof CountedItemProperty countedItem)) return;
 
@@ -53,7 +53,7 @@ public class ExtendedItemCountFeature extends UserFeature {
         int count = countedItem.getCount();
         // This is a bit ugly; would rather we hid the drawing but that was tricky to do
         // with mixins...
-        item.setCount(1);
+        itemStack.setCount(1);
 
         TextRenderSetting style = TextRenderSetting.DEFAULT
                 .withCustomColor(countedItem.getCountColor())

--- a/common/src/main/java/com/wynntils/features/user/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ItemHighlightFeature.java
@@ -165,14 +165,14 @@ public class ItemHighlightFeature extends UserFeature {
     public void onRenderHotbarSlot(HotbarSlotRenderEvent.Pre e) {
         if (!hotbarHighlightEnabled) return;
 
-        CustomColor color = getHighlightColor(e.getStack(), true);
+        CustomColor color = getHighlightColor(e.getItemStack(), true);
         if (color == CustomColor.NONE) return;
 
         RenderUtils.drawRect(color.withAlpha(hotbarOpacity), e.getX(), e.getY(), 0, 16, 16);
     }
 
-    private CustomColor getHighlightColor(ItemStack item, boolean hotbarHighlight) {
-        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(item);
+    private CustomColor getHighlightColor(ItemStack itemStack, boolean hotbarHighlight) {
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
         if (wynnItemOpt.isEmpty()) return CustomColor.NONE;
 
         WynnItem wynnItem = wynnItemOpt.get();

--- a/common/src/main/java/com/wynntils/features/user/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/ItemTextOverlayFeature.java
@@ -108,11 +108,11 @@ public class ItemTextOverlayFeature extends UserFeature {
     public void onRenderHotbarSlot(HotbarSlotRenderEvent.Post e) {
         if (!hotbarTextOverlayEnabled) return;
 
-        drawTextOverlay(e.getStack(), e.getX(), e.getY(), true);
+        drawTextOverlay(e.getItemStack(), e.getX(), e.getY(), true);
     }
 
-    private void drawTextOverlay(ItemStack item, int slotX, int slotY, boolean hotbar) {
-        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(item);
+    private void drawTextOverlay(ItemStack itemStack, int slotX, int slotY, boolean hotbar) {
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
         if (wynnItemOpt.isEmpty()) return;
 
         WynnItem wynnItem = wynnItemOpt.get();

--- a/common/src/main/java/com/wynntils/features/user/inventory/UnidentifiedItemIconFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/inventory/UnidentifiedItemIconFeature.java
@@ -50,11 +50,11 @@ public class UnidentifiedItemIconFeature extends UserFeature {
 
     @SubscribeEvent
     public void onHotbarSlotRender(HotbarSlotRenderEvent.Post e) {
-        drawIcon(e.getStack(), e.getX(), e.getY());
+        drawIcon(e.getItemStack(), e.getX(), e.getY());
     }
 
-    private void drawIcon(ItemStack item, int slotX, int slotY) {
-        Optional<GearBoxItem> gearBoxItemOpt = Models.Item.asWynnItem(item, GearBoxItem.class);
+    private void drawIcon(ItemStack itemStack, int slotX, int slotY) {
+        Optional<GearBoxItem> gearBoxItemOpt = Models.Item.asWynnItem(itemStack, GearBoxItem.class);
         if (gearBoxItemOpt.isEmpty()) return;
 
         GearType gearType = gearBoxItemOpt.get().getGearType();

--- a/common/src/main/java/com/wynntils/features/user/players/PreventTradesDuelsFeature.java
+++ b/common/src/main/java/com/wynntils/features/user/players/PreventTradesDuelsFeature.java
@@ -35,9 +35,9 @@ public class PreventTradesDuelsFeature extends UserFeature {
         event.setCanceled(true);
     }
 
-    private boolean shouldBlockClick(Player player, ItemStack item, Entity target) {
+    private boolean shouldBlockClick(Player player, ItemStack itemStack, Entity target) {
         return player.isShiftKeyDown()
-                && WynnItemMatchers.isWeapon(item)
+                && WynnItemMatchers.isWeapon(itemStack)
                 && target instanceof Player p
                 && Models.Player.isLocalPlayer(p);
     }

--- a/common/src/main/java/com/wynntils/handlers/container/ScriptedContainerQuery.java
+++ b/common/src/main/java/com/wynntils/handlers/container/ScriptedContainerQuery.java
@@ -203,9 +203,9 @@ public final class ScriptedContainerQuery {
                 throw new IllegalStateException("Set startAction twice");
             }
             this.startAction = (container) -> {
-                ItemStack item = container.items().get(slotNum);
-                if (!item.is(expectedItemType)
-                        || !item.getDisplayName().getString().equals(expectedItemName)) return false;
+                ItemStack itemStack = container.items().get(slotNum);
+                if (!itemStack.is(expectedItemType)
+                        || !itemStack.getDisplayName().getString().equals(expectedItemName)) return false;
 
                 ContainerUtils.clickOnSlot(
                         slotNum, container.containerId(), GLFW.GLFW_MOUSE_BUTTON_LEFT, container.items());

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -37,10 +37,10 @@ public class ItemHandler extends Handler {
     // Keep this as a field just of performance reasons to skip a new allocation in annotate()
     private List<ItemAnnotator> crashedAnnotators = new ArrayList<>();
 
-    public static Optional<ItemAnnotation> getItemStackAnnotation(ItemStack item) {
-        if (item == null) return Optional.empty();
+    public static Optional<ItemAnnotation> getItemStackAnnotation(ItemStack itemStack) {
+        if (itemStack == null) return Optional.empty();
 
-        ItemAnnotation annotation = ((ItemStackExtension) item).getAnnotation();
+        ItemAnnotation annotation = ((ItemStackExtension) itemStack).getAnnotation();
         return Optional.ofNullable(annotation);
     }
 
@@ -57,7 +57,7 @@ public class ItemHandler extends Handler {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onSetSlot(SetSlotEvent.Pre event) {
-        onItemStackUpdate(event.getContainer().getItem(event.getSlot()), event.getItem());
+        onItemStackUpdate(event.getContainer().getItem(event.getSlot()), event.getItemStack());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -167,14 +167,14 @@ public class ItemHandler extends Handler {
         return WILDCARD_ITEMS.contains(itemStack.getItem());
     }
 
-    private ItemAnnotation calculateAnnotation(ItemStack item, String name) {
+    private ItemAnnotation calculateAnnotation(ItemStack itemStack, String name) {
         long startTime = System.currentTimeMillis();
 
         ItemAnnotation annotation = null;
 
         for (ItemAnnotator annotator : annotators) {
             try {
-                annotation = annotator.getAnnotation(item, name);
+                annotation = annotator.getAnnotation(itemStack, name);
                 if (annotation != null) {
                     break;
                 }
@@ -182,9 +182,9 @@ public class ItemHandler extends Handler {
                 String annotatorName = annotator.getClass().getSimpleName();
                 WynntilsMod.error("Exception when processing item annotator " + annotatorName, t);
                 WynntilsMod.warn("This annotator will be disabled");
-                WynntilsMod.warn("Problematic item:" + item);
-                WynntilsMod.warn("Problematic item name:" + ComponentUtils.getCoded(item.getHoverName()));
-                WynntilsMod.warn("Problematic item tags:" + item.getTag());
+                WynntilsMod.warn("Problematic item:" + itemStack);
+                WynntilsMod.warn("Problematic item name:" + ComponentUtils.getCoded(itemStack.getHoverName()));
+                WynntilsMod.warn("Problematic item tags:" + itemStack.getTag());
                 McUtils.sendMessageToClient(Component.literal("Wynntils error: Item Annotator '" + annotatorName
                                 + "' has crashed and will be disabled. Not all items will be properly parsed.")
                         .withStyle(ChatFormatting.RED));
@@ -207,12 +207,12 @@ public class ItemHandler extends Handler {
         return annotation;
     }
 
-    private void annotate(ItemStack item) {
-        String name = WynnUtils.normalizeBadString(ComponentUtils.getCoded(item.getHoverName()));
-        ItemAnnotation annotation = calculateAnnotation(item, name);
+    private void annotate(ItemStack itemStack) {
+        String name = WynnUtils.normalizeBadString(ComponentUtils.getCoded(itemStack.getHoverName()));
+        ItemAnnotation annotation = calculateAnnotation(itemStack, name);
         if (annotation == null) return;
 
-        updateItem(item, annotation, name);
+        updateItem(itemStack, annotation, name);
     }
 
     private void logProfilingData(long startTime, ItemAnnotation annotation) {

--- a/common/src/main/java/com/wynntils/mc/EventFactory.java
+++ b/common/src/main/java/com/wynntils/mc/EventFactory.java
@@ -181,8 +181,8 @@ public final class EventFactory {
         return post(new PlayerRenderLayerEvent.Elytra(player));
     }
 
-    public static GroundItemEntityTransformEvent onGroundItemRender(PoseStack poseStack, ItemStack stack) {
-        return post(new GroundItemEntityTransformEvent(poseStack, stack));
+    public static GroundItemEntityTransformEvent onGroundItemRender(PoseStack poseStack, ItemStack itemStack) {
+        return post(new GroundItemEntityTransformEvent(poseStack, itemStack));
     }
 
     public static NametagRenderEvent onNameTagRender(
@@ -258,12 +258,12 @@ public final class EventFactory {
     }
 
     public static ItemTooltipRenderEvent.Pre onItemTooltipRenderPre(
-            PoseStack poseStack, ItemStack stack, List<Component> tooltips, int mouseX, int mouseY) {
-        return post(new ItemTooltipRenderEvent.Pre(poseStack, stack, tooltips, mouseX, mouseY));
+            PoseStack poseStack, ItemStack itemStack, List<Component> tooltips, int mouseX, int mouseY) {
+        return post(new ItemTooltipRenderEvent.Pre(poseStack, itemStack, tooltips, mouseX, mouseY));
     }
 
-    public static void onItemTooltipRenderPost(PoseStack poseStack, ItemStack stack, int mouseX, int mouseY) {
-        post(new ItemTooltipRenderEvent.Post(poseStack, stack, mouseX, mouseY));
+    public static void onItemTooltipRenderPost(PoseStack poseStack, ItemStack itemStack, int mouseX, int mouseY) {
+        post(new ItemTooltipRenderEvent.Post(poseStack, itemStack, mouseX, mouseY));
     }
 
     public static void onSlotRenderPre(Screen screen, Slot slot) {
@@ -274,12 +274,12 @@ public final class EventFactory {
         post(new SlotRenderEvent.Post(screen, slot));
     }
 
-    public static void onHotbarSlotRenderPre(ItemStack stack, int x, int y) {
-        post(new HotbarSlotRenderEvent.Pre(stack, x, y));
+    public static void onHotbarSlotRenderPre(ItemStack itemStack, int x, int y) {
+        post(new HotbarSlotRenderEvent.Pre(itemStack, x, y));
     }
 
-    public static void onHotbarSlotRenderPost(ItemStack stack, int x, int y) {
-        post(new HotbarSlotRenderEvent.Post(stack, x, y));
+    public static void onHotbarSlotRenderPost(ItemStack itemStack, int x, int y) {
+        post(new HotbarSlotRenderEvent.Post(itemStack, x, y));
     }
 
     public static DrawPotionGlintEvent onPotionIsFoil(PotionItem item) {
@@ -371,12 +371,12 @@ public final class EventFactory {
         post(new ContainerCloseEvent.Post());
     }
 
-    public static SetSlotEvent onSetSlotPre(Container container, int slot, ItemStack item) {
-        return post(new SetSlotEvent.Pre(container, slot, item));
+    public static SetSlotEvent onSetSlotPre(Container container, int slot, ItemStack itemStack) {
+        return post(new SetSlotEvent.Pre(container, slot, itemStack));
     }
 
-    public static void onSetSlotPost(Container container, int slot, ItemStack item) {
-        post(new SetSlotEvent.Post(container, slot, item));
+    public static void onSetSlotPost(Container container, int slot, ItemStack itemStack) {
+        post(new SetSlotEvent.Post(container, slot, itemStack));
     }
 
     public static InventoryKeyPressEvent onInventoryKeyPress(
@@ -394,8 +394,8 @@ public final class EventFactory {
         return post(new ContainerClickEvent(containerId, slotNum, itemStack, clickType, buttonNum));
     }
 
-    public static ItemTooltipHoveredNameEvent onGetHoverName(Component hoveredName, ItemStack stack) {
-        return post(new ItemTooltipHoveredNameEvent(hoveredName, stack));
+    public static ItemTooltipHoveredNameEvent onGetHoverName(Component hoveredName, ItemStack itemStack) {
+        return post(new ItemTooltipHoveredNameEvent(hoveredName, itemStack));
     }
 
     public static ItemTooltipFlags.Advanced onTooltipFlagsAdvanced(ItemStack itemStack, TooltipFlag flags) {

--- a/common/src/main/java/com/wynntils/mc/event/HotbarSlotRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/HotbarSlotRenderEvent.java
@@ -8,18 +8,18 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Event;
 
 public abstract class HotbarSlotRenderEvent extends Event {
-    private final ItemStack stack;
+    private final ItemStack itemStack;
     private final int x;
     private final int y;
 
-    protected HotbarSlotRenderEvent(ItemStack stack, int x, int y) {
-        this.stack = stack;
+    protected HotbarSlotRenderEvent(ItemStack itemStack, int x, int y) {
+        this.itemStack = itemStack;
         this.x = x;
         this.y = y;
     }
 
-    public ItemStack getStack() {
-        return stack;
+    public ItemStack getItemStack() {
+        return itemStack;
     }
 
     public int getX() {
@@ -31,14 +31,14 @@ public abstract class HotbarSlotRenderEvent extends Event {
     }
 
     public static class Pre extends HotbarSlotRenderEvent {
-        public Pre(ItemStack stack, int x, int y) {
-            super(stack, x, y);
+        public Pre(ItemStack itemStack, int x, int y) {
+            super(itemStack, x, y);
         }
     }
 
     public static class Post extends HotbarSlotRenderEvent {
-        public Post(ItemStack stack, int x, int y) {
-            super(stack, x, y);
+        public Post(ItemStack itemStack, int x, int y) {
+            super(itemStack, x, y);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/ItemTooltipHoveredNameEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemTooltipHoveredNameEvent.java
@@ -10,11 +10,11 @@ import net.minecraftforge.eventbus.api.Event;
 
 public class ItemTooltipHoveredNameEvent extends Event {
     private Component hoveredName;
-    private final ItemStack stack;
+    private final ItemStack itemStack;
 
-    public ItemTooltipHoveredNameEvent(Component hoveredName, ItemStack stack) {
+    public ItemTooltipHoveredNameEvent(Component hoveredName, ItemStack itemStack) {
         this.hoveredName = hoveredName;
-        this.stack = stack;
+        this.itemStack = itemStack;
     }
 
     public Component getHoveredName() {
@@ -25,7 +25,7 @@ public class ItemTooltipHoveredNameEvent extends Event {
         this.hoveredName = hoveredName;
     }
 
-    public ItemStack getStack() {
-        return stack;
+    public ItemStack getItemStack() {
+        return itemStack;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/SetSlotEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetSlotEvent.java
@@ -13,12 +13,12 @@ import net.minecraftforge.eventbus.api.Event;
 public abstract class SetSlotEvent extends Event {
     private final Container container;
     private final int slot;
-    protected ItemStack item;
+    protected ItemStack itemStack;
 
-    protected SetSlotEvent(Container container, int slot, ItemStack item) {
+    protected SetSlotEvent(Container container, int slot, ItemStack itemStack) {
         this.container = container;
         this.slot = slot;
-        this.item = item;
+        this.itemStack = itemStack;
     }
 
     public Container getContainer() {
@@ -29,18 +29,18 @@ public abstract class SetSlotEvent extends Event {
         return slot;
     }
 
-    public ItemStack getItem() {
-        return item;
+    public ItemStack getItemStack() {
+        return itemStack;
     }
 
     @Cancelable
     public static class Pre extends SetSlotEvent {
-        public Pre(Container container, int slot, ItemStack item) {
-            super(container, slot, item);
+        public Pre(Container container, int slot, ItemStack itemStack) {
+            super(container, slot, itemStack);
         }
 
-        public void setItem(ItemStack item) {
-            this.item = item;
+        public void setItemStack(ItemStack itemStack) {
+            this.itemStack = itemStack;
         }
     }
 

--- a/common/src/main/java/com/wynntils/mc/mixin/GuiMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/GuiMixin.java
@@ -32,15 +32,17 @@ public abstract class GuiMixin {
     @Inject(
             method = "renderSlot(IIFLnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/ItemStack;I)V",
             at = @At("HEAD"))
-    private void renderSlotPre(int x, int y, float ticks, Player player, ItemStack stack, int i, CallbackInfo info) {
-        EventFactory.onHotbarSlotRenderPre(stack, x, y);
+    private void renderSlotPre(
+            int x, int y, float ticks, Player player, ItemStack itemStack, int i, CallbackInfo info) {
+        EventFactory.onHotbarSlotRenderPre(itemStack, x, y);
     }
 
     @Inject(
             method = "renderSlot(IIFLnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/ItemStack;I)V",
             at = @At("RETURN"))
-    private void renderSlotPost(int x, int y, float ticks, Player player, ItemStack stack, int i, CallbackInfo info) {
-        EventFactory.onHotbarSlotRenderPost(stack, x, y);
+    private void renderSlotPost(
+            int x, int y, float ticks, Player player, ItemStack itemStack, int i, CallbackInfo info) {
+        EventFactory.onHotbarSlotRenderPost(itemStack, x, y);
     }
 
     // This does not work on Forge. See ForgeIngameGuiMixin for replacement.

--- a/common/src/main/java/com/wynntils/mc/mixin/SlotMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/SlotMixin.java
@@ -21,12 +21,12 @@ public abstract class SlotMixin {
                     @At(
                             value = "INVOKE",
                             target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V"))
-    private void redirectSetItem(Container container, int slot, ItemStack stack) {
-        SetSlotEvent result = EventFactory.onSetSlotPre(container, slot, stack);
+    private void redirectSetItem(Container container, int slot, ItemStack itemStack) {
+        SetSlotEvent result = EventFactory.onSetSlotPre(container, slot, itemStack);
         if (result.isCanceled()) return;
 
-        container.setItem(slot, result.getItem());
+        container.setItem(slot, result.getItemStack());
 
-        EventFactory.onSetSlotPost(container, slot, stack);
+        EventFactory.onSetSlotPost(container, slot, itemStack);
     }
 }

--- a/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
@@ -75,11 +75,11 @@ public final class CharacterSelectionModel extends Model {
 
         List<ItemStack> items = event.getItems();
         for (int i = 0; i < items.size(); i++) {
-            ItemStack item = items.get(i);
-            String itemName = ComponentUtils.getCoded(item.getHoverName());
+            ItemStack itemStack = items.get(i);
+            String itemName = ComponentUtils.getCoded(itemStack.getHoverName());
             Matcher classItemMatcher = CLASS_ITEM_NAME_PATTERN.matcher(itemName);
             if (classItemMatcher.matches()) {
-                ClassInfo classInfo = getClassInfoFromItem(item, i, classItemMatcher.group(1));
+                ClassInfo classInfo = getClassInfoFromItem(itemStack, i, classItemMatcher.group(1));
                 classInfoList.add(classInfo);
                 continue;
             }
@@ -96,13 +96,13 @@ public final class CharacterSelectionModel extends Model {
         }
     }
 
-    private ClassInfo getClassInfoFromItem(ItemStack item, int slot, String className) {
+    private ClassInfo getClassInfoFromItem(ItemStack itemStack, int slot, String className) {
         ClassType classType = null;
         int level = 0;
         int xp = 0;
         int soulPoints = 0;
         int finishedQuests = 0;
-        for (String line : LoreUtils.getLore(item)) {
+        for (String line : LoreUtils.getLore(itemStack)) {
             Matcher matcher = CLASS_ITEM_CLASS_PATTERN.matcher(line);
 
             if (matcher.matches()) {
@@ -138,7 +138,7 @@ public final class CharacterSelectionModel extends Model {
             }
         }
 
-        return new ClassInfo(className, item, slot, classType, level, xp, soulPoints, finishedQuests);
+        return new ClassInfo(className, itemStack, slot, classType, level, xp, soulPoints, finishedQuests);
     }
 
     public void playWithCharacter(int slot) {

--- a/common/src/main/java/com/wynntils/models/discoveries/DiscoveryContainerQueries.java
+++ b/common/src/main/java/com/wynntils/models/discoveries/DiscoveryContainerQueries.java
@@ -145,8 +145,8 @@ public class DiscoveryContainerQueries {
             for (int col = 0; col < 7; col++) {
                 int slot = row * 9 + col;
 
-                ItemStack item = container.items().get(slot);
-                DiscoveryInfo discoveryInfo = DiscoveryInfo.parseFromItemStack(item);
+                ItemStack itemStack = container.items().get(slot);
+                DiscoveryInfo discoveryInfo = DiscoveryInfo.parseFromItemStack(itemStack);
                 if (discoveryInfo == null) continue;
 
                 newDiscoveries.add(discoveryInfo);

--- a/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
+++ b/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
@@ -156,7 +156,7 @@ public final class EmeraldModel extends Model {
         // Subtract the outgoing object from our balance
         adjustBalance(event.getContainer().getItem(event.getSlot()), -1, isInventory);
         // And add the incoming value
-        adjustBalance(event.getItem(), 1, isInventory);
+        adjustBalance(event.getItemStack(), 1, isInventory);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/horse/HorseModel.java
+++ b/common/src/main/java/com/wynntils/models/horse/HorseModel.java
@@ -33,8 +33,8 @@ public class HorseModel extends Model {
     public int findHorseSlotNum() {
         Inventory inventory = McUtils.inventory();
         for (int slotNum = 0; slotNum <= 44; slotNum++) {
-            ItemStack stack = inventory.getItem(slotNum);
-            if (getHorseItem(stack) != null) {
+            ItemStack itemStack = inventory.getItem(slotNum);
+            if (getHorseItem(itemStack) != null) {
                 return slotNum;
             }
         }

--- a/common/src/main/java/com/wynntils/models/quests/QuestContainerQueries.java
+++ b/common/src/main/java/com/wynntils/models/quests/QuestContainerQueries.java
@@ -67,8 +67,8 @@ public class QuestContainerQueries {
                 // Very first slot is chat history
                 if (slot == 0) continue;
 
-                ItemStack item = container.items().get(slot);
-                QuestInfo questInfo = QuestInfoParser.parseItem(item, page, false);
+                ItemStack itemStack = container.items().get(slot);
+                QuestInfo questInfo = QuestInfoParser.parseItemStack(itemStack, page, false);
                 if (questInfo == null) continue;
 
                 newQuests.add(questInfo);
@@ -123,8 +123,8 @@ public class QuestContainerQueries {
             for (int col = 0; col < 7; col++) {
                 int slot = row * 9 + col;
 
-                ItemStack item = container.items().get(slot);
-                QuestInfo questInfo = QuestInfoParser.parseItem(item, page, true);
+                ItemStack itemStack = container.items().get(slot);
+                QuestInfo questInfo = QuestInfoParser.parseItemStack(itemStack, page, true);
                 if (questInfo == null) continue;
 
                 if (questInfo.isTracked()) {
@@ -176,9 +176,9 @@ public class QuestContainerQueries {
                 // Very first slot is chat history
                 if (slot == 0) continue;
 
-                ItemStack item = container.items().get(slot);
+                ItemStack itemStack = container.items().get(slot);
 
-                String questName = QuestInfoParser.getQuestName(item);
+                String questName = QuestInfoParser.getQuestName(itemStack);
                 if (Objects.equals(questName, questInfo.getName())) {
                     ContainerUtils.clickOnSlot(
                             slot, container.containerId(), GLFW.GLFW_MOUSE_BUTTON_LEFT, container.items());

--- a/common/src/main/java/com/wynntils/models/quests/QuestInfoParser.java
+++ b/common/src/main/java/com/wynntils/models/quests/QuestInfoParser.java
@@ -25,12 +25,12 @@ public final class QuestInfoParser {
     private static final Pattern LEVEL_MATCHER = Pattern.compile("^§..§r§7 Combat Lv. Min: §r§f(\\d+)$");
     private static final Pattern REQ_MATCHER = Pattern.compile("^§..§r§7 (.*) Lv. Min: §r§f(\\d+)$");
 
-    static QuestInfo parseItem(ItemStack item, int pageNumber, boolean isMiniQuest) {
+    static QuestInfo parseItemStack(ItemStack itemStack, int pageNumber, boolean isMiniQuest) {
         try {
-            String name = getQuestName(item);
+            String name = getQuestName(itemStack);
             if (name == null) return null;
 
-            LinkedList<String> lore = LoreUtils.getLore(item);
+            LinkedList<String> lore = LoreUtils.getLore(itemStack);
 
             QuestStatus status = getQuestStatus(lore);
             if (status == null) return null;
@@ -46,7 +46,7 @@ public final class QuestInfoParser {
             if (!skipEmptyLine(lore)) return null;
 
             String description = getDescription(lore);
-            boolean tracked = isQuestTracked(item);
+            boolean tracked = isQuestTracked(itemStack);
 
             return new QuestInfo(
                     name,
@@ -59,13 +59,13 @@ public final class QuestInfoParser {
                     pageNumber,
                     tracked);
         } catch (NoSuchElementException e) {
-            WynntilsMod.warn("Failed to parse quest book item: " + item);
+            WynntilsMod.warn("Failed to parse quest book item: " + itemStack);
             return null;
         }
     }
 
-    static String getQuestName(ItemStack item) {
-        String rawName = item.getHoverName().getString();
+    static String getQuestName(ItemStack itemStack) {
+        String rawName = itemStack.getHoverName().getString();
         if (rawName.trim().isEmpty()) {
             return null;
         }
@@ -77,8 +77,8 @@ public final class QuestInfoParser {
         return m.group(2);
     }
 
-    private static boolean isQuestTracked(ItemStack item) {
-        String rawName = item.getHoverName().getString();
+    private static boolean isQuestTracked(ItemStack itemStack) {
+        String rawName = itemStack.getHoverName().getString();
         if (rawName.trim().isEmpty()) {
             return false;
         }

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -35,8 +35,8 @@ public final class LoreUtils {
      *
      * @return an {@link List} containing all item lore
      */
-    public static LinkedList<String> getLore(ItemStack item) {
-        ListTag loreTag = getLoreTag(item);
+    public static LinkedList<String> getLore(ItemStack itemStack) {
+        ListTag loreTag = getLoreTag(itemStack);
 
         LinkedList<String> lore = new LinkedList<>();
         if (loreTag == null) return lore;
@@ -52,8 +52,8 @@ public final class LoreUtils {
      * Returns the lore for the given line, or the empty string if there is no
      * such line.
      */
-    public static String getLoreLine(ItemStack item, int line) {
-        ListTag loreTag = getLoreTag(item);
+    public static String getLoreLine(ItemStack itemStack, int line) {
+        ListTag loreTag = getLoreTag(itemStack);
         if (loreTag == null) return "";
 
         return ComponentUtils.getCoded(loreTag.getString(line));
@@ -64,10 +64,10 @@ public final class LoreUtils {
      * and checking 5 more lines. (The reason for this is that the Trade Market
      * inserts additional lines at the top of the lore.)
      */
-    public static Matcher matchLoreLine(ItemStack item, int startLineNum, Pattern pattern) {
+    public static Matcher matchLoreLine(ItemStack itemStack, int startLineNum, Pattern pattern) {
         Matcher matcher = null;
         for (int i = startLineNum; i <= startLineNum + 5; i++) {
-            String line = getLoreLine(item, i);
+            String line = getLoreLine(itemStack, i);
             matcher = pattern.matcher(line);
             if (matcher.matches()) return matcher;
         }
@@ -83,18 +83,18 @@ public final class LoreUtils {
      *
      * @return a {@link String} containing all item lore
      */
-    public static String getStringLore(ItemStack item) {
+    public static String getStringLore(ItemStack itemStack) {
         StringBuilder toReturn = new StringBuilder();
-        for (String x : getLore(item)) {
+        for (String x : getLore(itemStack)) {
             toReturn.append(x);
         }
         return toReturn.toString();
     }
 
     /** Get the lore NBT tag from an item, else return empty */
-    public static ListTag getLoreTagElseEmpty(ItemStack item) {
-        if (item.isEmpty()) return new ListTag();
-        CompoundTag display = item.getTagElement("display");
+    public static ListTag getLoreTagElseEmpty(ItemStack itemStack) {
+        if (itemStack.isEmpty()) return new ListTag();
+        CompoundTag display = itemStack.getTagElement("display");
 
         if (display == null || display.getType() != CompoundTag.TYPE || !display.contains("Lore")) return new ListTag();
         Tag loreBase = display.get("Lore");
@@ -104,9 +104,9 @@ public final class LoreUtils {
     }
 
     /** Get the lore NBT tag from an item, else return null */
-    public static ListTag getLoreTag(ItemStack item) {
-        if (item.isEmpty()) return null;
-        CompoundTag display = item.getTagElement("display");
+    public static ListTag getLoreTag(ItemStack itemStack) {
+        if (itemStack.isEmpty()) return null;
+        CompoundTag display = itemStack.getTagElement("display");
 
         if (display == null || display.getType() != CompoundTag.TYPE || !display.contains("Lore")) return null;
         Tag loreBase = display.get("Lore");
@@ -116,10 +116,10 @@ public final class LoreUtils {
     }
 
     /** Get the lore NBT tag from an item, else return null */
-    public static ListTag getOrCreateLoreTag(ItemStack item) {
-        if (item.isEmpty()) return null;
+    public static ListTag getOrCreateLoreTag(ItemStack itemStack) {
+        if (itemStack.isEmpty()) return null;
 
-        Tag display = getOrCreateTag(item.getOrCreateTag(), "display", CompoundTag::new);
+        Tag display = getOrCreateTag(itemStack.getOrCreateTag(), "display", CompoundTag::new);
         if (display.getType() != CompoundTag.TYPE) return null;
 
         Tag lore = getOrCreateTag((CompoundTag) display, "lore", ListTag::new);
@@ -135,15 +135,15 @@ public final class LoreUtils {
     /**
      * Replace the lore on an item's NBT tag.
      *
-     * @param stack The {@link ItemStack} to have its
+     * @param itemStack The {@link ItemStack} to have its
      * @param tag The {@link ListTag} to replace with
      */
-    public static void replaceLore(ItemStack stack, ListTag tag) {
-        CompoundTag nbt = stack.getOrCreateTag();
+    public static void replaceLore(ItemStack itemStack, ListTag tag) {
+        CompoundTag nbt = itemStack.getOrCreateTag();
         CompoundTag display = (CompoundTag) getOrCreateTag(nbt, "display", CompoundTag::new);
         display.put("Lore", tag);
         nbt.put("display", display);
-        stack.setTag(nbt);
+        itemStack.setTag(nbt);
     }
 
     /** Converts a string to a usable lore tag */
@@ -180,9 +180,9 @@ public final class LoreUtils {
         return StringTag.valueOf(Component.Serializer.toJson(toConvert));
     }
 
-    public static List<Component> getTooltipLines(ItemStack stack) {
+    public static List<Component> getTooltipLines(ItemStack itemStack) {
         TooltipFlag flag = McUtils.options().advancedItemTooltips ? TooltipFlag.ADVANCED : TooltipFlag.NORMAL;
-        return stack.getTooltipLines(McUtils.player(), flag);
+        return itemStack.getTooltipLines(McUtils.player(), flag);
     }
 
     public static List<Component> appendTooltip(

--- a/common/src/main/java/com/wynntils/utils/mc/SkinUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/SkinUtils.java
@@ -12,13 +12,13 @@ import net.minecraft.nbt.NbtUtils;
 import net.minecraft.world.item.ItemStack;
 
 public final class SkinUtils {
-    public static void setPlayerHeadSkin(ItemStack stack, String textureString) {
+    public static void setPlayerHeadSkin(ItemStack itemStack, String textureString) {
         // If this starts being done repeatedly for the same texture string, we should cache
         // the UUID.
         GameProfile gameProfile = new GameProfile(UUID.randomUUID(), null);
         gameProfile.getProperties().put("textures", new Property("textures", textureString, ""));
 
-        CompoundTag compoundTag = stack.getOrCreateTag();
+        CompoundTag compoundTag = itemStack.getOrCreateTag();
         compoundTag.put("SkullOwner", NbtUtils.writeGameProfile(new CompoundTag(), gameProfile));
     }
 }


### PR DESCRIPTION
I got tired of the mix of `itemStack`, `item` and `stack`...