### PR TITLE
fix: Stop warning about unknown URLs at startup

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/UrlManager.java
+++ b/common/src/main/java/com/wynntils/core/net/UrlManager.java
@@ -164,7 +164,6 @@ public final class UrlManager extends Manager {
 
             if (urlId.isEmpty()) {
                 // This is a URL we don't know about. Ignore it.
-                WynntilsMod.warn("Unknown URL: " + urlProfile.id);
                 continue;
             }
 


### PR DESCRIPTION
We have a bunch of old URLs that are no longer used, we can't really remove them and they will just accumulate going forward. So don't warn about them.