### PR TITLE
refactor: Round BlockPos coordinates to integers

### DIFF
--- a/common/src/main/java/com/wynntils/commands/LootrunCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LootrunCommand.java
@@ -18,6 +18,7 @@ import com.wynntils.models.lootruns.type.LootrunState;
 import com.wynntils.models.lootruns.type.LootrunUndoResult;
 import com.wynntils.screens.lootrun.WynntilsLootrunsScreen;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.PosUtils;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Stream;
@@ -113,7 +114,7 @@ public class LootrunCommand extends Command {
             return 0;
         }
 
-        BlockPos start = new BlockPos(startingPoint);
+        BlockPos start = PosUtils.newBlockPos(startingPoint);
         context.getSource()
                 .sendSuccess(
                         Component.translatable(
@@ -228,7 +229,7 @@ public class LootrunCommand extends Command {
         } else {
             MutableComponent component = Component.translatable("feature.wynntils.lootrunUtils.listNoteHeader");
             for (LootrunNote note : notes) {
-                BlockPos pos = new BlockPos(note.position());
+                BlockPos pos = PosUtils.newBlockPos(note.position());
                 String posString = pos.toShortString();
 
                 component

--- a/common/src/main/java/com/wynntils/models/lootruns/LootrunCompiler.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/LootrunCompiler.java
@@ -10,6 +10,7 @@ import com.wynntils.models.lootruns.type.ColoredPoint;
 import com.wynntils.models.lootruns.type.LootrunNote;
 import com.wynntils.models.lootruns.type.LootrunPath;
 import com.wynntils.utils.MathUtils;
+import com.wynntils.utils.mc.PosUtils;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.ArrayList;
@@ -200,7 +201,7 @@ public final class LootrunCompiler {
     private static Long2ObjectMap<List<LootrunNote>> getNotes(List<LootrunNote> notes) {
         Long2ObjectMap<List<LootrunNote>> result = new Long2ObjectOpenHashMap<>();
         for (LootrunNote note : notes) {
-            ChunkPos chunk = new ChunkPos(new BlockPos(note.position()));
+            ChunkPos chunk = new ChunkPos(PosUtils.newBlockPos(note.position()));
             List<LootrunNote> notesChunk = result.computeIfAbsent(chunk.toLong(), (chunkPos) -> new ArrayList<>());
             notesChunk.add(note);
         }

--- a/common/src/main/java/com/wynntils/models/lootruns/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/LootrunModel.java
@@ -24,6 +24,7 @@ import com.wynntils.models.lootruns.type.LootrunState;
 import com.wynntils.models.lootruns.type.LootrunUndoResult;
 import com.wynntils.utils.FileUtils;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.PosUtils;
 import java.io.File;
 import java.io.FileReader;
 import java.nio.charset.StandardCharsets;
@@ -228,7 +229,7 @@ public final class LootrunModel extends Model {
         List<LootrunNote> notes = current.notes();
         for (int i = 0; i < notes.size(); i++) {
             LootrunNote note = notes.get(i);
-            if (pos.equals(new BlockPos(note.position()))) {
+            if (pos.equals(PosUtils.newBlockPos(note.position()))) {
                 return notes.remove(i);
             }
         }

--- a/common/src/main/java/com/wynntils/models/lootruns/LootrunRenderer.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/LootrunRenderer.java
@@ -14,6 +14,7 @@ import com.wynntils.models.lootruns.type.ColoredPath;
 import com.wynntils.models.lootruns.type.ColoredPoint;
 import com.wynntils.models.lootruns.type.LootrunNote;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.PosUtils;
 import com.wynntils.utils.render.buffered.CustomRenderType;
 import com.wynntils.utils.type.Pair;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
@@ -155,7 +156,7 @@ public final class LootrunRenderer {
             BlockPos lastBlockPos = null;
 
             for (ColoredPoint point : locationsInRoute.points()) {
-                BlockPos blockPos = new BlockPos(point.vec3());
+                BlockPos blockPos = PosUtils.newBlockPos(point.vec3());
 
                 if (blockPos.equals(lastBlockPos)) { // Do not recalculate block validness
                     if (!toRender.points().isEmpty()) {
@@ -215,7 +216,7 @@ public final class LootrunRenderer {
 
             for (int i = 0; i < locationsInRoute.points().size() - 1; i += 10) {
                 ColoredPoint point = locationsInRoute.points().get(i);
-                BlockPos blockPos = new BlockPos(point.vec3());
+                BlockPos blockPos = PosUtils.newBlockPos(point.vec3());
 
                 ColoredPoint end = locationsInRoute
                         .points()

--- a/common/src/main/java/com/wynntils/models/lootruns/type/BlockValidness.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/type/BlockValidness.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.lootruns.type;
 
+import com.wynntils.utils.mc.PosUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
@@ -32,8 +33,8 @@ public enum BlockValidness {
     }
 
     private static Iterable<BlockPos> getBlocksForPoint(ColoredPoint loc) {
-        BlockPos minPos = new BlockPos(loc.vec3().x - 0.3D, loc.vec3().y - 1D, loc.vec3().z - 0.3D);
-        BlockPos maxPos = new BlockPos(loc.vec3().x + 0.3D, loc.vec3().y - 1D, loc.vec3().z + 0.3D);
+        BlockPos minPos = PosUtils.newBlockPos(loc.vec3().x - 0.3D, loc.vec3().y - 1D, loc.vec3().z - 0.3D);
+        BlockPos maxPos = PosUtils.newBlockPos(loc.vec3().x + 0.3D, loc.vec3().y - 1D, loc.vec3().z + 0.3D);
 
         return BlockPos.betweenClosed(minPos, maxPos);
     }

--- a/common/src/main/java/com/wynntils/utils/mc/PosUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/PosUtils.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.mc;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+public final class PosUtils {
+    public static BlockPos newBlockPos(double x, double y, double z) {
+        return new BlockPos((int) x, (int) y, (int) z);
+    }
+
+    public static BlockPos newBlockPos(Vec3 vec3) {
+        return new BlockPos((int) vec3.x, (int) vec3.y, (int) vec3.z);
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/mc/type/Location.java
+++ b/common/src/main/java/com/wynntils/utils/mc/type/Location.java
@@ -5,6 +5,7 @@
 package com.wynntils.utils.mc.type;
 
 import com.wynntils.models.map.PoiLocation;
+import com.wynntils.utils.mc.PosUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
 import net.minecraft.world.entity.Entity;
@@ -93,7 +94,7 @@ public class Location extends Vector3d implements Position {
     }
 
     public BlockPos toBlockPos() {
-        return new BlockPos(x, y, z);
+        return PosUtils.newBlockPos(x, y, z);
     }
 
     public Vec3 toVec3() {


### PR DESCRIPTION
BlockPos only deals in integer coordinates. In 1.19.4, the BlockPos constructor which accepts floating point coordinates will be removed. Let's fix our usage already.