### PR TITLE
fix: NPE in maps due to compass provider returning null location

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -21,6 +21,7 @@ import com.wynntils.core.features.overlays.annotations.OverlayInfo;
 import com.wynntils.core.features.overlays.sizes.GuiScaledOverlaySize;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.map.MapTexture;
+import com.wynntils.models.map.PoiLocation;
 import com.wynntils.models.map.pois.PlayerMiniMapPoi;
 import com.wynntils.models.map.pois.Poi;
 import com.wynntils.models.map.pois.WaypointPoi;
@@ -284,8 +285,11 @@ public class MinimapFeature extends UserFeature {
 
             WaypointPoi compass = compassOpt.get();
 
-            float compassOffsetX = (compass.getLocation().getX() - (float) playerX) / scale;
-            float compassOffsetZ = (compass.getLocation().getZ() - (float) playerZ) / scale;
+            PoiLocation compassLocation = compass.getLocation();
+            if (compassLocation == null) return;
+
+            float compassOffsetX = (compassLocation.getX() - (float) playerX) / scale;
+            float compassOffsetZ = (compassLocation.getZ() - (float) playerZ) / scale;
 
             if (followPlayerRotation) {
                 float tempCompassOffsetX = compassOffsetX * cosRotationRadians - compassOffsetZ * sinRotationRadians;

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.models.map.MapTexture;
+import com.wynntils.models.map.PoiLocation;
 import com.wynntils.models.map.pois.IconPoi;
 import com.wynntils.models.map.pois.LabelPoi;
 import com.wynntils.models.map.pois.Poi;
@@ -168,6 +169,11 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
         // Filter and find hovered
         for (int i = pois.size() - 1; i >= 0; i--) {
             Poi poi = pois.get(i);
+            PoiLocation location = poi.getLocation();
+            // This is due to bad design of the compass dynamic waypoint provider,
+            // once that is fixed this can be removed
+            if (location == null) continue;
+
 
             if (poi instanceof IconPoi iconPoi) {
                 // Check if the poi is visible
@@ -188,7 +194,7 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
             float poiHeight = poi.getHeight(currentZoom, poiScale);
 
             BoundingBox filterBox = BoundingBox.centered(
-                    poi.getLocation().getX(), poi.getLocation().getZ(), poiWidth, poiHeight);
+                    location.getX(), location.getZ(), poiWidth, poiHeight);
             BoundingBox mouseBox = BoundingBox.centered(poiRenderX, poiRenderZ, poiWidth, poiHeight);
 
             if (filterBox.intersects(textureBoundingBox)) {

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -174,7 +174,6 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
             // once that is fixed this can be removed
             if (location == null) continue;
 
-
             if (poi instanceof IconPoi iconPoi) {
                 // Check if the poi is visible
                 if (iconPoi.getIconAlpha(currentZoom) < 0.1f) {
@@ -193,8 +192,7 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
             float poiWidth = poi.getWidth(currentZoom, poiScale);
             float poiHeight = poi.getHeight(currentZoom, poiScale);
 
-            BoundingBox filterBox = BoundingBox.centered(
-                    location.getX(), location.getZ(), poiWidth, poiHeight);
+            BoundingBox filterBox = BoundingBox.centered(location.getX(), location.getZ(), poiWidth, poiHeight);
             BoundingBox mouseBox = BoundingBox.centered(poiRenderX, poiRenderZ, poiWidth, poiHeight);
 
             if (filterBox.intersects(textureBoundingBox)) {


### PR DESCRIPTION
This can happen if the quest compass provider returns null.

Ideally, we should re-think how this dynamic location provider thing works. We have a lot of null checks and optionals and stuff, but then we still ended up with a null location...