### PR TITLE
fix: Validate downloaded update hash before applying

### DIFF
--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -316,22 +316,7 @@ public class WynntilsCommand extends Command {
             WynntilsMod.info("Attempting to fetch Wynntils update.");
             CompletableFuture<UpdateManager.UpdateResult> completableFuture = Managers.Update.tryUpdate();
 
-            completableFuture.whenComplete((result, throwable) -> {
-                switch (result) {
-                    case SUCCESSFUL -> McUtils.sendMessageToClient(
-                            Component.translatable("feature.wynntils.updates.result.successful")
-                                    .withStyle(ChatFormatting.DARK_GREEN));
-                    case ERROR -> McUtils.sendMessageToClient(
-                            Component.translatable("feature.wynntils.updates.result.error")
-                                    .withStyle(ChatFormatting.DARK_RED));
-                    case ALREADY_ON_LATEST -> McUtils.sendMessageToClient(
-                            Component.translatable("feature.wynntils.updates.result.latest")
-                                    .withStyle(ChatFormatting.YELLOW));
-                    case UPDATE_PENDING -> McUtils.sendMessageToClient(
-                            Component.translatable("feature.wynntils.updates.result.pending")
-                                    .withStyle(ChatFormatting.YELLOW));
-                }
-            });
+            completableFuture.whenComplete((result, throwable) -> McUtils.sendMessageToClient(result.getMessage()));
         });
 
         context.getSource()

--- a/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
@@ -63,22 +63,8 @@ public class UpdatesFeature extends UserFeature {
 
                         CompletableFuture<UpdateManager.UpdateResult> completableFuture = Managers.Update.tryUpdate();
 
-                        completableFuture.whenCompleteAsync((result, t) -> {
-                            switch (result) {
-                                case SUCCESSFUL -> McUtils.sendMessageToClient(
-                                        Component.translatable("feature.wynntils.updates.result.successful")
-                                                .withStyle(ChatFormatting.DARK_GREEN));
-                                case ERROR -> McUtils.sendMessageToClient(
-                                        Component.translatable("feature.wynntils.updates.result.error")
-                                                .withStyle(ChatFormatting.DARK_RED));
-                                case ALREADY_ON_LATEST -> McUtils.sendMessageToClient(
-                                        Component.translatable("feature.wynntils.updates.result.latest")
-                                                .withStyle(ChatFormatting.YELLOW));
-                                case UPDATE_PENDING -> McUtils.sendMessageToClient(
-                                        Component.translatable("feature.wynntils.updates.result.pending")
-                                                .withStyle(ChatFormatting.YELLOW));
-                            }
-                        });
+                        completableFuture.whenCompleteAsync(
+                                (result, t) -> McUtils.sendMessageToClient(result.getMessage()));
                     }
                 })));
     }


### PR DESCRIPTION
Fixes #1324 