### PR TITLE
fix: Fix Telemetry command when using specific mods

### DIFF
--- a/common/src/main/java/com/wynntils/features/wynntils/TelemetryFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/TelemetryFeature.java
@@ -70,7 +70,7 @@ public class TelemetryFeature extends UserFeature {
                 .withStyle(ChatFormatting.GREEN)
                 .withStyle(ChatFormatting.UNDERLINE)
                 .withStyle(style -> style.withClickEvent(new ClickEvent(
-                        ClickEvent.Action.RUN_COMMAND, "/config set TelemetryFeature crashReports true"))));
+                        ClickEvent.Action.RUN_COMMAND, "/wynntils config set TelemetryFeature crashReports true"))));
         component.append(
                 Component.literal(" to accept crash report telemetry\n").withStyle(ChatFormatting.GREEN));
 
@@ -78,7 +78,7 @@ public class TelemetryFeature extends UserFeature {
                 .withStyle(ChatFormatting.RED)
                 .withStyle(ChatFormatting.UNDERLINE)
                 .withStyle(style -> style.withClickEvent(new ClickEvent(
-                        ClickEvent.Action.RUN_COMMAND, "/config set TelemetryFeature crashReports false"))));
+                        ClickEvent.Action.RUN_COMMAND, "/wynntils config set TelemetryFeature crashReports false"))));
         component.append(
                 Component.literal(" to opt out of crash report telemetry\n").withStyle(ChatFormatting.RED));
 


### PR DESCRIPTION
When using mods that implement `/config` command (for example, commonly used Legendary Tooltips) the Wynntils' alias for `/wynntils config` stops working, making it impossible to opt-in or opt-out of the sending crash reports using the chat message. This PR simply makes it use full `/wynntils config` command to make it always work.