### PR TITLE
refactor: Sort out position <-> location

### DIFF
--- a/common/src/main/java/com/wynntils/commands/LootrunCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LootrunCommand.java
@@ -30,12 +30,12 @@ import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.arguments.ComponentArgument;
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.phys.Vec3;
 
 public class LootrunCommand extends Command {
     private static final SuggestionProvider<CommandSourceStack> LOOTRUN_SUGGESTION_PROVIDER =
@@ -105,7 +105,7 @@ public class LootrunCommand extends Command {
         String fileName = StringArgumentType.getString(context, "lootrun");
 
         boolean successful = Models.Lootrun.loadFile(fileName);
-        Vec3 startingPoint = Models.Lootrun.getStartingPoint();
+        Position startingPoint = Models.Lootrun.getStartingPoint();
 
         if (!successful || startingPoint == null) {
             context.getSource()

--- a/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
@@ -20,7 +20,7 @@ import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.CustomBeaconRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BeaconRenderer;
-import net.minecraft.world.phys.Vec3;
+import net.minecraft.core.Position;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @ConfigCategory(Category.MAP)
@@ -36,12 +36,12 @@ public class BeaconBeamFeature extends UserFeature {
         MultiBufferSource.BufferSource bufferSource =
                 MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
 
-        Vec3 camera = event.getCamera().getPosition();
+        Position camera = event.getCamera().getPosition();
         Location location = Models.Compass.getCompassLocation().get();
 
-        double dx = location.x - camera.x;
-        double dy = location.y - camera.y;
-        double dz = location.z - camera.z;
+        double dx = location.x - camera.x();
+        double dy = location.y - camera.y();
+        double dz = location.z - camera.z();
 
         double distance = MathUtils.magnitude(dx, dz);
         int maxDistance = McUtils.mc().options.renderDistance().get() * 16;

--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -30,6 +30,7 @@ import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.Optional;
 import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.core.Position;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -74,7 +75,7 @@ public class WorldWaypointDistanceFeature extends UserFeature {
         Location location = Models.Compass.getCompassLocation().get();
         Matrix4f projection = new Matrix4f(event.getProjectionMatrix());
         Camera camera = event.getCamera();
-        Vec3 cameraPos = camera.getPosition();
+        Position cameraPos = camera.getPosition();
 
         // apply camera rotation
         Vector3f xp = new Vector3f(1, 0, 0);
@@ -85,9 +86,9 @@ public class WorldWaypointDistanceFeature extends UserFeature {
         projection.mul(new Matrix4f().rotation(yRotation));
 
         // offset to put text to the center of the block
-        float dx = (float) (location.x + 0.5 - cameraPos.x);
-        float dy = (float) (location.y + 0.5 - cameraPos.y);
-        float dz = (float) (location.z + 0.5 - cameraPos.z);
+        float dx = (float) (location.x + 0.5 - cameraPos.x());
+        float dy = (float) (location.y + 0.5 - cameraPos.y());
+        float dz = (float) (location.z + 0.5 - cameraPos.z());
 
         if (location.y <= 0 || location.y > 255) {
             dy = 0;
@@ -278,12 +279,12 @@ public class WorldWaypointDistanceFeature extends UserFeature {
                 (float) (centerRelativePosition.x + centerPoint.x), (float) (centerRelativePosition.y + centerPoint.y));
     }
 
-    private boolean isInBound(Vec3 position, Window window) {
-        return position.x > 0
-                && position.x < window.getGuiScaledWidth()
-                && position.y > 0
-                && position.y < window.getGuiScaledHeight()
-                && position.z < 1;
+    private boolean isInBound(Position position, Window window) {
+        return position.x() > 0
+                && position.x() < window.getGuiScaledWidth()
+                && position.y() > 0
+                && position.y() < window.getGuiScaledHeight()
+                && position.z() < 1;
     }
 
     // limit the bounding distance to prevent divided by zero in getBoundingIntersectPoint

--- a/common/src/main/java/com/wynntils/functions/SpellFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/SpellFunctions.java
@@ -9,6 +9,8 @@ import com.wynntils.core.functions.Function;
 import com.wynntils.core.functions.arguments.FunctionArguments;
 import com.wynntils.models.abilities.type.ShamanTotem;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.PosUtils;
+import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Locale;
 import net.minecraft.ChatFormatting;
@@ -81,7 +83,7 @@ public class SpellFunctions {
                 return "";
             }
 
-            return shamanTotem.getLocation().toString();
+            return Location.containing(shamanTotem.getPosition()).toString();
         }
 
         @Override
@@ -123,9 +125,7 @@ public class SpellFunctions {
                 return 0d;
             }
 
-            return McUtils.player()
-                    .position()
-                    .distanceTo(shamanTotem.getLocation().toVec3());
+            return McUtils.player().position().distanceTo(PosUtils.toVec3(shamanTotem.getPosition()));
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -43,6 +43,7 @@ import net.minecraft.client.multiplayer.ClientRegistryLayer;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.core.LayeredRegistryAccess;
+import net.minecraft.core.PositionImpl;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MessageSignatureCache;
@@ -73,7 +74,6 @@ import net.minecraft.network.protocol.game.ClientboundTabListPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
 import net.minecraft.network.protocol.game.ServerboundResourcePackPacket;
-import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -218,7 +218,7 @@ public abstract class ClientPacketListenerMixin {
         if (!isRenderThread()) return;
         if (!packet.getRelativeArguments().isEmpty()) return;
 
-        MixinHelper.post(new PlayerTeleportEvent(new Vec3(packet.getX(), packet.getY(), packet.getZ())));
+        MixinHelper.post(new PlayerTeleportEvent(new PositionImpl(packet.getX(), packet.getY(), packet.getZ())));
     }
 
     @Inject(

--- a/common/src/main/java/com/wynntils/models/abilities/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShamanTotemModel.java
@@ -19,13 +19,13 @@ import com.wynntils.models.spells.event.SpellEvent;
 import com.wynntils.models.spells.type.SpellType;
 import com.wynntils.models.worlds.WorldStateModel;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.type.Location;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.minecraft.core.Position;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.item.ItemStack;
@@ -88,12 +88,7 @@ public class ShamanTotemModel extends Model {
                     WynntilsMod.postEvent(new TotemEvent.Summoned(totemNumber, totemAS));
 
                     ShamanTotem newTotem = new ShamanTotem(
-                            totemNumber,
-                            -1,
-                            totemAS.getId(),
-                            -1,
-                            ShamanTotem.TotemState.SUMMONED,
-                            new Location(totemAS.position().x, totemAS.position().y, totemAS.position().z));
+                            totemNumber, -1, totemAS.getId(), -1, ShamanTotem.TotemState.SUMMONED, totemAS.position());
 
                     totems[totemNumber - 1] = newTotem;
                     pendingTotemVisibleIds[totemNumber - 1] = totemAS.getId();
@@ -132,19 +127,18 @@ public class ShamanTotemModel extends Model {
                                 possibleTimer.position().z + TOTEM_SEARCH_RADIUS));
 
         for (ArmorStand armorStand : toCheck) {
-            // Recreate location for each ArmorStand checked for most accurate coordinates
-            Location parsedLocation =
-                    new Location(armorStand.position().x, armorStand.position().y, armorStand.position().z);
+            // Recreate position for each ArmorStand checked for most accurate coordinates
+            Position position = armorStand.position();
 
             for (int i = 0; i < pendingTotemVisibleIds.length; i++) {
                 if (pendingTotemVisibleIds[i] != null && armorStand.getId() == pendingTotemVisibleIds[i]) {
                     ShamanTotem totem = totems[i];
 
                     totem.setTimerEntityId(entityId);
-                    totem.setLocation(parsedLocation);
+                    totem.setPosition(position);
                     totem.setState(ShamanTotem.TotemState.ACTIVE);
 
-                    WynntilsMod.postEvent(new TotemEvent.Activated(totem.getTotemNumber(), parsedLocation));
+                    WynntilsMod.postEvent(new TotemEvent.Activated(totem.getTotemNumber(), position));
 
                     pendingTotemVisibleIds[i] = null;
 
@@ -168,7 +162,7 @@ public class ShamanTotemModel extends Model {
         if (!m.find()) return;
 
         int parsedTime = Integer.parseInt(m.group(1));
-        Location parsedLocation = new Location(entity.position().x, entity.position().y, entity.position().z);
+        Position position = entity.position();
 
         int entityId = entity.getId();
         if (getBoundTotem(entityId) == null) return;
@@ -180,9 +174,9 @@ public class ShamanTotemModel extends Model {
         for (ShamanTotem totem : totems) {
             if (boundTotem == totem) {
                 totem.setTime(parsedTime);
-                totem.setLocation(parsedLocation);
+                totem.setPosition(position);
 
-                WynntilsMod.postEvent(new TotemEvent.Updated(totem.getTotemNumber(), parsedTime, parsedLocation));
+                WynntilsMod.postEvent(new TotemEvent.Updated(totem.getTotemNumber(), parsedTime, position));
 
                 break;
             }

--- a/common/src/main/java/com/wynntils/models/abilities/event/TotemEvent.java
+++ b/common/src/main/java/com/wynntils/models/abilities/event/TotemEvent.java
@@ -5,7 +5,7 @@
 package com.wynntils.models.abilities.event;
 
 import com.wynntils.models.abilities.type.ShamanTotem;
-import com.wynntils.utils.mc.type.Location;
+import net.minecraft.core.Position;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -24,15 +24,15 @@ public abstract class TotemEvent extends Event {
      * Fired when the totem's timer ArmorStand is bound to the visible totem
      */
     public static class Activated extends TotemEvent {
-        private final Location location;
+        private final Position position;
 
-        public Activated(int totemNumber, Location location) {
+        public Activated(int totemNumber, Position position) {
             super(totemNumber);
-            this.location = location;
+            this.position = position;
         }
 
-        public Location getLocation() {
-            return location;
+        public Position getPosition() {
+            return position;
         }
     }
 
@@ -41,20 +41,20 @@ public abstract class TotemEvent extends Event {
      */
     public static class Updated extends TotemEvent {
         private final int time;
-        private final Location location;
+        private final Position position;
 
-        public Updated(int totemNumber, int time, Location location) {
+        public Updated(int totemNumber, int time, Position position) {
             super(totemNumber);
             this.time = time;
-            this.location = location;
+            this.position = position;
         }
 
         public int getTime() {
             return time;
         }
 
-        public Location getLocation() {
-            return location;
+        public Position getPosition() {
+            return position;
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/abilities/type/ShamanTotem.java
+++ b/common/src/main/java/com/wynntils/models/abilities/type/ShamanTotem.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.models.abilities.type;
 
-import com.wynntils.utils.mc.type.Location;
+import net.minecraft.core.Position;
 
 public class ShamanTotem {
     private final int totemNumber;
@@ -12,7 +12,7 @@ public class ShamanTotem {
     private int timerEntityId;
     private int time;
     private TotemState state;
-    private Location location;
+    private Position position;
 
     public ShamanTotem(
             int totemNumber,
@@ -20,13 +20,13 @@ public class ShamanTotem {
             int visibleEntityId,
             int time,
             TotemState totemState,
-            Location location) {
+            Position position) {
         this.totemNumber = totemNumber;
         this.timerEntityId = timerEntityId;
         this.visibleEntityId = visibleEntityId;
         this.time = time;
         this.state = totemState;
-        this.location = location;
+        this.position = position;
     }
 
     public int getTotemNumber() {
@@ -61,12 +61,12 @@ public class ShamanTotem {
         this.state = state;
     }
 
-    public Location getLocation() {
-        return location;
+    public Position getPosition() {
+        return position;
     }
 
-    public void setLocation(Location location) {
-        this.location = location;
+    public void setPosition(Position position) {
+        this.position = position;
     }
 
     public enum TotemState {

--- a/common/src/main/java/com/wynntils/models/lootruns/LootrunCompiler.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/LootrunCompiler.java
@@ -6,7 +6,7 @@ package com.wynntils.models.lootruns;
 
 import com.wynntils.features.LootrunFeature;
 import com.wynntils.models.lootruns.type.ColoredPath;
-import com.wynntils.models.lootruns.type.ColoredPoint;
+import com.wynntils.models.lootruns.type.ColoredPosition;
 import com.wynntils.models.lootruns.type.LootrunNote;
 import com.wynntils.models.lootruns.type.LootrunPath;
 import com.wynntils.utils.MathUtils;
@@ -53,32 +53,32 @@ public final class LootrunCompiler {
     }
 
     private static List<LootrunPath> sample(LootrunPath raw, float sampleRate) {
-        List<LootrunPath> vec3s = new ArrayList<>();
-        LootrunPath currentVec3s = new LootrunPath(new ArrayList<>());
-        vec3s.add(currentVec3s);
+        List<LootrunPath> positions = new ArrayList<>();
+        LootrunPath currentPositions = new LootrunPath(new ArrayList<>());
+        positions.add(currentPositions);
         for (Vec3 element : raw.points()) {
-            if (!currentVec3s.points().isEmpty()
-                    && currentVec3s
+            if (!currentPositions.points().isEmpty()
+                    && currentPositions
                                     .points()
-                                    .get(currentVec3s.points().size() - 1)
+                                    .get(currentPositions.points().size() - 1)
                                     .distanceTo(element)
                             >= 32) {
-                currentVec3s = new LootrunPath(new ArrayList<>());
-                vec3s.add(currentVec3s);
+                currentPositions = new LootrunPath(new ArrayList<>());
+                positions.add(currentPositions);
             }
-            currentVec3s.points().add(element);
+            currentPositions.points().add(element);
         }
 
         List<LootrunPath> result = new ArrayList<>();
-        for (LootrunPath current : vec3s) {
+        for (LootrunPath current : positions) {
             float distance = 0f;
             CubicSpline.Builder<Float, ToFloatFunction<Float>> builderX = CubicSpline.builder(ToFloatFunction.IDENTITY);
             CubicSpline.Builder<Float, ToFloatFunction<Float>> builderY = CubicSpline.builder(ToFloatFunction.IDENTITY);
             CubicSpline.Builder<Float, ToFloatFunction<Float>> builderZ = CubicSpline.builder(ToFloatFunction.IDENTITY);
             for (int i = 0; i < current.points().size(); i++) {
-                Vec3 vec3 = current.points().get(i);
+                Vec3 position = current.points().get(i);
                 if (i > 0) {
-                    distance += current.points().get(i - 1).distanceTo(vec3);
+                    distance += current.points().get(i - 1).distanceTo(position);
                 }
 
                 float slopeX = 0f;
@@ -86,13 +86,13 @@ public final class LootrunCompiler {
                 float slopeZ = 0f;
                 if (i < current.points().size() - 1) {
                     Vec3 next = current.points().get(i + 1);
-                    slopeX = (float) ((next.x - vec3.x) / vec3.distanceTo(next));
-                    slopeY = (float) ((next.y - vec3.y) / vec3.distanceTo(next));
-                    slopeZ = (float) ((next.z - vec3.z) / vec3.distanceTo(next));
+                    slopeX = (float) ((next.x - position.x) / position.distanceTo(next));
+                    slopeY = (float) ((next.y - position.y) / position.distanceTo(next));
+                    slopeZ = (float) ((next.z - position.z) / position.distanceTo(next));
                 }
-                builderX.addPoint(distance, (float) vec3.x, slopeX);
-                builderY.addPoint(distance, (float) vec3.y, slopeY);
-                builderZ.addPoint(distance, (float) vec3.z, slopeZ);
+                builderX.addPoint(distance, (float) position.x, slopeX);
+                builderY.addPoint(distance, (float) position.y, slopeY);
+                builderZ.addPoint(distance, (float) position.z, slopeZ);
             }
             CubicSpline<Float, ToFloatFunction<Float>> splineX = builderX.build();
             CubicSpline<Float, ToFloatFunction<Float>> splineY = builderY.build();
@@ -112,7 +112,7 @@ public final class LootrunCompiler {
 
         List<List<Vec3>> sampled =
                 sample(raw, sampleRate).stream().map(LootrunPath::points).toList();
-        List<Vec3> vec3s = sampled.stream().flatMap(List::stream).toList();
+        List<Vec3> positions = sampled.stream().flatMap(List::stream).toList();
 
         ColoredPath locationsList = new ColoredPath(new ArrayList<>());
 
@@ -124,8 +124,8 @@ public final class LootrunCompiler {
         float differenceGreen = 0;
         float differenceBlue = 0;
 
-        for (int i = 0; i < vec3s.size(); i++) {
-            Vec3 location = vec3s.get(i);
+        for (int i = 0; i < positions.size(); i++) {
+            Vec3 position = positions.get(i);
 
             if (LootrunFeature.INSTANCE.rainbowLootRun && !recording) {
                 int cycleDistance = LootrunFeature.INSTANCE.cycleDistance;
@@ -152,12 +152,12 @@ public final class LootrunCompiler {
                     usedColor += (int) (differenceBlue * done);
                 }
 
-                locationsList.points().add(new ColoredPoint(location, usedColor | 0xff000000));
+                locationsList.points().add(new ColoredPosition(position, usedColor | 0xff000000));
             } else {
                 locationsList
                         .points()
-                        .add(new ColoredPoint(
-                                location,
+                        .add(new ColoredPosition(
+                                position,
                                 recording
                                         ? LootrunFeature.INSTANCE.recordingPathColor.asInt()
                                         : LootrunFeature.INSTANCE.activePathColor.asInt()));
@@ -168,12 +168,12 @@ public final class LootrunCompiler {
         Long2ObjectMap<List<ColoredPath>> sampleByChunk = new Long2ObjectOpenHashMap<>();
         ChunkPos lastChunkPos = null;
         for (int i = 0; i < locationsList.points().size(); i++) {
-            Vec3 location = locationsList.points().get(i).vec3();
+            Vec3 position = locationsList.points().get(i).position();
             ChunkPos currentChunkPos =
-                    new ChunkPos(MathUtils.floor(location.x()) >> 4, MathUtils.floor(location.z()) >> 4);
+                    new ChunkPos(MathUtils.floor(position.x()) >> 4, MathUtils.floor(position.z()) >> 4);
             if (!currentChunkPos.equals(lastChunkPos)) {
                 if (lastChunkPos != null
-                        && location.distanceTo(locationsList.points().get(i - 1).vec3()) < 32) {
+                        && position.distanceTo(locationsList.points().get(i - 1).position()) < 32) {
                     lastLocationList.points().add(locationsList.points().get(i));
                 }
 

--- a/common/src/main/java/com/wynntils/models/lootruns/LootrunFileParser.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/LootrunFileParser.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
+import net.minecraft.core.PositionImpl;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.phys.Vec3;
 
@@ -32,11 +34,11 @@ public final class LootrunFileParser {
         LootrunPath pointsList = new LootrunPath(new ArrayList<>());
         for (JsonElement element : points) {
             JsonObject pointJson = element.getAsJsonObject();
-            Vec3 location = new Vec3(
+            Vec3 position = new Vec3(
                     pointJson.get("x").getAsDouble(),
                     pointJson.get("y").getAsDouble(),
                     pointJson.get("z").getAsDouble());
-            pointsList.points().add(location);
+            pointsList.points().add(position);
         }
         JsonArray chestsJson = json.getAsJsonArray("chests");
         Set<BlockPos> chests = new HashSet<>();
@@ -63,7 +65,7 @@ public final class LootrunFileParser {
                     positionJson = noteJson.getAsJsonObject("location");
                 }
 
-                Vec3 position = new Vec3(
+                Position position = new PositionImpl(
                         positionJson.get("x").getAsDouble(),
                         positionJson.get("y").getAsDouble(),
                         positionJson.get("z").getAsDouble());
@@ -85,11 +87,11 @@ public final class LootrunFileParser {
 
             JsonObject json = new JsonObject();
             JsonArray points = new JsonArray();
-            for (Vec3 point : activeLootrun.path().points()) {
+            for (Position point : activeLootrun.path().points()) {
                 JsonObject pointJson = new JsonObject();
-                pointJson.addProperty("x", point.x);
-                pointJson.addProperty("y", point.y);
-                pointJson.addProperty("z", point.z);
+                pointJson.addProperty("x", point.x());
+                pointJson.addProperty("y", point.y());
+                pointJson.addProperty("z", point.z());
                 points.add(pointJson);
             }
             json.add("points", points);
@@ -109,10 +111,10 @@ public final class LootrunFileParser {
                 JsonObject noteJson = new JsonObject();
                 JsonObject locationJson = new JsonObject();
 
-                Vec3 location = note.position();
-                locationJson.addProperty("x", location.x);
-                locationJson.addProperty("y", location.y);
-                locationJson.addProperty("z", location.z);
+                Position position = note.position();
+                locationJson.addProperty("x", position.x());
+                locationJson.addProperty("y", position.y());
+                locationJson.addProperty("z", position.z());
                 noteJson.add("location", locationJson);
 
                 noteJson.add("note", Component.Serializer.toJsonTree(note.component()));

--- a/common/src/main/java/com/wynntils/models/lootruns/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/LootrunModel.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Blocks;
@@ -243,7 +244,7 @@ public final class LootrunModel extends Model {
         return activeLootrun.notes();
     }
 
-    public Vec3 getStartingPoint() {
+    public Position getStartingPoint() {
         LootrunUncompiled activeLootrun = getActiveLootrun();
         if (activeLootrun == null) return null;
 

--- a/common/src/main/java/com/wynntils/models/lootruns/type/BlockValidness.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/type/BlockValidness.java
@@ -15,7 +15,7 @@ public enum BlockValidness {
     HAS_BARRIER,
     INVALID;
 
-    public static BlockValidness checkBlockValidness(Level level, ColoredPoint point) {
+    public static BlockValidness checkBlockValidness(Level level, ColoredPosition point) {
         BlockValidness state = INVALID;
         Iterable<BlockPos> blocks = getBlocksForPoint(point);
 
@@ -32,9 +32,15 @@ public enum BlockValidness {
         return state;
     }
 
-    private static Iterable<BlockPos> getBlocksForPoint(ColoredPoint loc) {
-        BlockPos minPos = PosUtils.newBlockPos(loc.vec3().x - 0.3D, loc.vec3().y - 1D, loc.vec3().z - 0.3D);
-        BlockPos maxPos = PosUtils.newBlockPos(loc.vec3().x + 0.3D, loc.vec3().y - 1D, loc.vec3().z + 0.3D);
+    private static Iterable<BlockPos> getBlocksForPoint(ColoredPosition loc) {
+        BlockPos minPos = PosUtils.newBlockPos(
+                loc.position().x() - 0.3D,
+                loc.position().y() - 1D,
+                loc.position().z() - 0.3D);
+        BlockPos maxPos = PosUtils.newBlockPos(
+                loc.position().x() + 0.3D,
+                loc.position().y() - 1D,
+                loc.position().z() + 0.3D);
 
         return BlockPos.betweenClosed(minPos, maxPos);
     }

--- a/common/src/main/java/com/wynntils/models/lootruns/type/ColoredPath.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/type/ColoredPath.java
@@ -6,4 +6,4 @@ package com.wynntils.models.lootruns.type;
 
 import java.util.List;
 
-public record ColoredPath(List<ColoredPoint> points) {}
+public record ColoredPath(List<ColoredPosition> points) {}

--- a/common/src/main/java/com/wynntils/models/lootruns/type/ColoredPosition.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/type/ColoredPosition.java
@@ -6,4 +6,4 @@ package com.wynntils.models.lootruns.type;
 
 import net.minecraft.world.phys.Vec3;
 
-public record ColoredPoint(Vec3 vec3, int color) {}
+public record ColoredPosition(Vec3 position, int color) {}

--- a/common/src/main/java/com/wynntils/models/lootruns/type/LootrunNote.java
+++ b/common/src/main/java/com/wynntils/models/lootruns/type/LootrunNote.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.models.lootruns.type;
 
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.phys.Vec3;
 
-public record LootrunNote(Vec3 position, Component component) {}
+public record LootrunNote(Position position, Component component) {}

--- a/common/src/main/java/com/wynntils/models/map/PoiLocation.java
+++ b/common/src/main/java/com/wynntils/models/map/PoiLocation.java
@@ -52,7 +52,7 @@ public class PoiLocation {
     public static PoiLocation fromLocation(Location location) {
         if (location == null) return null;
 
-        return new PoiLocation((int) location.x, (int) location.y, (int) location.z);
+        return new PoiLocation(location.x, location.y, location.z);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/mobtotem/MobTotem.java
+++ b/common/src/main/java/com/wynntils/models/mobtotem/MobTotem.java
@@ -5,22 +5,21 @@
 package com.wynntils.models.mobtotem;
 
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.type.Location;
 import net.minecraft.core.Position;
 import net.minecraft.world.phys.Vec3;
 
 public class MobTotem {
-    private final Location location;
+    private final Position position;
     private final String owner;
     private String timerString;
 
-    public MobTotem(Location location, String owner) {
-        this.location = location;
+    public MobTotem(Position position, String owner) {
+        this.position = position;
         this.owner = owner;
     }
 
-    public Location getLocation() {
-        return location;
+    public Position getPosition() {
+        return position;
     }
 
     public String getOwner() {
@@ -37,14 +36,14 @@ public class MobTotem {
 
     public double getDistanceToPlayer() {
         // y() - 4 because the entity is 4 blocks above the ground
-        return Math.sqrt(McUtils.player().distanceToSqr(new Vec3(location.x(), location.y() - 4, location.z())));
+        return Math.sqrt(McUtils.player().distanceToSqr(new Vec3(position.x(), position.y() - 4, position.z())));
     }
 
     public double getLookAngleDiff() {
-        Vec3 playerLook = McUtils.player().getLookAngle();
-        double lookAngle = Math.toDegrees(StrictMath.atan2(playerLook.z, playerLook.x));
+        Position playerLook = McUtils.player().getLookAngle();
+        double lookAngle = Math.toDegrees(StrictMath.atan2(playerLook.z(), playerLook.x()));
 
-        Position mobTotemLocation = this.getLocation();
+        Position mobTotemLocation = this.getPosition();
         double angle = Math.toDegrees(StrictMath.atan2(
                 mobTotemLocation.z() - McUtils.player().getZ(),
                 mobTotemLocation.x() - McUtils.player().getX()));

--- a/common/src/main/java/com/wynntils/models/mobtotem/MobTotemModel.java
+++ b/common/src/main/java/com/wynntils/models/mobtotem/MobTotemModel.java
@@ -10,7 +10,7 @@ import com.wynntils.handlers.labels.event.EntityLabelChangedEvent;
 import com.wynntils.mc.event.RemoveEntitiesEvent;
 import com.wynntils.models.worlds.WorldStateModel;
 import com.wynntils.models.worlds.event.WorldStateEvent;
-import com.wynntils.utils.mc.type.Location;
+import com.wynntils.utils.mc.PosUtils;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,7 +47,7 @@ public class MobTotemModel extends Model {
 
             if (mobTotems.containsKey(mobTotemId)) return; // If the totem is already in the list, don't add it again
 
-            mobTotems.put(mobTotemId, new MobTotem(new Location(as), nameMatcher.group(1)));
+            mobTotems.put(mobTotemId, new MobTotem(PosUtils.newPosition(as), nameMatcher.group(1)));
             return;
         }
 
@@ -57,9 +57,9 @@ public class MobTotemModel extends Model {
         mobTotems.values().stream()
                 .filter(
                         // Exact equality is fine here because the totem is stationary
-                        mobTotem -> as.getX() == mobTotem.getLocation().x()
-                                && as.getY() == (mobTotem.getLocation().y() + TOTEM_COORDINATE_DIFFERENCE)
-                                && as.getZ() == mobTotem.getLocation().z())
+                        mobTotem -> as.getX() == mobTotem.getPosition().x()
+                                && as.getY() == (mobTotem.getPosition().y() + TOTEM_COORDINATE_DIFFERENCE)
+                                && as.getZ() == mobTotem.getPosition().z())
                 .forEach(mobTotem -> mobTotem.setTimerString(timerMatcher.group(1)));
     }
 

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -20,16 +20,16 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.core.Position;
+import net.minecraft.core.PositionImpl;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class WorldStateModel extends Model {
     private static final UUID WORLD_NAME_UUID = UUID.fromString("16ff7452-714f-3752-b3cd-c3cb2068f6af");
     private static final Pattern WORLD_NAME = Pattern.compile("^§f {2}§lGlobal \\[(.*)\\]$");
     private static final Pattern HUB_NAME = Pattern.compile("^\n§6§l play.wynncraft.com \n$");
-    private static final Position CHARACTER_SELECTION_POSITION = new Vec3(-1337.5, 16.2, -1120.5);
+    private static final Position CHARACTER_SELECTION_POSITION = new PositionImpl(-1337.5, 16.2, -1120.5);
     private static final Pattern WYNNCRAFT_SERVER_PATTERN = Pattern.compile("^(.*)\\.wynncraft\\.(?:com|net|org)$");
     private static final String WYNNCRAFT_BETA_NAME = "beta";
 

--- a/common/src/main/java/com/wynntils/screens/lootrun/WynntilsLootrunsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/lootrun/WynntilsLootrunsScreen.java
@@ -29,8 +29,8 @@ import java.util.Objects;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class WynntilsLootrunsScreen extends WynntilsListScreen<LootrunInstance, LootrunButton> {
@@ -205,12 +205,12 @@ public final class WynntilsLootrunsScreen extends WynntilsListScreen<LootrunInst
                             VerticalAlignment.Top,
                             TextShadow.NONE);
 
-            Vec3 start = currentLootrun.path().points().get(0);
+            Position start = currentLootrun.path().points().get(0);
             FontRenderer.getInstance()
                     .renderText(
                             poseStack,
                             I18n.get("screens.wynntils.lootruns.start") + ": "
-                                    + String.format("[%d, %d, %d]", (int) start.x, (int) start.y, (int) start.z),
+                                    + String.format("[%d, %d, %d]", (int) start.x(), (int) start.y(), (int) start.z()),
                             0,
                             39,
                             CommonColors.BLACK,
@@ -218,7 +218,7 @@ public final class WynntilsLootrunsScreen extends WynntilsListScreen<LootrunInst
                             VerticalAlignment.Top,
                             TextShadow.NONE);
 
-            Vec3 end = currentLootrun
+            Position end = currentLootrun
                     .path()
                     .points()
                     .get(currentLootrun.path().points().size() - 1);
@@ -226,7 +226,7 @@ public final class WynntilsLootrunsScreen extends WynntilsListScreen<LootrunInst
                     .renderText(
                             poseStack,
                             I18n.get("screens.wynntils.lootruns.end") + ": "
-                                    + String.format("[%d, %d, %d]", (int) end.x, (int) end.y, (int) end.z),
+                                    + String.format("[%d, %d, %d]", (int) end.x(), (int) end.y(), (int) end.z()),
                             0,
                             49,
                             CommonColors.BLACK,

--- a/common/src/main/java/com/wynntils/screens/lootrun/widgets/LootrunButton.java
+++ b/common/src/main/java/com/wynntils/screens/lootrun/widgets/LootrunButton.java
@@ -24,8 +24,8 @@ import com.wynntils.utils.render.type.VerticalAlignment;
 import java.io.File;
 import java.util.Objects;
 import net.minecraft.Util;
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.phys.Vec3;
 import org.lwjgl.glfw.GLFW;
 
 public class LootrunButton extends WynntilsButton {
@@ -98,9 +98,9 @@ public class LootrunButton extends WynntilsButton {
             }
 
             LootrunPath path = lootrun.path();
-            Vec3 start = path.points().get(0);
+            Position start = path.points().get(0);
 
-            McUtils.mc().setScreen(MainMapScreen.create((float) start.x, (float) start.z));
+            McUtils.mc().setScreen(MainMapScreen.create((float) start.x(), (float) start.z()));
             return true;
         }
 

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -143,7 +143,7 @@ public final class MainMapScreen extends AbstractMapScreen {
 
                     if (Models.Compass.getCompassLocation().isPresent()) {
                         Location location = Models.Compass.getCompassLocation().get();
-                        updateMapCenter((float) location.x, (float) location.z);
+                        updateMapCenter(location.x, location.z);
                     }
                 },
                 List.of(
@@ -254,7 +254,7 @@ public final class MainMapScreen extends AbstractMapScreen {
             if (McUtils.mc().player.isShiftKeyDown()
                     && Models.Compass.getCompassLocation().isPresent()) {
                 Location location = Models.Compass.getCompassLocation().get();
-                updateMapCenter((float) location.x, (float) location.z);
+                updateMapCenter(location.x, location.z);
                 return true;
             }
 
@@ -311,7 +311,7 @@ public final class MainMapScreen extends AbstractMapScreen {
     private void setCompassToMouseCoords(double mouseX, double mouseY) {
         double gameX = (mouseX - centerX) / currentZoom + mapCenterX;
         double gameZ = (mouseY - centerZ) / currentZoom + mapCenterZ;
-        Location compassLocation = new Location(gameX, 0, gameZ);
+        Location compassLocation = Location.containing(gameX, 0, gameZ);
         Models.Compass.setCompassLocation(compassLocation);
 
         McUtils.playSound(SoundEvents.EXPERIENCE_ORB_PICKUP);

--- a/common/src/main/java/com/wynntils/screens/questbook/widgets/QuestButton.java
+++ b/common/src/main/java/com/wynntils/screens/questbook/widgets/QuestButton.java
@@ -108,8 +108,7 @@ public class QuestButton extends WynntilsButton {
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_MIDDLE) {
             Optional<Location> nextLocation = this.questInfo.getNextLocation();
 
-            nextLocation.ifPresent(
-                    location -> McUtils.mc().setScreen(MainMapScreen.create((float) location.x, (float) location.z)));
+            nextLocation.ifPresent(location -> McUtils.mc().setScreen(MainMapScreen.create(location.x, location.z)));
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
             openQuestWiki();
         }

--- a/common/src/main/java/com/wynntils/utils/mc/PosUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/PosUtils.java
@@ -5,6 +5,9 @@
 package com.wynntils.utils.mc;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
+import net.minecraft.core.PositionImpl;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
 public final class PosUtils {
@@ -12,7 +15,15 @@ public final class PosUtils {
         return new BlockPos((int) x, (int) y, (int) z);
     }
 
-    public static BlockPos newBlockPos(Vec3 vec3) {
-        return new BlockPos((int) vec3.x, (int) vec3.y, (int) vec3.z);
+    public static BlockPos newBlockPos(Position position) {
+        return new BlockPos((int) position.x(), (int) position.y(), (int) position.z());
+    }
+
+    public static Position newPosition(Entity entity) {
+        return new PositionImpl(entity.getX(), entity.getY(), entity.getZ());
+    }
+
+    public static Vec3 toVec3(Position position) {
+        return new Vec3(position.x(), position.y(), position.z());
     }
 }

--- a/common/src/main/java/com/wynntils/utils/mc/type/Location.java
+++ b/common/src/main/java/com/wynntils/utils/mc/type/Location.java
@@ -5,20 +5,22 @@
 package com.wynntils.utils.mc.type;
 
 import com.wynntils.models.map.PoiLocation;
+import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.mc.PosUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
 
-public class Location extends Vector3d implements Position {
-    public Location(double x, double y, double z) {
-        super(x, y, z);
-    }
+public class Location {
+    public final int x;
+    public final int y;
+    public final int z;
 
-    public Location(Entity entity) {
-        this(entity.getX(), entity.getY(), entity.getZ());
+    public Location(int x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     public Location(BlockPos pos) {
@@ -29,68 +31,13 @@ public class Location extends Vector3d implements Position {
         this(location.getX(), location.getY().orElse(0), location.getZ());
     }
 
-    public Location(Position location) {
-        this(location.x(), location.y(), location.z());
+    public static Location containing(Position position) {
+        return new Location(
+                MathUtils.floor(position.x()), MathUtils.floor(position.y()), MathUtils.floor(position.z()));
     }
 
-    public Location add(double x, double y, double z) {
-        this.x += x;
-        this.y += y;
-        this.z += z;
-
-        return this;
-    }
-
-    // An egregious circumvention of the type system; Should have two signatures:
-    // public void subtract(Vector3d) and public Vector3d subtract(Point3d), but that would
-    // be confusing for method chaining, so just subtract *anything*, and this location might become
-    // a vector if we subtracted another location.
-    public Location subtract(Vector3d loc) {
-        x -= loc.x;
-        y -= loc.y;
-        z -= loc.z;
-
-        return this;
-    }
-
-    public Location subtract(double x, double y, double z) {
-        this.x -= x;
-        this.y -= y;
-        this.z -= z;
-
-        return this;
-    }
-
-    public Location subtract(double amount) {
-        this.x -= amount;
-        this.y -= amount;
-        this.z -= amount;
-
-        return this;
-    }
-
-    public Location multiply(Vector3d loc) {
-        x *= loc.x;
-        y *= loc.y;
-        z *= loc.z;
-
-        return this;
-    }
-
-    public Location multiply(double x, double y, double z) {
-        this.x *= x;
-        this.y *= y;
-        this.z *= z;
-
-        return this;
-    }
-
-    public Location multiply(double amount) {
-        this.x *= amount;
-        this.y *= amount;
-        this.z *= amount;
-
-        return this;
+    public static Location containing(double x, double y, double z) {
+        return new Location(MathUtils.floor(x), MathUtils.floor(y), MathUtils.floor(z));
     }
 
     public BlockPos toBlockPos() {
@@ -99,12 +46,6 @@ public class Location extends Vector3d implements Position {
 
     public Vec3 toVec3() {
         return new Vec3(x, y, z);
-    }
-
-    @Override
-    public Location clone() throws CloneNotSupportedException {
-        super.clone();
-        return new Location(x, y, z);
     }
 
     @Override
@@ -117,27 +58,19 @@ public class Location extends Vector3d implements Position {
         return false;
     }
 
-    public boolean equals(Vector3d other) {
-        if (other == null) return false;
-        return x == other.x && y == other.y && z == other.z;
-    }
-
     public String toString() {
         return "[" + (int) Math.round(this.x) + ", " + (int) Math.round(this.y) + ", " + (int) Math.round(this.z) + "]";
     }
 
-    @Override
-    public double x() {
+    public int x() {
         return x;
     }
 
-    @Override
-    public double y() {
+    public int y() {
         return y;
     }
 
-    @Override
-    public double z() {
+    public int z() {
         return z;
     }
 }


### PR DESCRIPTION
We are now consistently using "location" to refer to integer coordinates (like on a map, or a BlockPos), and "position" to refer to real number coordinates (typically entity positions).

I have replaced as many instaces as possible by the Vanilla interface "Position". I have redesigned our "Location" so it only deals with integer coordinates.