### PR TITLE
fix: Fix faulty dynamic logic causing some overlay configs to be not collected

### DIFF
--- a/common/src/main/java/com/wynntils/core/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/config/ConfigManager.java
@@ -79,7 +79,9 @@ public final class ConfigManager extends Manager {
         registerConfigOptions(feature);
 
         for (Overlay overlay : Managers.Overlay.getFeatureOverlays(feature).stream()
-                .filter(overlay -> !overlay.isDynamic())
+                .filter(overlay -> Managers.Overlay.getFeatureOverlayGroups(feature).stream()
+                        .noneMatch(overlayGroupHolder ->
+                                overlayGroupHolder.getOverlays().contains(overlay)))
                 .toList()) {
             registerConfigOptions(overlay);
         }

--- a/common/src/main/java/com/wynntils/core/features/overlays/DynamicOverlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/DynamicOverlay.java
@@ -80,11 +80,6 @@ public abstract class DynamicOverlay extends Overlay {
     }
 
     @Override
-    public boolean isDynamic() {
-        return true;
-    }
-
-    @Override
     public int compareTo(Overlay other) {
         return ComparisonChain.start()
                 .compareTrueFirst(this.isParentEnabled(), other.isParentEnabled())

--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -125,10 +125,6 @@ public abstract class Overlay extends AbstractConfigurable implements Translatab
         return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name);
     }
 
-    public boolean isDynamic() {
-        return false;
-    }
-
     public Boolean isUserEnabled() {
         return userEnabled.get();
     }


### PR DESCRIPTION
There was some (seemingly not) faulty logic behind DynamicOverlay, which in turn lead to non-dynamic TextOverlays (so every text overlay except info boxes) to have their configs not collected.

This fixes the problem, but we still have the weird inheritance issue, where we both want a `DynamicOverlay` and `TextOverlay` base class, but we can't extend from both. So now some of our overlays are `DynamicOverlays` even though they are actually not. I am not sure what we can do with this, since it is not easy to convert either of these classes to an interface.