### PR TITLE
fix: Storage persist should not happen before init, or we wipe our storage

### DIFF
--- a/common/src/main/java/com/wynntils/features/wynntils/ChangelogFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/ChangelogFeature.java
@@ -49,7 +49,6 @@ public class ChangelogFeature extends Feature {
                     String changelog = jsonObject.get("changelog").getAsString();
 
                     lastShownVersion.store(WynntilsMod.getVersion());
-                    Managers.Config.saveConfig();
 
                     if (autoClassMenu.get()) {
                         McUtils.sendCommand("class");


### PR DESCRIPTION
We wrote something to a storage at feature init, making it so we saved storages before even initing.