### PR TITLE
refactor: Just use MultiBufferSource interface

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/overlays/BarOverlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/BarOverlay.java
@@ -48,8 +48,7 @@ public abstract class BarOverlay extends DynamicOverlay {
     }
 
     @Override
-    public void render(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+    public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
         if (!isRendered()) return;
 
         BarOverlayTemplatePair template = getTemplate();
@@ -57,17 +56,13 @@ public abstract class BarOverlay extends DynamicOverlay {
     }
 
     @Override
-    public void renderPreview(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+    public void renderPreview(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
         BarOverlayTemplatePair template = getPreviewTemplate();
         render(poseStack, bufferSource, template.textTemplate, template.valueTemplate);
     }
 
     protected void render(
-            PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
-            String textTemplate,
-            String valueTemplate) {
+            PoseStack poseStack, MultiBufferSource bufferSource, String textTemplate, String valueTemplate) {
         updateCachedLines(textTemplate, valueTemplate);
 
         ErrorOr<CappedValue> valueOrError = templateCache.b();
@@ -102,11 +97,7 @@ public abstract class BarOverlay extends DynamicOverlay {
     protected abstract float getTextureHeight();
 
     protected void renderBar(
-            PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
-            float renderY,
-            float renderHeight,
-            float progress) {
+            PoseStack poseStack, MultiBufferSource bufferSource, float renderY, float renderHeight, float progress) {
         Texture texture = getTexture();
 
         if (getRenderColor() == CommonColors.WHITE) {
@@ -141,8 +132,7 @@ public abstract class BarOverlay extends DynamicOverlay {
         }
     }
 
-    protected void renderText(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float renderY, String text) {
+    protected void renderText(PoseStack poseStack, MultiBufferSource bufferSource, float renderY, String text) {
         BufferedFontRenderer.getInstance()
                 .renderAlignedTextInBox(
                         poseStack,

--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -72,11 +72,9 @@ public abstract class Overlay extends AbstractConfigurable implements Translatab
         this.verticalAlignmentOverride.updateConfig(verticalAlignmentOverride);
     }
 
-    public abstract void render(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window);
+    public abstract void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window);
 
-    public void renderPreview(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+    public void renderPreview(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
         this.render(poseStack, bufferSource, partialTicks, window);
     }
 

--- a/common/src/main/java/com/wynntils/core/features/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/TextOverlay.java
@@ -63,23 +63,21 @@ public abstract class TextOverlay extends DynamicOverlay {
     }
 
     @Override
-    public void render(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+    public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
         if (!Models.WorldState.onWorld()) return;
 
         renderTemplate(poseStack, bufferSource, getTemplate(), getTextScale());
     }
 
     @Override
-    public void renderPreview(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+    public void renderPreview(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
         if (!Models.WorldState.onWorld()) return;
 
         renderTemplate(poseStack, bufferSource, getPreviewTemplate(), getTextScale());
     }
 
     protected void renderTemplate(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, String template, float textScale) {
+            PoseStack poseStack, MultiBufferSource bufferSource, String template, float textScale) {
         updateCachedLines(template);
 
         float renderX = this.getRenderX();

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -113,8 +113,7 @@ public class MinimapFeature extends Feature {
         // FIXME: This is the only overlay not to use buffer sources for rendering. This is due to `createMask`
         // currently not working with buffer sources.
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             if (!Models.WorldState.onWorld()) return;
 
             RenderSystem.setShaderColor(1f, 1f, 1f, 1f);

--- a/common/src/main/java/com/wynntils/features/overlays/CustomBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CustomBarsOverlayFeature.java
@@ -95,7 +95,7 @@ public class CustomBarsOverlayFeature extends Feature {
         @Override
         protected void renderBar(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 float renderY,
                 float renderHeight,
                 float progress) {
@@ -141,7 +141,7 @@ public class CustomBarsOverlayFeature extends Feature {
         @Override
         protected void renderBar(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 float renderY,
                 float renderHeight,
                 float progress) {
@@ -186,11 +186,7 @@ public class CustomBarsOverlayFeature extends Feature {
 
         @Override
         protected void renderBar(
-                PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
-                float renderY,
-                float barHeight,
-                float progress) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float renderY, float barHeight, float progress) {
             BufferedRenderUtils.drawProgressBar(
                     poseStack,
                     bufferSource,
@@ -232,11 +228,7 @@ public class CustomBarsOverlayFeature extends Feature {
 
         @Override
         protected void renderBar(
-                PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
-                float renderY,
-                float barHeight,
-                float progress) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float renderY, float barHeight, float progress) {
             BufferedRenderUtils.drawProgressBar(
                     poseStack,
                     bufferSource,

--- a/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
@@ -121,8 +121,7 @@ public class GameBarsOverlayFeature extends Feature {
         protected abstract boolean isActive();
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             if (!Models.WorldState.onWorld() || !isActive()) return;
 
             float barHeight = textureHeight() * (this.getWidth() / 81);
@@ -152,7 +151,7 @@ public class GameBarsOverlayFeature extends Feature {
 
         protected void renderBar(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 float renderY,
                 float renderHeight,
                 float progress) {
@@ -174,8 +173,7 @@ public class GameBarsOverlayFeature extends Feature {
                     progress);
         }
 
-        protected void renderText(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float renderY, String text) {
+        protected void renderText(PoseStack poseStack, MultiBufferSource bufferSource, float renderY, String text) {
             BufferedFontRenderer.getInstance()
                     .renderAlignedTextInBox(
                             poseStack,
@@ -239,7 +237,7 @@ public class GameBarsOverlayFeature extends Feature {
         @Override
         protected void renderBar(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 float renderY,
                 float renderHeight,
                 float progress) {
@@ -389,7 +387,7 @@ public class GameBarsOverlayFeature extends Feature {
         @Override
         protected void renderBar(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 float renderY,
                 float renderHeight,
                 float progress) {

--- a/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
@@ -109,8 +109,7 @@ public class GameNotificationOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             List<TimedMessageContainer> toRender = new ArrayList<>();
 
             ListIterator<TimedMessageContainer> messages = messageQueue.listIterator(messageQueue.size());
@@ -181,7 +180,7 @@ public class GameNotificationOverlayFeature extends Feature {
 
         @Override
         public void renderPreview(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             BufferedFontRenderer.getInstance()
                     .renderTextWithAlignment(
                             poseStack,

--- a/common/src/main/java/com/wynntils/features/overlays/GuildAttackTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GuildAttackTimerOverlayFeature.java
@@ -70,8 +70,7 @@ public class GuildAttackTimerOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             BufferedFontRenderer.getInstance()
                     .renderTextsWithAlignment(
                             poseStack,
@@ -91,7 +90,7 @@ public class GuildAttackTimerOverlayFeature extends Feature {
 
         @Override
         public void renderPreview(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             BufferedFontRenderer.getInstance()
                     .renderTextWithAlignment(
                             poseStack,

--- a/common/src/main/java/com/wynntils/features/overlays/NpcDialogueOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/NpcDialogueOverlayFeature.java
@@ -233,7 +233,7 @@ public class NpcDialogueOverlayFeature extends Feature {
 
         private void renderDialogue(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 List<String> currentDialogue,
                 NpcDialogueType dialogueType) {
             List<TextRenderTask> dialogueRenderTasks = currentDialogue.stream()
@@ -334,8 +334,7 @@ public class NpcDialogueOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             if (currentDialogue.isEmpty() && confirmationlessDialogues.isEmpty()) return;
 
             LinkedList<String> allDialogues = new LinkedList<>(currentDialogue);
@@ -353,7 +352,7 @@ public class NpcDialogueOverlayFeature extends Feature {
 
         @Override
         public void renderPreview(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             List<String> fakeDialogue = List.of(
                     "§7[1/1] §r§2Random Citizen: §r§aDid you know that Wynntils is the best Wynncraft mod you'll probably find?§r");
             // we have to force update every time

--- a/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
@@ -82,8 +82,7 @@ public class ObjectivesOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             WynnObjective guildObjective = Models.Objectives.getGuildObjective();
 
             if (guildObjective == null) {
@@ -170,8 +169,7 @@ public class ObjectivesOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             List<WynnObjective> objectives = Models.Objectives.getPersonalObjectives();
 
             final int barHeight = this.enableProgressBar.get() ? 5 : 0;

--- a/common/src/main/java/com/wynntils/features/overlays/PowderSpecialBarOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/PowderSpecialBarOverlayFeature.java
@@ -61,8 +61,7 @@ public class PowderSpecialBarOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             float powderSpecialCharge = Models.CharacterStats.getPowderSpecialCharge();
             Powder powderSpecialType = Models.CharacterStats.getPowderSpecialType();
             if (this.onlyIfWeaponHeld.get()
@@ -74,7 +73,7 @@ public class PowderSpecialBarOverlayFeature extends Feature {
 
         @Override
         public void renderPreview(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             renderWithSpecificSpecial(poseStack, bufferSource, 40, Powder.THUNDER);
         }
 
@@ -83,7 +82,7 @@ public class PowderSpecialBarOverlayFeature extends Feature {
 
         private void renderWithSpecificSpecial(
                 PoseStack poseStack,
-                MultiBufferSource.BufferSource bufferSource,
+                MultiBufferSource bufferSource,
                 float powderSpecialCharge,
                 Powder powderSpecialType) {
             Texture universalBarTexture = Texture.UNIVERSAL_BAR;

--- a/common/src/main/java/com/wynntils/features/overlays/QuestInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/QuestInfoOverlayFeature.java
@@ -135,8 +135,7 @@ public class QuestInfoOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             QuestInfo trackedQuest = Models.Quest.getTrackedQuest();
 
             if (trackedQuest == null) {
@@ -161,7 +160,7 @@ public class QuestInfoOverlayFeature extends Feature {
 
         @Override
         public void renderPreview(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             updateTextRenderSettings(toRenderPreview); // we have to force update every time
 
             BufferedFontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/features/overlays/ShamanMasksOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ShamanMasksOverlayFeature.java
@@ -60,8 +60,7 @@ public class ShamanMasksOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             ShamanMaskType currentMaskType = Models.ShamanMask.getCurrentMaskType();
 
             if (currentMaskType == ShamanMaskType.NONE && !displayNone.get()) return;

--- a/common/src/main/java/com/wynntils/features/overlays/SpellCastRenderFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/SpellCastRenderFeature.java
@@ -115,8 +115,7 @@ public class SpellCastRenderFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             if (spellTimer <= 0) return;
 
             // Render it the same way vanilla renders item changes

--- a/common/src/main/java/com/wynntils/features/overlays/StatusOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/StatusOverlayFeature.java
@@ -67,8 +67,7 @@ public class StatusOverlayFeature extends Feature {
         }
 
         @Override
-        public void render(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+        public void render(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             BufferedFontRenderer.getInstance()
                     .renderTextsWithAlignment(
                             poseStack,
@@ -84,7 +83,7 @@ public class StatusOverlayFeature extends Feature {
 
         @Override
         public void renderPreview(
-                PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float partialTicks, Window window) {
+                PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
             BufferedFontRenderer.getInstance()
                     .renderTextWithAlignment(
                             poseStack,

--- a/common/src/main/java/com/wynntils/models/map/pois/IconPoi.java
+++ b/common/src/main/java/com/wynntils/models/map/pois/IconPoi.java
@@ -61,7 +61,7 @@ public abstract class IconPoi implements Poi {
     @Override
     public void renderAt(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             boolean hovered,

--- a/common/src/main/java/com/wynntils/models/map/pois/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/models/map/pois/LabelPoi.java
@@ -92,7 +92,7 @@ public class LabelPoi implements Poi {
     @Override
     public void renderAt(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             boolean hovered,

--- a/common/src/main/java/com/wynntils/models/map/pois/PlayerMainMapPoi.java
+++ b/common/src/main/java/com/wynntils/models/map/pois/PlayerMainMapPoi.java
@@ -28,7 +28,7 @@ public class PlayerMainMapPoi extends PlayerPoiBase {
     @Override
     public void renderAt(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             boolean hovered,

--- a/common/src/main/java/com/wynntils/models/map/pois/PlayerMiniMapPoi.java
+++ b/common/src/main/java/com/wynntils/models/map/pois/PlayerMiniMapPoi.java
@@ -26,7 +26,7 @@ public class PlayerMiniMapPoi extends PlayerPoiBase {
     @Override
     public void renderAt(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             boolean hovered,

--- a/common/src/main/java/com/wynntils/models/map/pois/Poi.java
+++ b/common/src/main/java/com/wynntils/models/map/pois/Poi.java
@@ -22,7 +22,7 @@ public interface Poi {
 
     void renderAt(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             boolean hovered,

--- a/common/src/main/java/com/wynntils/models/map/pois/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/models/map/pois/TerritoryPoi.java
@@ -47,7 +47,7 @@ public class TerritoryPoi implements Poi {
     @Override
     public void renderAt(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             boolean hovered,

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
@@ -170,7 +170,7 @@ public final class BufferedFontRenderer {
 
     public void renderAlignedTextInBox(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             String text,
             float x1,
             float x2,
@@ -212,7 +212,7 @@ public final class BufferedFontRenderer {
 
     public void renderAlignedTextInBox(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             String text,
             float x1,
             float x2,
@@ -241,7 +241,7 @@ public final class BufferedFontRenderer {
 
     public void renderAlignedTextInBox(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             String text,
             float x1,
             float x2,
@@ -268,7 +268,7 @@ public final class BufferedFontRenderer {
 
     public void renderAlignedTextInBox(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             String text,
             float x,
             float y1,
@@ -359,7 +359,7 @@ public final class BufferedFontRenderer {
 
     public void renderTextsWithAlignment(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float x,
             float y,
             List<TextRenderTask> toRender,
@@ -385,11 +385,7 @@ public final class BufferedFontRenderer {
     }
 
     public void renderTexts(
-            PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
-            float x,
-            float y,
-            List<TextRenderTask> lines) {
+            PoseStack poseStack, MultiBufferSource bufferSource, float x, float y, List<TextRenderTask> lines) {
         float currentY = y;
         for (TextRenderTask line : lines) {
             renderText(poseStack, bufferSource, x, currentY, line);
@@ -401,8 +397,7 @@ public final class BufferedFontRenderer {
         }
     }
 
-    public void renderText(
-            PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, float x, float y, TextRenderTask line) {
+    public void renderText(PoseStack poseStack, MultiBufferSource bufferSource, float x, float y, TextRenderTask line) {
         renderText(
                 poseStack,
                 bufferSource,
@@ -418,7 +413,7 @@ public final class BufferedFontRenderer {
 
     public void renderText(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             String text,
             float x,
             float y,
@@ -443,7 +438,7 @@ public final class BufferedFontRenderer {
 
     public void renderTextWithAlignment(
             PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
+            MultiBufferSource bufferSource,
             float renderX,
             float renderY,
             TextRenderTask toRender,

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedRenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedRenderUtils.java
@@ -546,13 +546,7 @@ public final class BufferedRenderUtils {
     }
 
     public static void createMask(
-            PoseStack poseStack,
-            MultiBufferSource.BufferSource bufferSource,
-            Texture texture,
-            int x1,
-            int y1,
-            int x2,
-            int y2) {
+            PoseStack poseStack, MultiBufferSource bufferSource, Texture texture, int x1, int y1, int x2, int y2) {
         createMask(poseStack, bufferSource, texture, x1, y1, x2, y2, 0, 0, texture.width(), texture.height());
     }
 


### PR DESCRIPTION
We should only use the concrete implementation MultiBufferSource.BufferSource when absolutely needed.