### PR TITLE
fix: item counts hiding stacked items

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
@@ -52,14 +52,12 @@ public class ExtendedItemCountFeature extends Feature {
 
         WynnItem wynnItem = wynnItemOpt.get();
 
-        int count;
-        CustomColor countColor;
         if (wynnItem instanceof LeveledItemProperty leveledItem
                 && KeyboardUtils.isKeyDown(GLFW.GLFW_KEY_LEFT_CONTROL)
                 && isInventory) {
             event.setCountString(String.valueOf(leveledItem.getLevel()));
         } else if (wynnItem instanceof CountedItemProperty countedItem && countedItem.hasCount()) {
-            event.setCountString(String.valueOf(countedItem.getCount()));
+            event.setCountString(String.valueOf(countedItem.getCount() * event.getItemStack().getCount()));
             event.setCountColor(countedItem.getCountColor().asInt());
         }
     }

--- a/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.CountedItemProperty;
 import com.wynntils.models.items.properties.LeveledItemProperty;
-import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.KeyboardUtils;
 import java.util.Optional;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -57,7 +56,8 @@ public class ExtendedItemCountFeature extends Feature {
                 && isInventory) {
             event.setCountString(String.valueOf(leveledItem.getLevel()));
         } else if (wynnItem instanceof CountedItemProperty countedItem && countedItem.hasCount()) {
-            event.setCountString(String.valueOf(countedItem.getCount() * event.getItemStack().getCount()));
+            event.setCountString(
+                    String.valueOf(countedItem.getCount() * event.getItemStack().getCount()));
             event.setCountColor(countedItem.getCountColor().asInt());
         }
     }


### PR DESCRIPTION
Noticed with the event fireworks. [1/1] items can be stacked, and this fixes it just saying `1` in the hotbar.