### PR TITLE
fix: The config UI reset button has stopped working

### DIFF
--- a/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigButton.java
@@ -117,7 +117,7 @@ public class ConfigButton extends WynntilsButton {
         double actualMouseX = mouseX - getRenderX();
         double actualMouseY = mouseY - getRenderY();
 
-        return resetButton.mouseClicked(actualMouseX, actualMouseY, button)
+        return resetButton.mouseClicked(mouseX, mouseY, button)
                 || configOptionElement.mouseClicked(actualMouseX, actualMouseY, button);
     }
 


### PR DESCRIPTION
This is a regression, most likely caused by the text input widget changes