### PR TITLE
feat: Make reset button grayed-out if no change has been made

### DIFF
--- a/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigButton.java
@@ -38,17 +38,27 @@ public class ConfigButton extends WynntilsButton {
         super(x, y, width, height, Component.literal(configHolder.getJsonName()));
         this.settingsScreen = settingsScreen;
         this.configHolder = configHolder;
-        this.resetButton = new GeneralSettingsButton(
-                this.getX() + this.width - 40,
-                this.getY() + 13,
-                35,
-                12,
-                Component.translatable("screens.wynntils.settingsScreen.reset.name"),
-                () -> {
-                    configHolder.reset();
-                    this.configOptionElement = getWidgetFromConfigHolder(configHolder);
-                },
-                List.of(Component.translatable("screens.wynntils.settingsScreen.reset.description")));
+        this.resetButton =
+                new GeneralSettingsButton(
+                        this.getX() + this.width - 40,
+                        this.getY() + 13,
+                        35,
+                        12,
+                        Component.translatable("screens.wynntils.settingsScreen.reset.name"),
+                        () -> {
+                            if (!configHolder.valueChanged()) return;
+
+                            configHolder.reset();
+                            this.configOptionElement = getWidgetFromConfigHolder(configHolder);
+                        },
+                        List.of(Component.translatable("screens.wynntils.settingsScreen.reset.description"))) {
+                    @Override
+                    protected CustomColor getTextColor(boolean isHovered) {
+                        if (!configHolder.valueChanged()) return CommonColors.GRAY;
+
+                        return super.getTextColor(isHovered);
+                    }
+                };
         this.configOptionElement = getWidgetFromConfigHolder(configHolder);
     }
 

--- a/common/src/main/java/com/wynntils/screens/settings/widgets/GeneralSettingsButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/GeneralSettingsButton.java
@@ -56,7 +56,7 @@ public class GeneralSettingsButton extends WynntilsButton {
                         this.getY(),
                         this.getY() + this.height,
                         0,
-                        isHovered ? CommonColors.YELLOW : CommonColors.WHITE,
+                        getTextColor(isHovered),
                         HorizontalAlignment.Center,
                         VerticalAlignment.Middle,
                         TextShadow.OUTLINE);
@@ -71,6 +71,10 @@ public class GeneralSettingsButton extends WynntilsButton {
                     FontRenderer.getInstance().getFont(),
                     true);
         }
+    }
+
+    protected CustomColor getTextColor(boolean isHovered) {
+        return isHovered ? CommonColors.YELLOW : CommonColors.WHITE;
     }
 
     @Override


### PR DESCRIPTION
This makes it easy to spot if a setting is left at default or has been changed by the user