### PR TITLE
fix: Fix enum converting bug, also try to fix config corruption (bubble bar POIs)

### DIFF
--- a/common/src/main/java/com/wynntils/core/config/upfixers/ConfigUpfixerManager.java
+++ b/common/src/main/java/com/wynntils/core/config/upfixers/ConfigUpfixerManager.java
@@ -11,6 +11,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Manager;
 import com.wynntils.core.config.ConfigHolder;
 import com.wynntils.core.config.upfixers.impl.CustomCommandKeybindSlashStartUpfixer;
+import com.wynntils.core.config.upfixers.impl.CustomPoiIconEnumBugUpfixer;
 import com.wynntils.core.config.upfixers.impl.CustomPoiVisbilityUpfixer;
 import com.wynntils.core.config.upfixers.impl.EnumNamingUpfixer;
 import com.wynntils.core.config.upfixers.impl.GameBarOverlayMoveUpfixer;
@@ -31,6 +32,7 @@ public class ConfigUpfixerManager extends Manager {
         registerUpfixer(new CustomCommandKeybindSlashStartUpfixer());
         registerUpfixer(new GameBarOverlayMoveUpfixer());
         registerUpfixer(new EnumNamingUpfixer());
+        registerUpfixer(new CustomPoiIconEnumBugUpfixer());
     }
 
     private void registerUpfixer(ConfigUpfixer upfixer) {

--- a/common/src/main/java/com/wynntils/core/config/upfixers/impl/CustomPoiIconEnumBugUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/config/upfixers/impl/CustomPoiIconEnumBugUpfixer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.config.upfixers.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.wynntils.core.config.ConfigHolder;
+import com.wynntils.core.config.upfixers.ConfigUpfixer;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CustomPoiIconEnumBugUpfixer implements ConfigUpfixer {
+    private static final String POI_LIST_KEY = "mapFeature.customPois";
+    private static final Pattern POI_NAME_CHEST_PATTERN = Pattern.compile("Loot Chest T?(\\d)");
+
+    @Override
+    public boolean apply(JsonObject configObject, Set<ConfigHolder> configHolders) {
+        for (ConfigHolder configHolder : configHolders) {
+            if (!configHolder.getJsonName().equals(POI_LIST_KEY)) continue;
+
+            JsonArray array = configObject.get(POI_LIST_KEY).getAsJsonArray();
+
+            for (int i = 0; i < array.size(); i++) {
+                JsonObject poi = array.get(i).getAsJsonObject();
+                if (poi.has("icon")) {
+                    String icon = poi.get("icon").getAsString();
+
+                    if (!icon.equals("bubbleBar")) continue;
+
+                    String name = poi.get("name").getAsString();
+                    Matcher matcher = POI_NAME_CHEST_PATTERN.matcher(name);
+
+                    if (!matcher.matches()) {
+                        // We can't leave the texture as bubble bar...
+                        poi.addProperty("icon", "chestT1");
+                        continue;
+                    }
+
+                    String tier = matcher.group(1);
+
+                    poi.addProperty("icon", "chestT" + tier);
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/EnumUtils.java
+++ b/common/src/main/java/com/wynntils/utils/EnumUtils.java
@@ -28,8 +28,8 @@ public final class EnumUtils {
         // CaseFormat cannot do round-trip conversion of e.g. TIER_3, hence the
         // replaceAll
         // We have to account for CHEST_T1, which works fine with CaseFormat, hence the [a-z] regex
-        String enumName = CaseFormat.LOWER_CAMEL
-                .to(CaseFormat.UPPER_UNDERSCORE, jsonFormattedName.replaceAll("([a-z])(\\d)", "$1_$2"));
+        String enumName = CaseFormat.LOWER_CAMEL.to(
+                CaseFormat.UPPER_UNDERSCORE, jsonFormattedName.replaceAll("([a-z])(\\d)", "$1_$2"));
 
         try {
             // The double casting is needed, or javac will complain...

--- a/common/src/main/java/com/wynntils/utils/EnumUtils.java
+++ b/common/src/main/java/com/wynntils/utils/EnumUtils.java
@@ -27,9 +27,9 @@ public final class EnumUtils {
     public static Enum<?> fromJsonFormat(Class<? extends Enum<?>> enumClazz, String jsonFormattedName) {
         // CaseFormat cannot do round-trip conversion of e.g. TIER_3, hence the
         // replaceAll
+        // We have to account for CHEST_T1, which works fine with CaseFormat, hence the [a-z] regex
         String enumName = CaseFormat.LOWER_CAMEL
-                .to(CaseFormat.UPPER_UNDERSCORE, jsonFormattedName)
-                .replaceAll("(\\D)(\\d)", "$1_$2");
+                .to(CaseFormat.UPPER_UNDERSCORE, jsonFormattedName.replaceAll("([a-z])(\\d)", "$1_$2"));
 
         try {
             // The double casting is needed, or javac will complain...


### PR DESCRIPTION
This was caused by #1390. There was an issue converting texture enum, making it all reset to bubble bar. I think the issue is now fixed, and an upfixer was deployed to mitigate the damage.