### PR TITLE
fix: Fix translations feature crashes

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/translation/GoogleApiTranslationService.java
+++ b/common/src/main/java/com/wynntils/core/net/translation/GoogleApiTranslationService.java
@@ -24,7 +24,7 @@ public class GoogleApiTranslationService extends CachingTranslationService {
     @Override
     protected void translateNew(List<String> messageList, String toLanguage, Consumer<List<String>> handleTranslation) {
         if (toLanguage == null || toLanguage.isEmpty()) {
-            handleTranslation.accept(null);
+            handleTranslation.accept(List.copyOf(messageList));
             return;
         }
 
@@ -50,7 +50,7 @@ public class GoogleApiTranslationService extends CachingTranslationService {
                 },
                 onError -> {
                     // If Google translate return no data ( 500 error ), display default lang
-                    handleTranslation.accept(null);
+                    handleTranslation.accept(List.copyOf(messageList));
                 });
     }
 }


### PR DESCRIPTION
The bug is caused by design that I could not fully understand, so I patched it in a sane, but maybe not so design friendly way. The `TranslationService` classes used to return null to signal that the translation should not happen, and the original text should be used. However, none of the users of translation manager handled this (I think the method should return a boolean indicating success/fault, or have a separate error consumer..).