### PR TITLE
fix: Prevent crash in DialogueOptionOverrideFeature

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/DialogueOptionOverrideFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/DialogueOptionOverrideFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.config.ConfigCategory;
 import com.wynntils.core.features.Feature;
 import com.wynntils.mc.event.KeyInputEvent;
 import com.wynntils.utils.mc.McUtils;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -18,8 +19,10 @@ public class DialogueOptionOverrideFeature extends Feature {
     @SubscribeEvent
     public void onDialogueKeyPress(KeyInputEvent e) {
         if (!Models.WorldState.onWorld() || e.getAction() != 1) return; // Only send packet on presses, not releases
+        LocalPlayer player = McUtils.player();
+        if (player == null) return;
 
-        if (e.getKey() - 49 == McUtils.inventory().selected) { // keys 1-9 are +49 offset from hotbar
+        if (e.getKey() == player.getInventory().selected + 49) { // keys 1-9 are +49 offset from hotbar
             McUtils.sendPacket(new ServerboundSetCarriedItemPacket(e.getKey() - 49));
         }
     }


### PR DESCRIPTION
This does not solve the core problem, but it will prevent a crash. It is still unclear why the player can be null and we still receive an event...