### PR TITLE
fix: Clean up overlay enabled state checks

### DIFF
--- a/common/src/main/java/com/wynntils/features/overlays/GuildAttackTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GuildAttackTimerOverlayFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.overlays;
 
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.config.Category;
 import com.wynntils.core.config.Config;
@@ -45,7 +46,7 @@ public class GuildAttackTimerOverlayFeature extends Feature {
     public void onScoreboardSegmentChange(ScoreboardSegmentAdditionEvent event) {
         if (disableAttackTimersOnScoreboard.get()) {
             if (event.getSegment().getScoreboardPart() instanceof GuildAttackScoreboardPart
-                    && territoryAttackTimerOverlay.shouldBeEnabled()) {
+                    && Managers.Overlay.isEnabled(territoryAttackTimerOverlay)) {
                 event.setCanceled(true);
             }
         }

--- a/common/src/main/java/com/wynntils/features/overlays/NpcDialogueOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/NpcDialogueOverlayFeature.java
@@ -222,7 +222,7 @@ public class NpcDialogueOverlayFeature extends Feature {
         }
 
         private void updateDialogExtractionSettings() {
-            if (shouldBeEnabled()) {
+            if (Managers.Overlay.isEnabled(this)) {
                 Handlers.Chat.addNpcDialogExtractionDependent(NpcDialogueOverlayFeature.this);
             } else {
                 Handlers.Chat.removeNpcDialogExtractionDependent(NpcDialogueOverlayFeature.this);

--- a/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.overlays;
 
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.config.Category;
 import com.wynntils.core.config.Config;
@@ -50,12 +51,12 @@ public class ObjectivesOverlayFeature extends Feature {
         if (disableObjectiveTrackingOnScoreboard.get()) {
             ScoreboardSegment segment = event.getSegment();
             if (segment.getScoreboardPart() instanceof DailyObjectiveScoreboardPart
-                    && guildObjectiveOverlay.shouldBeEnabled()) {
+                    && Managers.Overlay.isEnabled(guildObjectiveOverlay)) {
                 event.setCanceled(true);
                 return;
             }
             if (segment.getScoreboardPart() instanceof GuildObjectiveScoreboardPart
-                    && dailyObjectiveOverlay.shouldBeEnabled()) {
+                    && Managers.Overlay.isEnabled(dailyObjectiveOverlay)) {
                 event.setCanceled(true);
                 return;
             }

--- a/common/src/main/java/com/wynntils/features/overlays/QuestInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/QuestInfoOverlayFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.overlays;
 
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.config.Category;
 import com.wynntils.core.config.Config;
@@ -47,7 +48,7 @@ public class QuestInfoOverlayFeature extends Feature {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onScoreboardSegmentChange(ScoreboardSegmentAdditionEvent event) {
-        if (questInfoOverlay.shouldBeEnabled()
+        if (Managers.Overlay.isEnabled(questInfoOverlay)
                 && disableQuestTrackingOnScoreboard.get()
                 && event.getSegment().getScoreboardPart() instanceof QuestScoreboardPart) {
             event.setCanceled(true);

--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -728,7 +728,7 @@ public final class OverlayManagementScreen extends WynntilsScreen {
         }
 
         for (Overlay overlay : Managers.Overlay.getOverlays().stream()
-                .filter(Overlay::shouldBeEnabled)
+                .filter(Managers.Overlay::isEnabled)
                 .toList()) {
             if (overlay == selectedOverlay) continue;
 

--- a/common/src/main/java/com/wynntils/screens/overlays/selection/OverlayEntry.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/selection/OverlayEntry.java
@@ -116,12 +116,12 @@ public class OverlayEntry extends ContainerObjectSelectionList.Entry<OverlayEntr
                     .filter(configHolder -> configHolder.getParent() == overlay
                             && configHolder.getFieldName().equals("userEnabled"))
                     .findFirst()
-                    .ifPresent(configHolder -> configHolder.setValue(!overlay.shouldBeEnabled()));
+                    .ifPresent(configHolder -> configHolder.setValue(!Managers.Overlay.isEnabled(overlay)));
             Managers.Config.saveConfig();
             return true;
         }
 
-        if (!overlay.shouldBeEnabled()) return false;
+        if (!Managers.Overlay.isEnabled(overlay)) return false;
 
         McUtils.mc().setScreen(OverlayManagementScreen.create(this.overlay));
         return true;

--- a/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
@@ -131,7 +131,7 @@ public final class WynntilsBookSettingsScreen extends WynntilsScreen implements 
         String name = "";
         boolean enabled = false;
         if (selected instanceof Overlay selectedOverlay) {
-            enabled = selectedOverlay.shouldBeEnabled();
+            enabled = Managers.Overlay.isEnabled(selectedOverlay);
             name = selectedOverlay.getTranslatedName();
         } else if (selected instanceof Feature selectedFeature) {
             enabled = selectedFeature.isEnabled();


### PR DESCRIPTION
When I renamed `isEnabled` to `shouldBeEnabled` in `Overlay`, I should have done this, but I did not notice. But it is clear with the new name, that the method is not something for state checks. The overlay itself does not know it's state. Now we use the manager to check for state (as we should).