### PR TITLE
chore: Make the github bot stop spamming us with comments

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -24,6 +24,3 @@ jobs:
       - name: 'Qodana Scan'
         id: qodana
         uses: JetBrains/qodana-action@v2022.3.4
-      - uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json


### PR DESCRIPTION
I got help from JetBrains to get rid of this. It will still give us Qodana comments on PRs.

https://github.com/JetBrains/Qodana/discussions/164#discussioncomment-5509443