### PR TITLE
perf: Some minor optimization in config saving

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/Overlay.java
@@ -71,11 +71,15 @@ public abstract class Overlay extends AbstractConfigurable implements Translatab
 
     @Override
     public final void updateConfigOption(ConfigHolder configHolder) {
-        // if user toggle was changed, enable/disable feature accordingly
+        // if user toggle was changed, enable/disable overlay accordingly
         if (configHolder.getFieldName().equals("userEnabled")) {
-            // This is done so all state checks run in order
-            Managers.Overlay.disableOverlay(this);
-            Managers.Overlay.enableOverlay(this);
+            if (configHolder.getValue() == Boolean.FALSE) {
+                Managers.Overlay.disableOverlay(this);
+            } else {
+                // If new state is TRUE or null, try to enable overlay
+                // (worst case overlay.shouldBeEnabled() will return false)
+                Managers.Overlay.enableOverlay(this);
+            }
         }
 
         onConfigUpdate(configHolder);

--- a/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
@@ -80,9 +80,11 @@ public final class OverlayManager extends Manager {
         overlayParentMap.getOrDefault(parent, List.of()).forEach(this::disableOverlay);
     }
 
-    public void disableOverlay(Overlay disabled) {
-        enabledOverlays.remove(disabled);
-        WynntilsMod.unregisterEventListener(disabled);
+    public void disableOverlay(Overlay disabledOverlay) {
+        if (!isEnabled(disabledOverlay)) return;
+
+        enabledOverlays.remove(disabledOverlay);
+        WynntilsMod.unregisterEventListener(disabledOverlay);
 
         enabledOverlays.forEach(
                 overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::onConfigUpdate));
@@ -93,7 +95,7 @@ public final class OverlayManager extends Manager {
     }
 
     public void enableOverlay(Overlay enableOverlay) {
-        if (!enableOverlay.shouldBeEnabled()) return;
+        if (!enableOverlay.shouldBeEnabled() || isEnabled(enableOverlay)) return;
 
         enabledOverlays.add(enableOverlay);
         WynntilsMod.registerEventListener(enableOverlay);


### PR DESCRIPTION
Apparently, closing the config/overlay management screen a few times causes huge FPS drops. I tested with 100/1000 closes (which is basically config reload), nothing happened. This is a minor optimization that I found + a fix for some old weirdness with overlays enabled state. 