### PR TITLE
perf: Stop leaking overlays from overlay groups on config reload

### DIFF
--- a/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/features/overlays/OverlayManager.java
@@ -72,6 +72,8 @@ public final class OverlayManager extends Manager {
     public void unregisterOverlay(Overlay overlay) {
         overlayParentMap.get(overlayInfoMap.get(overlay).parent()).remove(overlay);
 
+        WynntilsMod.unregisterEventListener(overlay);
+
         overlayInfoMap.remove(overlay);
         enabledOverlays.remove(overlay);
     }


### PR DESCRIPTION
This was a nasty one...  Forge Event bus does not hold a reference to registered objects, but, since these overlay group overlays have onTick methods, the garbage collector could not mark it to be collected.. This meant that we piled up overlays on every config reload.