### PR TITLE
fix: Fix color enums showing up as an empty string, disallow non color chatformatting enums

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
@@ -14,11 +14,11 @@ import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
+import com.wynntils.utils.colors.ColorChatFormatting;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.IterationDecision;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.sounds.SoundEvents;
@@ -33,7 +33,7 @@ public class ChatMentionFeature extends Feature {
     public final Config<Boolean> dingMention = new Config<>(true);
 
     @RegisterConfig
-    public final Config<ChatFormatting> mentionColor = new Config<>(ChatFormatting.YELLOW);
+    public final Config<ColorChatFormatting> mentionColor = new Config<>(ColorChatFormatting.YELLOW);
 
     @RegisterConfig
     public final Config<String> aliases = new Config<>("");
@@ -78,7 +78,7 @@ public class ChatMentionFeature extends Feature {
                 StyledTextPart first = new StyledTextPart(firstPart, partStyle.getStyle(), null, Style.EMPTY);
                 StyledTextPart mention = new StyledTextPart(
                         mentionPart,
-                        partStyle.getStyle().withColor(mentionColor.get()),
+                        partStyle.getStyle().withColor(mentionColor.get().getChatFormatting()),
                         null,
                         first.getPartStyle().getStyle());
                 StyledTextPart last = new StyledTextPart(

--- a/common/src/main/java/com/wynntils/features/combat/TokenTrackerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/TokenTrackerFeature.java
@@ -17,6 +17,7 @@ import com.wynntils.core.features.overlays.OverlaySize;
 import com.wynntils.core.features.overlays.annotations.OverlayInfo;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.token.event.TokenGatekeeperEvent;
+import com.wynntils.utils.colors.ColorChatFormatting;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.Texture;
@@ -24,7 +25,6 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.CappedValue;
 import java.util.List;
-import net.minecraft.ChatFormatting;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -73,7 +73,7 @@ public class TokenTrackerFeature extends Feature {
 
     protected static final class TokenBarOverlay extends BarOverlay {
         @RegisterConfig
-        public final Config<ChatFormatting> color = new Config<>(ChatFormatting.GOLD);
+        public final Config<ColorChatFormatting> color = new Config<>(ColorChatFormatting.GOLD);
 
         public TokenBarOverlay(int id) {
             super(id, new OverlaySize(81, 21));
@@ -100,7 +100,7 @@ public class TokenTrackerFeature extends Feature {
 
         @Override
         public CustomColor getRenderColor() {
-            return CustomColor.fromChatFormatting(color.get());
+            return CustomColor.fromChatFormatting(color.get().getChatFormatting());
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/features/overlays/ShamanTotemTrackingFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ShamanTotemTrackingFeature.java
@@ -18,6 +18,7 @@ import com.wynntils.core.text.CodedString;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.extension.EntityExtension;
 import com.wynntils.models.abilities.event.TotemEvent;
+import com.wynntils.utils.colors.ColorChatFormatting;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.RenderedStringUtils;
@@ -76,16 +77,18 @@ public class ShamanTotemTrackingFeature extends Feature {
         public final Config<TotemTrackingDetail> totemTrackingDetail = new Config<>(TotemTrackingDetail.COORDS);
 
         @RegisterConfig
-        public final Config<ChatFormatting> firstTotemTextColor = new Config<>(ChatFormatting.WHITE);
+        public final Config<ColorChatFormatting> firstTotemTextColor = new Config<>(ColorChatFormatting.WHITE);
 
         @RegisterConfig
-        public final Config<ChatFormatting> secondTotemTextColor = new Config<>(ChatFormatting.BLUE);
+        public final Config<ColorChatFormatting> secondTotemTextColor = new Config<>(ColorChatFormatting.BLUE);
 
         @RegisterConfig
-        public final Config<ChatFormatting> thirdTotemTextColor = new Config<>(ChatFormatting.RED);
+        public final Config<ColorChatFormatting> thirdTotemTextColor = new Config<>(ColorChatFormatting.RED);
 
         private final ChatFormatting[] totemColorsArray = {
-            firstTotemTextColor.get(), secondTotemTextColor.get(), thirdTotemTextColor.get()
+            firstTotemTextColor.get().getChatFormatting(),
+            secondTotemTextColor.get().getChatFormatting(),
+            thirdTotemTextColor.get().getChatFormatting()
         };
 
         protected ShamanTotemTimerOverlay() {

--- a/common/src/main/java/com/wynntils/utils/colors/ColorChatFormatting.java
+++ b/common/src/main/java/com/wynntils/utils/colors/ColorChatFormatting.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.colors;
+
+import net.minecraft.ChatFormatting;
+
+/**
+ * This enum is used for configs that need a ChatFormatting color,
+ * but does not want to allow other types of formatting.
+ */
+public enum ColorChatFormatting {
+    BLACK(ChatFormatting.BLACK),
+    DARK_BLUE(ChatFormatting.DARK_BLUE),
+    DARK_GREEN(ChatFormatting.DARK_GREEN),
+    DARK_AQUA(ChatFormatting.DARK_AQUA),
+    DARK_RED(ChatFormatting.DARK_RED),
+    DARK_PURPLE(ChatFormatting.DARK_PURPLE),
+    GOLD(ChatFormatting.GOLD),
+    GRAY(ChatFormatting.GRAY),
+    DARK_GRAY(ChatFormatting.DARK_GRAY),
+    BLUE(ChatFormatting.BLUE),
+    GREEN(ChatFormatting.GREEN),
+    AQUA(ChatFormatting.AQUA),
+    RED(ChatFormatting.RED),
+    LIGHT_PURPLE(ChatFormatting.LIGHT_PURPLE),
+    YELLOW(ChatFormatting.YELLOW),
+    WHITE(ChatFormatting.WHITE);
+
+    private final ChatFormatting chatFormatting;
+
+    ColorChatFormatting(ChatFormatting chatFormatting) {
+        this.chatFormatting = chatFormatting;
+    }
+
+    public ChatFormatting getChatFormatting() {
+        return chatFormatting;
+    }
+}


### PR DESCRIPTION
This PR indirectly fixes ChatFormatting enum showing up as "" buttons (toString returns the formatting code..)