### PR TITLE
Add Default value in TradeMarketBulkSellFeature

### DIFF
--- a/common/src/main/java/com/wynntils/features/overlays/TradeMarketBulkSellFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TradeMarketBulkSellFeature.java
@@ -35,7 +35,7 @@ public class TradeMarketBulkSellFeature extends Feature {
     public Config<Integer> bulkSell1Amount = new Config<>(64);
 
     @RegisterConfig
-    public Config<Integer> bulkSell2Amount = new Config<>(0);
+    public Config<Integer> bulkSell2Amount = new Config<>(6399);
 
     @RegisterConfig
     public Config<Integer> bulkSell3Amount = new Config<>(0);


### PR DESCRIPTION
6399 is the maximum number of items you can put into a single market slot, so i think it makes sense to have it as one of the default options.