### PR TITLE
fix: fix chat tabs and container search not appearing (ScreenInitEvent)

### DIFF
--- a/common/src/main/java/com/wynntils/mc/event/ScreenInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenInitEvent.java
@@ -12,12 +12,18 @@ import net.minecraftforge.eventbus.api.Event;
  */
 public class ScreenInitEvent extends Event {
     private final Screen screen;
+    private final boolean firstInit;
 
-    public ScreenInitEvent(Screen screen) {
+    public ScreenInitEvent(Screen screen, boolean firstInit) {
         this.screen = screen;
+        this.firstInit = firstInit;
     }
 
     public Screen getScreen() {
         return screen;
+    }
+
+    public boolean isFirstInit() {
+        return firstInit;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -96,7 +96,16 @@ public abstract class ScreenMixin implements ScreenExtension {
             method = "rebuildWidgets()V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;init()V"))
     private void onScreenInit(CallbackInfo ci) {
-        MixinHelper.post(new ScreenInitEvent((Screen) (Object) this));
+        // This is called whenever a screen is re-inited (e.g. when the window is resized)
+        MixinHelper.post(new ScreenInitEvent((Screen) (Object) this, false));
+    }
+
+    @Inject(
+            method = "init(Lnet/minecraft/client/Minecraft;II)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;init()V"))
+    private void onFirstScreenInit(CallbackInfo ci) {
+        // This is called only once, when the screen is first initialized
+        MixinHelper.post(new ScreenInitEvent((Screen) (Object) this, true));
     }
 
     @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At("RETURN"))


### PR DESCRIPTION
Minecraft now inits the screen differently when it is the first init. We now handle it. (After writing the fix, I checked, and Forge does the same implementation of events, I think that is a good sign :))