### PR TITLE
fix: Stupid workaround for improbable NPE in translation

### DIFF
--- a/common/src/main/java/com/wynntils/features/TranslationFeature.java
+++ b/common/src/main/java/com/wynntils/features/TranslationFeature.java
@@ -60,14 +60,15 @@ public class TranslationFeature extends Feature {
         Managers.Translation.getTranslator(translationService.get())
                 .translate(List.of(wrapped), languageName.get(), translatedMsgList -> {
                     CodedString messageToSend;
-                    if (!translatedMsgList.isEmpty()) {
-                        String result = translatedMsgList.get(0);
-                        messageToSend = unwrapCoding(result);
-                    } else {
+                    // translatedMsgList should not be null, but yet it happens...
+                    if (translatedMsgList == null || translatedMsgList.isEmpty()) {
                         if (keepOriginal.get()) return;
 
                         // We failed to get a translation; send the original message so it's not lost
                         messageToSend = origCoded;
+                    } else {
+                        String result = translatedMsgList.get(0);
+                        messageToSend = unwrapCoding(result);
                     }
                     McUtils.mc()
                             .doRunTask(() -> McUtils.sendMessageToClient(


### PR DESCRIPTION
There is no way this argument could be null, yet it happens. I have no idea how this can happen, but let at least avoid the crash.