### PR TITLE
fix: Try improving resilience on coordinate pattern

### DIFF
--- a/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
@@ -12,10 +12,10 @@ import java.util.regex.Pattern;
 
 public final class LocationUtils {
     private static final Pattern COORDINATE_PATTERN = Pattern.compile(
-            "(?<x>[-+]?\\d+)(?:.\\d+)?([^0-9+-]{1,5}(?<y>[-+]?\\d+)(?:.\\d+)?)?[^0-9+-]{1,5}(?<z>[-+]?\\d+)(?:.\\d+)?");
+            "(?<x>[-+]?\\d{1,6})(?:.\\d+)?([^0-9.+-]{1,5}(?<y>[-+]?\\d{1,3})(?:.\\d+)?)?[^0-9.+-]{1,5}(?<z>[-+]?\\d{1,6})(?:.\\d+)?");
 
     private static final Pattern STRICT_COORDINATE_PATTERN = Pattern.compile(
-            "([-+]?\\d{1,5})(?:.\\d+)?([,\\s]{1,2}([-+]?\\d{1,4})(?:.\\d+)?)?[,\\s]{1,2}([-+]?\\d{1,5})(?:.\\d+)?");
+            "([-+]?\\d{1,6})(?:.\\d+)?([,\\s]{1,2}([-+]?\\d{1,3})(?:.\\d+)?)?[,\\s]{1,2}([-+]?\\d{1,6})(?:.\\d+)?");
 
     public static Optional<Location> parseFromString(String locString) {
         Matcher matcher = COORDINATE_PATTERN.matcher(locString);


### PR DESCRIPTION
Right now, sometimes, somehow they accept "1357111317192329" as a number, which is too large to be parsed as an integer, with a resulting crash.