### PR TITLE
fix: Try to detect a possible cause of null by verifying Wynncraft data

### DIFF
--- a/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
@@ -199,6 +199,9 @@ public class GearInfoRegistry {
             }
 
             GearType type = parseType(json);
+            if (type == null) {
+                throw new RuntimeException("Invalid Wynncraft data: item has no gear type");
+            }
             GearTier tier = GearTier.fromString(json.get("tier").getAsString());
             int powderSlots = JsonUtils.getNullableJsonInt(json, "sockets");
 


### PR DESCRIPTION
This does not trigger for me, and it should not, as long as our gear data is correct, but I have a case of a type being null and I can't figure out how it can be. This is one possible way that I want to stop early, if e.g. the json file has been corrupted.

https://athena.wynntils.com/crash/view/4786f949192efcfe80dc313cb6174ce3