### PR TITLE
fix: 0 star ingredients don't get highlighted

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class IngredientAnnotator implements ItemAnnotator {
+    // Test suite: https://regexr.com/7co3b
     private static final Pattern INGREDIENT_PATTERN =
             Pattern.compile("^§7(.+?)(?:§[3567])? \\[§([8bde])✫(§8)?✫(§8)?✫§[3567]\\]$");
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
@@ -17,7 +17,7 @@ import net.minecraft.world.item.ItemStack;
 
 public final class IngredientAnnotator implements ItemAnnotator {
     private static final Pattern INGREDIENT_PATTERN =
-            Pattern.compile("^§7(.*)§[3567] \\[§([8bde])✫(§8)?✫(§8)?✫§[3567]\\]$");
+            Pattern.compile("^§7(.+?)(?:§[3567])? \\[§([8bde])✫(§8)?✫(§8)?✫§[3567]\\]$");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {


### PR DESCRIPTION
Zero star ingredients no longer contain the §7 in front of the stars. So now it is optional, but this also means the name matcher in front has to be lazy so it doesn't accidentally capture the § code for 1-3 star ingredients.