### PR TITLE
fix: Don't render wynntils cosmetics if WynntilsCosmeticsFeature is disabled

### DIFF
--- a/common/src/main/java/com/wynntils/models/cosmetics/type/WynntilsCapeLayer.java
+++ b/common/src/main/java/com/wynntils/models/cosmetics/type/WynntilsCapeLayer.java
@@ -7,7 +7,9 @@ package com.wynntils.models.cosmetics.type;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
+import com.wynntils.features.players.WynntilsCosmeticsFeature;
 import com.wynntils.utils.MathUtils;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.player.AbstractClientPlayer;
@@ -36,6 +38,7 @@ public final class WynntilsCapeLayer extends WynntilsLayer {
             float ageInTicks,
             float netHeadYaw,
             float headPitch) {
+        if (!Managers.Feature.getFeatureInstance(WynntilsCosmeticsFeature.class).isEnabled()) return;
         if (!Models.Cosmetics.shouldRenderCape(player, false)) return;
 
         ResourceLocation texture = Models.Cosmetics.getCapeTexture(player);

--- a/common/src/main/java/com/wynntils/models/cosmetics/type/WynntilsElytraLayer.java
+++ b/common/src/main/java/com/wynntils/models/cosmetics/type/WynntilsElytraLayer.java
@@ -6,7 +6,9 @@ package com.wynntils.models.cosmetics.type;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
+import com.wynntils.features.players.WynntilsCosmeticsFeature;
 import net.minecraft.client.model.ElytraModel;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -41,6 +43,7 @@ public final class WynntilsElytraLayer extends WynntilsLayer {
             float ageInTicks,
             float netHeadYaw,
             float headPitch) {
+        if (!Managers.Feature.getFeatureInstance(WynntilsCosmeticsFeature.class).isEnabled()) return;
         if (!Models.Cosmetics.shouldRenderCape(player, true)) return;
 
         ResourceLocation texture = Models.Cosmetics.getCapeTexture(player);


### PR DESCRIPTION
Fixes #1494 