### PR TITLE
feat: Enhance Default Settings

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/CombatXpGainMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/CombatXpGainMessageFeature.java
@@ -20,7 +20,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 @ConfigCategory(Category.COMBAT)
 public class CombatXpGainMessageFeature extends Feature {
     @RegisterConfig
-    public final Config<Float> secondDelay = new Config<>(2f);
+    public final Config<Float> secondDelay = new Config<>(5f);
 
     private long lastXpDisplayTime = 0;
 

--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -45,7 +45,7 @@ public class InventoryEmeraldCountFeature extends Feature {
     public final Config<Boolean> showContainerEmeraldCount = new Config<>(true);
 
     @RegisterConfig
-    public final Config<Boolean> showZerosInEmeraldCount = new Config<>(false);
+    public final Config<Boolean> showZerosInEmeraldCount = new Config<>(true);
 
     @RegisterConfig
     public final Config<Boolean> combineInventoryAndContainer = new Config<>(false);

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -59,16 +59,16 @@ public class MinimapFeature extends Feature {
     private final Overlay coordinatesOverlay = new CoordinateOverlay();
 
     public static class MinimapOverlay extends Overlay {
-        private static final int DEFAULT_SIZE = 150;
+        private static final int DEFAULT_SIZE = 130;
 
         @RegisterConfig
         public final Config<Float> scale = new Config<>(1f);
 
         @RegisterConfig
-        public final Config<Float> poiScale = new Config<>(0.8f);
+        public final Config<Float> poiScale = new Config<>(0.6f);
 
         @RegisterConfig
-        public final Config<Float> pointerScale = new Config<>(1f);
+        public final Config<Float> pointerScale = new Config<>(0.8f);
 
         @RegisterConfig
         public final Config<Boolean> followPlayerRotation = new Config<>(true);
@@ -77,7 +77,7 @@ public class MinimapFeature extends Feature {
         public final Config<CustomColor> pointerColor = new Config<>(new CustomColor(1f, 1f, 1f, 1f));
 
         @RegisterConfig
-        public final Config<MapMaskType> maskType = new Config<>(MapMaskType.CIRCLE);
+        public final Config<MapMaskType> maskType = new Config<>(MapMaskType.RECTANGULAR);
 
         @RegisterConfig
         public final Config<MapBorderType> borderType = new Config<>(MapBorderType.WYNN);
@@ -95,12 +95,12 @@ public class MinimapFeature extends Feature {
         public final Config<Boolean> renderRemotePartyPlayers = new Config<>(true);
 
         @RegisterConfig
-        public final Config<Float> remotePlayersHeadScale = new Config<>(0.6f);
+        public final Config<Float> remotePlayersHeadScale = new Config<>(0.4f);
 
         protected MinimapOverlay() {
             super(
                     new OverlayPosition(
-                            5,
+                            5.25f,
                             5,
                             VerticalAlignment.TOP,
                             HorizontalAlignment.LEFT,
@@ -506,12 +506,12 @@ public class MinimapFeature extends Feature {
         protected CoordinateOverlay() {
             super(
                     new OverlayPosition(
-                            160,
-                            20,
+                            136,
+                            6,
                             VerticalAlignment.TOP,
                             HorizontalAlignment.LEFT,
                             OverlayPosition.AnchorSection.TOP_LEFT),
-                    new OverlaySize(120, 20),
+                    new OverlaySize(130, 20),
                     HorizontalAlignment.CENTER,
                     VerticalAlignment.MIDDLE);
         }

--- a/common/src/main/java/com/wynntils/features/overlays/CombatExperienceOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CombatExperienceOverlayFeature.java
@@ -32,7 +32,7 @@ public class CombatExperienceOverlayFeature extends Feature {
         protected CombatExperienceOverlay() {
             super(
                     new OverlayPosition(
-                            -73,
+                            -68,
                             0,
                             VerticalAlignment.BOTTOM,
                             HorizontalAlignment.CENTER,

--- a/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
@@ -309,7 +309,7 @@ public class GameBarsOverlayFeature extends Feature {
         protected HealthBarOverlay() {
             this(
                     new OverlayPosition(
-                            -30,
+                            -29,
                             -52,
                             VerticalAlignment.BOTTOM,
                             HorizontalAlignment.CENTER,
@@ -408,7 +408,7 @@ public class GameBarsOverlayFeature extends Feature {
         protected ManaBarOverlay() {
             this(
                     new OverlayPosition(
-                            -30,
+                            -29,
                             52,
                             VerticalAlignment.BOTTOM,
                             HorizontalAlignment.CENTER,

--- a/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
@@ -77,10 +77,10 @@ public class GameNotificationOverlayFeature extends Feature {
 
     public static class GameNotificationOverlay extends Overlay {
         @RegisterConfig
-        public final Config<Float> messageTimeLimit = new Config<>(10f);
+        public final Config<Float> messageTimeLimit = new Config<>(12f);
 
         @RegisterConfig
-        public final Config<Integer> messageLimit = new Config<>(5);
+        public final Config<Integer> messageLimit = new Config<>(8);
 
         @RegisterConfig
         public final Config<Boolean> invertGrowth = new Config<>(true);


### PR DESCRIPTION
- Smaller map overlay
   - Made rectangular by default
   - Generally reduced POI sizes
   - Adjusted Coordinates accordingly
- Moved HP and MP bars slightly lower
- Moved Combat XP slightly lower
- Game notifications last a bit longer
   - And also fits 3 more messages
   - XP Consolation lasts a bit longer