### PR TITLE
fix: Text box bottom align highlight broken

### DIFF
--- a/common/src/main/java/com/wynntils/screens/base/widgets/SearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/SearchWidget.java
@@ -23,7 +23,6 @@ import net.minecraft.sounds.SoundEvents;
 public class SearchWidget extends TextInputBoxWidget {
     private static final Component DEFAULT_TEXT =
             Component.translatable("screens.wynntils.searchWidget.defaultSearchText");
-    private static final float VERTICAL_OFFSET = 6.5f;
 
     public SearchWidget(
             int x, int y, int width, int height, Consumer<String> onUpdateConsumer, TextboxScreen textboxScreen) {
@@ -76,10 +75,12 @@ public class SearchWidget extends TextInputBoxWidget {
                         StyledText.fromString(defaultText ? DEFAULT_TEXT.getString() : firstPortion),
                         this.getX() + textPadding,
                         this.getX() + this.width - textPadding - lastWidth - highlightedWidth,
-                        this.getY() + VERTICAL_OFFSET,
+                        this.getY() + this.getHeight() / 2,
+                        this.getY() + this.getHeight() / 2,
                         0,
                         defaultText ? CommonColors.LIGHT_GRAY : CommonColors.WHITE,
                         HorizontalAlignment.LEFT,
+                        VerticalAlignment.MIDDLE,
                         TextShadow.NORMAL);
 
         if (defaultText) return;
@@ -90,13 +91,13 @@ public class SearchWidget extends TextInputBoxWidget {
                         StyledText.fromString(highlightedPortion),
                         this.getX() + textPadding + firstWidth,
                         this.getX() + this.width - textPadding - lastWidth,
-                        this.getY() + VERTICAL_OFFSET,
-                        this.getY() + VERTICAL_OFFSET,
+                        this.getY() + this.getHeight() / 2,
+                        this.getY() + this.getHeight() / 2,
                         0,
                         CommonColors.BLUE,
                         CommonColors.WHITE,
                         HorizontalAlignment.LEFT,
-                        VerticalAlignment.TOP);
+                        VerticalAlignment.MIDDLE);
 
         FontRenderer.getInstance()
                 .renderAlignedTextInBox(
@@ -104,10 +105,12 @@ public class SearchWidget extends TextInputBoxWidget {
                         StyledText.fromString(lastPortion),
                         this.getX() + textPadding + firstWidth + highlightedWidth,
                         this.getX() + this.width - textPadding,
-                        this.getY() + VERTICAL_OFFSET,
+                        this.getY() + this.getHeight() / 2,
+                        this.getY() + this.getHeight() / 2,
                         0,
                         defaultText ? CommonColors.LIGHT_GRAY : CommonColors.WHITE,
                         HorizontalAlignment.LEFT,
+                        VerticalAlignment.MIDDLE,
                         TextShadow.NORMAL);
 
         drawCursor(
@@ -116,8 +119,8 @@ public class SearchWidget extends TextInputBoxWidget {
                         + font.width(renderedText.substring(0, Math.min(cursorPosition, renderedText.length())))
                         + textPadding
                         - 2,
-                this.getY() + VERTICAL_OFFSET,
-                VerticalAlignment.TOP,
+                this.getY() + this.getHeight() / 2,
+                VerticalAlignment.MIDDLE,
                 false);
     }
 

--- a/common/src/main/java/com/wynntils/screens/base/widgets/TextInputBoxWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/TextInputBoxWidget.java
@@ -30,7 +30,6 @@ import net.minecraft.util.Mth;
 import org.lwjgl.glfw.GLFW;
 
 public class TextInputBoxWidget extends AbstractWidget {
-    private static final int CURSOR_PADDING = 3;
     private static final int CURSOR_TICK = 350;
 
     private final Consumer<String> onUpdateConsumer;
@@ -175,7 +174,7 @@ public class TextInputBoxWidget extends AbstractWidget {
         drawCursor(
                 poseStack,
                 font.width(renderedText.substring(0, Math.min(cursorPosition, renderedText.length()))),
-                (textPadding + this.height - textPadding) / 2,
+                this.height / 2,
                 VerticalAlignment.MIDDLE,
                 false);
 
@@ -505,14 +504,16 @@ public class TextInputBoxWidget extends AbstractWidget {
         if (isFocused() || forceUnfocusedCursor) {
             Font font = FontRenderer.getInstance().getFont();
 
+            int cursorHeight = font.lineHeight + 2;
+
             float cursorRenderY =
                     switch (verticalAlignment) {
-                        case TOP -> y - (CURSOR_PADDING - 1);
-                        case MIDDLE -> y - font.lineHeight + (CURSOR_PADDING - 1);
-                        case BOTTOM -> y - font.lineHeight - (CURSOR_PADDING - 1);
+                        case TOP -> y - 1 - cursorHeight;
+                        case MIDDLE -> y - 1 - cursorHeight / 2;
+                        case BOTTOM -> y - (font.lineHeight / 2);
                     };
 
-            RenderUtils.drawRect(poseStack, CommonColors.WHITE, x + 1, cursorRenderY, 0, 1, font.lineHeight + 3);
+            RenderUtils.drawRect(poseStack, CommonColors.WHITE, x + 1, cursorRenderY, 0, 1, cursorHeight);
         }
     }
 

--- a/common/src/main/java/com/wynntils/utils/render/FontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/FontRenderer.java
@@ -178,7 +178,7 @@ public final class FontRenderer {
                 switch (verticalAlignment) {
                     case TOP -> renderY - 2;
                     case MIDDLE -> renderY - (font.lineHeight / 2f) - 2;
-                    case BOTTOM -> renderY - font.lineHeight + 2;
+                    case BOTTOM -> renderY - font.lineHeight - 2;
                 };
 
         RenderUtils.drawRect(


### PR DESCRIPTION
Fixes bottom aligned text having broken highlights:
![image](https://github.com/Wynntils/Artemis/assets/57310593/d4ad8b24-57c1-4070-aa62-0ee4b9813b22)

Also does some refactoring to improve cursor and highlight alignments on all alignment settings. Cursors and highlights match positions 1:1 now (you can see when you press shift+arrow to highlight). Also removed arbitrary CURSOR_PADDING and VERTICAL_OFFSET constants that were used for hacky alignments.

Tested on the info box config input, the config book search, the quest list search, and the bank search. (Not every single alignment on every single text input, just most of them).