### PR TITLE
fix: Beta/pre-alpha usability fixes

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -113,7 +113,8 @@ public final class WynntilsMod {
     }
 
     public static boolean isPreAlpha() {
-        return version.contains("pre-alpha");
+        // This is hard-coded in the development branch
+        return true;
     }
 
     public static boolean isDevelopmentBuild() {

--- a/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
@@ -36,12 +36,17 @@ import org.apache.commons.lang3.Validate;
 
 @ConfigCategory(Category.UI)
 public class WynncraftButtonFeature extends Feature {
-    private static final String GAME_SERVER = "play.wynncraft.com";
-    private static final String LOBBY_SERVER = "lobby.wynncraft.com";
+    private static final String GAME_SERVER = "play";
+    private static final String BETA_SERVER = "beta";
+    private static final String LOBBY_SERVER = "lobby";
+    private static final String WYNNCRAFT_DOMAIN = ".wynncraft.com";
     private boolean firstTitleScreenInit = true;
 
     @RegisterConfig
     public final Config<Boolean> connectToLobby = new Config<>(false);
+
+    @RegisterConfig
+    public final Config<Boolean> connectToBetaServer = new Config<>(false);
 
     @RegisterConfig
     public final Config<Boolean> autoConnect = new Config<>(false);
@@ -81,8 +86,11 @@ public class WynncraftButtonFeature extends Feature {
     }
 
     private ServerData getWynncraftServer() {
-        ServerData wynncraftServer =
-                new ServerData("Wynncraft", connectToLobby.get() ? LOBBY_SERVER : GAME_SERVER, false);
+        ServerData wynncraftServer = new ServerData(
+                "Wynncraft",
+                (connectToLobby.get() ? LOBBY_SERVER : connectToBetaServer.get() ? BETA_SERVER : GAME_SERVER)
+                        + WYNNCRAFT_DOMAIN,
+                false);
         wynncraftServer.setResourcePackStatus(
                 loadResourcePack.get() ? ServerData.ServerPackStatus.ENABLED : ServerData.ServerPackStatus.DISABLED);
 

--- a/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
@@ -17,7 +17,7 @@ public class BetaWarningFeature extends Feature {
 
     @SubscribeEvent
     public void onConnect(WynncraftConnectionEvent.Connected event) {
-        if (event.getHost().equals("beta") && !WynntilsMod.isPreAlpha()) {
+        if (event.getHost().equals("beta") != WynntilsMod.isPreAlpha()) {
             warn = true;
         }
     }
@@ -30,6 +30,6 @@ public class BetaWarningFeature extends Feature {
         warn = false;
         McUtils.sendMessageToClient(
                 Component.literal(
-                        "You are using a non pre-alpha version of Wynntils. This version is not supported on Wynncraft Beta. Please use the pre-alpha version instead."));
+                        "You are using a pre-alpha version of Wynntils. This version is only supported on Wynncraft Beta. Please use the normal alpha version, or connect to the beta server instead."));
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -893,6 +893,8 @@
   "feature.wynntils.wybelSound.name": "Wybel Sounds",
   "feature.wynntils.wynncraftButton.autoConnect.description": "Should the mod auto-connect to Wynncraft on startup?",
   "feature.wynntils.wynncraftButton.autoConnect.name": "Auto-Connect on Startup",
+  "feature.wynntils.wynncraftButton.connectToBetaServer.description": "Should the button connect to the beta server instead of the normal game server? This has no meaning if Connect to Lobby is enabled",
+  "feature.wynntils.wynncraftButton.connectToBetaServer.name": "Connect to Beta",
   "feature.wynntils.wynncraftButton.connectToLobby.description": "Should the button connect to the lobby or the game server?",
   "feature.wynntils.wynncraftButton.connectToLobby.name": "Connect to Lobby",
   "feature.wynntils.wynncraftButton.loadResourcePack.description": "Should the Wynncraft resource pack be loaded?",


### PR DESCRIPTION
fix: Add option to connect to beta from Wynncraft button.
fix: Hard-code development version to behave as pre-alpha.
fix: On pre-alpha, warn if user connects to non-beta server.