### PR TITLE
feat: Show queue position in loading screen

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
@@ -11,6 +11,8 @@ import com.wynntils.mc.event.LoadingProgressEvent;
 import com.wynntils.mc.event.LocalSoundEvent;
 import com.wynntils.mc.event.ResourcePackEvent;
 import com.wynntils.mc.event.ScreenOpenedEvent;
+import com.wynntils.mc.event.SubtitleSetTextEvent;
+import com.wynntils.mc.event.TitleSetTextEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.screens.characterselector.LoadingScreen;
 import com.wynntils.utils.mc.McUtils;
@@ -52,6 +54,20 @@ public class CustomLoadingScreenFeature extends Feature {
         if (loadingScreen == null) return;
 
         loadingScreen.setMessage("Downloading resource pack...");
+    }
+
+    @SubscribeEvent
+    public void onTitleSetText(TitleSetTextEvent e) {
+        if (loadingScreen == null) return;
+
+        loadingScreen.setTitle(e.getComponent().getString());
+    }
+
+    @SubscribeEvent
+    public void onSuntitleSetText(SubtitleSetTextEvent e) {
+        if (loadingScreen == null) return;
+
+        loadingScreen.setSubtitle(e.getComponent().getString());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
@@ -25,7 +25,9 @@ public final class LoadingScreen extends WynntilsScreen {
     private static final CustomColor MOSS_GREEN = CustomColor.fromInt(0x527529).withAlpha(255);
     private static final int SPINNER_SPEED = 1200;
 
-    private String message;
+    private String message = "";
+    private String title = "";
+    private String subtitle = "";
 
     private LoadingScreen() {
         super(Component.translatable("screens.wynntils.characterSelection.name"));
@@ -37,6 +39,14 @@ public final class LoadingScreen extends WynntilsScreen {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setSubtitle(String subtitle) {
+        this.subtitle = subtitle;
     }
 
     @Override
@@ -83,7 +93,29 @@ public final class LoadingScreen extends WynntilsScreen {
                         poseStack,
                         StyledText.fromString(message),
                         centerX,
+                        100,
+                        MOSS_GREEN,
+                        HorizontalAlignment.CENTER,
+                        VerticalAlignment.TOP,
+                        TextShadow.NONE);
+
+        // Draw additional messages (typically about queue position)
+        FontRenderer.getInstance()
+                .renderText(
+                        poseStack,
+                        StyledText.fromString(""),
+                        centerX,
                         120,
+                        MOSS_GREEN,
+                        HorizontalAlignment.CENTER,
+                        VerticalAlignment.TOP,
+                        TextShadow.NONE);
+        FontRenderer.getInstance()
+                .renderText(
+                        poseStack,
+                        StyledText.fromString(""),
+                        centerX,
+                        130,
                         MOSS_GREEN,
                         HorizontalAlignment.CENTER,
                         VerticalAlignment.TOP,


### PR DESCRIPTION
According to the problem expressed in #1628, the loading screen might hide queue information.

This is a rare situation and I have not been able to reproduce it myself. However, based on the screenshot in 
https://github.com/Wynntils/Artemis/pull/1628#issuecomment-1615977751, this is an optimistic implementation which is likely to work.