### PR TITLE
fix: Proper fix for duplicated container content events

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/container/ContainerQueryStep.java
+++ b/common/src/main/java/com/wynntils/handlers/container/ContainerQueryStep.java
@@ -47,11 +47,8 @@ public interface ContainerQueryStep {
     /** A way to identify this query. It is used to help avoid queueing the same query twice. */
     String getName();
 
-    // FIXME: This might not be the best way to handle this
-    /** Some gui's do not reopen the menu, they just refresh the content (pressing dialogue history in quest book).
-     * Use this to indicate that a content refresh is enough for us, and we do not need to wait for opening a menu
-     */
-    default boolean shouldWaitForMenuReopen() {
-        return true;
+    /** If this is true, a resent screen with no changed values will be accepted, and not filtered. */
+    default boolean acceptNoOp() {
+        return false;
     }
 }

--- a/common/src/main/java/com/wynntils/handlers/container/ScriptedContainerQuery.java
+++ b/common/src/main/java/com/wynntils/handlers/container/ScriptedContainerQuery.java
@@ -71,17 +71,17 @@ public final class ScriptedContainerQuery {
         final StartAction startAction;
         final ContainerVerification verification;
         final ContainerAction handleContent;
-        final boolean waitForMenuReopen;
+        final boolean acceptNoOp;
 
         private ScriptedQueryStep(
                 StartAction startAction,
                 ContainerVerification verification,
                 ContainerAction handleContent,
-                boolean waitForMenuReopen) {
+                boolean acceptNoOp) {
             this.startAction = startAction;
             this.verification = verification;
             this.handleContent = handleContent;
-            this.waitForMenuReopen = waitForMenuReopen;
+            this.acceptNoOp = acceptNoOp;
         }
 
         @Override
@@ -124,8 +124,8 @@ public final class ScriptedContainerQuery {
         }
 
         @Override
-        public boolean shouldWaitForMenuReopen() {
-            return this.waitForMenuReopen;
+        public boolean acceptNoOp() {
+            return this.acceptNoOp;
         }
     }
 
@@ -143,7 +143,7 @@ public final class ScriptedContainerQuery {
         private StartAction startAction;
         private ContainerVerification verification;
         private ContainerAction handleContent;
-        private boolean waitForMenuReopen = true;
+        private boolean acceptNoOp = false;
 
         private final ScriptedContainerQuery query;
 
@@ -151,8 +151,8 @@ public final class ScriptedContainerQuery {
             query = scriptedContainerQuery;
         }
 
-        public QueryBuilder setWaitForMenuReopen(boolean wait) {
-            this.waitForMenuReopen = wait;
+        public QueryBuilder setAcceptNoOp(boolean acceptNoOp) {
+            this.acceptNoOp = acceptNoOp;
             return this;
         }
 
@@ -256,11 +256,12 @@ public final class ScriptedContainerQuery {
         private void checkForCompletion() {
             if (startAction != null && verification != null && handleContent != null) {
                 ScriptedQueryStep nextStep =
-                        query.new ScriptedQueryStep(startAction, verification, handleContent, waitForMenuReopen);
+                        query.new ScriptedQueryStep(startAction, verification, handleContent, acceptNoOp);
                 query.steps.add(nextStep);
                 startAction = null;
                 verification = null;
                 handleContent = null;
+                acceptNoOp = false;
             }
         }
     }

--- a/common/src/main/java/com/wynntils/models/abilitytree/AbilityTreeContainerQueries.java
+++ b/common/src/main/java/com/wynntils/models/abilitytree/AbilityTreeContainerQueries.java
@@ -57,7 +57,6 @@ public class AbilityTreeContainerQueries {
                 .useItemInHotbar(InventoryUtils.COMPASS_SLOT_NUM)
                 .matchTitle("Character Info")
                 .processContainer(container -> {})
-                .setWaitForMenuReopen(false)
                 .clickOnSlot(ABILITY_TREE_SLOT)
                 .matchTitle(Models.Container.ABILITY_TREE_PATTERN.pattern())
                 .processContainer(c -> {});
@@ -68,32 +67,21 @@ public class AbilityTreeContainerQueries {
             queryBuilder
                     .clickOnSlotIfExists(PREVIOUS_PAGE_SLOT, DUMMY_SLOT)
                     .matchTitle(Models.Container.ABILITY_TREE_PATTERN.pattern())
+                    .setAcceptNoOp(true)
                     .processContainer(c -> {});
         }
 
         // endregion
 
-        // We are on the first page now
+        // We are on the first page now. Re-read it by clicking a dummy slot,
+        // and accepting no-op changes.
         queryBuilder
                 .clickOnSlot(DUMMY_SLOT)
+                .setAcceptNoOp(true)
                 .matchTitle(Models.Container.ABILITY_TREE_PATTERN.pattern())
                 .processContainer(c -> processor.processPage(c, 1));
 
-        // region Hack for setWaitForMenuReopen to work with page 2
-        // Going from first page to second adds a new button, "previous". This triggers processContainer prematurely.
-
-        queryBuilder
-                .clickOnSlotWithName(NEXT_PAGE_SLOT, Items.STONE_AXE, NEXT_PAGE_ITEM_NAME)
-                .matchTitle(Models.Container.ABILITY_TREE_PATTERN.pattern())
-                .processContainer(c -> {});
-        queryBuilder
-                .clickOnSlot(DUMMY_SLOT)
-                .matchTitle(Models.Container.ABILITY_TREE_PATTERN.pattern())
-                .processContainer(c -> processor.processPage(c, 2));
-
-        // endregion
-
-        for (int i = 3; i <= Models.AbilityTree.ABILITY_TREE_PAGES; i++) {
+        for (int i = 2; i <= Models.AbilityTree.ABILITY_TREE_PAGES; i++) {
             final int page = i; // Lambdas need final variables
             queryBuilder
                     .clickOnSlotWithName(NEXT_PAGE_SLOT, Items.STONE_AXE, NEXT_PAGE_ITEM_NAME)

--- a/common/src/main/java/com/wynntils/models/quests/DialogueHistoryQueries.java
+++ b/common/src/main/java/com/wynntils/models/quests/DialogueHistoryQueries.java
@@ -60,7 +60,6 @@ public class DialogueHistoryQueries {
                 .onError(msg -> WynntilsMod.warn("Problem getting dialogue history (2) in Quest Book: " + msg))
                 .useItemInHotbar(InventoryUtils.QUEST_BOOK_SLOT_NUM)
                 .matchTitle(Models.Quest.getQuestBookTitleRegex(1))
-                .setWaitForMenuReopen(false)
                 .processContainer((c) -> {
                     ItemStack dialogueHistoryItem = c.items().get(0);
 
@@ -82,7 +81,6 @@ public class DialogueHistoryQueries {
             queryBuilder
                     .clickOnSlot(0)
                     .matchTitle(Models.Quest.getQuestBookTitleRegex(1))
-                    .setWaitForMenuReopen(false)
                     .processContainer((c) -> {
                         ItemStack dialogueHistoryItem = c.items().get(0);
 

--- a/common/src/main/java/com/wynntils/utils/wynn/InventoryUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/InventoryUtils.java
@@ -60,6 +60,22 @@ public final class InventoryUtils {
         return accessories;
     }
 
+    public static boolean isItemListsEqual(List<ItemStack> firstItems, List<ItemStack> secondItems) {
+        if (firstItems.size() != secondItems.size()) return false;
+
+        for (int i = 0; i < firstItems.size(); i++) {
+            var newItem = firstItems.get(i);
+            var oldItem = secondItems.get(i);
+            if (!newItem.getItem().equals(oldItem.getItem())
+                    || newItem.getDamageValue() != oldItem.getDamageValue()
+                    || newItem.getCount() != oldItem.getCount()
+                    || !ItemStack.tagMatches(oldItem, newItem)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public enum MouseClickType {
         LEFT_CLICK,
         RIGHT_CLICK


### PR DESCRIPTION
Proper fix for duplicated container content events when using the container query.

This is a prerequisite for dynamic queries.