### PR TITLE
Fix: Button clicks in ChatTabEditingScreen even though there isn't any button selected

### DIFF
--- a/common/src/main/java/com/wynntils/screens/base/widgets/TextInputBoxWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/TextInputBoxWidget.java
@@ -257,15 +257,16 @@ public class TextInputBoxWidget extends AbstractWidget {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
-
         if (this.isHovered) {
+            McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
             setCursorAndHighlightPositions(getIndexAtPosition(mouseX));
             isDragging = true;
             textboxScreen.setFocusedTextInput(this);
             this.setFocused(true);
             return true;
-        } else {
+        }
+        if (isFocused()) {
+            McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
             setCursorAndHighlightPositions(cursorPosition); // remove highlights when clicking off
             this.setFocused(false);
             textboxScreen.setFocusedTextInput(null);


### PR DESCRIPTION
In the ChatTabEditingScreen you can click anywhere you want and it makes a click sound. This should fix it.