### PR TITLE
fix: Damage detection was broken, and missed poison

### DIFF
--- a/common/src/main/java/com/wynntils/models/damage/DamageModel.java
+++ b/common/src/main/java/com/wynntils/models/damage/DamageModel.java
@@ -24,7 +24,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class DamageModel extends Model {
     // https://regexr.com/7968a
-    private static final Pattern DAMAGE_LABEL_PATTERN = Pattern.compile("(?:§[24bcef]-(\\d+) ([❤✦✤❉❋✹]) )");
+    private static final Pattern DAMAGE_LABEL_PATTERN = Pattern.compile("(?:§[245bcef](?:§l)?-(\\d+) ([❤✦✤❉❋✹☠]) )");
 
     // https://regexr.com/7965g
     private static final Pattern DAMAGE_BAR_PATTERN = Pattern.compile("^§[ac](.*) - §c(\\d+)§4❤(?: - §7(.*)§7)?$");

--- a/common/src/main/java/com/wynntils/models/stats/builders/DamageStatBuilder.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/DamageStatBuilder.java
@@ -15,7 +15,7 @@ public final class DamageStatBuilder extends StatBuilder<DamageStatType> {
     @Override
     public void buildStats(Consumer<DamageStatType> callback) {
         for (AttackType attackType : AttackType.values()) {
-            for (DamageType damageType : DamageType.values()) {
+            for (DamageType damageType : DamageType.statValues()) {
                 DamageStatType percentType = buildDamageStat(attackType, damageType, StatUnit.PERCENT);
                 callback.accept(percentType);
 

--- a/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
@@ -5,6 +5,8 @@
 package com.wynntils.models.stats.type;
 
 import com.wynntils.models.elements.type.Element;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 
@@ -16,7 +18,8 @@ public enum DamageType {
     AIR(Element.AIR),
     THUNDER(Element.THUNDER),
     EARTH(Element.EARTH),
-    RAINBOW("Elemental");
+    RAINBOW("Elemental"),
+    POISON("Poison", "☠", ChatFormatting.DARK_PURPLE);
 
     private final Element element;
     private final String displayName;
@@ -50,6 +53,10 @@ public enum DamageType {
         this.apiName = element.getDisplayName();
         this.symbol = element.getSymbol();
         this.colorCode = element.getColorCode();
+    }
+
+    public static List<DamageType> statValues() {
+        return Arrays.stream(values()).filter(d -> d == POISON).toList();
     }
 
     public static DamageType fromElement(Element element) {

--- a/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
@@ -56,7 +56,8 @@ public enum DamageType {
     }
 
     public static List<DamageType> statValues() {
-        return Arrays.stream(values()).filter(d -> d == POISON).toList();
+        // Poison is only used in damage labels, not stats
+        return Arrays.stream(values()).filter(type -> type != POISON).toList();
     }
 
     public static DamageType fromElement(Element element) {


### PR DESCRIPTION
This patch solves two problems:

1) Sometimes Wynn inserts a `§l` after the color code in damage labels

2) We missed poison damage completely. I added this as a damage type, but made sure it is not mixed in with normal stats.