### PR TITLE
feat: Right-click text field to clear it

### DIFF
--- a/common/src/main/java/com/wynntils/screens/base/widgets/SearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/SearchWidget.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
+import org.lwjgl.glfw.GLFW;
 
 public class SearchWidget extends TextInputBoxWidget {
     private static final Component DEFAULT_TEXT =
@@ -146,7 +147,12 @@ public class SearchWidget extends TextInputBoxWidget {
                 && mouseY >= this.getY()
                 && mouseY <= this.getY() + this.height) {
             McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
-            setCursorAndHighlightPositions(getIndexAtPosition(mouseX));
+            if (button == GLFW.GLFW_MOUSE_BUTTON_2) {
+                setTextBoxInput("");
+                setCursorAndHighlightPositions(0);
+            } else {
+                setCursorAndHighlightPositions(getIndexAtPosition(mouseX));
+            }
             isDragging = true;
             textboxScreen.setFocusedTextInput(this);
             return true;

--- a/common/src/main/java/com/wynntils/screens/base/widgets/TextInputBoxWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/TextInputBoxWidget.java
@@ -259,7 +259,12 @@ public class TextInputBoxWidget extends AbstractWidget {
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (this.isHovered) {
             McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
-            setCursorAndHighlightPositions(getIndexAtPosition(mouseX));
+            if (button == GLFW.GLFW_MOUSE_BUTTON_2) {
+                setTextBoxInput("");
+                setCursorAndHighlightPositions(0);
+            } else {
+                setCursorAndHighlightPositions(getIndexAtPosition(mouseX));
+            }
             isDragging = true;
             textboxScreen.setFocusedTextInput(this);
             this.setFocused(true);


### PR DESCRIPTION
Add a feature so you can right-click a `TextInputBoxWidget` to clear its contents.