### PR TITLE
feat: Capture exceptions in key handling

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -245,23 +245,26 @@ public final class WynntilsMod {
         Managers.CrashReport.registerCrashContext("In Development", () -> isDevelopmentEnvironment() ? "Yes" : "No");
     }
 
-    public static void reportCrash(String fullName, String niceName, CrashType type, Throwable throwable) {
-        reportCrash(fullName, niceName, type, throwable, true, true);
+    public static void reportCrash(
+            CrashType type, String niceName, String fullName, String reason, Throwable throwable) {
+        reportCrash(type, niceName, fullName, reason, true, true, throwable);
     }
 
     public static void reportCrash(
-            String fullName,
-            String niceName,
             CrashType type,
-            Throwable throwable,
+            String niceName,
+            String fullName,
+            String reason,
             boolean shouldSendChat,
-            boolean isDisabled) {
-        WynntilsMod.warn("Disabling " + type.toString().toLowerCase(Locale.ROOT) + " " + niceName);
+            boolean isDisabled,
+            Throwable throwable) {
+        WynntilsMod.warn(
+                "Disabling " + type.toString().toLowerCase(Locale.ROOT) + " " + niceName + " due to " + reason);
         WynntilsMod.error("Exception thrown by " + fullName, throwable);
 
         if (shouldSendChat) {
-            McUtils.sendErrorToClient("Wynntils error: " + type.getName() + " '" + niceName + "' has crashed"
-                    + (isDisabled ? " and has been disabled" : ""));
+            McUtils.sendErrorToClient("Wynntils error: " + type.getName() + " '" + niceName + "' has crashed in "
+                    + reason + (isDisabled ? " and has been disabled" : ""));
         }
 
         postEvent(new WynntilsCrashEvent(fullName, type, throwable));

--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -368,12 +368,13 @@ public final class FeatureManager extends Manager {
             // Log and handle gracefully, just disable this feature
             crashFeature(feature);
             WynntilsMod.reportCrash(
-                    feature.getClass().getName() + ":initialize",
-                    feature.getClass().getSimpleName() + " during init",
                     CrashType.FEATURE,
-                    exception,
+                    feature.getClass().getSimpleName(),
+                    feature.getClass().getName(),
+                    "init",
                     false,
-                    true);
+                    true,
+                    exception);
         }
     }
 
@@ -505,7 +506,13 @@ public final class FeatureManager extends Manager {
         boolean shouldSendChat = !(event instanceof ClientsideMessageEvent);
 
         WynntilsMod.reportCrash(
-                feature.getClass().getName(), feature.getTranslatedName(), CrashType.FEATURE, t, shouldSendChat, true);
+                CrashType.FEATURE,
+                feature.getTranslatedName(),
+                feature.getClass().getName(),
+                "event listener",
+                shouldSendChat,
+                true,
+                t);
 
         if (shouldSendChat) {
             MutableComponent enableMessage = Component.literal("Click here to enable it again.")

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -102,7 +102,11 @@ public final class FunctionManager extends Manager {
             crashFunction(function);
 
             WynntilsMod.reportCrash(
-                    function.getClass().getName(), function.getTranslatedName(), CrashType.FUNCTION, throwable);
+                    CrashType.FUNCTION,
+                    function.getTranslatedName(),
+                    function.getClass().getName(),
+                    "calculation",
+                    throwable);
         }
 
         return Optional.empty();

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -259,7 +259,11 @@ public final class OverlayManager extends Manager {
                 crashedOverlays.add(overlay);
 
                 WynntilsMod.reportCrash(
-                        overlay.getClass().getName(), overlay.getTranslatedName(), CrashType.OVERLAY, t);
+                        CrashType.OVERLAY,
+                        overlay.getTranslatedName(),
+                        overlay.getClass().getName(),
+                        "render",
+                        t);
             }
         }
 

--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -20,12 +20,13 @@ public abstract class WynntilsScreen extends Screen {
         McUtils.mc().setScreen(null);
 
         WynntilsMod.reportCrash(
-                this.getClass().getName() + "." + method + "()",
-                this.getClass().getSimpleName() + " during " + method,
                 CrashType.SCREEN,
-                throwable,
+                this.getClass().getSimpleName(),
+                this.getClass().getName(),
+                method,
                 true,
-                false);
+                false,
+                throwable);
         McUtils.sendErrorToClient("Screen was forcefully closed.");
     }
 
@@ -68,5 +69,13 @@ public abstract class WynntilsScreen extends Screen {
 
     public boolean doMouseClicked(double mouseX, double mouseY, int button) {
         return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    public void wrapCurrentScreenError(Runnable action, String errorDesc, String screenName) {
+        try {
+            action.run();
+        } catch (Throwable t) {
+            failure(errorDesc, t);
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
@@ -166,7 +166,11 @@ public final class KeyBindManager extends Manager {
                     crashedKeyBinds.add(Pair.of(parent, keyBind.key()));
 
                     WynntilsMod.reportCrash(
-                            parent.getClass().getName() + "." + keyBind.value(), keyBind.value(), CrashType.KEYBIND, t);
+                            CrashType.KEYBIND,
+                            keyBind.value(),
+                            parent.getClass().getName() + "." + keyBind.value(),
+                            "handling",
+                            t);
                 }
             }
         }

--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -188,7 +188,8 @@ public class ItemHandler extends Handler {
                 crashedAnnotators.add(annotator);
 
                 String annotatorName = annotator.getClass().getSimpleName();
-                WynntilsMod.reportCrash(annotator.getClass().getName(), annotatorName, CrashType.ANNOTATOR, t);
+                WynntilsMod.reportCrash(
+                        CrashType.ANNOTATOR, annotatorName, annotator.getClass().getName(), "handling", t);
 
                 WynntilsMod.warn("Problematic item:" + itemStack);
                 WynntilsMod.warn("Problematic item name:" + StyledText.fromComponent(itemStack.getHoverName()));

--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -8,6 +8,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.core.consumers.screens.WynntilsScreen;
 import com.wynntils.core.events.MixinHelper;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.event.PauseMenuInitEvent;
@@ -128,6 +129,19 @@ public abstract class ScreenMixin implements ScreenExtension {
     @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At("RETURN"))
     private void onScreenRenderPost(PoseStack poseStack, int mouseX, int mouseY, float partialTick, CallbackInfo ci) {
         MixinHelper.post(new ScreenRenderEvent((Screen) (Object) this, poseStack, mouseX, mouseY, partialTick));
+    }
+
+    @Inject(
+            method =
+                    "Lnet/minecraft/client/gui/screens/Screen;wrapScreenError(Ljava/lang/Runnable;Ljava/lang/String;Ljava/lang/String;)V",
+            at = @At("HEAD"),
+            cancellable = true)
+    private static void wrapScreenErrorPre(Runnable action, String errorDesc, String screenName, CallbackInfo ci) {
+        if (!(Minecraft.getInstance().screen instanceof WynntilsScreen wynntilsScreen)) return;
+
+        // This is too involved in error handling to worth risk sending events
+        wynntilsScreen.wrapCurrentScreenError(action, errorDesc, screenName);
+        ci.cancel();
     }
 
     @Override


### PR DESCRIPTION
If an exception occurs during key handling, default vanilla behavior is to crash the game. We should handle that as any other errors.

Also fix the wording of the error message which looked quite odd for some cases.