### PR TITLE
chore: Update copyright year with Spotless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.PRIVATE_TOKEN }}
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ allprojects {
             palantirJavaFormat(spotless_palantir_version)
             trimTrailingWhitespace()
             endWithNewline()
+            ratchetFrom('origin/main')
             // Custom rule from https://github.com/apache/geode
             custom "Refuse wildcard imports", {
                 if (it =~ /\nimport .*\*;/) {
@@ -110,10 +111,11 @@ allprojects {
             custom "No empty line after opening curly brace", {
                 it.replaceAll(/\{\n\n/, '{\n')
             }
-            licenseHeader "/*\n" +
+            licenseHeader("/*\n" +
                     " * Copyright © Wynntils \$YEAR.\n" +
                     " * This file is released under AGPLv3. See LICENSE for full license details.\n" +
-                    " */"
+                    " */")
+                    .updateYearWithLatest(true)
         }
         json {
             target "src/**/*.json"


### PR DESCRIPTION
This was a bit tricky to get right. 

The `ratchetFrom` functionality did not work on Github; I pulled my hair until I finally found https://github.com/diffplug/spotless/issues/710, where the spotless developers basically says "yeah, we know this feature is worthless since all CI systems do shallow clones, but they can just change that by a configuration in the CI system". 

Since we have not done this from the start, we have some files with non-updated copyright year. I might follow this up with running a script to get these up to date.