### PR TITLE
fix: Change À to Á in translation replacement

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/TranslationFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranslationFeature.java
@@ -115,7 +115,7 @@ public class TranslationFeature extends Feature {
         // Some translated text (e.g. from pt_br) contains À. This will be stripped later on,
         // so convert it to A (not ideal but better than nothing).
         return StyledText.fromString(
-                origCoded.replaceAll("\\{ ?§ ?([0-9a-fklmnor]) ?\\}", "§$1").replace('À', 'A'));
+                origCoded.replaceAll("\\{ ?§ ?([0-9a-fklmnor]) ?\\}", "§$1").replace('Á', 'A'));
     }
 
     private String wrapCoding(StyledText origCoded) {

--- a/common/src/main/java/com/wynntils/features/utilities/TranslationFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranslationFeature.java
@@ -112,7 +112,7 @@ public class TranslationFeature extends Feature {
     }
 
     private StyledText unwrapCoding(String origCoded) {
-        // Some translated text (e.g. from pt_br) contains À. This will be stripped later on,
+        // Some translated text (e.g. from pt_br) contains Á. This will be stripped later on,
         // so convert it to A (not ideal but better than nothing).
         return StyledText.fromString(
                 origCoded.replaceAll("\\{ ?§ ?([0-9a-fklmnor]) ?\\}", "§$1").replace('Á', 'A'));


### PR DESCRIPTION
It appears the Á symbol was the issue, not Á according to the logs