### PR TITLE
feat: improve stat screen formatting

### DIFF
--- a/common/src/main/java/com/wynntils/screens/statistics/WynntilsStatisticsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/statistics/WynntilsStatisticsScreen.java
@@ -171,14 +171,25 @@ public final class WynntilsStatisticsScreen
                         HorizontalAlignment.LEFT,
                         VerticalAlignment.TOP,
                         TextShadow.NONE);
-
+        // Note: Count is not formatted according to the formatter
+        FontRenderer.getInstance()
+                .renderText(
+                        poseStack,
+                        StyledText.fromString(I18n.get("screens.wynntils.statistics.count", entry.count())),
+                        0,
+                        40,
+                        Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
+                        CommonColors.BLACK,
+                        HorizontalAlignment.LEFT,
+                        VerticalAlignment.TOP,
+                        TextShadow.NONE);
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
                         StyledText.fromString(I18n.get(
                                 "screens.wynntils.statistics.min", statisticKind.getFormattedValue(entry.min()))),
                         0,
-                        40,
+                        50,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
                         CommonColors.BLACK,
                         HorizontalAlignment.LEFT,
@@ -191,7 +202,7 @@ public final class WynntilsStatisticsScreen
                         StyledText.fromString(I18n.get(
                                 "screens.wynntils.statistics.max", statisticKind.getFormattedValue(entry.max()))),
                         0,
-                        50,
+                        60,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
                         CommonColors.BLACK,
                         HorizontalAlignment.LEFT,
@@ -205,7 +216,7 @@ public final class WynntilsStatisticsScreen
                                 "screens.wynntils.statistics.average",
                                 statisticKind.getFormattedValue(entry.average()))),
                         0,
-                        60,
+                        70,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
                         CommonColors.BLACK,
                         HorizontalAlignment.LEFT,

--- a/common/src/main/java/com/wynntils/screens/statistics/WynntilsStatisticsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/statistics/WynntilsStatisticsScreen.java
@@ -143,11 +143,11 @@ public final class WynntilsStatisticsScreen
     }
 
     private static void renderCountStatistics(PoseStack poseStack, StatisticKind statisticKind, StatisticEntry entry) {
-        // Note: Count is not formatted according to the formatter
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.statistics.count", entry.count())),
+                        StyledText.fromString(I18n.get(
+                                "screens.wynntils.statistics.count", statisticKind.getFormattedValue(entry.count()))),
                         0,
                         30,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,

--- a/common/src/main/java/com/wynntils/screens/statistics/WynntilsStatisticsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/statistics/WynntilsStatisticsScreen.java
@@ -134,6 +134,31 @@ public final class WynntilsStatisticsScreen
         poseStack.popPose();
 
         // Statistics
+        switch (statisticKind.getType()) {
+            case COUNT -> renderCountStatistics(poseStack, statisticKind, entry);
+            case ADVANCED -> renderAdvancedStatistics(poseStack, statisticKind, entry);
+        }
+
+        poseStack.popPose();
+    }
+
+    private static void renderCountStatistics(PoseStack poseStack, StatisticKind statisticKind, StatisticEntry entry) {
+        // Note: Count is not formatted according to the formatter
+        FontRenderer.getInstance()
+                .renderText(
+                        poseStack,
+                        StyledText.fromString(I18n.get("screens.wynntils.statistics.count", entry.count())),
+                        0,
+                        30,
+                        Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
+                        CommonColors.BLACK,
+                        HorizontalAlignment.LEFT,
+                        VerticalAlignment.TOP,
+                        TextShadow.NONE);
+    }
+
+    private static void renderAdvancedStatistics(
+            PoseStack poseStack, StatisticKind statisticKind, StatisticEntry entry) {
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
@@ -147,11 +172,11 @@ public final class WynntilsStatisticsScreen
                         VerticalAlignment.TOP,
                         TextShadow.NONE);
 
-        // Note: Count is not formatted according to the formatter
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.statistics.count", entry.count())),
+                        StyledText.fromString(I18n.get(
+                                "screens.wynntils.statistics.min", statisticKind.getFormattedValue(entry.min()))),
                         0,
                         40,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
@@ -164,22 +189,9 @@ public final class WynntilsStatisticsScreen
                 .renderText(
                         poseStack,
                         StyledText.fromString(I18n.get(
-                                "screens.wynntils.statistics.min", statisticKind.getFormattedValue(entry.min()))),
-                        0,
-                        50,
-                        Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
-                        CommonColors.BLACK,
-                        HorizontalAlignment.LEFT,
-                        VerticalAlignment.TOP,
-                        TextShadow.NONE);
-
-        FontRenderer.getInstance()
-                .renderText(
-                        poseStack,
-                        StyledText.fromString(I18n.get(
                                 "screens.wynntils.statistics.max", statisticKind.getFormattedValue(entry.max()))),
                         0,
-                        60,
+                        50,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
                         CommonColors.BLACK,
                         HorizontalAlignment.LEFT,
@@ -193,14 +205,12 @@ public final class WynntilsStatisticsScreen
                                 "screens.wynntils.statistics.average",
                                 statisticKind.getFormattedValue(entry.average()))),
                         0,
-                        70,
+                        60,
                         Texture.QUEST_BOOK_BACKGROUND.width() / 2 - 20,
                         CommonColors.BLACK,
                         HorizontalAlignment.LEFT,
                         VerticalAlignment.TOP,
                         TextShadow.NONE);
-
-        poseStack.popPose();
     }
 
     public void setHighlightedButton(StatisticButton button) {

--- a/common/src/main/java/com/wynntils/services/statistics/CustomStatFormatters.java
+++ b/common/src/main/java/com/wynntils/services/statistics/CustomStatFormatters.java
@@ -4,6 +4,9 @@
  */
 package com.wynntils.services.statistics;
 
+import com.wynntils.utils.StringUtils;
+import java.text.NumberFormat;
+import java.util.Locale;
 import net.minecraft.stats.StatFormatter;
 
 public final class CustomStatFormatters {
@@ -25,4 +28,7 @@ public final class CustomStatFormatters {
             return minutes >= 1 ? StatFormatter.DECIMAL_FORMAT.format(minutes) + " m" : seconds + " s";
         }
     };
+
+    public static StatFormatter FORMATTED_NUMBER = (number) ->
+            NumberFormat.getIntegerInstance(Locale.US).format(number) + " (" + StringUtils.formatAmount(number) + ")";
 }

--- a/common/src/main/java/com/wynntils/services/statistics/type/StatisticKind.java
+++ b/common/src/main/java/com/wynntils/services/statistics/type/StatisticKind.java
@@ -65,6 +65,6 @@ public enum StatisticKind {
 
     public enum StatisticType {
         COUNT, // only the count is relevant
-        ADVANCED // min, max, average are all relevant, BUT count is not
+        ADVANCED // min, max, average are all relevant
     }
 }

--- a/common/src/main/java/com/wynntils/services/statistics/type/StatisticKind.java
+++ b/common/src/main/java/com/wynntils/services/statistics/type/StatisticKind.java
@@ -11,27 +11,29 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.stats.StatFormatter;
 
 public enum StatisticKind {
-    DAMAGE_DEALT(StatFormatter.DEFAULT),
-    SPELLS_CAST(StatFormatter.DEFAULT),
+    DAMAGE_DEALT(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.ADVANCED),
+    SPELLS_CAST(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.COUNT),
 
     // region Lootruns
 
-    LOOTRUNS_COMPLETED(StatFormatter.DEFAULT),
-    LOOTRUNS_FAILED(StatFormatter.DEFAULT),
-    LOOTRUNS_CHALLENGES_COMPLETED(StatFormatter.DEFAULT),
-    LOOTRUNS_TIME_ELAPSED(CustomStatFormatters.TIME),
-    LOOTRUNS_REWARD_PULLS(StatFormatter.DEFAULT),
-    LOOTRUNS_REWARD_REROLLS(StatFormatter.DEFAULT),
-    LOOTRUNS_EXPERIENCE_GAINED(StatFormatter.DEFAULT),
-    LOOTRUNS_MOBS_KILLED(StatFormatter.DEFAULT);
+    LOOTRUNS_COMPLETED(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.COUNT),
+    LOOTRUNS_FAILED(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.COUNT),
+    LOOTRUNS_CHALLENGES_COMPLETED(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.ADVANCED),
+    LOOTRUNS_TIME_ELAPSED(CustomStatFormatters.TIME, StatisticType.ADVANCED),
+    LOOTRUNS_REWARD_PULLS(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.ADVANCED),
+    LOOTRUNS_REWARD_REROLLS(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.ADVANCED),
+    LOOTRUNS_EXPERIENCE_GAINED(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.ADVANCED),
+    LOOTRUNS_MOBS_KILLED(CustomStatFormatters.FORMATTED_NUMBER, StatisticType.ADVANCED);
 
     // endregion
 
     private final StatFormatter formatter;
+    private final StatisticType type;
     private final String id;
 
-    StatisticKind(StatFormatter formatter) {
+    StatisticKind(StatFormatter formatter, StatisticType type) {
         this.formatter = formatter;
+        this.type = type;
         this.id = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name().toLowerCase(Locale.ROOT));
     }
 
@@ -49,11 +51,20 @@ public enum StatisticKind {
         return id;
     }
 
+    public StatisticType getType() {
+        return type;
+    }
+
     public String getName() {
         return I18n.get("statistics.wynntils." + id + ".name");
     }
 
     public String getFormattedValue(int value) {
         return formatter.format(value);
+    }
+
+    public enum StatisticType {
+        COUNT, // only the count is relevant
+        ADVANCED // min, max, average are all relevant, BUT count is not
     }
 }


### PR DESCRIPTION
Count and everything else is basically two different statistic types. Maybe this could be reflected in the stored stuff itself, but formatting it is good enough too, IMO. Especially it is a lot easier on us if we want to add new types.

I also added the custom formatter for the readable number formats.

![image](https://github.com/Wynntils/Artemis/assets/49001742/98dcf4ce-3658-485f-84bd-83219492af28)
![image](https://github.com/Wynntils/Artemis/assets/49001742/80bf1a58-f3da-48e5-93c8-ea090120f7aa)