### PR TITLE
feat: Config to disable parsing content book immediately

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
@@ -95,6 +95,9 @@ public class WynntilsContentBookFeature extends Feature {
     @RegisterConfig
     public final Config<Boolean> showContentBookLoadingUpdates = new Config<>(true);
 
+    @RegisterConfig
+    public final Config<Boolean> displayOverallProgress = new Config<>(true);
+
     @SubscribeEvent
     public void onUseItem(UseItemEvent event) {
         if (McUtils.player().isShiftKeyDown() || !replaceWynncraftContentBook.get()) return;

--- a/common/src/main/java/com/wynntils/screens/wynntilsmenu/WynntilsMenuScreen.java
+++ b/common/src/main/java/com/wynntils/screens/wynntilsmenu/WynntilsMenuScreen.java
@@ -10,6 +10,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.features.map.MainMapFeature;
+import com.wynntils.features.ui.WynntilsContentBookFeature;
 import com.wynntils.screens.activities.WynntilsCaveScreen;
 import com.wynntils.screens.activities.WynntilsDialogueHistoryScreen;
 import com.wynntils.screens.activities.WynntilsDiscoveriesScreen;
@@ -57,7 +58,11 @@ public final class WynntilsMenuScreen extends WynntilsMenuScreenBase {
     private WynntilsMenuScreen() {
         super(Component.translatable("screens.wynntils.wynntilsMenu.name"));
         setup();
-        Models.Activity.scanOverallProgress();
+        if (Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class)
+                .displayOverallProgress
+                .get()) {
+            Models.Activity.scanOverallProgress();
+        }
     }
 
     public static Screen create() {
@@ -360,20 +365,24 @@ public final class WynntilsMenuScreen extends WynntilsMenuScreenBase {
                         CommonColors.PURPLE,
                         HorizontalAlignment.CENTER,
                         TextShadow.NONE);
-        CappedValue progress = Models.Activity.getOverallProgress();
-        FontRenderer.getInstance()
-                .renderAlignedTextInBox(
-                        poseStack,
-                        StyledText.fromString(ChatFormatting.BLACK + "Progress: " + ChatFormatting.DARK_AQUA
-                                + progress.getPercentageInt() + "%" + ChatFormatting.BLACK + " ["
-                                + ChatFormatting.DARK_AQUA + progress + ChatFormatting.BLACK + "]"),
-                        Texture.QUEST_BOOK_BACKGROUND.width() / 2f,
-                        Texture.QUEST_BOOK_BACKGROUND.width(),
-                        160,
-                        0,
-                        CommonColors.BLACK,
-                        HorizontalAlignment.CENTER,
-                        TextShadow.NONE);
+        if (Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class)
+                .displayOverallProgress
+                .get()) {
+            CappedValue progress = Models.Activity.getOverallProgress();
+            FontRenderer.getInstance()
+                    .renderAlignedTextInBox(
+                            poseStack,
+                            StyledText.fromString(ChatFormatting.BLACK + "Progress: " + ChatFormatting.DARK_AQUA
+                                    + progress.getPercentageInt() + "%" + ChatFormatting.BLACK + " ["
+                                    + ChatFormatting.DARK_AQUA + progress + ChatFormatting.BLACK + "]"),
+                            Texture.QUEST_BOOK_BACKGROUND.width() / 2f,
+                            Texture.QUEST_BOOK_BACKGROUND.width(),
+                            160,
+                            0,
+                            CommonColors.BLACK,
+                            HorizontalAlignment.CENTER,
+                            TextShadow.NONE);
+        }
 
         String currentSplash = Services.Splash.getCurrentSplash() == null ? "" : Services.Splash.getCurrentSplash();
         StyledText[] wrappedSplash = RenderedStringUtils.wrapTextBySize(

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1098,6 +1098,8 @@
   "feature.wynntils.wynncraftPauseScreen.territoryMap.name": "Territory Map",
   "feature.wynntils.wynncraftPauseScreen.wynntilsMenuButton.name": "Wynntils Menu",
   "feature.wynntils.wynntilsContentBook.description": "Adds a custom content book.",
+  "feature.wynntils.wynntilsContentBook.displayOverallProgress.description": "Disabling this stops the mod from parsing the content book when opening the Wynntils menu.",
+  "feature.wynntils.wynntilsContentBook.displayOverallProgress.name": "Display Overall Progress",
   "feature.wynntils.wynntilsContentBook.initialPage.description": "Choose the default page when opening the custom book",
   "feature.wynntils.wynntilsContentBook.initialPage.name": "Initial Page",
   "feature.wynntils.wynntilsContentBook.name": "Wynntils Content Book",


### PR DESCRIPTION
Parsing the content book to get overall progress immediately despawns your horse. This can be rather annoying.