### PR TITLE
fix: fix content tracker scoreboard adding spaces (and setting wrong waypoints)

### DIFF
--- a/common/src/main/java/com/wynntils/models/activities/ActivityTrackerScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityTrackerScoreboardPart.java
@@ -43,9 +43,8 @@ public class ActivityTrackerScoreboardPart extends ScoreboardPart {
 
         for (StyledText line : taskLines) {
             nextTask.append(line.getString()
-                            .replaceAll(ChatFormatting.WHITE.toString(), ChatFormatting.AQUA.toString())
-                            .replaceAll(ChatFormatting.GRAY.toString(), ChatFormatting.RESET.toString()))
-                    .append(" ");
+                    .replaceAll(ChatFormatting.WHITE.toString(), ChatFormatting.AQUA.toString())
+                    .replaceAll(ChatFormatting.GRAY.toString(), ChatFormatting.RESET.toString()));
         }
 
         String type = matcher.group(1);


### PR DESCRIPTION
I tracked around 15 quests to see if we are missing a space. We are not. Also tested that this fixes the issue on quests that were previously bugged.