### PR TITLE
feat: Add crash protection to config updates in features and overlays

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/Feature.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/Feature.java
@@ -6,11 +6,13 @@ package com.wynntils.core.consumers.features;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ComparisonChain;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.config.Category;
 import com.wynntils.core.config.Config;
 import com.wynntils.core.config.ConfigHolder;
 import com.wynntils.core.config.RegisterConfig;
+import com.wynntils.core.mod.type.CrashType;
 import com.wynntils.core.storage.Storageable;
 import net.minecraft.client.resources.language.I18n;
 
@@ -64,6 +66,20 @@ public abstract class Feature extends AbstractConfigurable implements Storageabl
     /** Used to react to config option updates */
     protected void onConfigUpdate(ConfigHolder<?> configHolder) {}
 
+    private void callOnConfigUpdate(ConfigHolder<?> configHolder) {
+        try {
+            onConfigUpdate(configHolder);
+        } catch (Throwable t) {
+            // We can't stop disabled features from getting config updates, so if it crashes again,
+            // just ignore it
+            if (!Managers.Feature.isEnabled(this)) return;
+
+            Managers.Feature.crashFeature(this);
+            WynntilsMod.reportCrash(
+                    CrashType.FEATURE, getTranslatedName(), getClass().getName(), "config update", t);
+        }
+    }
+
     public void onEnable() {}
 
     public void onDisable() {}
@@ -88,7 +104,7 @@ public abstract class Feature extends AbstractConfigurable implements Storageabl
         }
 
         // otherwise, trigger regular config update
-        onConfigUpdate(configHolder);
+        callOnConfigUpdate(configHolder);
     }
 
     /** Updates the feature's enabled/disabled state to match the user's setting, if necessary */

--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -454,7 +454,7 @@ public final class FeatureManager extends Manager {
         Managers.KeyBind.disableFeatureKeyBinds(feature);
     }
 
-    private void crashFeature(Feature feature) {
+    public void crashFeature(Feature feature) {
         if (!FEATURES.containsKey(feature)) {
             throw new IllegalArgumentException("Tried to crash an unregistered feature: " + feature);
         }

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -90,7 +90,7 @@ public final class OverlayManager extends Manager {
         WynntilsMod.unregisterEventListener(disabledOverlay);
 
         enabledOverlays.forEach(
-                overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::onConfigUpdate));
+                overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::callOnConfigUpdate));
     }
 
     public void enableOverlays(Feature parent) {
@@ -104,7 +104,7 @@ public final class OverlayManager extends Manager {
         WynntilsMod.registerEventListener(enableOverlay);
 
         enabledOverlays.forEach(
-                overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::onConfigUpdate));
+                overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::callOnConfigUpdate));
     }
 
     public void discoverOverlays(Feature feature) {


### PR DESCRIPTION
As reported in https://github.com/Wynntils/Artemis/issues/1917, crashing during a config update can bring down the entire config system, with potentially catastrophic results.