### PR TITLE
refactor: Profession percent now returns a float

### DIFF
--- a/common/src/main/java/com/wynntils/functions/ProfessionFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/ProfessionFunctions.java
@@ -36,12 +36,12 @@ public class ProfessionFunctions {
         }
     }
 
-    public static class ProfessionPercentageFunction extends Function<Double> {
+    public static class ProfessionPercentageFunction extends Function<Float> {
         @Override
-        public Double getValue(FunctionArguments arguments) {
+        public Float getValue(FunctionArguments arguments) {
             ProfessionType professionType = ProfessionType.fromString(
                     arguments.getArgument("profession").getStringValue());
-            if (professionType == null) return -1.0;
+            if (professionType == null) return -1.0f;
 
             return Models.Profession.getProgress(professionType);
         }

--- a/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
+++ b/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
@@ -235,7 +235,7 @@ public class ProfessionModel extends Model {
                 .level();
     }
 
-    public double getProgress(ProfessionType type) {
+    public float getProgress(ProfessionType type) {
         return professionProgressMap
                 .getOrDefault(type, ProfessionProgress.NO_PROGRESS)
                 .progress();


### PR DESCRIPTION
Before & after
![Double](https://github.com/Wynntils/Artemis/assets/8337467/7d7a1f38-1d47-4936-bc80-ccd3b2a02b54)
![Float](https://github.com/Wynntils/Artemis/assets/8337467/e8a893c0-b4e6-4dec-9637-cc55a11df1e1)

Unless there's a reason why it's stored as a float yet returns a double?