### PR TITLE
feat: Add new 2.0.3 minor IDs

### DIFF
--- a/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
@@ -110,9 +110,16 @@ public final class StatListOrderer {
             "spellCostRaw3",
             "spellCostPct3",
             "spellCostRaw4",
-            "spellCostPct4");
+            "spellCostPct4",
+            // These were added in 2.0.3 and is not present in Legacy
+            "healingEfficiency",
+            "knockback",
+            "slowEnemy",
+            "weakenEnemy"
+            );
 
     private static final List<MiscStatKind> WYNNCRAFT_MISC_ORDER_1 = List.of(
+            MiscStatKind.KNOCKBACK,
             MiscStatKind.HEALTH_REGEN_PERCENT,
             MiscStatKind.MANA_REGEN,
             MiscStatKind.LIFE_STEAL,
@@ -128,7 +135,10 @@ public final class StatListOrderer {
             MiscStatKind.HEALTH,
             MiscStatKind.SOUL_POINT_REGEN,
             MiscStatKind.STEALING,
-            MiscStatKind.HEALTH_REGEN_RAW);
+            MiscStatKind.HEALTH_REGEN_RAW,
+            MiscStatKind.HEALING_EFFICIENCY,
+            MiscStatKind.SLOW_ENEMY,
+            MiscStatKind.WEAKEN_ENEMY);
     private static final List<MiscStatKind> WYNNCRAFT_MISC_ORDER_2 =
             List.of(MiscStatKind.SPRINT, MiscStatKind.SPRINT_REGEN);
     private static final List<MiscStatKind> WYNNCRAFT_MISC_ORDER_3 = List.of(

--- a/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
@@ -115,8 +115,7 @@ public final class StatListOrderer {
             "healingEfficiency",
             "knockback",
             "slowEnemy",
-            "weakenEnemy"
-            );
+            "weakenEnemy");
 
     private static final List<MiscStatKind> WYNNCRAFT_MISC_ORDER_1 = List.of(
             MiscStatKind.KNOCKBACK,

--- a/common/src/main/java/com/wynntils/models/stats/builders/MiscStatKind.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/MiscStatKind.java
@@ -12,6 +12,7 @@ public enum MiscStatKind {
     HEALTH("Health", StatUnit.RAW, "healthBonus"),
     HEALTH_REGEN_PERCENT("Health Regen", StatUnit.PERCENT, "healthRegen"),
     HEALTH_REGEN_RAW("Health Regen", StatUnit.RAW, "healthRegenRaw"),
+    HEALING_EFFICIENCY("Healing Efficiency", StatUnit.PERCENT, "healingEfficiency"),
     LIFE_STEAL("Life Steal", StatUnit.PER_3_S, "lifeSteal"),
     MANA_REGEN("Mana Regen", StatUnit.PER_5_S, "manaRegen"),
     MANA_STEAL("Mana Steal", StatUnit.PER_3_S, "manaSteal"),
@@ -28,6 +29,9 @@ public enum MiscStatKind {
     THORNS("Thorns", StatUnit.PERCENT, "thorns"),
     EXPLODING("Exploding", StatUnit.PERCENT, "exploding"),
     POISON("Poison", StatUnit.PER_3_S, "poison"),
+    KNOCKBACK("Knockback", StatUnit.PERCENT, "knockback"),
+    SLOW_ENEMY("Slow Enemy", StatUnit.PERCENT, "slowEnemy"),
+    WEAKEN_ENEMY("Weaken Enemy", StatUnit.PERCENT, "weakenEnemy"),
 
     // Bonuses for soul points, emeralds, XP, loot and gathering
     SOUL_POINT_REGEN("Soul Point Regen", StatUnit.PERCENT, "soulPoints"),


### PR DESCRIPTION
This might break the item chat tooltips for users on older versions of Artemis and Legacy