### PR TITLE
chore: Properly update all missing copyright years

### DIFF
--- a/common/src/main/java/com/wynntils/core/components/Handlers.java
+++ b/common/src/main/java/com/wynntils/core/components/Handlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.components;

--- a/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
+++ b/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.events;

--- a/common/src/main/java/com/wynntils/core/events/MixinHelper.java
+++ b/common/src/main/java/com/wynntils/core/events/MixinHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.events;

--- a/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
+++ b/common/src/main/java/com/wynntils/core/mod/CrashReportManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.mod;

--- a/common/src/main/java/com/wynntils/core/mod/TickSchedulerManager.java
+++ b/common/src/main/java/com/wynntils/core/mod/TickSchedulerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.mod;

--- a/common/src/main/java/com/wynntils/core/net/ApiResponse.java
+++ b/common/src/main/java/com/wynntils/core/net/ApiResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.net;

--- a/common/src/main/java/com/wynntils/core/net/Download.java
+++ b/common/src/main/java/com/wynntils/core/net/Download.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.net;

--- a/common/src/main/java/com/wynntils/core/net/UrlManager.java
+++ b/common/src/main/java/com/wynntils/core/net/UrlManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.net;

--- a/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/MessageContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.notifications;

--- a/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
+++ b/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.notifications;

--- a/common/src/main/java/com/wynntils/core/notifications/TimedMessageContainer.java
+++ b/common/src/main/java/com/wynntils/core/notifications/TimedMessageContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.notifications;

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.actionbar;

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarSegment.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.actionbar;

--- a/common/src/main/java/com/wynntils/handlers/actionbar/type/ActionBarPosition.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/type/ActionBarPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.actionbar.type;

--- a/common/src/main/java/com/wynntils/handlers/bossbar/BossBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/bossbar/BossBarHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.bossbar;

--- a/common/src/main/java/com/wynntils/handlers/bossbar/TrackedBar.java
+++ b/common/src/main/java/com/wynntils/handlers/bossbar/TrackedBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.bossbar;

--- a/common/src/main/java/com/wynntils/handlers/bossbar/type/BossBarProgress.java
+++ b/common/src/main/java/com/wynntils/handlers/bossbar/type/BossBarProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.bossbar.type;

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.chat.event;

--- a/common/src/main/java/com/wynntils/handlers/chat/event/NpcDialogEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/NpcDialogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.chat.event;

--- a/common/src/main/java/com/wynntils/handlers/chat/type/MessageType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/MessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.chat.type;

--- a/common/src/main/java/com/wynntils/handlers/chat/type/NpcDialogueType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/NpcDialogueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.chat.type;

--- a/common/src/main/java/com/wynntils/handlers/container/type/ContainerContent.java
+++ b/common/src/main/java/com/wynntils/handlers/container/type/ContainerContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.container.type;

--- a/common/src/main/java/com/wynntils/handlers/item/ItemAnnotation.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.item;

--- a/common/src/main/java/com/wynntils/handlers/item/ItemAnnotator.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.item;

--- a/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.scoreboard;

--- a/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardSegment.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.scoreboard;

--- a/common/src/main/java/com/wynntils/handlers/scoreboard/event/ScoreboardSegmentAdditionEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/event/ScoreboardSegmentAdditionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.scoreboard.event;

--- a/common/src/main/java/com/wynntils/handlers/scoreboard/type/ScoreboardLine.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/type/ScoreboardLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.scoreboard.type;

--- a/common/src/main/java/com/wynntils/mc/event/ArmSwingEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ArmSwingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ChatPacketReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ChatPacketReceivedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ClientsideMessageEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ClientsideMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/CommandSuggestionsEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandSuggestionsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/CommandsAddedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandsAddedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerClickEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerClickEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerSetContentEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerSetContentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ContainerSetSlotEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ContainerSetSlotEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/GroundItemEntityTransformEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/GroundItemEntityTransformEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/HotbarSlotRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/HotbarSlotRenderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/MobEffectEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/MobEffectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/MouseScrollEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/MouseScrollEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PauseMenuInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PauseMenuInitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerInfoFooterChangedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerInfoFooterChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerJoinedWorldEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerJoinedWorldEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerNametagRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerNametagRenderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerRenderLayerEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerRenderLayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerTeamEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerTeamEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/RecipeBookOpenEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/RecipeBookOpenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/RenderLevelEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/RenderLevelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ResourcePackClearEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ResourcePackClearEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ScreenInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenInitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/ScreenOpenedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ScreenOpenedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/SetPlayerTeamEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SetPlayerTeamEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/SlotRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/SlotRenderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/TickEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/TickEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/TitleScreenInitEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/TitleScreenInitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/extension/ItemStackExtension.java
+++ b/common/src/main/java/com/wynntils/mc/extension/ItemStackExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.extension;

--- a/common/src/main/java/com/wynntils/mc/extension/ScreenExtension.java
+++ b/common/src/main/java/com/wynntils/mc/extension/ScreenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.extension;

--- a/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/AbstractContainerScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BossHealthOverlayMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ChatScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ChatScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ChestMenuMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ChestMenuMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientLevelMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientLevelMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ConnectScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ConnectScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ConnectionMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ConnectionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/CrashReportMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CrashReportMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/CustomHeadLayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CustomHeadLayerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/DownloadedPackSourceMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/DownloadedPackSourceMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/EntityLookupMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/EntityLookupMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/GuiMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/GuiMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/HumanoidArmorLayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/HumanoidArmorLayerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ItemRendererMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/KeyMappingMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/KeyMappingMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/KeyboardHandlerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/KeyboardHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/LevelRendererMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LevelRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LocalPlayerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/MainMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MainMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/MouseHandlerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MouseHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MultiPlayerGameModeMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/PlayerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/PlayerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScoreboardMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin;

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/LerpingBossEventAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/LerpingBossEventAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.mixin.accessors;

--- a/common/src/main/java/com/wynntils/models/abilities/BossBarModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/BossBarModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities;

--- a/common/src/main/java/com/wynntils/models/abilities/ShamanMaskModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShamanMaskModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities;

--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/AwakenedBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/AwakenedBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.bossbars;

--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/BloodPoolBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/BloodPoolBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.bossbars;

--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/CorruptedBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/CorruptedBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.bossbars;

--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/FocusBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/FocusBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.bossbars;

--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/ManaBankBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/ManaBankBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.bossbars;

--- a/common/src/main/java/com/wynntils/models/abilities/event/ShamanMaskTitlePacketEvent.java
+++ b/common/src/main/java/com/wynntils/models/abilities/event/ShamanMaskTitlePacketEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.event;

--- a/common/src/main/java/com/wynntils/models/abilities/type/ShamanMaskType.java
+++ b/common/src/main/java/com/wynntils/models/abilities/type/ShamanMaskType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.type;

--- a/common/src/main/java/com/wynntils/models/character/event/CharacterUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/models/character/event/CharacterUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.character.event;

--- a/common/src/main/java/com/wynntils/models/character/type/ClassInfo.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.character.type;

--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.character.type;

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.characterstats;

--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/CoordinatesSegment.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/CoordinatesSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.characterstats.actionbar;

--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/SprintSegment.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/SprintSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.characterstats.actionbar;

--- a/common/src/main/java/com/wynntils/models/containers/PlayerInventoryModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/PlayerInventoryModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.containers;

--- a/common/src/main/java/com/wynntils/models/elements/type/Powder.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Powder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements.type;

--- a/common/src/main/java/com/wynntils/models/elements/type/PowderTierInfo.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/PowderTierInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements.type;

--- a/common/src/main/java/com/wynntils/models/elements/type/Skill.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Skill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements.type;

--- a/common/src/main/java/com/wynntils/models/gear/tooltip/GearTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/models/gear/tooltip/GearTooltipBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.tooltip;

--- a/common/src/main/java/com/wynntils/models/gear/type/GearAttackSpeed.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearAttackSpeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;

--- a/common/src/main/java/com/wynntils/models/gear/type/GearTier.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearTier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;

--- a/common/src/main/java/com/wynntils/models/gear/type/GearType.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;

--- a/common/src/main/java/com/wynntils/models/horse/HorseModel.java
+++ b/common/src/main/java/com/wynntils/models/horse/HorseModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.horse;

--- a/common/src/main/java/com/wynntils/models/items/WynnItem.java
+++ b/common/src/main/java/com/wynntils/models/items/WynnItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items;

--- a/common/src/main/java/com/wynntils/models/items/WynnItemCache.java
+++ b/common/src/main/java/com/wynntils/models/items/WynnItemCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/AmplifierAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/AmplifierAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedConsumableAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedConsumableAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedGearAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/DungeonKeyAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/DungeonKeyAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldPouchAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldPouchAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearBoxAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearBoxAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/HorseAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/HorseAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MaterialAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MaterialAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MiscAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MiscAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MultiHealthPotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MultiHealthPotionAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/PotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/PotionAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/PowderAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/PowderAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/TeleportScrollAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/TeleportScrollAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/TrinketAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/TrinketAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/CosmeticTierAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/CosmeticTierAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/DailyRewardMultiplierAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/DailyRewardMultiplierAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/SeaskipperDestinationAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/SeaskipperDestinationAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/ServerAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/ServerAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/SkillCrystalAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/SkillCrystalAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/SoulPointAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/SoulPointAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/game/CraftedConsumableItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CraftedConsumableItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/GameItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GameItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/GatheringToolItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GatheringToolItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/GearBoxItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GearBoxItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/HorseItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/HorseItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/MaterialItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/MaterialItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/MultiHealthPotionItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/MultiHealthPotionItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/PowderItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/PowderItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/TeleportScrollItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/TeleportScrollItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/AbilityTreeItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/AbilityTreeItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/CosmeticItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/CosmeticItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/DailyRewardItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/DailyRewardItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/GuiItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/GuiItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/SeaskipperDestinationItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/SeaskipperDestinationItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/ServerItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/ServerItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/SkillCrystalItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/SkillCrystalItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/SkillPointItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/SkillPointItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/items/gui/SoulPointItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/SoulPointItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;

--- a/common/src/main/java/com/wynntils/models/items/properties/CountedItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/CountedItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/items/properties/DurableItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/DurableItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/items/properties/GearTierItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/GearTierItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/items/properties/LeveledItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/LeveledItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/items/properties/NumberedTierItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/NumberedTierItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/items/properties/QualityTierItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/QualityTierItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/items/properties/TargetedItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/TargetedItemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;

--- a/common/src/main/java/com/wynntils/models/objectives/AbstractObjectivesScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/models/objectives/AbstractObjectivesScoreboardPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.objectives;

--- a/common/src/main/java/com/wynntils/models/objectives/ObjectivesModel.java
+++ b/common/src/main/java/com/wynntils/models/objectives/ObjectivesModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.objectives;

--- a/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
+++ b/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.objectives;

--- a/common/src/main/java/com/wynntils/models/players/WynntilsUser.java
+++ b/common/src/main/java/com/wynntils/models/players/WynntilsUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.players;

--- a/common/src/main/java/com/wynntils/models/players/event/HadesRelationsUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/models/players/event/HadesRelationsUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.players.event;

--- a/common/src/main/java/com/wynntils/models/players/type/AccountType.java
+++ b/common/src/main/java/com/wynntils/models/players/type/AccountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.players.type;

--- a/common/src/main/java/com/wynntils/models/profession/type/ProfessionType.java
+++ b/common/src/main/java/com/wynntils/models/profession/type/ProfessionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.profession.type;

--- a/common/src/main/java/com/wynntils/models/spells/actionbar/SpellSegment.java
+++ b/common/src/main/java/com/wynntils/models/spells/actionbar/SpellSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.spells.actionbar;

--- a/common/src/main/java/com/wynntils/models/spells/type/SpellType.java
+++ b/common/src/main/java/com/wynntils/models/spells/type/SpellType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.spells.type;

--- a/common/src/main/java/com/wynntils/models/stats/type/StatActualValue.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/StatActualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.type;

--- a/common/src/main/java/com/wynntils/models/statuseffects/event/StatusEffectsChangedEvent.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/event/StatusEffectsChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.statuseffects.event;

--- a/common/src/main/java/com/wynntils/models/territories/GuildAttackScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/models/territories/GuildAttackScoreboardPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories;

--- a/common/src/main/java/com/wynntils/models/territories/GuildAttackTimerModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/GuildAttackTimerModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories;

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryAttackTimer.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryAttackTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories;

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryInfo.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories;

--- a/common/src/main/java/com/wynntils/models/territories/type/GuildResource.java
+++ b/common/src/main/java/com/wynntils/models/territories/type/GuildResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories.type;

--- a/common/src/main/java/com/wynntils/models/territories/type/GuildResourceValues.java
+++ b/common/src/main/java/com/wynntils/models/territories/type/GuildResourceValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories.type;

--- a/common/src/main/java/com/wynntils/models/territories/type/TerritoryStorage.java
+++ b/common/src/main/java/com/wynntils/models/territories/type/TerritoryStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories.type;

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds;

--- a/common/src/main/java/com/wynntils/models/worlds/ServerListModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/ServerListModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds;

--- a/common/src/main/java/com/wynntils/models/worlds/event/WorldStateEvent.java
+++ b/common/src/main/java/com/wynntils/models/worlds/event/WorldStateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds.event;

--- a/common/src/main/java/com/wynntils/models/worlds/profile/ServerProfile.java
+++ b/common/src/main/java/com/wynntils/models/worlds/profile/ServerProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds.profile;

--- a/common/src/main/java/com/wynntils/models/worlds/type/BombInfo.java
+++ b/common/src/main/java/com/wynntils/models/worlds/type/BombInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds.type;

--- a/common/src/main/java/com/wynntils/models/worlds/type/BombType.java
+++ b/common/src/main/java/com/wynntils/models/worlds/type/BombType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds.type;

--- a/common/src/main/java/com/wynntils/screens/base/TextboxScreen.java
+++ b/common/src/main/java/com/wynntils/screens/base/TextboxScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base;

--- a/common/src/main/java/com/wynntils/screens/base/TooltipProvider.java
+++ b/common/src/main/java/com/wynntils/screens/base/TooltipProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base;

--- a/common/src/main/java/com/wynntils/screens/base/WynntilsPagedScreen.java
+++ b/common/src/main/java/com/wynntils/screens/base/WynntilsPagedScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base;

--- a/common/src/main/java/com/wynntils/screens/base/widgets/BackButton.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/BackButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base.widgets;

--- a/common/src/main/java/com/wynntils/screens/base/widgets/BasicTexturedButton.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/BasicTexturedButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base.widgets;

--- a/common/src/main/java/com/wynntils/screens/base/widgets/PageSelectorButton.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/PageSelectorButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base.widgets;

--- a/common/src/main/java/com/wynntils/screens/base/widgets/WynntilsButton.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/WynntilsButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base.widgets;

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassInfoButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassInfoButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.characterselector.widgets;

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionAddButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionAddButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.characterselector.widgets;

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionDeleteButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionDeleteButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.characterselector.widgets;

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionEditButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionEditButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.characterselector.widgets;

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/PlayButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/PlayButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.characterselector.widgets;

--- a/common/src/main/java/com/wynntils/screens/chattabs/widgets/ChatTabAddButton.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/widgets/ChatTabAddButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.chattabs.widgets;

--- a/common/src/main/java/com/wynntils/screens/gearviewer/widgets/ViewPlayerStatsButton.java
+++ b/common/src/main/java/com/wynntils/screens/gearviewer/widgets/ViewPlayerStatsButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.gearviewer.widgets;

--- a/common/src/main/java/com/wynntils/screens/guides/GuideItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/GuideItemStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides;

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/GuidesButton.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/GuidesButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.widgets;

--- a/common/src/main/java/com/wynntils/screens/settings/widgets/ScrollButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/ScrollButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.settings.widgets;

--- a/common/src/main/java/com/wynntils/screens/wynntilsmenu/widgets/WynntilsMenuButton.java
+++ b/common/src/main/java/com/wynntils/screens/wynntilsmenu/widgets/WynntilsMenuButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.wynntilsmenu.widgets;

--- a/common/src/main/java/com/wynntils/utils/FileUtils.java
+++ b/common/src/main/java/com/wynntils/utils/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils;

--- a/common/src/main/java/com/wynntils/utils/SystemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/SystemUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils;

--- a/common/src/main/java/com/wynntils/utils/colors/CustomColor.java
+++ b/common/src/main/java/com/wynntils/utils/colors/CustomColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.colors;

--- a/common/src/main/java/com/wynntils/utils/mc/ComponentUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/ComponentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.mc;

--- a/common/src/main/java/com/wynntils/utils/mc/KeyboardUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/KeyboardUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.mc;

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021.
+ * Copyright © Wynntils 2021-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.mc;

--- a/common/src/main/java/com/wynntils/utils/render/FontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/FontRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render;

--- a/common/src/main/java/com/wynntils/utils/render/TextRenderSetting.java
+++ b/common/src/main/java/com/wynntils/utils/render/TextRenderSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render;

--- a/common/src/main/java/com/wynntils/utils/render/TextRenderTask.java
+++ b/common/src/main/java/com/wynntils/utils/render/TextRenderTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render;

--- a/common/src/main/java/com/wynntils/utils/render/buffered/CustomRenderType.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/CustomRenderType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.buffered;

--- a/common/src/main/java/com/wynntils/utils/render/type/PointerType.java
+++ b/common/src/main/java/com/wynntils/utils/render/type/PointerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.type;

--- a/common/src/main/java/com/wynntils/utils/type/BoundingBox.java
+++ b/common/src/main/java/com/wynntils/utils/type/BoundingBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/type/CappedValue.java
+++ b/common/src/main/java/com/wynntils/utils/type/CappedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/type/Pair.java
+++ b/common/src/main/java/com/wynntils/utils/type/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/type/QuadConsumer.java
+++ b/common/src/main/java/com/wynntils/utils/type/QuadConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.wynn;

--- a/common/src/main/java/com/wynntils/utils/wynn/RaycastUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/RaycastUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.wynn;

--- a/fabric/src/main/java/com/wynntils/fabric/mixins/RenderTargetMixin.java
+++ b/fabric/src/main/java/com/wynntils/fabric/mixins/RenderTargetMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.fabric.mixins;

--- a/forge/src/main/java/com/wynntils/forge/mixins/ForgeGuiMixin.java
+++ b/forge/src/main/java/com/wynntils/forge/mixins/ForgeGuiMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.forge.mixins;

--- a/quilt/src/main/java/com/wynntils/quilt/mixins/RenderTargetMixin.java
+++ b/quilt/src/main/java/com/wynntils/quilt/mixins/RenderTargetMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under AGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.quilt.mixins;


### PR DESCRIPTION
I finally figured out how to do this properly retroactively. Now we should have no more surprises like this.