### PR TITLE
fix: Fix overlays not sticking to cursor when moving them

### DIFF
--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -610,13 +610,14 @@ public final class OverlayManagementScreen extends WynntilsScreen {
 
     // Pair<dragX, dragY>
     private Pair<Double, Double> calculateDragAfterSnapping(double dragX, double dragY) {
+        if (!snappingEnabled) {
+            return new Pair<>(dragX, dragY);
+        }
+
         dragX += snapOffsetX;
         dragY += snapOffsetY;
         snapOffsetX = dragX;
         snapOffsetY = dragY;
-        if (!snappingEnabled) {
-            return new Pair<>(dragX, dragY);
-        }
 
         List<Edge> edgesToSnapTo =
                 switch (this.selectionMode) {

--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -96,6 +96,8 @@ public final class OverlayManagementScreen extends WynntilsScreen {
 
     private boolean userInteracted = false;
     private int animationLengthRemaining;
+    private double totalDragX;
+    private double totalDragY;
 
     private OverlayManagementScreen(Overlay overlay) {
         super(Component.translatable("screens.wynntils.overlayManagement.name"));
@@ -608,6 +610,10 @@ public final class OverlayManagementScreen extends WynntilsScreen {
 
     // Pair<dragX, dragY>
     private Pair<Double, Double> calculateDragAfterSnapping(double dragX, double dragY) {
+        dragX += totalDragX;
+        dragY += totalDragY;
+        totalDragX = dragX;
+        totalDragY = dragY;
         if (!snappingEnabled) {
             return new Pair<>(dragX, dragY);
         }
@@ -675,7 +681,8 @@ public final class OverlayManagementScreen extends WynntilsScreen {
             edgeAlignmentSnapMap.remove(edge);
             alignmentLinesToRender.remove(edge);
         }
-
+        totalDragX -= dragX;
+        totalDragY -= dragY;
         return new Pair<>(dragX, dragY);
     }
 

--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -96,8 +96,8 @@ public final class OverlayManagementScreen extends WynntilsScreen {
 
     private boolean userInteracted = false;
     private int animationLengthRemaining;
-    private double totalDragX;
-    private double totalDragY;
+    private double snapOffsetX;
+    private double snapOffsetY;
 
     private OverlayManagementScreen(Overlay overlay) {
         super(Component.translatable("screens.wynntils.overlayManagement.name"));
@@ -610,10 +610,10 @@ public final class OverlayManagementScreen extends WynntilsScreen {
 
     // Pair<dragX, dragY>
     private Pair<Double, Double> calculateDragAfterSnapping(double dragX, double dragY) {
-        dragX += totalDragX;
-        dragY += totalDragY;
-        totalDragX = dragX;
-        totalDragY = dragY;
+        dragX += snapOffsetX;
+        dragY += snapOffsetY;
+        snapOffsetX = dragX;
+        snapOffsetY = dragY;
         if (!snappingEnabled) {
             return new Pair<>(dragX, dragY);
         }
@@ -681,8 +681,9 @@ public final class OverlayManagementScreen extends WynntilsScreen {
             edgeAlignmentSnapMap.remove(edge);
             alignmentLinesToRender.remove(edge);
         }
-        totalDragX -= dragX;
-        totalDragY -= dragY;
+
+        snapOffsetX -= dragX;
+        snapOffsetY -= dragY;
         return new Pair<>(dragX, dragY);
     }
 

--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -616,8 +616,8 @@ public final class OverlayManagementScreen extends WynntilsScreen {
 
         dragX += snapOffsetX;
         dragY += snapOffsetY;
-        snapOffsetX = dragX;
-        snapOffsetY = dragY;
+        double originalDragX = dragX;
+        double originalDragY = dragY;
 
         List<Edge> edgesToSnapTo =
                 switch (this.selectionMode) {
@@ -683,8 +683,8 @@ public final class OverlayManagementScreen extends WynntilsScreen {
             alignmentLinesToRender.remove(edge);
         }
 
-        snapOffsetX -= dragX;
-        snapOffsetY -= dragY;
+        snapOffsetX = originalDragX - dragX;
+        snapOffsetY = originalDragY - dragY;
         return new Pair<>(dragX, dragY);
     }
 


### PR DESCRIPTION
in OverlayManagementScreen we adapt the drag x and y to snap to edges but the distance we snap doesn't get saved so the Overlay snaps further away from the cursor every time you move it. Maybe the name "totalDrag" is a bit misleading.