### PR TITLE
perf: Make functions templates compiled and cached

### DIFF
--- a/common/src/main/java/com/wynntils/commands/FunctionCommand.java
+++ b/common/src/main/java/com/wynntils/commands/FunctionCommand.java
@@ -36,7 +36,7 @@ public class FunctionCommand extends Command {
                     Stream.concat(
                             Managers.Function.getFunctions().stream().map(Function::getName),
                             Managers.Function.getFunctions().stream()
-                                    .map(Function::getAliases)
+                                    .map(Function::getAliasList)
                                     .flatMap(Collection::stream)),
                     builder);
 
@@ -146,8 +146,8 @@ public class FunctionCommand extends Command {
                                             : ChatFormatting.YELLOW))
                     .withStyle(style -> style.withClickEvent(
                             new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/function help " + function.getName())));
-            if (!function.getAliases().isEmpty()) {
-                String aliasList = String.join(", ", function.getAliases());
+            if (!function.getAliasList().isEmpty()) {
+                String aliasList = String.join(", ", function.getAliasList());
 
                 functionComponent
                         .append(Component.literal(" [alias: ").withStyle(ChatFormatting.GRAY))
@@ -242,7 +242,7 @@ public class FunctionCommand extends Command {
         helpComponent.append(
                 ChatFormatting.GRAY + "Description: " + ChatFormatting.WHITE + function.getDescription() + "\n");
         helpComponent.append(ChatFormatting.GRAY + "Aliases:" + ChatFormatting.WHITE + " ["
-                + String.join(", ", function.getAliases()) + "]\n");
+                + String.join(", ", function.getAliasList()) + "]\n");
         helpComponent.append(ChatFormatting.GRAY + "Returns: " + ChatFormatting.WHITE
                 + function.getFunctionType().getSimpleName() + "\n");
         helpComponent.append(ChatFormatting.GRAY + "Arguments:" + ChatFormatting.WHITE + " ("

--- a/common/src/main/java/com/wynntils/core/consumers/functions/Function.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/Function.java
@@ -15,6 +15,8 @@ public abstract class Function<T> implements Translatable {
     private final String name;
     private final String translationName;
 
+    private List<String> aliases;
+
     protected Function() {
         String name = this.getClass().getSimpleName().replace("Function", "");
         this.name = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);
@@ -31,8 +33,19 @@ public abstract class Function<T> implements Translatable {
         return name;
     }
 
-    public List<String> getAliases() {
+    protected List<String> getAliasList() {
         return List.of();
+    }
+
+    public List<String> getAliases() {
+        // Optimization: we use lazy loading here,
+        // because returning a new list every time does a lot of allocations,
+        // and the JVM is not interested in optimizing that.
+        if (aliases == null) {
+            aliases = getAliasList();
+        }
+
+        return aliases;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/core/consumers/functions/Function.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/Function.java
@@ -33,16 +33,16 @@ public abstract class Function<T> implements Translatable {
         return name;
     }
 
-    protected List<String> getAliasList() {
+    protected List<String> getAliases() {
         return List.of();
     }
 
-    public List<String> getAliases() {
+    public List<String> getAliasList() {
         // Optimization: we use lazy loading here,
         // because returning a new list every time does a lot of allocations,
         // and the JVM is not interested in optimizing that.
         if (aliases == null) {
-            aliases = getAliasList();
+            aliases = getAliases();
         }
 
         return aliases;

--- a/common/src/main/java/com/wynntils/core/consumers/functions/Function.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/Function.java
@@ -37,7 +37,7 @@ public abstract class Function<T> implements Translatable {
         return List.of();
     }
 
-    public List<String> getAliasList() {
+    public final List<String> getAliasList() {
         // Optimization: we use lazy loading here,
         // because returning a new list every time does a lot of allocations,
         // and the JVM is not interested in optimizing that.

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -91,7 +91,7 @@ public final class FunctionManager extends Manager {
 
     private boolean hasName(Function<?> function, String name) {
         if (function.getName().equalsIgnoreCase(name)) return true;
-        for (String alias : function.getAliases()) {
+        for (String alias : function.getAliasList()) {
             if (alias.equalsIgnoreCase(name)) return true;
         }
         return false;

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.functions.arguments.FunctionArguments;
 import com.wynntils.core.consumers.functions.arguments.parser.ArgumentParser;
 import com.wynntils.core.consumers.functions.expressions.Expression;
 import com.wynntils.core.consumers.functions.expressions.parser.ExpressionParser;
+import com.wynntils.core.consumers.functions.templates.Template;
 import com.wynntils.core.consumers.functions.templates.parser.TemplateParser;
 import com.wynntils.core.mod.type.CrashType;
 import com.wynntils.core.text.StyledText;
@@ -39,8 +40,10 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import net.minecraft.ChatFormatting;
@@ -51,6 +54,9 @@ import net.minecraft.network.chat.MutableComponent;
 public final class FunctionManager extends Manager {
     private final List<Function<?>> functions = new ArrayList<>();
     private final Set<Function<?>> crashedFunctions = new HashSet<>();
+
+    // We do not clear this cache, as it is not expected to grow too large
+    private final Map<String, Template> calculatedTemplateCache = new HashMap<>();
 
     public FunctionManager() {
         super(List.of());
@@ -121,14 +127,33 @@ public final class FunctionManager extends Manager {
                 ? Component.literal(function.getTranslatedName() + ": ").withStyle(ChatFormatting.WHITE)
                 : Component.literal("");
 
-        ErrorOr<FunctionArguments> errorOrArguments =
+        ErrorOr<List<Expression>> errorOrArgumentExpressions =
                 ArgumentParser.parseArguments(function.getArgumentsBuilder(), rawArguments);
 
-        if (errorOrArguments.hasError()) {
-            return header.append(Component.literal(errorOrArguments.getError()).withStyle(ChatFormatting.RED));
+        if (errorOrArgumentExpressions.hasError()) {
+            return header.append(
+                    Component.literal(errorOrArgumentExpressions.getError()).withStyle(ChatFormatting.RED));
         }
 
-        Optional<Object> value = getFunctionValueSafely(function, errorOrArguments.getValue());
+        List<ErrorOr<Object>> errorsOrargumentObjects = errorOrArgumentExpressions.getValue().stream()
+                .map(Expression::calculate)
+                .toList();
+
+        Optional<ErrorOr<Object>> argumentError =
+                errorsOrargumentObjects.stream().filter(ErrorOr::hasError).findFirst();
+        if (argumentError.isPresent()) {
+            return header.append(
+                    Component.literal(argumentError.get().getError()).withStyle(ChatFormatting.RED));
+        }
+
+        ErrorOr<FunctionArguments> errorOrArgument = function.getArgumentsBuilder()
+                .buildWithValues(
+                        errorsOrargumentObjects.stream().map(ErrorOr::getValue).toList());
+        if (errorOrArgument.hasError()) {
+            return header.append(Component.literal(errorOrArgument.getError()).withStyle(ChatFormatting.RED));
+        }
+
+        Optional<Object> value = getFunctionValueSafely(function, errorOrArgument.getValue());
         if (value.isEmpty()) {
             return header.append(Component.literal("??"));
         }
@@ -211,7 +236,8 @@ public final class FunctionManager extends Manager {
     // region Template formatting
 
     private String doFormat(String templateString) {
-        return TemplateParser.doFormat(templateString);
+        calculatedTemplateCache.computeIfAbsent(templateString, TemplateParser::getTemplateFromString);
+        return calculatedTemplateCache.get(templateString).getString();
     }
 
     public StyledText[] doFormatLines(String templateString) {

--- a/common/src/main/java/com/wynntils/core/consumers/functions/arguments/FunctionArguments.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/arguments/FunctionArguments.java
@@ -119,8 +119,8 @@ public final class FunctionArguments {
             }
         }
 
-        public FunctionArguments buildWithDefaults() {
-            return new FunctionArguments(this.arguments);
+        public List<Object> getDefaults() {
+            return this.arguments.stream().map(Argument::getDefaultValue).collect(Collectors.toList());
         }
     }
 
@@ -152,10 +152,6 @@ public final class FunctionArguments {
 
         @SuppressWarnings("unchecked")
         protected void setValue(Object value) {
-            if (this.value != null) {
-                throw new IllegalStateException("Tried setting argument value twice.");
-            }
-
             this.value = (T) value;
         }
 

--- a/common/src/main/java/com/wynntils/core/consumers/functions/expressions/ConstantExpression.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/expressions/ConstantExpression.java
@@ -47,6 +47,10 @@ public final class ConstantExpression extends Expression {
         return ErrorOr.of(Optional.empty());
     }
 
+    public static Expression fromObject(Object value) {
+        return new ConstantExpression(value.toString(), value);
+    }
+
     // region Parsers
 
     private static Optional<Object> markedStringParser(String rawString) {

--- a/common/src/main/java/com/wynntils/core/consumers/functions/templates/ExpressionTemplatePart.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/templates/ExpressionTemplatePart.java
@@ -9,7 +9,7 @@ import com.wynntils.core.consumers.functions.expressions.parser.ExpressionParser
 import com.wynntils.utils.type.ErrorOr;
 
 public class ExpressionTemplatePart extends TemplatePart {
-    private final String expressionString;
+    private final ErrorOr<Expression> expression;
 
     public ExpressionTemplatePart(String part) {
         super(part);
@@ -18,18 +18,16 @@ public class ExpressionTemplatePart extends TemplatePart {
             throw new IllegalArgumentException("Expression was not wrapped in curly braces.");
         }
 
-        this.expressionString = this.part.substring(1, this.part.length() - 1);
+        this.expression = ExpressionParser.tryParse(this.part.substring(1, this.part.length() - 1));
     }
 
     @Override
     public String getValue() {
-        ErrorOr<Expression> parse = ExpressionParser.tryParse(this.expressionString);
-
-        if (parse.hasError()) {
-            return parse.getError();
+        if (expression.hasError()) {
+            return expression.getError();
         }
 
-        ErrorOr<String> calculatedValue = parse.getValue().calculateFormattedString();
+        ErrorOr<String> calculatedValue = expression.getValue().calculateFormattedString();
 
         if (calculatedValue.hasError()) {
             return calculatedValue.getError();
@@ -40,6 +38,6 @@ public class ExpressionTemplatePart extends TemplatePart {
 
     @Override
     public String toString() {
-        return "ExpressionTemplatePart{" + "expressionString='" + expressionString + "'}";
+        return "ExpressionTemplatePart{" + "expressionString='" + expression + "'}";
     }
 }

--- a/common/src/main/java/com/wynntils/core/consumers/functions/templates/Template.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/templates/Template.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.consumers.functions.templates;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Template {
+    private final List<TemplatePart> parts;
+
+    public Template(List<TemplatePart> parts) {
+        this.parts = parts;
+    }
+
+    public String getString() {
+        return parts.stream().map(TemplatePart::getValue).collect(Collectors.joining());
+    }
+}

--- a/common/src/main/java/com/wynntils/core/consumers/functions/templates/parser/TemplateParser.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/templates/parser/TemplateParser.java
@@ -6,16 +6,17 @@ package com.wynntils.core.consumers.functions.templates.parser;
 
 import com.wynntils.core.consumers.functions.templates.ExpressionTemplatePart;
 import com.wynntils.core.consumers.functions.templates.LiteralTemplatePart;
+import com.wynntils.core.consumers.functions.templates.Template;
 import com.wynntils.core.consumers.functions.templates.TemplatePart;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class TemplateParser {
-    public static String doFormat(String templateString) {
+    public static Template getTemplateFromString(String templateString) {
         List<TemplatePart> parts = parseTemplate(templateString);
 
-        return parts.stream().map(TemplatePart::getValue).collect(Collectors.joining());
+        return new Template(Collections.unmodifiableList(parts));
     }
 
     private static List<TemplatePart> parseTemplate(String templateString) {

--- a/common/src/main/java/com/wynntils/features/debug/FunctionDumpFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/FunctionDumpFeature.java
@@ -65,7 +65,7 @@ public class FunctionDumpFeature extends Feature {
         dataLines.add(new String[] {String.join(",", FUNCTION_MAP.keySet())});
 
         for (Function<?> function : Managers.Function.getFunctions()) {
-            String aliases = "{" + String.join(",", function.getAliases()) + "}";
+            String aliases = "{" + String.join(",", function.getAliasList()) + "}";
             String[] dataLine = {
                 String.valueOf(dataLines.size()),
                 function.getName(),

--- a/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
@@ -49,7 +49,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sp");
         }
     }
@@ -61,7 +61,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sp_max");
         }
     }
@@ -98,7 +98,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sp_timer");
         }
     }
@@ -112,7 +112,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sp_timer_m");
         }
     }
@@ -126,7 +126,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sp_timer_s");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
@@ -49,7 +49,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sp");
         }
     }
@@ -61,7 +61,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sp_max");
         }
     }
@@ -98,7 +98,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sp_timer");
         }
     }
@@ -112,7 +112,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sp_timer_m");
         }
     }
@@ -126,7 +126,7 @@ public class CharacterFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sp_timer_s");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/CombatFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CombatFunctions.java
@@ -17,7 +17,7 @@ public class CombatFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("adps");
         }
     }
@@ -36,7 +36,7 @@ public class CombatFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("adavg");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/CombatFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CombatFunctions.java
@@ -17,7 +17,7 @@ public class CombatFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("adps");
         }
     }
@@ -36,7 +36,7 @@ public class CombatFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("adavg");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/CombatXpFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CombatXpFunctions.java
@@ -35,7 +35,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("xpm_raw");
         }
     }
@@ -49,7 +49,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("xpm");
         }
     }
@@ -63,7 +63,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("xppm");
         }
     }
@@ -75,7 +75,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("lvl");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/CombatXpFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CombatXpFunctions.java
@@ -35,7 +35,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("xpm_raw");
         }
     }
@@ -49,7 +49,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("xpm");
         }
     }
@@ -63,7 +63,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("xppm");
         }
     }
@@ -75,7 +75,7 @@ public class CombatXpFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("lvl");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/EnvironmentFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/EnvironmentFunctions.java
@@ -23,7 +23,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             // FIXME: These aliases are a bit backwards, let's clean it up in the future
             return List.of("capped_memory");
         }
@@ -54,7 +54,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("stopwatch_is_zero");
         }
     }
@@ -101,7 +101,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("memorymax", "memmax");
         }
     }
@@ -113,7 +113,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("memoryused", "memused");
         }
     }
@@ -125,7 +125,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("memorypct", "mempct");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/EnvironmentFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/EnvironmentFunctions.java
@@ -23,7 +23,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             // FIXME: These aliases are a bit backwards, let's clean it up in the future
             return List.of("capped_memory");
         }
@@ -54,7 +54,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("stopwatch_is_zero");
         }
     }
@@ -101,7 +101,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("memorymax", "memmax");
         }
     }
@@ -113,7 +113,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("memoryused", "memused");
         }
     }
@@ -125,7 +125,7 @@ public class EnvironmentFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("memorypct", "mempct");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/HorseFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/HorseFunctions.java
@@ -43,7 +43,7 @@ public class HorseFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("h_lvl");
         }
     }
@@ -58,7 +58,7 @@ public class HorseFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("h_mlvl");
         }
     }
@@ -73,7 +73,7 @@ public class HorseFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("h_xp");
         }
     }
@@ -88,7 +88,7 @@ public class HorseFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("h_tier");
         }
     }
@@ -104,7 +104,7 @@ public class HorseFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("h_name");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/HorseFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/HorseFunctions.java
@@ -43,7 +43,7 @@ public class HorseFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("h_lvl");
         }
     }
@@ -58,7 +58,7 @@ public class HorseFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("h_mlvl");
         }
     }
@@ -73,7 +73,7 @@ public class HorseFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("h_xp");
         }
     }
@@ -88,7 +88,7 @@ public class HorseFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("h_tier");
         }
     }
@@ -104,7 +104,7 @@ public class HorseFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("h_name");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/InventoryFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/InventoryFunctions.java
@@ -60,7 +60,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("estr");
         }
     }
@@ -73,7 +73,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("le");
         }
     }
@@ -86,7 +86,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("eb");
         }
     }
@@ -98,7 +98,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("em");
         }
     }
@@ -117,7 +117,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("inv_free");
         }
     }
@@ -129,7 +129,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("inv_used");
         }
     }
@@ -141,7 +141,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("pouch_open", "pouch_free");
         }
     }
@@ -153,7 +153,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("pouch_used");
         }
     }
@@ -170,7 +170,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("current_held_durability");
         }
     }
@@ -187,7 +187,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("max_held_durability");
         }
     }
@@ -211,7 +211,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("held_type");
         }
     }
@@ -234,7 +234,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("held_item", "held_name");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/InventoryFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/InventoryFunctions.java
@@ -60,7 +60,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("estr");
         }
     }
@@ -73,7 +73,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("le");
         }
     }
@@ -86,7 +86,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("eb");
         }
     }
@@ -98,7 +98,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("em");
         }
     }
@@ -117,7 +117,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("inv_free");
         }
     }
@@ -129,7 +129,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("inv_used");
         }
     }
@@ -141,7 +141,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("pouch_open", "pouch_free");
         }
     }
@@ -153,7 +153,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("pouch_used");
         }
     }
@@ -170,7 +170,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("current_held_durability");
         }
     }
@@ -187,7 +187,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("max_held_durability");
         }
     }
@@ -211,7 +211,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("held_type");
         }
     }
@@ -234,7 +234,7 @@ public class InventoryFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("held_item", "held_name");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/LootrunFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/LootrunFunctions.java
@@ -23,7 +23,7 @@ public class LootrunFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("dry_s");
         }
     }
@@ -35,7 +35,7 @@ public class LootrunFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("dry_b", "dry_boxes_count");
         }
     }
@@ -79,7 +79,7 @@ public class LootrunFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("chest_count");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/LootrunFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/LootrunFunctions.java
@@ -23,7 +23,7 @@ public class LootrunFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("dry_s");
         }
     }
@@ -35,7 +35,7 @@ public class LootrunFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("dry_b", "dry_boxes_count");
         }
     }
@@ -79,7 +79,7 @@ public class LootrunFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("chest_count");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
@@ -19,7 +19,7 @@ public class MinecraftFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("my_loc");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
@@ -19,7 +19,7 @@ public class MinecraftFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("my_loc");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/ProfessionFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/ProfessionFunctions.java
@@ -31,7 +31,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("prof_lvl");
         }
     }
@@ -53,7 +53,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("prof_pct");
         }
     }
@@ -77,7 +77,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("prof_xpm_raw");
         }
     }
@@ -102,7 +102,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("prof_xpm");
         }
     }
@@ -174,7 +174,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("mat_dry");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/ProfessionFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/ProfessionFunctions.java
@@ -31,7 +31,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("prof_lvl");
         }
     }
@@ -53,7 +53,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("prof_pct");
         }
     }
@@ -77,7 +77,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("prof_xpm_raw");
         }
     }
@@ -102,7 +102,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("prof_xpm");
         }
     }
@@ -174,7 +174,7 @@ public class ProfessionFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("mat_dry");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/SpellFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/SpellFunctions.java
@@ -23,7 +23,7 @@ public class SpellFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("arrow_shield");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/SpellFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/SpellFunctions.java
@@ -23,7 +23,7 @@ public class SpellFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("arrow_shield");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/WorldFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/WorldFunctions.java
@@ -34,7 +34,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("world");
         }
     }
@@ -61,7 +61,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("world_uptime", "uptime");
         }
     }
@@ -80,7 +80,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("token_count");
         }
     }
@@ -102,7 +102,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("token_dep");
         }
     }
@@ -124,7 +124,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("token");
         }
     }
@@ -146,7 +146,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("token_type");
         }
     }
@@ -259,7 +259,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("territory");
         }
     }
@@ -280,7 +280,7 @@ public class WorldFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("territory_owner");
         }
 

--- a/common/src/main/java/com/wynntils/functions/WorldFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/WorldFunctions.java
@@ -34,7 +34,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("world");
         }
     }
@@ -61,7 +61,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("world_uptime", "uptime");
         }
     }
@@ -80,7 +80,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("token_count");
         }
     }
@@ -102,7 +102,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("token_dep");
         }
     }
@@ -124,7 +124,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("token");
         }
     }
@@ -146,7 +146,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("token_type");
         }
     }
@@ -259,7 +259,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("territory");
         }
     }
@@ -280,7 +280,7 @@ public class WorldFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("territory_owner");
         }
 

--- a/common/src/main/java/com/wynntils/functions/WynnAlphabetFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/WynnAlphabetFunctions.java
@@ -29,7 +29,7 @@ public class WynnAlphabetFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("gavellian");
         }
     }
@@ -51,7 +51,7 @@ public class WynnAlphabetFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("wynnic");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/WynnAlphabetFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/WynnAlphabetFunctions.java
@@ -29,7 +29,7 @@ public class WynnAlphabetFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("gavellian");
         }
     }
@@ -51,7 +51,7 @@ public class WynnAlphabetFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("wynnic");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/CappedFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/CappedFunctions.java
@@ -23,7 +23,7 @@ public final class CappedFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("curr");
         }
     }
@@ -54,7 +54,7 @@ public final class CappedFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("rem");
         }
     }
@@ -72,7 +72,7 @@ public final class CappedFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("pct");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/CappedFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/CappedFunctions.java
@@ -23,7 +23,7 @@ public final class CappedFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("curr");
         }
     }
@@ -54,7 +54,7 @@ public final class CappedFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("rem");
         }
     }
@@ -72,7 +72,7 @@ public final class CappedFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("pct");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/ConditionalFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/ConditionalFunctions.java
@@ -32,7 +32,7 @@ public class ConditionalFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("if_str");
         }
     }
@@ -47,7 +47,7 @@ public class ConditionalFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("if_num");
         }
     }
@@ -62,7 +62,7 @@ public class ConditionalFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("if_capped", "if_cap");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/ConditionalFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/ConditionalFunctions.java
@@ -32,7 +32,7 @@ public class ConditionalFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("if_str");
         }
     }
@@ -47,7 +47,7 @@ public class ConditionalFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("if_num");
         }
     }
@@ -62,7 +62,7 @@ public class ConditionalFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("if_capped", "if_cap");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/LocationFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/LocationFunctions.java
@@ -67,7 +67,7 @@ public final class LocationFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("loc");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/LocationFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/LocationFunctions.java
@@ -67,7 +67,7 @@ public final class LocationFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("loc");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/LogicFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/LogicFunctions.java
@@ -26,7 +26,7 @@ public class LogicFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("eq");
         }
     }
@@ -47,7 +47,7 @@ public class LogicFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("neq");
         }
     }
@@ -112,7 +112,7 @@ public class LogicFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("lt");
         }
     }
@@ -132,7 +132,7 @@ public class LogicFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("lte");
         }
     }
@@ -152,7 +152,7 @@ public class LogicFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("mt", "more_than", "gt");
         }
     }
@@ -172,7 +172,7 @@ public class LogicFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("mte", "more_than_equals", "gte");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/LogicFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/LogicFunctions.java
@@ -26,7 +26,7 @@ public class LogicFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("eq");
         }
     }
@@ -47,7 +47,7 @@ public class LogicFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("neq");
         }
     }
@@ -112,7 +112,7 @@ public class LogicFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("lt");
         }
     }
@@ -132,7 +132,7 @@ public class LogicFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("lte");
         }
     }
@@ -152,7 +152,7 @@ public class LogicFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("mt", "more_than", "gt");
         }
     }
@@ -172,7 +172,7 @@ public class LogicFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("mte", "more_than_equals", "gte");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/MathFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/MathFunctions.java
@@ -40,7 +40,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sub");
         }
     }
@@ -61,7 +61,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("mul");
         }
     }
@@ -81,7 +81,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("div");
         }
     }
@@ -101,7 +101,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("mod");
         }
     }
@@ -122,7 +122,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("pow");
         }
     }
@@ -140,7 +140,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("sqrt");
         }
     }
@@ -206,7 +206,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("int");
         }
     }
@@ -227,7 +227,7 @@ public final class MathFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("rand");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/MathFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/MathFunctions.java
@@ -40,7 +40,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sub");
         }
     }
@@ -61,7 +61,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("mul");
         }
     }
@@ -81,7 +81,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("div");
         }
     }
@@ -101,7 +101,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("mod");
         }
     }
@@ -122,7 +122,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("pow");
         }
     }
@@ -140,7 +140,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("sqrt");
         }
     }
@@ -206,7 +206,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("int");
         }
     }
@@ -227,7 +227,7 @@ public final class MathFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("rand");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/StringFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/StringFunctions.java
@@ -56,7 +56,7 @@ public class StringFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("str");
         }
     }
@@ -94,7 +94,7 @@ public class StringFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("eq_str");
         }
     }
@@ -116,7 +116,7 @@ public class StringFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("contains_str");
         }
     }
@@ -138,7 +138,7 @@ public class StringFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("parse_int");
         }
     }
@@ -195,7 +195,7 @@ public class StringFunctions {
         }
 
         @Override
-        public List<String> getAliases() {
+        protected List<String> getAliasList() {
             return List.of("cap_str", "str_cap");
         }
     }

--- a/common/src/main/java/com/wynntils/functions/generic/StringFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/generic/StringFunctions.java
@@ -56,7 +56,7 @@ public class StringFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("str");
         }
     }
@@ -94,7 +94,7 @@ public class StringFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("eq_str");
         }
     }
@@ -116,7 +116,7 @@ public class StringFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("contains_str");
         }
     }
@@ -138,7 +138,7 @@ public class StringFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("parse_int");
         }
     }
@@ -195,7 +195,7 @@ public class StringFunctions {
         }
 
         @Override
-        protected List<String> getAliasList() {
+        protected List<String> getAliases() {
             return List.of("cap_str", "str_cap");
         }
     }

--- a/common/src/main/java/com/wynntils/utils/type/ErrorOr.java
+++ b/common/src/main/java/com/wynntils/utils/type/ErrorOr.java
@@ -40,4 +40,9 @@ public final class ErrorOr<T> {
     public boolean hasError() {
         return error != null;
     }
+
+    @Override
+    public String toString() {
+        return "ErrorOr{" + "value=" + value + ", error='" + error + '\'' + '}';
+    }
 }


### PR DESCRIPTION
This PR greatly improves function speed, as they became an essential part of the mod, with many function based overlays. Now we compile a function tree only once, and just get the values. This saves us having to parse expressions more than one times. 

To give some statistics, Rafii, a heavy function user experienced a 7 ms of measured tick time improvement. That is 14%, since a tick is 50 ms.  The allocations we do is also infinitely less, reducing GC calls.

Reviewing per commit is recommended.