### PR TITLE
fix: Transcribed NPC dialogue repeating

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -161,9 +161,11 @@ public class TranscribeMessagesFeature extends Feature {
 
             if (transcribeGavellian || transcribeWynnic) {
                 String text = showTooltip.get() ? partText : transcriptedText;
-                Component hoverComponent = (npcDialogue || showTooltip.get()) ? Component.literal(transcriptedText) : Component.translatable("feature.wynntils.transcribeMessages.transcribedFrom", partText);
+                Component hoverComponent = (npcDialogue || showTooltip.get())
+                        ? Component.literal(transcriptedText)
+                        : Component.translatable("feature.wynntils.transcribeMessages.transcribedFrom", partText);
                 Style style = Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent));
-                
+
                 newPart = new StyledTextPart(text, style, null, Style.EMPTY);
             } else {
                 newPart = part;

--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -157,25 +157,19 @@ public class TranscribeMessagesFeature extends Feature {
                         defaultColor);
             }
 
-            Style style;
+            StyledTextPart newPart;
 
             if (transcribeGavellian || transcribeWynnic) {
-                if (showTooltip.get()) {
-                    style = Style.EMPTY.withHoverEvent(
-                            new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(transcriptedText)));
-
-                    transcriptedText = partText;
-                } else {
-                    style = Style.EMPTY.withHoverEvent(new HoverEvent(
-                            HoverEvent.Action.SHOW_TEXT,
-                            Component.translatable("feature.wynntils.transcribeMessages.transcribedFrom", partText)));
-                }
+                String text = showTooltip.get() ? partText : transcriptedText;
+                Component hoverComponent = (npcDialogue || showTooltip.get()) ? Component.literal(transcriptedText) : Component.translatable("feature.wynntils.transcribeMessages.transcribedFrom", partText);
+                Style style = Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent));
+                
+                newPart = new StyledTextPart(text, style, null, Style.EMPTY);
             } else {
-                style = part.getPartStyle().getStyle();
+                newPart = part;
             }
 
             changes.remove(part);
-            StyledTextPart newPart = new StyledTextPart(transcriptedText, style, null, Style.EMPTY);
             changes.add(newPart);
 
             return IterationDecision.CONTINUE;


### PR DESCRIPTION
Since the hover event contained the original text, when the NpcDialogEvent was triggered again, hasWynnicOrGavellian would return true