### PR TITLE
feat: Support shiny stats in ItemHandler

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -105,7 +105,7 @@ public class ItemHandler extends Handler {
         }
 
         // This might be just a name update. Check if lore matches:
-        if (!LoreUtils.loreSoftMatches(existingItem, newItem, 3)) {
+        if (!loreSoftMatches(existingItem, newItem, 3)) {
             // This could be a new item, or a crafted item losing in durability
             annotate(newItem);
             return;
@@ -170,6 +170,31 @@ public class ItemHandler extends Handler {
     private boolean isWildcardItem(ItemStack itemStack) {
         // This checks for gear skin items, which are a special exception for item comparisons
         return WILDCARD_ITEMS.contains(itemStack.getItem());
+    }
+
+    /**
+     * This checks if the lore of the second item contains the entirety of the first item's lore, or vice versa.
+     * It might have additional lines added, but these are not checked.
+     */
+    private boolean loreSoftMatches(ItemStack firstItem, ItemStack secondItem, int tolerance) {
+        List<StyledText> firstLines = LoreUtils.getLore(firstItem);
+        List<StyledText> secondLines = LoreUtils.getLore(secondItem);
+        int firstLinesLen = firstLines.size();
+        int secondLinesLen = secondLines.size();
+
+        // Only allow a maximum number of additional lines in the longer tooltip
+        if (Math.abs(firstLinesLen - secondLinesLen) > tolerance) return false;
+
+        int linesToCheck = Math.min(firstLinesLen, secondLinesLen);
+        // Prevent soft matching on tooltips that are very small
+        if (linesToCheck < 3 && firstLinesLen != secondLinesLen) return false;
+
+        for (int i = 0; i < linesToCheck; i++) {
+            if (!firstLines.get(i).equals(secondLines.get(i))) return false;
+        }
+
+        // Every lore line matches from the first to the second (or second to the first), so we have a match
+        return true;
     }
 
     private ItemAnnotation calculateAnnotation(ItemStack itemStack, StyledText name) {

--- a/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/LoreUtils.java
@@ -235,31 +235,6 @@ public final class LoreUtils {
     }
 
     /**
-     * This checks if the lore of the second item contains the entirety of the first item's lore, or vice versa.
-     * It might have additional lines added, but these are not checked.
-     */
-    public static boolean loreSoftMatches(ItemStack firstItem, ItemStack secondItem, int tolerance) {
-        List<StyledText> firstLines = getLore(firstItem);
-        List<StyledText> secondLines = getLore(secondItem);
-        int firstLinesLen = firstLines.size();
-        int secondLinesLen = secondLines.size();
-
-        // Only allow a maximum number of additional lines in the longer tooltip
-        if (Math.abs(firstLinesLen - secondLinesLen) > tolerance) return false;
-
-        int linesToCheck = Math.min(firstLinesLen, secondLinesLen);
-        // Prevent soft matching on tooltips that are very small
-        if (linesToCheck < 3 && firstLinesLen != secondLinesLen) return false;
-
-        for (int i = 0; i < linesToCheck; i++) {
-            if (!firstLines.get(i).equals(secondLines.get(i))) return false;
-        }
-
-        // Every lore line matches from the first to the second (or second to the first), so we have a match
-        return true;
-    }
-
-    /**
      * This is used to extract the lore from an ingame item that is held by another player.
      * This lore has a completely different format from the normal lore shown to the player
      */


### PR DESCRIPTION
This PR replaces #1957 and partially replaces #1941. The fix in #1941 does some attempt at handling she shiny value in itself, since it reads it for further processing, but it is not further integrated. This PR does not concern itself with using the shiny stat at all, but only makes sure that it does not break the item handler. So some variant of #1941 will be needed even after this fix,

This PR mixes ideas from both PRs. We relax the check for "same lore" in respect to shiny stats (and also durability) from #1941. But we make the changes in the ItemHandler, from #1957. However, there is no inverse model -> handler relationship here. Instead the Handler only knows about a very generic regexp to determine shiny values. Furthermore, there is now a framework in place for adding future "unstable" lines (lines that may change even if the item is essentially the same) to the lore parsing. I also took the opportunity to streamline (I hope; at least I thought so) the central code in ItemHandler.