### PR TITLE
chore: Update url md5 for major ID file

### DIFF
--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -129,7 +129,7 @@
   },
   {
     "id": "dataStaticMajorIds",
-    "md5": "a0013f56ac6434c7b37abdccf238d159",
+    "md5": "370a3208e21274ba247c64db3d597162",
     "url": "https://raw.githubusercontent.com/Wynntils/WynntilsWebsite-API/master/major_ids.json"
   },
   {


### PR DESCRIPTION
Requires https://github.com/Wynntils/WynntilsWebsite-API/pull/127 to be merged first