### PR TITLE
[ci skip] chore: Add automatic updating of urls.json

### DIFF
--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.PRIVATE_TOKEN }}
           ref: ${{ github.head_ref }}
 
-      - name: Update Gear Data
+      - name: Update Urls
         run: |
           wget -O common/src/main/resources/assets/wynntils/urls.json "https://raw.githubusercontent.com/Wynntils/WynntilsWebsite-API/master/urls.json"
 

--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -3,7 +3,7 @@
 name: Update urls.json
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs at midnight
+    - cron: '0 * * * *' # Runs every hour
 
 jobs:
   update-urls:

--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -1,0 +1,35 @@
+# Github actions runner will run this script on a schedule
+
+name: Update urls.json
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight
+
+jobs:
+  update-urls:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          ref: ${{ github.head_ref }}
+
+      - name: Update Gear Data
+        run: |
+          wget -O common/src/main/resources/assets/wynntils/urls.json "https://raw.githubusercontent.com/Wynntils/WynntilsWebsite-API/master/urls.json"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          labels: auto-generated
+          committer: 'WynntilsBot <admin@wynntils.com>'
+          commit-message: "chore: [auto-generated] Update urls.json [ci skip]"
+          title: "chore: [auto-generated] Update urls.json [ci skip]"
+          body: |
+            The URL list on [Wynntils API site](https://github.com/Wynntils/WynntilsWebsite-API) has changed.
+            This should be incorporated into the next release of Artemis.
+            
+            This PR has been automatically generated.
+          branch: auto-update-urls


### PR DESCRIPTION
(The category `chore` is not really right, but it is not a user-visible change either, so...)

This will (hopefully!) pull the latest version of urls.json and automatically create a PR when it is updated. For obvious practical reasons, I have not tested this. Let's see how it fares with the next update to the API repo. It is based on existing GHA scripts so I have a fairly high level of confidence in it, though.