### PR TITLE
refactor: Move the PersistedMetadata into a map in the PersistedManager

### DIFF
--- a/common/src/main/java/com/wynntils/commands/ConfigCommand.java
+++ b/common/src/main/java/com/wynntils/commands/ConfigCommand.java
@@ -47,7 +47,7 @@ public class ConfigCommand extends Command {
 
                         return foundFeature
                                 .map(feature -> Managers.Overlay.getFeatureOverlays(feature).stream()
-                                        .map(Overlay::getConfigJsonName)
+                                        .map(Overlay::getJsonName)
                                         .iterator())
                                 .orElse(Collections.emptyIterator());
                     },
@@ -88,7 +88,7 @@ public class ConfigCommand extends Command {
 
                         Feature feature = featureOptional.get();
                         Optional<Overlay> overlayOptional = Managers.Overlay.getFeatureOverlays(feature).stream()
-                                .filter(overlay -> overlay.getConfigJsonName().equals(overlayName))
+                                .filter(overlay -> overlay.getJsonName().equals(overlayName))
                                 .findFirst();
 
                         return overlayOptional
@@ -696,7 +696,7 @@ public class ConfigCommand extends Command {
         }
 
         Optional<Overlay> overlayOptional = Managers.Overlay.getFeatureOverlays(feature).stream()
-                .filter(overlay -> overlay.getConfigJsonName().equals(overlayName))
+                .filter(overlay -> overlay.getJsonName().equals(overlayName))
                 .findFirst();
 
         if (overlayOptional.isEmpty()) {

--- a/common/src/main/java/com/wynntils/core/components/Managers.java
+++ b/common/src/main/java/com/wynntils/core/components/Managers.java
@@ -35,9 +35,9 @@ public final class Managers {
     public static final JsonManager Json = new JsonManager();
     public static final KeyBindManager KeyBind = new KeyBindManager();
     public static final NotificationManager Notification = new NotificationManager();
-    public static final PersistedManager Persisted = new PersistedManager();
 
     // Managers with dependencies, ordered alphabetically as far as possible
+    public static final PersistedManager Persisted = new PersistedManager(Json);
     public static final OverlayManager Overlay = new OverlayManager(CrashReport);
     public static final FeatureManager Feature = new FeatureManager(Command, CrashReport, KeyBind, Overlay);
     public static final ConfigManager Config = new ConfigManager(ConfigUpfixer, Json, Feature, Overlay);

--- a/common/src/main/java/com/wynntils/core/consumers/features/AbstractConfigurable.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/AbstractConfigurable.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.core.consumers.features;
 
-import com.google.common.base.CaseFormat;
 import com.wynntils.core.persisted.config.Config;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,11 +33,5 @@ public abstract class AbstractConfigurable implements Configurable {
         return getConfigOptions().stream()
                 .filter(c -> c.getFieldName().equals(name))
                 .findFirst();
-    }
-
-    @Override
-    public String getConfigJsonName() {
-        String name = this.getClass().getSimpleName();
-        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name);
     }
 }

--- a/common/src/main/java/com/wynntils/core/consumers/features/Configurable.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/Configurable.java
@@ -23,6 +23,4 @@ public interface Configurable extends PersistedOwner {
 
     /** Returns the config option matching the given name, if it exists */
     Optional<Config<?>> getConfigOptionFromString(String name);
-
-    String getConfigJsonName();
 }

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/DynamicOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/DynamicOverlay.java
@@ -54,8 +54,8 @@ public abstract class DynamicOverlay extends Overlay {
     }
 
     @Override
-    public String getConfigJsonName() {
-        return super.getConfigJsonName() + id;
+    public String getJsonName() {
+        return super.getJsonName() + id;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/core/persisted/PersistedManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/PersistedManager.java
@@ -41,7 +41,7 @@ public final class PersistedManager extends Manager {
 
         Map<PersistedValue<?>, PersistedMetadata<?>> newMetadatas = new HashMap<>();
 
-        getPersisted(owner, Config.class).stream().forEach(p -> {
+        getPersisted(owner, Config.class).forEach(p -> {
             Field configField = p.a();
             Config<?> configObj;
             try {

--- a/common/src/main/java/com/wynntils/core/persisted/PersistedManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/PersistedManager.java
@@ -4,16 +4,58 @@
  */
 package com.wynntils.core.persisted;
 
+import com.google.common.base.CaseFormat;
 import com.wynntils.core.components.Manager;
+import com.wynntils.core.components.Managers;
+import com.wynntils.core.consumers.overlays.Overlay;
+import com.wynntils.core.json.JsonManager;
+import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.NullableConfig;
 import com.wynntils.utils.type.Pair;
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
-public class PersistedManager extends Manager {
-    public PersistedManager() {
-        super(List.of());
+public final class PersistedManager extends Manager {
+    private final Map<PersistedValue<?>, PersistedMetadata<?>> metadatas = new HashMap<>();
+    private final Set<PersistedValue<?>> persisteds = new TreeSet<>();
+
+    public PersistedManager(JsonManager jsonManager) {
+        super(List.of(jsonManager));
+    }
+
+    public void setRaw(PersistedValue<?> persisted, Object value) {
+        // Hack to allow Config/Storage manager to get around package limitations
+        // Will be removed when refactoring is done
+        persisted.setRaw(value);
+    }
+
+    public void registerOwner(PersistedOwner owner) {
+        verifyAnnotations(owner);
+
+        Map<PersistedValue<?>, PersistedMetadata<?>> newMetadatas = new HashMap<>();
+
+        getPersisted(owner, Config.class).stream().forEach(p -> {
+            Field configField = p.a();
+            Config<?> configObj;
+            try {
+                configObj = (Config<?>) FieldUtils.readField(configField, owner, true);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Cannot read persisted field: " + configField, e);
+            }
+
+            PersistedMetadata<?> metadata = createMetadata((PersistedValue<?>) configObj, owner, configField, p.b());
+            newMetadatas.put(configObj, metadata);
+        });
+
+        metadatas.putAll(newMetadatas);
+        persisteds.addAll(newMetadatas.keySet());
     }
 
     public List<Pair<Field, Persisted>> getPersisted(PersistedOwner owner, Class<? extends PersistedValue> clazzType) {
@@ -43,5 +85,39 @@ public class PersistedManager extends Manager {
                         throw new RuntimeException("A persisted datatype is missing @Persisted annotation:" + field);
                     }
                 });
+    }
+
+    public <T> PersistedMetadata<T> getMetadata(PersistedValue<T> persisted) {
+        return (PersistedMetadata<T>) metadatas.get(persisted);
+    }
+
+    private <T> PersistedMetadata<T> createMetadata(
+            PersistedValue<T> persisted, PersistedOwner owner, Field configField, Persisted annotation) {
+        Type valueType = Managers.Json.getJsonValueType(configField);
+        String fieldName = configField.getName();
+
+        String i18nKeyOverride = annotation.i18nKey();
+
+        // save default value to enable easy resetting
+        // We have to deep copy the value, so it is guaranteed that we detect changes
+        T defaultValue = Managers.Json.deepCopy(persisted.get(), valueType);
+
+        boolean allowNull = valueType instanceof Class<?> clazz && NullableConfig.class.isAssignableFrom(clazz);
+        if (defaultValue == null && !allowNull) {
+            throw new RuntimeException("Default config value is null in " + owner.getJsonName() + "." + fieldName);
+        }
+
+        String jsonName = getPrefix(owner) + owner.getJsonName() + "." + fieldName;
+
+        return new PersistedMetadata<T>(
+                owner, fieldName, valueType, defaultValue, i18nKeyOverride, allowNull, jsonName);
+    }
+
+    private String getPrefix(PersistedOwner owner) {
+        // "featureName.overlayName.settingName" vs "featureName.settingName"
+        if (!(owner instanceof Overlay overlay)) return "";
+
+        String name = overlay.getDeclaringClassName();
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name) + ".";
     }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/PersistedMetadata.java
+++ b/common/src/main/java/com/wynntils/core/persisted/PersistedMetadata.java
@@ -4,196 +4,59 @@
  */
 package com.wynntils.core.persisted;
 
-import com.google.common.base.CaseFormat;
-import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
-import com.wynntils.core.consumers.features.Configurable;
-import com.wynntils.core.consumers.features.Translatable;
-import com.wynntils.core.consumers.overlays.Overlay;
-import com.wynntils.core.persisted.config.Config;
-import com.wynntils.core.persisted.config.NullableConfig;
-import com.wynntils.utils.EnumUtils;
 import java.lang.reflect.Type;
-import java.util.Objects;
-import java.util.stream.Stream;
-import net.minecraft.client.resources.language.I18n;
-import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 
-public class PersistedMetadata<T> implements Comparable<PersistedMetadata<T>> {
-    private final Configurable parent;
-    private final Config<T> configObj;
+public class PersistedMetadata<T> {
+    private final PersistedOwner owner;
     private final String fieldName;
-    private final String i18nKey;
-    private final boolean visible;
     private final Type valueType;
-    private final boolean allowNull;
-
     private final T defaultValue;
+    private final String i18nKeyOverride;
+    private final boolean allowNull;
+    private final String jsonName;
 
-    private boolean userEdited = false;
-
-    public <P extends Configurable & Translatable> PersistedMetadata(
-            P parent, Config<T> configObj, String fieldName, String i18nKey, boolean visible, Type valueType) {
-        this.parent = parent;
-        this.configObj = configObj;
+    public PersistedMetadata(
+            PersistedOwner owner,
+            String fieldName,
+            Type valueType,
+            T defaultValue,
+            String i18nKeyOverride,
+            boolean allowNull,
+            String jsonName) {
+        this.owner = owner;
         this.fieldName = fieldName;
-        this.i18nKey = i18nKey;
-        this.visible = visible;
         this.valueType = valueType;
-
-        // save default value to enable easy resetting
-        // We have to deep copy the value, so it is guaranteed that we detect changes
-        this.defaultValue = Managers.Json.deepCopy(getValue(), valueType);
-
-        this.allowNull = valueType instanceof Class<?> clazz && NullableConfig.class.isAssignableFrom(clazz);
-        if (configObj.get() == null && !allowNull) {
-            throw new RuntimeException(
-                    "Default config value is null in " + parent.getConfigJsonName() + "." + fieldName);
-        }
+        this.defaultValue = defaultValue;
+        this.i18nKeyOverride = i18nKeyOverride;
+        this.allowNull = allowNull;
+        this.jsonName = jsonName;
     }
 
-    public Stream<String> getValidLiterals() {
-        if (valueType instanceof Class<?> clazz && clazz.isEnum()) {
-            return EnumUtils.getEnumConstants(clazz).stream().map(EnumUtils::toJsonFormat);
-        }
-        if (valueType.equals(Boolean.class)) {
-            return Stream.of("true", "false");
-        }
-        return Stream.of();
-    }
-
-    public Type getType() {
-        return valueType;
+    public PersistedOwner getOwner() {
+        return owner;
     }
 
     public String getFieldName() {
         return fieldName;
     }
 
-    public Configurable getParent() {
-        return parent;
-    }
-
-    public String getJsonName() {
-        if (parent instanceof Overlay overlay) {
-            // "featureName.overlayName.settingName"
-            return getDeclaringFeatureNameCamelCase(overlay) + "." + parent.getConfigJsonName() + "." + getFieldName();
-        }
-        // "featureName.settingName"
-        return parent.getConfigJsonName() + "." + getFieldName();
-    }
-
-    private String getDeclaringFeatureNameCamelCase(Overlay overlay) {
-        String name = overlay.getDeclaringClassName();
-        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name);
-    }
-
-    private String getI18nKey() {
-        return i18nKey;
-    }
-
-    public boolean isVisible() {
-        return visible;
-    }
-
-    public String getDisplayName() {
-        if (!getI18nKey().isEmpty()) {
-            return I18n.get(getI18nKey() + ".name");
-        }
-        return ((Translatable) parent).getTranslation(getFieldName() + ".name");
-    }
-
-    public String getDescription() {
-        if (!getI18nKey().isEmpty()) {
-            return I18n.get(getI18nKey() + ".description");
-        }
-        return ((Translatable) parent).getTranslation(getFieldName() + ".description");
-    }
-
-    public T getValue() {
-        return configObj.get();
-    }
-
-    public String getValueString() {
-        if (configObj.get() == null) return "(null)";
-
-        if (isEnum()) {
-            return EnumUtils.toNiceString((Enum<?>) this.getValue());
-        }
-
-        return configObj.get().toString();
-    }
-
-    public boolean isEnum() {
-        return valueType instanceof Class<?> clazz && clazz.isEnum();
+    public Type getValueType() {
+        return valueType;
     }
 
     public T getDefaultValue() {
         return defaultValue;
     }
 
-    public void setValue(T value) {
-        if (value == null && !allowNull) {
-            WynntilsMod.warn("Trying to set null to config " + getJsonName() + ". Will be replaced by default.");
-            reset();
-            return;
-        }
-
-        configObj.store(value);
-        parent.updateConfigOption(configObj);
-        userEdited = true;
+    public String getI18nKeyOverride() {
+        return i18nKeyOverride;
     }
 
-    public void restoreValue(Object value) {
-        setValue((T) value);
+    public boolean isAllowNull() {
+        return allowNull;
     }
 
-    public boolean valueChanged() {
-        if (this.userEdited) {
-            return true;
-        }
-
-        boolean deepEquals = Objects.deepEquals(getValue(), defaultValue);
-
-        if (deepEquals) {
-            return false;
-        }
-
-        try {
-            return !EqualsBuilder.reflectionEquals(getValue(), defaultValue);
-        } catch (RuntimeException ignored) {
-            // Reflection equals does not always work, use deepEquals instead of assuming no change
-            // Since deepEquals is already false when we reach this, we can assume change
-            return true;
-        }
-    }
-
-    public void reset() {
-        // deep copy because writeField set's the field to be our default value instance when resetting, making default
-        // value change with the field's actual value
-        setValue(Managers.Json.deepCopy(defaultValue, this.valueType));
-        // reset this flag so option is no longer saved to file
-        userEdited = false;
-    }
-
-    public <E extends Enum<E>> T tryParseStringValue(String value) {
-        if (isEnum()) {
-            return (T) EnumUtils.fromJsonFormat((Class<E>) getType(), value);
-        }
-
-        try {
-            Class<?> wrapped = ClassUtils.primitiveToWrapper(((Class<?>) valueType));
-            return (T) wrapped.getConstructor(String.class).newInstance(value);
-        } catch (Exception ignored) {
-        }
-
-        // couldn't parse value
-        return null;
-    }
-
-    @Override
-    public int compareTo(PersistedMetadata other) {
-        return getJsonName().compareTo(other.getJsonName());
+    public String getJsonName() {
+        return jsonName;
     }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/PersistedOwner.java
+++ b/common/src/main/java/com/wynntils/core/persisted/PersistedOwner.java
@@ -4,4 +4,11 @@
  */
 package com.wynntils.core.persisted;
 
-public interface PersistedOwner {}
+import com.google.common.base.CaseFormat;
+
+public interface PersistedOwner {
+    default String getJsonName() {
+        String name = this.getClass().getSimpleName();
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name);
+    }
+}

--- a/common/src/main/java/com/wynntils/core/persisted/PersistedValue.java
+++ b/common/src/main/java/com/wynntils/core/persisted/PersistedValue.java
@@ -4,8 +4,11 @@
  */
 package com.wynntils.core.persisted;
 
-public abstract class PersistedValue<T> {
-    protected T value;
+import com.wynntils.core.components.Managers;
+import java.lang.reflect.Type;
+
+public abstract class PersistedValue<T> implements Comparable<PersistedValue<T>> {
+    private T value;
 
     protected PersistedValue(T value) {
         this.value = value;
@@ -20,5 +23,27 @@ public abstract class PersistedValue<T> {
     public void store(T value) {
         this.value = value;
         touched();
+    }
+
+    public String getJsonName() {
+        // Available after owner is registered in registerOwner()
+        return Managers.Persisted.getMetadata(this).getJsonName();
+    }
+
+    public Type getType() {
+        // Available after owner is registered in registerOwner()
+        return Managers.Persisted.getMetadata(this).getValueType();
+    }
+
+    // This can only be called from Managers.Persisted, since all writes to the
+    // value need to be handled properly
+    @SuppressWarnings("unchecked")
+    void setRaw(Object value) {
+        this.value = (T) value;
+    }
+
+    @Override
+    public int compareTo(PersistedValue<T> other) {
+        return getJsonName().compareTo(other.getJsonName());
     }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/config/Config.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/Config.java
@@ -4,18 +4,21 @@
  */
 package com.wynntils.core.persisted.config;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Configurable;
 import com.wynntils.core.consumers.features.Translatable;
-import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.PersistedMetadata;
 import com.wynntils.core.persisted.PersistedValue;
-import java.lang.reflect.Field;
-import java.lang.reflect.Type;
+import com.wynntils.utils.EnumUtils;
+import java.util.Objects;
 import java.util.stream.Stream;
+import net.minecraft.client.resources.language.I18n;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
-public class Config<T> extends PersistedValue<T> implements Comparable<Config<T>> {
-    private PersistedMetadata<T> persistedMetadata;
+public class Config<T> extends PersistedValue<T> {
+    private boolean userEdited = false;
 
     public Config(T value) {
         super(value);
@@ -28,95 +31,138 @@ public class Config<T> extends PersistedValue<T> implements Comparable<Config<T>
 
     @Override
     public void store(T value) {
-        this.value = value;
+        Managers.Persisted.setRaw(this, value);
         // For now, do not call touch() on configs
     }
 
-    <P extends Configurable & Translatable> void createConfigHolder(P parent, Field configField, Persisted configInfo) {
-        Type valueType = Managers.Json.getJsonValueType(configField);
-        String fieldName = configField.getName();
-
-        boolean visible = !(this instanceof HiddenConfig<?>);
-
-        String i18nKey = configInfo.i18nKey();
-
-        persistedMetadata = new PersistedMetadata<>(parent, this, fieldName, i18nKey, visible, valueType);
-    }
-
-    @Override
-    public int compareTo(Config<T> other) {
-        return getPersistedMetadata().getJsonName().compareTo(other.getJsonName());
-    }
-
-    public Stream<String> getValidLiterals() {
-        return getPersistedMetadata().getValidLiterals();
-    }
-
-    public Type getType() {
-        return getPersistedMetadata().getType();
-    }
-
-    public String getFieldName() {
-        return getPersistedMetadata().getFieldName();
-    }
-
-    public Configurable getParent() {
-        return getPersistedMetadata().getParent();
-    }
-
-    public String getJsonName() {
-        return getPersistedMetadata().getJsonName();
-    }
-
-    public boolean isVisible() {
-        return getPersistedMetadata().isVisible();
-    }
-
-    public String getDisplayName() {
-        return getPersistedMetadata().getDisplayName();
-    }
-
-    public String getDescription() {
-        return getPersistedMetadata().getDescription();
-    }
-
     public T getValue() {
-        return getPersistedMetadata().getValue();
+        // FIXME: This is just an alias now, should be changed to get() everywhere
+        return get();
     }
 
-    public String getValueString() {
-        return getPersistedMetadata().getValueString();
-    }
-
-    public boolean isEnum() {
-        return getPersistedMetadata().isEnum();
-    }
-
-    public T getDefaultValue() {
-        return getPersistedMetadata().getDefaultValue();
-    }
+    // FIXME: Old ways of setting the value. These should be unified, but since
+    // they have slightly different semantics, let's do it carfeully step by step.
 
     public void setValue(T value) {
-        getPersistedMetadata().setValue(value);
+        if (value == null && !getMetadata().isAllowNull()) {
+            WynntilsMod.warn("Trying to set null to config " + getJsonName() + ". Will be replaced by default.");
+            reset();
+            return;
+        }
+
+        Managers.Persisted.setRaw(this, value);
+        ((Configurable) getMetadata().getOwner()).updateConfigOption(this);
+        this.userEdited = true;
     }
 
     void restoreValue(Object value) {
-        getPersistedMetadata().restoreValue(value);
-    }
-
-    public boolean valueChanged() {
-        return getPersistedMetadata().valueChanged();
+        setValue((T) value);
     }
 
     public void reset() {
-        getPersistedMetadata().reset();
+        T defaultValue = getMetadata().getDefaultValue();
+
+        // deep copy because writeField set's the field to be our default value instance when resetting, making default
+        // value change with the field's actual value
+        setValue(Managers.Json.deepCopy(defaultValue, getMetadata().getValueType()));
+        // reset this flag so option is no longer saved to file
+        this.userEdited = false;
     }
 
-    public T tryParseStringValue(String value) {
-        return getPersistedMetadata().tryParseStringValue(value);
+    public boolean isVisible() {
+        return true;
     }
 
-    private PersistedMetadata<T> getPersistedMetadata() {
-        return persistedMetadata;
+    public boolean valueChanged() {
+        if (this.userEdited) {
+            return true;
+        }
+
+        // FIXME: I guess at this point the userEdited change would suffice,
+        // but check this carefully before removing the old logic below.
+        T defaultValue = getMetadata().getDefaultValue();
+        boolean deepEquals = Objects.deepEquals(getValue(), defaultValue);
+
+        if (deepEquals) {
+            return false;
+        }
+
+        try {
+            return !EqualsBuilder.reflectionEquals(getValue(), defaultValue);
+        } catch (RuntimeException ignored) {
+            // Reflection equals does not always work, use deepEquals instead of assuming no change
+            // Since deepEquals is already false when we reach this, we can assume change
+            return true;
+        }
+    }
+
+    public String getFieldName() {
+        return getMetadata().getFieldName();
+    }
+
+    public Configurable getParent() {
+        return (Configurable) getMetadata().getOwner();
+    }
+
+    public boolean isEnum() {
+        return getMetadata().getValueType() instanceof Class<?> clazz && clazz.isEnum();
+    }
+
+    public T getDefaultValue() {
+        return getMetadata().getDefaultValue();
+    }
+
+    public String getDisplayName() {
+        return getI18n(".name");
+    }
+
+    public String getDescription() {
+        return getI18n(".description");
+    }
+
+    public Stream<String> getValidLiterals() {
+        if (isEnum()) {
+            return EnumUtils.getEnumConstants((Class<?>) getType()).stream().map(EnumUtils::toJsonFormat);
+        }
+        if (getType().equals(Boolean.class)) {
+            return Stream.of("true", "false");
+        }
+        return Stream.of();
+    }
+
+    public String getValueString() {
+        if (get() == null) return "(null)";
+
+        if (isEnum()) {
+            return EnumUtils.toNiceString((Enum<?>) get());
+        }
+
+        return get().toString();
+    }
+
+    public <E extends Enum<E>> T tryParseStringValue(String value) {
+        if (isEnum()) {
+            return (T) EnumUtils.fromJsonFormat((Class<E>) getType(), value);
+        }
+
+        try {
+            Class<?> wrapped = ClassUtils.primitiveToWrapper(((Class<?>) getType()));
+            return (T) wrapped.getConstructor(String.class).newInstance(value);
+        } catch (Exception ignored) {
+        }
+
+        // couldn't parse value
+        return null;
+    }
+
+    private String getI18n(String suffix) {
+        if (!getMetadata().getI18nKeyOverride().isEmpty()) {
+            return I18n.get(getMetadata().getI18nKeyOverride() + suffix);
+        }
+        return ((Translatable) getParent()).getTranslation(getFieldName() + suffix);
+    }
+
+    private PersistedMetadata<T> getMetadata() {
+        return Managers.Persisted.getMetadata(this);
     }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
@@ -13,12 +13,12 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Configurable;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.FeatureManager;
-import com.wynntils.core.consumers.features.Translatable;
 import com.wynntils.core.consumers.overlays.DynamicOverlay;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.OverlayManager;
 import com.wynntils.core.json.JsonManager;
 import com.wynntils.core.persisted.Persisted;
+import com.wynntils.core.persisted.PersistedOwner;
 import com.wynntils.core.persisted.upfixers.ConfigUpfixerManager;
 import com.wynntils.utils.JsonUtils;
 import com.wynntils.utils.mc.McUtils;
@@ -87,9 +87,11 @@ public final class ConfigManager extends Manager {
         }
     }
 
-    private <P extends Configurable & Translatable> void registerConfigOptions(P configurable) {
-        List<Config<?>> configs = getConfigOptions(configurable);
+    private void registerConfigOptions(Configurable configurable) {
+        // Hook this in here for the time being
+        Managers.Persisted.registerOwner(configurable);
 
+        List<Config<?>> configs = getConfigOptions(configurable);
         configurable.addConfigOptions(configs);
         CONFIGS.addAll(configs);
     }
@@ -131,6 +133,9 @@ public final class ConfigManager extends Manager {
                 }
             }
 
+            // Hook this in here for the time being
+            holder.getOverlays().forEach(Managers.Persisted::registerOwner);
+
             holder.getOverlays().forEach(overlay -> overlay.addConfigOptions(this.getConfigOptions(overlay)));
         }
 
@@ -170,6 +175,9 @@ public final class ConfigManager extends Manager {
     }
 
     public void saveConfig() {
+        // Requesting to save before we have read the old config? Just skip it
+        if (configObject == null) return;
+
         // create json object, with entry for each option of each container
         JsonObject configJson = new JsonObject();
         for (Config<?> config : getConfigList()) {
@@ -216,9 +224,7 @@ public final class ConfigManager extends Manager {
         Managers.Json.savePreciousJson(DEFAULT_CONFIG, configJson);
     }
 
-    private <P extends Configurable & Translatable> List<Config<?>> getConfigOptions(P owner) {
-        Managers.Persisted.verifyAnnotations(owner);
-
+    private List<Config<?>> getConfigOptions(PersistedOwner owner) {
         List<Config<?>> options = new ArrayList<>();
         options.addAll(Managers.Persisted.getPersisted(owner, Config.class).stream()
                 .map(p -> processConfig(owner, p.a(), p.b()))
@@ -226,16 +232,13 @@ public final class ConfigManager extends Manager {
         return options;
     }
 
-    private static <P extends Configurable & Translatable> Config<?> processConfig(
-            P owner, Field configField, Persisted configInfo) {
+    private static Config<?> processConfig(PersistedOwner owner, Field configField, Persisted configInfo) {
         Config<?> configObj;
         try {
             configObj = (Config<?>) FieldUtils.readField(configField, owner, true);
         } catch (IllegalAccessException e) {
             throw new RuntimeException("Cannot read Config field: " + configField, e);
         }
-
-        configObj.createConfigHolder(owner, configField, configInfo);
 
         if (WynntilsMod.isDevelopmentEnvironment()) {
             if (configObj.isVisible()) {

--- a/common/src/main/java/com/wynntils/core/persisted/config/HiddenConfig.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/HiddenConfig.java
@@ -8,4 +8,9 @@ public class HiddenConfig<T> extends Config<T> {
     public HiddenConfig(T value) {
         super(value);
     }
+
+    @Override
+    public boolean isVisible() {
+        return false;
+    }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/config/OverlayGroupHolder.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/OverlayGroupHolder.java
@@ -49,7 +49,7 @@ public class OverlayGroupHolder {
     }
 
     public String getConfigKey() {
-        return parent.getConfigJsonName() + ".groupedOverlay." + field.getName() + ".ids";
+        return parent.getJsonName() + ".groupedOverlay." + field.getName() + ".ids";
     }
 
     public int getOverlayCount() {

--- a/common/src/main/java/com/wynntils/core/persisted/storage/Storage.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/Storage.java
@@ -16,10 +16,4 @@ public class Storage<T> extends PersistedValue<T> {
     public void touched() {
         Managers.Storage.persist();
     }
-
-    // This must only be called by StorageManager when restoring value from disk
-    @SuppressWarnings("unchecked")
-    void set(Object value) {
-        this.value = (T) value;
-    }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
@@ -119,7 +119,7 @@ public final class StorageManager extends Manager {
             // read value and update option
             JsonElement jsonElem = storageJson.get(jsonName);
             Object value = Managers.Json.GSON.fromJson(jsonElem, storageTypes.get(storage));
-            storage.set(value);
+            Managers.Persisted.setRaw(storage, value);
 
             Storageable owner = storageOwner.get(storage);
             owner.onStorageLoad();

--- a/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
@@ -420,7 +420,7 @@ public final class WynntilsBookSettingsScreen extends WynntilsScreen implements 
                             .map(overlay -> (Configurable) overlay));
 
             Configurable newSelected = configurablesList
-                    .filter(configurable -> configurable.getConfigJsonName().equals(selected.getConfigJsonName()))
+                    .filter(configurable -> configurable.getJsonName().equals(selected.getJsonName()))
                     .findFirst()
                     .orElse(null);
 


### PR DESCRIPTION
This one is a bit more tricky. Briefly, I have moved logic from PersistedMetadata, so now it is only a simple holder (will convert it to a record in a follow-up). These methods were previously called by wrappers in Config, and have now been inlined there (and simplified).

The metadata itself is also no longer stored within the Config, but separately in a map in the PersistedManager.

There are still a fair amount of wrappers and redirects, but I will address all those in follow-up bugs. (Changing everything at once will make the PR harder to read and follow.)

There is still a lot of different ways to set the value of a config. This too will be addressed later on.

I've also continued to generalize abilities to PersistedValue from subclasses.

I have done the normal testing to verify that config changing, saving, loading and resetting works as before, for an arbitrarily selected config, so it is not DOA.