### PR TITLE
Revert "fix: custom loading screen no longer loads indefinitely when joining housing (#1985)"

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -29,7 +29,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 public final class WorldStateModel extends Model {
     private static final UUID WORLD_NAME_UUID = UUID.fromString("16ff7452-714f-3752-b3cd-c3cb2068f6af");
     private static final Pattern WORLD_NAME = Pattern.compile("^§f {2}§lGlobal \\[(.*)\\]$");
-    private static final Pattern HOUSING_NAME = Pattern.compile("^§f  §l([^§\"\\\\]{1,18})$");
     private static final Pattern HUB_NAME = Pattern.compile("^\n§6§l play.wynncraft.com \n$");
     private static final Position CHARACTER_SELECTION_POSITION = new PositionImpl(-1337.5, 16.2, -1120.5);
     private static final Pattern WYNNCRAFT_SERVER_PATTERN = Pattern.compile("^(.*)\\.wynncraft\\.(?:com|net|org)$");
@@ -148,21 +147,11 @@ public final class WorldStateModel extends Model {
         Component displayName = e.getDisplayName();
         StyledText name = StyledText.fromComponent(displayName);
         Matcher m = name.getMatcher(WORLD_NAME);
-        if (setWorldIfMatched(m)) return;
-        // must check in this order as housing name regex matches anything that WORLD_NAME would match, housing names
-        // need to exclude world names.
-        Matcher housingNameMatcher = name.getMatcher(HOUSING_NAME);
-        setWorldIfMatched(housingNameMatcher);
-    }
-
-    private boolean setWorldIfMatched(Matcher m) {
         if (m.find()) {
             String worldName = m.group(1);
             setState(WorldState.WORLD, worldName, !hasJoinedAnyWorld);
             hasJoinedAnyWorld = true;
-            return true;
         }
-        return false;
     }
 
     public String getCurrentWorldName() {


### PR DESCRIPTION
This reverts commit https://github.com/Wynntils/Artemis/commit/273a3259d1fadd7995378f84ddfd125711878446.

This was the sole commit to Wynntils by @geekazodium, who is the only remaining contributor to have not yet accepted the transition from AGPL to LGPL (https://github.com/Wynntils/Artemis/issues/1970). Unfortunately, this PR was very recently merged by me, in the mistaken belief that geekazodium had already contributed to Wynntils and accepted the license change in #1970.

I have not received a response from @geekazodium about the license change, but to be fair, not much time has passed since I first pinged them. Nevertheless, I'd rather see we revert this for now, and proceed with the license change, and if/when they get back to us with acceptance on the license change, we can restore the PR.