### PR TITLE
chore: Move Wynntils dependencies to Jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,7 @@ subprojects {
 
     repositories {
         maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
-        maven {
-            name = "remote"
-            // Adapt the URL for your remote repository
-            url = uri("https://maven.pkg.github.com/Wynntils/Hades")
-            credentials {
-                // Use this if the repo requires auth
-                // see https://docs.gradle.org/6.4/userguide/declaring_repositories.html#sec:supported_transport_protocols
-                username = new String(Base64.getDecoder().decode("V3lubnRpbHNCb3Q="))
-                password = new String(Base64.getDecoder().decode("Z2hwX1VjRzJxNEtPOG5oUGZBakU1NVFGRVFxM2tKMGZkbDE4eFZpdw=="))
-            }
-        }
+        maven { url = "https://jitpack.io" }
     }
 
     loom {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     // This dependency is provided by forge naturally and by fabric in its build.gradle
     compileOnly "net.minecraftforge:eventbus:${forge_eventbus_version}"
 
-    implementation("com.wynntils.hades:hades:${hades_version}")
-    implementation("com.wynntils:antiope:${antiope_version}")
+    implementation("com.github.wynntils:hades:v${hades_version}")
+    implementation("com.github.wynntils:antiope:v${antiope_version}")
 
     implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-common:${mixinextras_version}"))
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -66,8 +66,8 @@ dependencies {
     }
 
     // Hades Protocol
-    shadowImplementation("com.wynntils.hades:hades:${hades_version}") { transitive false }
-    shadowImplementation("com.wynntils:antiope:${antiope_version}") { transitive false }
+    shadowImplementation("com.github.wynntils:hades:v${hades_version}") { transitive false }
+    shadowImplementation("com.github.wynntils:antiope:v${antiope_version}") { transitive false }
 
     include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixinextras_version}")))
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
 
     // Hades Protocol
-    include(forgeRuntimeLibrary("com.wynntils.hades:hades:${hades_version}"))
-    include(forgeRuntimeLibrary("com.wynntils:antiope:${antiope_version}"))
+    include(forgeRuntimeLibrary("com.github.wynntils:hades:v${hades_version}"))
+    include(forgeRuntimeLibrary("com.github.wynntils:antiope:v${antiope_version}"))
 
     implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-common:${mixinextras_version}"))
     implementation(include("com.github.llamalad7.mixinextras:mixinextras-forge:${mixinextras_version}"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,10 +49,10 @@ event_bus_transformer_version=2.0.2
 shadow_version=8.1.1
 
 # Hades
-hades_version=0.5.0
+hades_version=0.5.1
 
 # Antiope
-antiope_version=0.2.1
+antiope_version=0.2.2
 
 # JUnit
 # Check for latest at https://central.sonatype.com/search?namespace=org.junit.jupiter

--- a/quilt/build.gradle
+++ b/quilt/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     }
 
     // Hades Protocol
-    shadowImplementation("com.wynntils.hades:hades:${hades_version}") { transitive false }
-    shadowImplementation("com.wynntils:antiope:${antiope_version}") { transitive false }
+    shadowImplementation("com.github.wynntils:hades:v${hades_version}") { transitive false }
+    shadowImplementation("com.github.wynntils:antiope:v${antiope_version}") { transitive false }
 
     include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixinextras_version}"))) { transitive false }
 


### PR DESCRIPTION
This should make us not rely on Github Maven. Our "hack" to use it stopped working recently..