### PR TITLE
fix: Custom Bank Pages Names crash

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/CustomBankPageNamesFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/CustomBankPageNamesFeature.java
@@ -29,8 +29,7 @@ public class CustomBankPageNamesFeature extends Feature {
     @SubscribeEvent
     public void onScreenInit(ScreenInitEvent event) {
         if (Models.Bank.getCurrentContainer() == null) return;
-
-        AbstractContainerScreen<?> screen = (AbstractContainerScreen<?>) event.getScreen();
+        if (!(event.getScreen() instanceof AbstractContainerScreen<?> screen)) return;
 
         // This is screen.topPos and screen.leftPos, but they are not calculated yet when this is called
         int renderX = (screen.width - screen.imageWidth) / 2;


### PR DESCRIPTION
Should fix the following crash but I've been unable to reproduce it.

`Crashed feature: com.wynntils.features.inventory.CustomBankPageNamesFeature
java.lang.ClassCastException: class net.minecraft.class_500 cannot be cast to class net.minecraft.class_465 (net.minecraft.class_500 and net.minecraft.class_465 are in unnamed module of loader net.fabricmc.loader.impl.launch.knot.KnotClassLoader @62e136d3)
    at com.wynntils.features.inventory.CustomBankPageNamesFeature.onScreenInit(CustomBankPageNamesFeature.java:33)
    at com.wynntils.features.inventory.__CustomBankPageNamesFeature_onScreenInit_ScreenInitEvent.invoke(.dynamic)
    at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:73)
    at net.minecraftforge.eventbus.EventBus.post(EventBus.java:315)
    at net.minecraftforge.eventbus.EventBus.post(EventBus.java:296)
    at com.wynntils.core.WynntilsMod.postEvent(WynntilsMod.java:68)
    at com.wynntils.core.events.MixinHelper.postAlways(MixinHelper.java:28)
    at net.minecraft.class_437.handler$dee000$wynntils$onScreenInit(class_437.java:6373)`