### PR TITLE
fix: The great tooltip rendering cleanup, fix tooltip rendering glitches

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -272,7 +272,6 @@ public class ContainerSearchFeature extends Feature {
                 Texture.INFO.height() / 3,
                 Texture.INFO,
                 a -> {},
-                false,
                 true);
 
         screen.addRenderableWidget(lastItemSearchHelperWidget);

--- a/common/src/main/java/com/wynntils/screens/activities/WynntilsDialogueHistoryScreen.java
+++ b/common/src/main/java/com/wynntils/screens/activities/WynntilsDialogueHistoryScreen.java
@@ -21,7 +21,6 @@ import com.wynntils.screens.wynntilsmenu.WynntilsMenuScreen;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.TextRenderSetting;
 import com.wynntils.utils.render.TextRenderTask;
 import com.wynntils.utils.render.Texture;
@@ -223,14 +222,7 @@ public final class WynntilsDialogueHistoryScreen extends WynntilsMenuScreenBase 
 
         if (tooltipLines.isEmpty()) return;
 
-        RenderUtils.drawTooltipAt(
-                poseStack,
-                mouseX,
-                mouseY,
-                100,
-                tooltipLines,
-                FontRenderer.getInstance().getFont(),
-                true);
+        this.renderComponentTooltip(poseStack, tooltipLines, mouseX, mouseY);
     }
 
     private void renderWidgets(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {

--- a/common/src/main/java/com/wynntils/screens/activities/WynntilsQuestBookScreen.java
+++ b/common/src/main/java/com/wynntils/screens/activities/WynntilsQuestBookScreen.java
@@ -30,7 +30,6 @@ import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.RenderedStringUtils;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
@@ -303,14 +302,7 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
             return;
         }
 
-        RenderUtils.drawTooltipAt(
-                poseStack,
-                mouseX,
-                mouseY,
-                100,
-                tooltipLines,
-                FontRenderer.getInstance().getFont(),
-                true);
+        this.renderComponentTooltip(poseStack, tooltipLines, mouseX, mouseY);
     }
 
     private void renderDescription(PoseStack poseStack) {

--- a/common/src/main/java/com/wynntils/screens/base/WynntilsListScreen.java
+++ b/common/src/main/java/com/wynntils/screens/base/WynntilsListScreen.java
@@ -20,7 +20,6 @@ import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
@@ -114,7 +113,7 @@ public abstract class WynntilsListScreen<E, B extends WynntilsButton> extends Wy
 
         if (tooltipLines.isEmpty()) return;
 
-        this.renderTooltip(poseStack, tooltipLines, Optional.empty(), mouseX, mouseY);
+        this.renderComponentTooltip(poseStack, tooltipLines, mouseX, mouseY);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/base/widgets/BasicTexturedButton.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/BasicTexturedButton.java
@@ -5,16 +5,15 @@
 package com.wynntils.screens.base.widgets;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.screens.base.TooltipProvider;
 import com.wynntils.utils.mc.ComponentUtils;
-import com.wynntils.utils.mc.TooltipUtils;
-import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
 import java.util.function.Consumer;
 import net.minecraft.network.chat.Component;
 
-public class BasicTexturedButton extends WynntilsButton {
+public class BasicTexturedButton extends WynntilsButton implements TooltipProvider {
     private final Texture texture;
 
     private final Consumer<Integer> onClick;
@@ -25,7 +24,7 @@ public class BasicTexturedButton extends WynntilsButton {
 
     public BasicTexturedButton(
             int x, int y, int width, int height, Texture texture, Consumer<Integer> onClick, List<Component> tooltip) {
-        this(x, y, width, height, texture, onClick, tooltip, true, false);
+        this(x, y, width, height, texture, onClick, tooltip, false);
     }
 
     public BasicTexturedButton(
@@ -36,12 +35,10 @@ public class BasicTexturedButton extends WynntilsButton {
             Texture texture,
             Consumer<Integer> onClick,
             List<Component> tooltip,
-            boolean renderTooltipAboveMouse,
             boolean scaleTexture) {
         super(x, y, width, height, Component.literal("Basic Button"));
         this.texture = texture;
         this.onClick = onClick;
-        this.renderTooltipAboveMouse = renderTooltipAboveMouse;
         this.scaleTexture = scaleTexture;
         this.setTooltip(tooltip);
     }
@@ -62,21 +59,6 @@ public class BasicTexturedButton extends WynntilsButton {
         } else {
             RenderUtils.drawTexturedRect(poseStack, texture, this.getX(), this.getY());
         }
-
-        if (this.isHovered) {
-            int renderY = renderTooltipAboveMouse
-                    ? mouseY - TooltipUtils.getToolTipHeight(TooltipUtils.componentToClientTooltipComponent(tooltip))
-                    : mouseY;
-
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    renderY,
-                    0,
-                    tooltip,
-                    FontRenderer.getInstance().getFont(),
-                    true);
-        }
     }
 
     @Override
@@ -90,6 +72,11 @@ public class BasicTexturedButton extends WynntilsButton {
 
     @Override
     public void onPress() {}
+
+    @Override
+    public List<Component> getTooltipLines() {
+        return tooltip;
+    }
 
     public void setTooltip(List<Component> newTooltip) {
         tooltip = ComponentUtils.wrapTooltips(newTooltip, 250);

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
@@ -5,7 +5,6 @@
 package com.wynntils.screens.base.widgets;
 
 import com.wynntils.core.components.Services;
-import com.wynntils.screens.base.TooltipProvider;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.services.itemfilter.type.StatFilter;
 import com.wynntils.services.itemfilter.type.StatFilterFactory;
@@ -18,7 +17,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
-public class ItemSearchHelperWidget extends BasicTexturedButton implements TooltipProvider {
+public class ItemSearchHelperWidget extends BasicTexturedButton {
     private static final int ELEMENTS_PER_PAGE = 4;
 
     private final List<List<Component>> tooltipPages = new ArrayList<>();
@@ -26,15 +25,8 @@ public class ItemSearchHelperWidget extends BasicTexturedButton implements Toolt
     private int page = 0;
 
     public ItemSearchHelperWidget(
-            int x,
-            int y,
-            int width,
-            int height,
-            Texture texture,
-            Consumer<Integer> onClick,
-            boolean renderTooltipAboveMouse,
-            boolean scaleTexture) {
-        super(x, y, width, height, texture, onClick, List.of(), renderTooltipAboveMouse, scaleTexture);
+            int x, int y, int width, int height, Texture texture, Consumer<Integer> onClick, boolean scaleTexture) {
+        super(x, y, width, height, texture, onClick, List.of(), scaleTexture);
 
         generateTooltipPages();
     }

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ChangeWorldButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ChangeWorldButton.java
@@ -4,17 +4,15 @@
  */
 package com.wynntils.screens.characterselector.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.characterselector.CharacterSelectorScreen;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.TooltipUtils;
-import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.network.chat.Component;
 
 public class ChangeWorldButton extends WynntilsButton {
@@ -53,19 +51,7 @@ public class ChangeWorldButton extends WynntilsButton {
                 Texture.CHANGE_WORLD_BUTTON.height());
 
         if (isHovered) {
-            poseStack.pushPose();
-            List<ClientTooltipComponent> clientTooltipComponents =
-                    TooltipUtils.componentToClientTooltipComponent(TOOLTIP);
-            poseStack.translate(
-                    mouseX
-                            - TooltipUtils.getToolTipWidth(
-                                    clientTooltipComponents,
-                                    FontRenderer.getInstance().getFont()),
-                    mouseY - TooltipUtils.getToolTipHeight(clientTooltipComponents),
-                    100);
-            RenderUtils.drawTooltip(
-                    poseStack, TOOLTIP, FontRenderer.getInstance().getFont(), true);
-            poseStack.popPose();
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionAddButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionAddButton.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.screens.characterselector.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.characterselector.CharacterSelectorScreen;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
@@ -59,14 +60,13 @@ public class ClassSelectionAddButton extends WynntilsButton {
                 Texture.ADD_ICON_OFFSET.height());
 
         if (isHovered) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    100,
-                    characterSelectorScreen.getFirstNewCharacterSlot() == -1 ? TOOLTIP_CANNOT_ADD : TOOLTIP_CAN_ADD,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc()
+                    .screen
+                    .setTooltipForNextRenderPass(Lists.transform(
+                            characterSelectorScreen.getFirstNewCharacterSlot() == -1
+                                    ? TOOLTIP_CANNOT_ADD
+                                    : TOOLTIP_CAN_ADD,
+                            Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionDeleteButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionDeleteButton.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.screens.characterselector.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.characterselector.CharacterSelectorScreen;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
@@ -55,14 +56,7 @@ public class ClassSelectionDeleteButton extends WynntilsButton {
                 Texture.REMOVE_ICON_OFFSET.height());
 
         if (isHovered && characterSelectorScreen.getSelected() != null) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    100,
-                    TOOLTIP,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionEditButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/ClassSelectionEditButton.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.screens.characterselector.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.characterselector.CharacterSelectorScreen;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
@@ -52,14 +53,7 @@ public class ClassSelectionEditButton extends WynntilsButton {
                 Texture.EDIT_ICON.height());
 
         if (isHovered) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    100,
-                    TOOLTIP,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/DisconnectButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/DisconnectButton.java
@@ -4,18 +4,16 @@
  */
 package com.wynntils.screens.characterselector.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.characterselector.CharacterSelectorScreen;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.TooltipUtils;
-import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.TitleScreen;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.network.chat.Component;
 
 public class DisconnectButton extends WynntilsButton {
@@ -58,19 +56,7 @@ public class DisconnectButton extends WynntilsButton {
                 Texture.DISCONNECT_BUTTON.height());
 
         if (isHovered) {
-            poseStack.pushPose();
-            List<ClientTooltipComponent> clientTooltipComponents =
-                    TooltipUtils.componentToClientTooltipComponent(TOOLTIP);
-            poseStack.translate(
-                    mouseX
-                            - TooltipUtils.getToolTipWidth(
-                                    clientTooltipComponents,
-                                    FontRenderer.getInstance().getFont()),
-                    mouseY - TooltipUtils.getToolTipHeight(clientTooltipComponents),
-                    100);
-            RenderUtils.drawTooltip(
-                    poseStack, TOOLTIP, FontRenderer.getInstance().getFont(), true);
-            poseStack.popPose();
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/characterselector/widgets/PlayButton.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/widgets/PlayButton.java
@@ -4,17 +4,16 @@
  */
 package com.wynntils.screens.characterselector.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.characterselector.CharacterSelectorScreen;
-import com.wynntils.utils.mc.TooltipUtils;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.network.chat.Component;
 
 public class PlayButton extends WynntilsButton {
@@ -56,19 +55,7 @@ public class PlayButton extends WynntilsButton {
                 Texture.PLAY_BUTTON.height());
 
         if (isHovered) {
-            poseStack.pushPose();
-            List<ClientTooltipComponent> clientTooltipComponents =
-                    TooltipUtils.componentToClientTooltipComponent(TOOLTIP);
-            poseStack.translate(
-                    mouseX
-                            - TooltipUtils.getToolTipWidth(
-                                    clientTooltipComponents,
-                                    FontRenderer.getInstance().getFont()),
-                    mouseY - TooltipUtils.getToolTipHeight(clientTooltipComponents),
-                    100);
-            RenderUtils.drawTooltip(
-                    poseStack, TOOLTIP, FontRenderer.getInstance().getFont(), true);
-            poseStack.popPose();
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/container/widgets/ContainerEditNameButton.java
+++ b/common/src/main/java/com/wynntils/screens/container/widgets/ContainerEditNameButton.java
@@ -4,10 +4,11 @@
  */
 package com.wynntils.screens.container.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.widgets.WynntilsButton;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
@@ -46,14 +47,9 @@ public class ContainerEditNameButton extends WynntilsButton {
         if (isHovered) {
             List<Component> tooltipToUse = Models.Bank.isEditingName() ? CANCEL_TOOLTIP : EDIT_TOOLTIP;
 
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    100,
-                    tooltipToUse,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc()
+                    .screen
+                    .setTooltipForNextRenderPass(Lists.transform(tooltipToUse, Component::getVisualOrderText));
         }
     }
 

--- a/common/src/main/java/com/wynntils/screens/gearviewer/widgets/ViewPlayerStatsButton.java
+++ b/common/src/main/java/com/wynntils/screens/gearviewer/widgets/ViewPlayerStatsButton.java
@@ -4,13 +4,12 @@
  */
 package com.wynntils.screens.gearviewer.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.network.chat.Component;
@@ -38,14 +37,9 @@ public class ViewPlayerStatsButton extends WynntilsButton {
         super.renderWidget(poseStack, mouseX, mouseY, partialTick);
 
         if (isHovered) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    0,
-                    VIEW_STATS_TOOLTIP,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc()
+                    .screen
+                    .setTooltipForNextRenderPass(Lists.transform(VIEW_STATS_TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
@@ -35,7 +35,6 @@ public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends W
                 (int) (Texture.INFO.height() / 1.7f),
                 Texture.INFO,
                 a -> {},
-                false,
                 true);
         this.addRenderableWidget(helperButton);
 

--- a/common/src/main/java/com/wynntils/screens/guides/WynntilsGuidesListScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/WynntilsGuidesListScreen.java
@@ -7,7 +7,6 @@ package com.wynntils.screens.guides;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.screens.base.TooltipProvider;
 import com.wynntils.screens.base.WynntilsListScreen;
 import com.wynntils.screens.base.widgets.BackButton;
 import com.wynntils.screens.base.widgets.PageSelectorButton;
@@ -21,8 +20,6 @@ import com.wynntils.screens.guides.widgets.ImportButton;
 import com.wynntils.screens.wynntilsmenu.WynntilsMenuScreen;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,22 +135,6 @@ public final class WynntilsGuidesListScreen extends WynntilsListScreen<Screen, G
         poseStack.popPose();
 
         renderTooltip(poseStack, mouseX, mouseY);
-    }
-
-    protected void renderTooltip(PoseStack poseStack, int mouseX, int mouseY) {
-        if (!(this.hovered instanceof TooltipProvider tooltipWidget)) return;
-
-        List<Component> tooltipLines = tooltipWidget.getTooltipLines();
-        if (tooltipLines.isEmpty()) return;
-
-        RenderUtils.drawTooltipAt(
-                poseStack,
-                mouseX,
-                mouseY,
-                100,
-                tooltipLines,
-                FontRenderer.getInstance().getFont(),
-                true);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/lootrunpaths/WynntilsLootrunPathsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/lootrunpaths/WynntilsLootrunPathsScreen.java
@@ -20,7 +20,6 @@ import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.TaskUtils;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
@@ -124,14 +123,7 @@ public final class WynntilsLootrunPathsScreen extends WynntilsListScreen<Lootrun
                                 .withStyle(ChatFormatting.RED));
             }
 
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    100,
-                    tooltipLines,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            this.renderComponentTooltip(poseStack, tooltipLines, mouseX, mouseY);
             return;
         }
 

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -10,6 +10,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.screens.WynntilsScreen;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.screens.base.TooltipProvider;
 import com.wynntils.services.map.MapTexture;
 import com.wynntils.services.map.pois.IconPoi;
 import com.wynntils.services.map.pois.LabelPoi;
@@ -34,6 +35,7 @@ import java.util.List;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
 import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
@@ -102,6 +104,15 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
         mapHeight = renderHeight - renderedBorderYOffset * 2f;
         centerX = renderX + renderedBorderXOffset + mapWidth / 2f;
         centerZ = renderY + renderedBorderYOffset + mapHeight / 2f;
+    }
+
+    protected void renderTooltip(PoseStack poseStack, int mouseX, int mouseY) {
+        for (GuiEventListener child : children) {
+            if (child instanceof TooltipProvider tooltipProvider && child.isMouseOver(mouseX, mouseY)) {
+                this.renderComponentTooltip(poseStack, tooltipProvider.getTooltipLines(), mouseX, mouseY);
+                return;
+            }
+        }
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -200,6 +200,8 @@ public final class GuildMapScreen extends AbstractMapScreen {
         renderMapButtons(poseStack, mouseX, mouseY, partialTick);
 
         renderHoveredTerritoryInfo(poseStack);
+
+        renderTooltip(poseStack, mouseX, mouseY);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -273,6 +273,8 @@ public final class MainMapScreen extends AbstractMapScreen {
         renderCoordinates(poseStack, mouseX, mouseY);
 
         renderMapButtons(poseStack, mouseX, mouseY, partialTick);
+
+        renderTooltip(poseStack, mouseX, mouseY);
     }
 
     private void renderPois(PoseStack poseStack, int mouseX, int mouseY) {

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -477,6 +477,8 @@ public final class PoiCreationScreen extends AbstractMapScreen implements Textbo
                         HorizontalAlignment.CENTER,
                         VerticalAlignment.MIDDLE,
                         TextShadow.NORMAL);
+
+        renderTooltip(poseStack, mouseX, mouseY);
     }
 
     private void renderIcon(PoseStack poseStack) {

--- a/common/src/main/java/com/wynntils/screens/maps/SeaskipperDepartureBoardScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/SeaskipperDepartureBoardScreen.java
@@ -153,6 +153,8 @@ public final class SeaskipperDepartureBoardScreen extends AbstractMapScreen {
                 Texture.DESTINATION_LIST.height());
 
         renderWidgets(poseStack, mouseX, mouseY, partialTick);
+
+        renderTooltip(poseStack, mouseX, mouseY);
     }
 
     private void renderDestinations(

--- a/common/src/main/java/com/wynntils/screens/maps/SeaskipperMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/SeaskipperMapScreen.java
@@ -174,6 +174,8 @@ public final class SeaskipperMapScreen extends AbstractMapScreen {
         renderMapButtons(poseStack, mouseX, mouseY, partialTick);
 
         renderHoveredSeaskipperDestination(poseStack);
+
+        renderTooltip(poseStack, mouseX, mouseY);
     }
 
     private void renderPois(PoseStack poseStack, int mouseX, int mouseY) {

--- a/common/src/main/java/com/wynntils/screens/maps/widgets/SeaskipperBoatButton.java
+++ b/common/src/main/java/com/wynntils/screens/maps/widgets/SeaskipperBoatButton.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.screens.maps.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.screens.base.widgets.WynntilsButton;
-import com.wynntils.utils.mc.TooltipUtils;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
@@ -50,14 +50,7 @@ public class SeaskipperBoatButton extends WynntilsButton {
                 Texture.BOAT_BUTTON.height());
 
         if (isHovered) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY - TooltipUtils.getToolTipHeight(TooltipUtils.componentToClientTooltipComponent(TOOLTIP)),
-                    0,
-                    TOOLTIP,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(TOOLTIP, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/maps/widgets/SeaskipperTravelButton.java
+++ b/common/src/main/java/com/wynntils/screens/maps/widgets/SeaskipperTravelButton.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.screens.maps.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.maps.SeaskipperDepartureBoardScreen;
-import com.wynntils.utils.mc.TooltipUtils;
-import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
@@ -51,14 +51,7 @@ public class SeaskipperTravelButton extends WynntilsButton {
                     List.of(Component.translatable("screens.wynntils.seaskipperMapGui.travelToDestination")
                             .withStyle(ChatFormatting.GRAY));
 
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY - TooltipUtils.getToolTipHeight(TooltipUtils.componentToClientTooltipComponent(tooltip)),
-                    0,
-                    tooltip,
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(tooltip, Component::getVisualOrderText));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.screens.overlays.placement;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.overlays.Corner;
@@ -21,7 +22,6 @@ import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.TooltipUtils;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.TextRenderSetting;
@@ -41,7 +41,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.phys.Vec2;
@@ -221,32 +220,14 @@ public final class OverlayManagementScreen extends WynntilsScreen {
             }
 
             if (isMouseHoveringOverlay(selectedOverlay, mouseX, mouseY) && selectionMode == SelectionMode.NONE) {
-                List<ClientTooltipComponent> clientTooltipComponents =
-                        TooltipUtils.componentToClientTooltipComponent(HELP_TOOLTIP_LINES);
-                int tooltipWidth = TooltipUtils.getToolTipWidth(
-                        clientTooltipComponents, FontRenderer.getInstance().getFont());
-                int tooltipHeight = TooltipUtils.getToolTipHeight(clientTooltipComponents);
-
-                float renderX = mouseX > McUtils.window().getGuiScaledWidth() / 2f ? mouseX - tooltipWidth : mouseX;
-                float renderY = mouseY > McUtils.window().getGuiScaledHeight() / 2f ? mouseY - tooltipHeight : mouseY;
-
-                RenderUtils.drawTooltipAt(
-                        poseStack,
-                        renderX,
-                        renderY,
-                        100,
-                        HELP_TOOLTIP_LINES,
-                        FontRenderer.getInstance().getFont(),
-                        false);
+                McUtils.mc()
+                        .screen
+                        .setTooltipForNextRenderPass(
+                                Lists.transform(HELP_TOOLTIP_LINES, Component::getVisualOrderText));
             }
         }
 
         super.doRender(poseStack, mouseX, mouseY, partialTick); // This renders widgets
-        // This renders button tooltips
-        if (this.deferredTooltipRendering != null) {
-            this.renderTooltip(poseStack, this.deferredTooltipRendering, mouseX, mouseY);
-            this.deferredTooltipRendering = null;
-        }
     }
 
     private CustomColor getOverlayColor(Overlay overlay) {

--- a/common/src/main/java/com/wynntils/screens/overlays/selection/OverlayList.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/selection/OverlayList.java
@@ -4,12 +4,11 @@
  */
 package com.wynntils.screens.overlays.selection;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,23 +64,14 @@ public class OverlayList extends ContainerObjectSelectionList<OverlayEntry> {
                         + Managers.Overlay.getOverlayParent(hovered.getOverlay())
                                 .getTranslatedName()));
 
-                RenderUtils.drawTooltipAt(
-                        poseStack,
-                        mouseX,
-                        mouseY,
-                        100,
-                        helpModified,
-                        FontRenderer.getInstance().getFont(),
-                        false);
+                McUtils.mc()
+                        .screen
+                        .setTooltipForNextRenderPass(Lists.transform(helpModified, Component::getVisualOrderText));
             } else {
-                RenderUtils.drawTooltipAt(
-                        poseStack,
-                        mouseX,
-                        mouseY,
-                        100,
-                        HELP_TOOLTIP_LINES,
-                        FontRenderer.getInstance().getFont(),
-                        false);
+                McUtils.mc()
+                        .screen
+                        .setTooltipForNextRenderPass(
+                                Lists.transform(HELP_TOOLTIP_LINES, Component::getVisualOrderText));
             }
         }
     }

--- a/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigurableButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigurableButton.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.screens.settings.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.consumers.features.Configurable;
 import com.wynntils.core.consumers.features.Feature;
@@ -16,7 +17,6 @@ import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
@@ -64,14 +64,9 @@ public class ConfigurableButton extends WynntilsButton {
                         TextShadow.NORMAL);
 
         if (isHovered && configurable instanceof Feature) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    0,
-                    descriptionTooltip,
-                    FontRenderer.getInstance().getFont(),
-                    false);
+            McUtils.mc()
+                    .screen
+                    .setTooltipForNextRenderPass(Lists.transform(descriptionTooltip, Component::getVisualOrderText));
         }
     }
 

--- a/common/src/main/java/com/wynntils/screens/settings/widgets/GeneralSettingsButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/GeneralSettingsButton.java
@@ -4,11 +4,13 @@
  */
 package com.wynntils.screens.settings.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
@@ -57,14 +59,7 @@ public abstract class GeneralSettingsButton extends WynntilsButton {
                         TextShadow.OUTLINE);
 
         if (isHovered) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX,
-                    mouseY,
-                    0,
-                    tooltip,
-                    FontRenderer.getInstance().getFont(),
-                    false);
+            McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(tooltip, Component::getVisualOrderText));
         }
     }
 

--- a/common/src/main/java/com/wynntils/screens/wynntilsmenu/WynntilsMenuScreen.java
+++ b/common/src/main/java/com/wynntils/screens/wynntilsmenu/WynntilsMenuScreen.java
@@ -416,14 +416,8 @@ public final class WynntilsMenuScreen extends WynntilsMenuScreenBase {
 
     private void renderTooltip(PoseStack poseStack, int mouseX, int mouseY, float translationX, float translationY) {
         if (this.hovered != null) {
-            RenderUtils.drawTooltipAt(
-                    poseStack,
-                    mouseX - translationX,
-                    mouseY - translationY,
-                    0,
-                    this.hovered.tooltipList(),
-                    FontRenderer.getInstance().getFont(),
-                    true);
+            this.renderComponentTooltip(poseStack, this.hovered.tooltipList(), (int) (mouseX - translationX), (int)
+                    (mouseY - translationY));
         }
     }
 

--- a/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
@@ -646,22 +646,6 @@ public final class RenderUtils {
         poseStack.popPose();
     }
 
-    public static void drawTooltipAt(
-            PoseStack poseStack,
-            double renderX,
-            double renderY,
-            double renderZ,
-            List<Component> componentLines,
-            Font font,
-            boolean firstLineHasPlusHeight) {
-        poseStack.pushPose();
-
-        poseStack.translate(renderX, renderY, renderZ);
-        drawTooltip(poseStack, componentLines, font, firstLineHasPlusHeight);
-
-        poseStack.popPose();
-    }
-
     /**
      * drawProgressBar
      * Draws a progress bar (textureY1 and textureY2 now specify both textures with background being on top of the bar)

--- a/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
@@ -17,13 +17,10 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.TooltipUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
-import java.util.List;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
@@ -516,134 +513,6 @@ public final class RenderUtils {
             int outerRadius,
             float angleOffset) {
         drawArc(poseStack, color, x, y, z, 0.25f, innerRadius, outerRadius, angleOffset);
-    }
-
-    public static void drawTooltip(
-            PoseStack poseStack, List<Component> componentLines, Font font, boolean firstLineHasPlusHeight) {
-        List<ClientTooltipComponent> lines = TooltipUtils.componentToClientTooltipComponent(componentLines);
-
-        int tooltipWidth = TooltipUtils.getToolTipWidth(lines, font);
-        int tooltipHeight = TooltipUtils.getToolTipHeight(lines);
-
-        // background box
-        poseStack.pushPose();
-        int tooltipX = 4;
-        int tooltipY = 4;
-        int zLevel = 400;
-        Tesselator tesselator = Tesselator.getInstance();
-        BufferBuilder bufferBuilder = tesselator.getBuilder();
-        RenderSystem.setShader(GameRenderer::getPositionColorShader);
-        bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-        Matrix4f matrix4f = poseStack.last().pose();
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 3,
-                tooltipY - 4,
-                tooltipX + tooltipWidth + 3,
-                tooltipY - 3,
-                zLevel,
-                BACKGROUND,
-                BACKGROUND);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 3,
-                tooltipY + tooltipHeight + 3,
-                tooltipX + tooltipWidth + 3,
-                tooltipY + tooltipHeight + 4,
-                zLevel,
-                BACKGROUND,
-                BACKGROUND);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 3,
-                tooltipY - 3,
-                tooltipX + tooltipWidth + 3,
-                tooltipY + tooltipHeight + 3,
-                zLevel,
-                BACKGROUND,
-                BACKGROUND);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 4,
-                tooltipY - 3,
-                tooltipX - 3,
-                tooltipY + tooltipHeight + 3,
-                zLevel,
-                BACKGROUND,
-                BACKGROUND);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX + tooltipWidth + 3,
-                tooltipY - 3,
-                tooltipX + tooltipWidth + 4,
-                tooltipY + tooltipHeight + 3,
-                zLevel,
-                BACKGROUND,
-                BACKGROUND);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 3,
-                tooltipY - 3 + 1,
-                tooltipX - 3 + 1,
-                tooltipY + tooltipHeight + 3 - 1,
-                zLevel,
-                BORDER_START,
-                BORDER_END);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX + tooltipWidth + 2,
-                tooltipY - 3 + 1,
-                tooltipX + tooltipWidth + 3,
-                tooltipY + tooltipHeight + 3 - 1,
-                zLevel,
-                BORDER_START,
-                BORDER_END);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 3,
-                tooltipY - 3,
-                tooltipX + tooltipWidth + 3,
-                tooltipY - 3 + 1,
-                zLevel,
-                BORDER_START,
-                BORDER_START);
-        fillGradient(
-                matrix4f,
-                bufferBuilder,
-                tooltipX - 3,
-                tooltipY + tooltipHeight + 2,
-                tooltipX + tooltipWidth + 3,
-                tooltipY + tooltipHeight + 3,
-                zLevel,
-                BORDER_END,
-                BORDER_END);
-        RenderSystem.enableDepthTest();
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-        BufferUploader.drawWithShader(bufferBuilder.end());
-        RenderSystem.disableBlend();
-
-        // text
-        MultiBufferSource.BufferSource bufferSource =
-                MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        poseStack.translate(0.0, 0.0, 400.0);
-        int s = tooltipY;
-        boolean first = firstLineHasPlusHeight;
-        for (ClientTooltipComponent line : lines) {
-            line.renderText(font, tooltipX, s, matrix4f, bufferSource);
-            s += line.getHeight() + (first ? 2 : 0);
-            first = false;
-        }
-        bufferSource.endBatch();
-        poseStack.popPose();
     }
 
     /**

--- a/common/src/main/resources/wynntils.accessWidener
+++ b/common/src/main/resources/wynntils.accessWidener
@@ -1,5 +1,6 @@
 accessWidener v2 named
 
+accessible class net/minecraft/client/gui/screens/Screen$DeferredTooltipRendering
 accessible class net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation
 accessible class net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
 accessible class net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
@@ -20,12 +21,12 @@ accessible field net/minecraft/client/gui/screens/Screen renderables Ljava/util/
 accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen hoveredSlot Lnet/minecraft/world/inventory/Slot;
 accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen imageHeight I
 accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen imageWidth I
-accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen leftPos I
-accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen topPos I
-accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen titleLabelX I
-accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen titleLabelY I
 accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen inventoryLabelX I
 accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen inventoryLabelY I
+accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen leftPos I
+accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen titleLabelX I
+accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen titleLabelY I
+accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen topPos I
 accessible field net/minecraft/client/renderer/entity/ItemRenderer textureManager Lnet/minecraft/client/renderer/texture/TextureManager;
 accessible field net/minecraft/client/resources/DownloadedPackSource serverPack Lnet/minecraft/server/packs/repository/Pack;
 accessible field net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation name Lnet/minecraft/network/chat/Component;
@@ -42,6 +43,7 @@ accessible method net/minecraft/client/gui/screens/Screen clearWidgets ()V
 accessible method net/minecraft/client/gui/screens/Screen removeWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)V
 accessible method net/minecraft/client/gui/screens/Screen renderTooltip (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/gui/screens/Screen$DeferredTooltipRendering;II)V
 accessible method net/minecraft/client/gui/screens/Screen renderTooltip (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/item/ItemStack;II)V
+accessible method net/minecraft/client/gui/screens/Screen$DeferredTooltipRendering <init> (Ljava/util/List;Lnet/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipPositioner;)V
 accessible method net/minecraft/client/multiplayer/MultiPlayerGameMode startPrediction (Lnet/minecraft/client/multiplayer/ClientLevel;Lnet/minecraft/client/multiplayer/prediction/PredictiveAction;)V
 accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;ILnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType;
 accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType;


### PR DESCRIPTION
Fixes #2062 and fixes #2064.

I originally wanted to do this in 1.20, but it was easy enough here. MC tooltip rendering does a lot of calculations for us, like fitting tooltips into the screen, so I could remove a lot of code like that.