### PR TITLE
fix: unescaped any char in pattern

### DIFF
--- a/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
@@ -15,7 +15,7 @@ public final class LocationUtils {
             "(?<x>[-+]?\\d{1,6})(?:\\.\\d+)?([^0-9.+-]{1,5}(?<y>[-+]?\\d{1,3})(?:\\.\\d+)?)?[^0-9.+-]{1,5}(?<z>[-+]?\\d{1,6})(?:\\.\\d+)?");
 
     private static final Pattern STRICT_COORDINATE_PATTERN = Pattern.compile(
-            "([-+]?\\d{1,6})(?:\\.\\d+)?([,\\s]{1,2}([-+]?\\d{1,3})(?:\\.\\d+)?)?[,\\s]{1,2}([-+]?\\d{1,6})(?:\\.\\d+)?");
+            "(?:^|\\s)([-+]?\\d{1,6})(?:\\.\\d+)?((,\\s?|\\s)([-+]?\\d{1,3})(?:\\.\\d+)?)?(,\\s?|\\s)([-+]?\\d{1,6})(?:\\.\\d+)?(?:\\s|$)");
 
     public static Optional<Location> parseFromString(String locString) {
         Matcher matcher = COORDINATE_PATTERN.matcher(locString);

--- a/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
@@ -12,10 +12,10 @@ import java.util.regex.Pattern;
 
 public final class LocationUtils {
     private static final Pattern COORDINATE_PATTERN = Pattern.compile(
-            "(?<x>[-+]?\\d{1,6})(?:.\\d+)?([^0-9.+-]{1,5}(?<y>[-+]?\\d{1,3})(?:.\\d+)?)?[^0-9.+-]{1,5}(?<z>[-+]?\\d{1,6})(?:.\\d+)?");
+            "(?<x>[-+]?\\d{1,6})(?:\\.\\d+)?([^0-9.+-]{1,5}(?<y>[-+]?\\d{1,3})(?:\\.\\d+)?)?[^0-9.+-]{1,5}(?<z>[-+]?\\d{1,6})(?:\\.\\d+)?");
 
     private static final Pattern STRICT_COORDINATE_PATTERN = Pattern.compile(
-            "([-+]?\\d{1,6})(?:.\\d+)?([,\\s]{1,2}([-+]?\\d{1,3})(?:.\\d+)?)?[,\\s]{1,2}([-+]?\\d{1,6})(?:.\\d+)?");
+            "([-+]?\\d{1,6})(?:\\.\\d+)?([,\\s]{1,2}([-+]?\\d{1,3})(?:\\.\\d+)?)?[,\\s]{1,2}([-+]?\\d{1,6})(?:\\.\\d+)?");
 
     public static Optional<Location> parseFromString(String locString) {
         Matcher matcher = COORDINATE_PATTERN.matcher(locString);


### PR DESCRIPTION
This fixes `3a3 4b4 5c5 => [3, 4, 5]` or `1 3/4 => [1, 0, 3]` from being seen as a coordinates. Unfortunately, `1 3/4` is still partially matched as `[1, 0, 3]/4`, but I don't see a clear path on how to resolve that without losing a large number of valid matches.