### PR TITLE
fix: fix inventory emerald count being wrong, container not being counted

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -167,7 +167,10 @@ public class ItemHandler extends Handler {
         if (!firstItem.getItem().equals(secondItem.getItem())) return false;
 
         // We have to use the count field here to bypass the getCount method empty flag
-        if (firstItem.count != secondItem.count) {
+        // If the count is not 1, we need to reannotate, since we can't tell the old item count
+        // This is because we set the item count locally, then the server sends a packet to confirm,
+        // which passes this check, but the annotation is not updated
+        if (firstItem.count != secondItem.count || firstItem.count != 1) {
             return false;
         }
 

--- a/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
+++ b/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
@@ -151,7 +151,7 @@ public final class EmeraldModel extends Model {
     }
 
     public int getAmountInContainer() {
-        return containerEmeralds;
+        return containerEmeralds - inventoryEmeralds;
     }
 
     public String convertEmeraldPrice(String inputStr) {

--- a/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
+++ b/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
@@ -8,7 +8,7 @@ import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.mc.event.ContainerCloseEvent;
 import com.wynntils.mc.event.MenuEvent;
-import com.wynntils.mc.event.SetSlotEvent;
+import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.character.CharacterModel;
 import com.wynntils.models.emeralds.type.EmeraldUnits;
 import com.wynntils.models.items.ItemModel;
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -56,39 +55,28 @@ public final class EmeraldModel extends Model {
 
         inventoryEmeralds = 0;
         containerEmeralds = 0;
-
-        // Rescan inventory at login
-        Inventory inventory = McUtils.inventory();
-        for (int i = 0; i < inventory.getContainerSize(); i++) {
-            adjustBalance(null, inventory.getItem(i), true);
-        }
     }
 
     @SubscribeEvent
-    public void onSetSlot(SetSlotEvent.Post event) {
-        boolean isInventory = event.getContainer() == McUtils.inventory();
-        if (pouchContainerId != -1 && !isInventory) return;
+    public void onTick(TickEvent event) {
+        recountEmeralds();
+    }
 
-        // FIXME: This is a hack to always have up-to-date emerald counts
-        //        When Wynncraft fixes emerald stacking,
-        //        this can be simplified greatly (by using old and new stacks)
-        //        However, this is really fast so maybe we can keep it (pending profiling)
-        if (isInventory) {
-            inventoryEmeralds = 0;
+    private void recountEmeralds() {
+        inventoryEmeralds = 0;
 
-            // Rescan inventory after merging items
-            List<ItemStack> items = McUtils.inventoryMenu().getItems();
-            for (ItemStack item : items) {
-                adjustBalance(null, item, true);
-            }
-        } else if (event.getContainer() == McUtils.containerMenu()) {
-            containerEmeralds = 0;
+        // Rescan inventory after merging items
+        List<ItemStack> items = McUtils.inventoryMenu().getItems();
+        for (ItemStack item : items) {
+            adjustBalance(null, item, true);
+        }
 
-            // Rescan container after merging items
-            List<ItemStack> items = McUtils.containerMenu().getItems();
-            for (ItemStack item : items) {
-                adjustBalance(null, item, false);
-            }
+        containerEmeralds = 0;
+
+        // Rescan container after merging items
+        items = McUtils.containerMenu().getItems();
+        for (ItemStack item : items) {
+            adjustBalance(null, item, false);
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
+++ b/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
@@ -68,7 +68,7 @@ public final class EmeraldModel extends Model {
         // Rescan inventory after merging items
         List<ItemStack> items = McUtils.inventoryMenu().getItems();
         for (ItemStack item : items) {
-            adjustBalance(null, item, true);
+            adjustBalance(item, true);
         }
 
         containerEmeralds = 0;
@@ -76,7 +76,7 @@ public final class EmeraldModel extends Model {
         // Rescan container after merging items
         items = McUtils.containerMenu().getItems();
         for (ItemStack item : items) {
-            adjustBalance(null, item, false);
+            adjustBalance(item, false);
         }
     }
 
@@ -101,27 +101,18 @@ public final class EmeraldModel extends Model {
         containerEmeralds = 0;
     }
 
-    private void adjustBalance(ItemStack oldItemStack, ItemStack newItemStack, boolean isInventory) {
+    private void adjustBalance(ItemStack newItemStack, boolean isInventory) {
         int adjustValue = 0;
-        Optional<EmeraldValuedItemProperty> oldItemValueOpt =
-                Models.Item.asWynnItemPropery(oldItemStack, EmeraldValuedItemProperty.class);
-        if (oldItemValueOpt.isPresent()) {
-            adjustValue -= oldItemValueOpt.get().getEmeraldValue();
-        }
-
         Optional<EmeraldValuedItemProperty> newItemValueOpt =
                 Models.Item.asWynnItemPropery(newItemStack, EmeraldValuedItemProperty.class);
         if (newItemValueOpt.isPresent()) {
             adjustValue += newItemValueOpt.get().getEmeraldValue();
         }
 
-        // We most likely replaced the same item, so we don't need to adjust
-        if (adjustValue == 0) return;
-
         if (isInventory) {
-            inventoryEmeralds = Math.max(0, inventoryEmeralds + adjustValue);
+            inventoryEmeralds += adjustValue;
         } else {
-            containerEmeralds = Math.max(0, containerEmeralds + adjustValue);
+            containerEmeralds += adjustValue;
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldAnnotator.java
@@ -25,6 +25,6 @@ public final class EmeraldAnnotator implements ItemAnnotator {
         Matcher matcher = name.getMatcher(EMERALD_PATTERN);
         if (!matcher.matches()) return null;
 
-        return new EmeraldItem(itemStack.getCount(), unit);
+        return new EmeraldItem(itemStack::getCount, unit);
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/game/EmeraldItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/EmeraldItem.java
@@ -6,18 +6,19 @@ package com.wynntils.models.items.items.game;
 
 import com.wynntils.models.emeralds.type.EmeraldUnits;
 import com.wynntils.models.items.properties.EmeraldValuedItemProperty;
+import java.util.function.Supplier;
 
 public class EmeraldItem extends GameItem implements EmeraldValuedItemProperty {
-    private final int amount;
+    private final Supplier<Integer> amountSupplier;
     private final EmeraldUnits unit;
 
-    public EmeraldItem(int amount, EmeraldUnits unit) {
-        this.amount = amount;
+    public EmeraldItem(Supplier<Integer> amountSupplier, EmeraldUnits unit) {
+        this.amountSupplier = amountSupplier;
         this.unit = unit;
     }
 
     public int getAmount() {
-        return amount;
+        return amountSupplier.get();
     }
 
     public EmeraldUnits getUnit() {
@@ -26,11 +27,11 @@ public class EmeraldItem extends GameItem implements EmeraldValuedItemProperty {
 
     @Override
     public int getEmeraldValue() {
-        return amount * unit.getMultiplier();
+        return getAmount() * unit.getMultiplier();
     }
 
     @Override
     public String toString() {
-        return "EmeraldItem{" + "amount=" + amount + ", unit=" + unit + '}';
+        return "EmeraldItem{" + "amount=" + getAmount() + ", unit=" + unit + '}';
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Artemis/issues/1548.

**Review by commit.** Yes, all of these are needed for this to reliably work, Minecraft does have a lot of cases for ItemStack count updates, it's impossible to catch all of them. So we use a supplier.

I also moved to the tick method in emerald model, since we don't do any parsing there anymore (unlike when it was written) it is probably even faster than 90 set slots.