### PR TITLE
fix: CustomColor now properly handles hex string conversion (to/from), add unit tests

### DIFF
--- a/fabric/src/test/java/TestCustomColor.java
+++ b/fabric/src/test/java/TestCustomColor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.wynntils.utils.colors.CustomColor;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestCustomColor {
+    @BeforeAll
+    public static void setup() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    public void customColor_toHexStringWorks() {
+        final CustomColor color = CustomColor.fromInt(11141290).withAlpha(255);
+
+        final String expected = "#aa00aa";
+
+        String result = color.toHexString();
+
+        Assertions.assertEquals(expected, result, "CustomColor#toHexString() did not return the expected value");
+    }
+
+    @Test
+    public void customColor_toHexStringWithAlphaWorks() {
+        final CustomColor color = CustomColor.fromInt(11141290).withAlpha(170);
+
+        final String expected = "#aa00aaaa";
+
+        String result = color.toHexString();
+
+        Assertions.assertEquals(expected, result, "CustomColor#toHexString() did not return the expected value");
+    }
+
+    @Test
+    public void customColor_toHexStringWithLeadingZeroWorks() {
+        final CustomColor color = CustomColor.fromInt(0x00aabb).withAlpha(255);
+
+        final String expected = "#00aabb";
+
+        String result = color.toHexString();
+
+        Assertions.assertEquals(expected, result, "CustomColor#toHexString() did not return the expected value");
+    }
+
+    @Test
+    public void customColor_toHexStringWithSingleDigitAlphaWorks() {
+        final CustomColor color = CustomColor.fromInt(11141290).withAlpha(1);
+
+        final String expected = "#aa00aa01";
+
+        String result = color.toHexString();
+
+        Assertions.assertEquals(expected, result, "CustomColor#toHexString() did not return the expected value");
+    }
+
+    @Test
+    public void customColor_fromHexStringWorks() {
+        final String hex = "#bbcdaa";
+
+        final CustomColor expected = CustomColor.fromInt(12307882).withAlpha(255);
+
+        CustomColor result = CustomColor.fromHexString(hex);
+
+        Assertions.assertEquals(expected, result, "CustomColor#fromHexString() did not return the expected value");
+    }
+
+    @Test
+    public void customColor_fromHexStringWithAlphaWorks() {
+        final String hex = "#bbcdaaaa";
+
+        final CustomColor expected = CustomColor.fromInt(12307882).withAlpha(170);
+
+        CustomColor result = CustomColor.fromHexString(hex);
+
+        Assertions.assertEquals(expected, result, "CustomColor#fromHexString() did not return the expected value");
+    }
+
+    @Test
+    public void customColor_fromRGBWorks() {
+        final CustomColor color = new CustomColor(0, 255, 255);
+
+        final int expected = 0xff00ffff;
+
+        Assertions.assertEquals(expected, color.asInt(), "CustomColor#init() did not return the expected value");
+    }
+}

--- a/fabric/src/test/java/TestStyledText.java
+++ b/fabric/src/test/java/TestStyledText.java
@@ -4,6 +4,7 @@
  */
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.utils.colors.CustomColor;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -506,5 +507,19 @@ public class TestStyledText {
                 result,
                 styledText.getString(PartStyle.StyleType.NONE),
                 "StyledText.replaceAll() returned an unexpected value.");
+    }
+
+    @Test
+    public void styledText_getStringWithNonChatFormattingColors() {
+        final CustomColor color = new CustomColor(36, 12, 42);
+        final Component component = Component.literal("test").withStyle(style -> style.withColor(color.asInt()));
+
+        StyledText styledText = StyledText.fromComponent(component);
+
+        final String result = "§#240c2atest";
+        Assertions.assertEquals(
+                result,
+                styledText.getString(PartStyle.StyleType.DEFAULT),
+                "StyledText.getString() returned an unexpected value.");
     }
 }


### PR DESCRIPTION
Quite unfortunate since we always used hex color configs. However, it seems that only toHex was broken, so some values just couldn't be saved. This means we technically don't corrupt/change any colors. fromHexString also got alpha support now, for full support.