### PR TITLE
fix: Map icon bar alignment

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -67,12 +67,12 @@ public final class GuildMapScreen extends AbstractMapScreen {
         // Buttons have to be added in reverse order (right to left) so they don't overlap
 
         this.addRenderableWidget(new BasicTexturedButton(
-                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20 * 6,
+                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 7 + 20 * 6,
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
-                16,
+                        - 8),
+                10,
                 16,
                 Texture.HELP_ICON,
                 (b) -> {},
@@ -86,11 +86,11 @@ public final class GuildMapScreen extends AbstractMapScreen {
 
         this.addRenderableWidget(
                 hybridModeButton = new BasicTexturedButton(
-                        width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20 * 2,
+                        width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 4 + 20 * 2,
                         (int) (this.renderHeight
                                 - this.renderedBorderYOffset
                                 - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                                - 6),
+                                - 8),
                         16,
                         16,
                         Texture.OVERLAY_EXTRA_ICON,
@@ -101,11 +101,11 @@ public final class GuildMapScreen extends AbstractMapScreen {
                         getHybridModeTooltip()));
 
         territoryDefenseFilterButton = this.addRenderableWidget(new BasicTexturedButton(
-                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20,
+                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 4 + 20,
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
+                        - 8),
                 16,
                 16,
                 Texture.DEFENSE_FILTER_ICON,
@@ -145,9 +145,9 @@ public final class GuildMapScreen extends AbstractMapScreen {
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
-                16,
-                16,
+                        - 7),
+                14,
+                14,
                 Texture.ADD_ICON,
                 (b) -> resourceMode = !resourceMode,
                 List.of(

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -69,12 +69,12 @@ public final class MainMapScreen extends AbstractMapScreen {
         super.doInit();
 
         this.addRenderableWidget(new BasicTexturedButton(
-                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20 * 6,
+                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 7 + 20 * 6,
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
-                16,
+                        - 8),
+                10,
                 16,
                 Texture.HELP_ICON,
                 (b) -> {},
@@ -118,8 +118,8 @@ public final class MainMapScreen extends AbstractMapScreen {
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
-                16,
+                        - 8),
+                12,
                 16,
                 Texture.WAYPOINT_MANAGER_ICON,
                 (b) -> McUtils.mc().setScreen(PoiManagementScreen.create(this)),
@@ -131,13 +131,13 @@ public final class MainMapScreen extends AbstractMapScreen {
                                 .withStyle(ChatFormatting.GRAY))));
 
         this.addRenderableWidget(new BasicTexturedButton(
-                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 6 + 20 * 2,
+                width / 2 - Texture.MAP_BUTTONS_BACKGROUND.width() / 2 + 4 + 20 * 2,
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
+                        - 7),
                 16,
-                16,
+                14,
                 Texture.SHARE_ICON,
                 this::shareLocationOrCompass,
                 List.of(
@@ -162,8 +162,8 @@ public final class MainMapScreen extends AbstractMapScreen {
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
-                16,
+                        - 8),
+                12,
                 16,
                 Texture.WAYPOINT_FOCUS_ICON,
                 (b) -> {
@@ -200,9 +200,9 @@ public final class MainMapScreen extends AbstractMapScreen {
                 (int) (this.renderHeight
                         - this.renderedBorderYOffset
                         - Texture.MAP_BUTTONS_BACKGROUND.height() / 2
-                        - 6),
-                16,
-                16,
+                        - 7),
+                14,
+                14,
                 Texture.ADD_ICON,
                 (b) -> McUtils.mc().setScreen(PoiCreationScreen.create(this)),
                 List.of(


### PR DESCRIPTION
Fixes #2102. See issue for old, misaligned images.

Guild map:
![image](https://github.com/Wynntils/Artemis/assets/57310593/ca560390-6a0a-43b7-928b-f4290d0bf4f8)

Main map:
![image](https://github.com/Wynntils/Artemis/assets/57310593/01d93bc0-d3d2-4259-ada2-420e36b9d6db)

