### PR TITLE
fix: In preparation for 1.20.2, always use undashed UUIDs in config files

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
@@ -47,7 +47,7 @@ public final class ConfigManager extends Manager {
             UpfixerManager upfixerManager, JsonManager jsonManager, FeatureManager feature, OverlayManager overlay) {
         super(List.of(upfixerManager, jsonManager, feature, overlay));
 
-        userConfig = new File(CONFIG_DIR, McUtils.mc().getUser().getUuid() + FILE_SUFFIX);
+        userConfig = new File(CONFIG_DIR, McUtils.mc().getUser().getUuid().replaceAll("-", "") + FILE_SUFFIX);
     }
 
     public void init() {

--- a/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
@@ -46,7 +46,7 @@ public final class StorageManager extends Manager {
 
     public StorageManager(JsonManager jsonManager, FeatureManager feature) {
         super(List.of(jsonManager, feature));
-        userStorageFile = new File(STORAGE_DIR, McUtils.mc().getUser().getUuid() + FILE_SUFFIX);
+        userStorageFile = new File(STORAGE_DIR, McUtils.mc().getUser().getUuid().replaceAll("-", "") + FILE_SUFFIX);
     }
 
     public void initComponents() {


### PR DESCRIPTION
DO NOT MERGE THIS! Needs announcement.

This was actually a problem with 1.19.4 as well, but only certain launchers triggered it. Now it should be always correct. This WILL break some configs, but they can be fixed by renaming.  