### PR TITLE
chore: Update to Loom 1.3 (and other dependency updates)

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation("com.github.wynntils:hades:v${hades_version}")
     implementation("com.github.wynntils:antiope:v${antiope_version}")
 
-    implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-common:${mixinextras_version}"))
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixinextras_version}"))
 }
 
 architectury {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     shadowImplementation("com.github.wynntils:hades:v${hades_version}") { transitive false }
     shadowImplementation("com.github.wynntils:antiope:v${antiope_version}") { transitive false }
 
-    include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixinextras_version}")))
+    include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:${mixinextras_version}")))
 
     // EventBusTransform needs to only be available for the dev env at runtime and
     // does not need to be shadowed

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     include(forgeRuntimeLibrary("com.github.wynntils:hades:v${hades_version}"))
     include(forgeRuntimeLibrary("com.github.wynntils:antiope:v${antiope_version}"))
 
-    implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-common:${mixinextras_version}"))
-    implementation(include("com.github.llamalad7.mixinextras:mixinextras-forge:${mixinextras_version}"))
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixinextras_version}"))
+    implementation(include("io.github.llamalad7:mixinextras-forge:${mixinextras_version}"))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ minecraft_version=1.19.4
 # Check for latest at https://maven.architectury.dev/architectury-plugin/architectury-plugin.gradle.plugin
 architectury_plugin_version=3.4-SNAPSHOT
 # Check for latest at https://maven.architectury.dev/dev/architectury/loom/dev.architectury.loom.gradle.plugin
-architectury_loom_version=1.2-SNAPSHOT
+architectury_loom_version=1.3-SNAPSHOT
 enabled_platforms=fabric,forge,quilt
 
 # Parchment
@@ -39,7 +39,7 @@ qsl_version=5.0.0-beta.10+1.19.4
 
 # MixinExtras
 # Check for updates at https://github.com/LlamaLad7/MixinExtras/releases
-mixinextras_version=0.2.0-beta.9
+mixinextras_version=0.2.0-rc.5
 
 # Event Bus Transformer
 event_bus_transformer_version=2.0.2
@@ -70,10 +70,10 @@ loom_vineflower_version=1.11.0
 
 # Spotless
 # Check for latest at https://plugins.gradle.org/plugin/com.diffplug.spotless
-spotless_version=6.19.0
+spotless_version=6.21.0
 
 # Check for latest at https://plugins.gradle.org/plugin/com.palantir.java-format-spotless
-spotless_palantir_version=2.33.0
+spotless_palantir_version=2.38.0
 
 # Check for latest at https://github.com/google/gson/releases
 spotless_gson_version=2.10.1

--- a/quilt/build.gradle
+++ b/quilt/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     shadowImplementation("com.github.wynntils:hades:v${hades_version}") { transitive false }
     shadowImplementation("com.github.wynntils:antiope:v${antiope_version}") { transitive false }
 
-    include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixinextras_version}"))) { transitive false }
+    include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:${mixinextras_version}"))) { transitive false }
 
     // EventBusTransform needs to only be available for the dev env at runtime and
     // does not need to be shadowed


### PR DESCRIPTION
Loom 1.3 fixes line number mappings used in decompilation, which makes debugging much easier. This is why I opt to use it this early after release. I also want this done before 1.20.2. This loom version also supports neoforge..