### PR TITLE
fix: Fix corrupted lost sanctuary key overlay text showing as gray instead of red

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -237,12 +237,10 @@ public class ItemTextOverlayFeature extends Feature {
             String text = dungeon.getInitials();
 
             CustomColor textColor;
-            if (dungeon.isRemoved()) {
-                textColor = REMOVED_COLOR;
-            } else if (item.isCorrupted()) {
-                textColor = CORRUPTED_COLOR;
+            if (item.isCorrupted()) {
+                textColor = dungeon.isCorruptedRemoved() ? REMOVED_COLOR : CORRUPTED_COLOR;
             } else {
-                textColor = STANDARD_COLOR;
+                textColor = dungeon.isRemoved() ? REMOVED_COLOR : STANDARD_COLOR;
             }
 
             TextRenderSetting style =

--- a/common/src/main/java/com/wynntils/models/dungeon/type/Dungeon.java
+++ b/common/src/main/java/com/wynntils/models/dungeon/type/Dungeon.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 public enum Dungeon {
     DECREPIT_SEWERS,
     INFESTED_PIT,
-    LOST_SANCTUARY(true),
+    LOST_SANCTUARY(true, false),
     UNDERWORLD_CRYPT,
     TIMELOST_SANCTUM,
     SAND_SWEPT_TOMB("Sand-Swept Tomb"),
@@ -23,19 +23,22 @@ public enum Dungeon {
 
     private final String name;
     private final boolean removed;
+    private final boolean corruptedRemoved;
 
     Dungeon() {
-        this(false);
+        this(false, false);
     }
 
-    Dungeon(boolean removed) {
+    Dungeon(boolean removed, boolean corruptedRemoved) {
         this.name = EnumUtils.toNiceString(name());
         this.removed = removed;
+        this.corruptedRemoved = corruptedRemoved;
     }
 
     Dungeon(String name) {
         this.name = name;
         this.removed = false;
+        this.corruptedRemoved = false;
     }
 
     public static Dungeon fromName(String name) {
@@ -54,6 +57,9 @@ public enum Dungeon {
 
     public boolean isRemoved() {
         return removed;
+    }
+    public boolean isCorruptedRemoved() {
+        return corruptedRemoved;
     }
 
     public String getInitials() {

--- a/common/src/main/java/com/wynntils/models/dungeon/type/Dungeon.java
+++ b/common/src/main/java/com/wynntils/models/dungeon/type/Dungeon.java
@@ -58,6 +58,7 @@ public enum Dungeon {
     public boolean isRemoved() {
         return removed;
     }
+
     public boolean isCorruptedRemoved() {
         return corruptedRemoved;
     }


### PR DESCRIPTION
A follow-up to #2057. In that PR, I colored all Lost Sanctuary keys gray because the dungeon was removed, unaware that the corrupted version still exists. This PR reverts the corrupted keys to the correct color.