### PR TITLE
fix: Improve chat screen handling for game messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@ classes/
 .gradle/
 .architectury-transformer/
 
-# Data generated while running Minecraft
+# Data generated while running Minecraft or tests
 run/
 .devauth/microsoft_accounts.json
+*/logs/*
 
 # IDEs
 .idea/

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -18,7 +18,6 @@ import com.wynntils.handlers.chat.type.RecipientType;
 import com.wynntils.mc.event.ChatPacketReceivedEvent;
 import com.wynntils.mc.event.MobEffectEvent;
 import com.wynntils.mc.event.TickEvent;
-import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.McUtils;
 import java.util.ArrayList;

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -8,6 +8,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handler;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.handlers.chat.event.NpcDialogEvent;
@@ -17,6 +18,7 @@ import com.wynntils.handlers.chat.type.RecipientType;
 import com.wynntils.mc.event.ChatPacketReceivedEvent;
 import com.wynntils.mc.event.MobEffectEvent;
 import com.wynntils.mc.event.TickEvent;
+import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.McUtils;
 import java.util.ArrayList;
@@ -102,6 +104,18 @@ public final class ChatHandler extends Handler {
 
     public void removeNpcDialogExtractionDependent(Feature feature) {
         dialogExtractionDependents.remove(feature);
+    }
+
+    @SubscribeEvent
+    public void onConnectionChange(WynncraftConnectionEvent event) {
+        // Reset chat handler
+        collectedLines = new ArrayList<>();
+        chatScreenTicks = 0;
+        lastRealChat = null;
+        lastSlowdownApplied = 0;
+        lastScreenNpcDialog = List.of();
+        delayedDialogue = null;
+        delayedType = NpcDialogueType.NONE;
     }
 
     @SubscribeEvent
@@ -349,9 +363,12 @@ public final class ChatHandler extends Handler {
     private void handleFakeChatLine(Component message) {
         // This is a normal, single line chat, sent in the background
         StyledText styledText = StyledText.fromComponent(message);
+        if (styledText.isEmpty()) return;
 
-        // But it can weirdly enough actually also be a foreground NPC chat message...
-        if (getRecipientType(styledText, MessageType.FOREGROUND) == RecipientType.NPC) {
+        // But it can weirdly enough actually also be a foreground NPC chat message, or
+        // a game message; similar to a dialogue but not uttered by an NPC.
+        RecipientType recipientType = getRecipientType(styledText, MessageType.FOREGROUND);
+        if (recipientType == RecipientType.NPC || recipientType == RecipientType.GAME_MESSAGE) {
             // In this case, do *not* save this as last chat, since it will soon disappear
             // from history!
             postNpcDialogue(List.of(message), NpcDialogueType.CONFIRMATIONLESS, false);
@@ -383,7 +400,7 @@ public final class ChatHandler extends Handler {
         WynntilsMod.info("[CHAT] " + styledText.getString().replace("§", "&"));
         RecipientType recipientType = getRecipientType(styledText, messageType);
 
-        if (recipientType == RecipientType.NPC) {
+        if (recipientType == RecipientType.NPC || recipientType == RecipientType.GAME_MESSAGE) {
             if (shouldSeparateNPC()) {
                 postNpcDialogue(List.of(message), NpcDialogueType.CONFIRMATIONLESS, false);
                 // We need to cancel the original chat event, if any

--- a/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
@@ -24,7 +24,8 @@ public enum RecipientType {
     PARTY("^§7\\[§e[^➤]*§7\\] §f.*$", "^(§8)?\\[§7[^➤]*§8\\] §7[^§]*$", "Party"),
     PRIVATE("^§7\\[.* ➤ .*\\] §f.*$", "^(§8)?\\[.* ➤ .*\\] §7.*$", "Private"),
     SHOUT("^§5.* \\[[A-Z0-9]+\\] shouts: §d.*$", "^(§8)?.* \\[[A-Z0-9]+\\] shouts: §7.*$", "Shout"),
-    PETS("^§2(.*): §a(.*)$", "^§8(.*): §7(.*)$", "Pets");
+    PETS("^§2(.*): §a(.*)$", "^§8(.*): §7(.*)$", "Pets"),
+    GAME_MESSAGE("^§7[A-Z0-9].*$", null, "Game Message"); // Like dialogues but not uttered by an NPC
 
     private final Pattern foregroundPattern;
     private final Pattern backgroundPattern;


### PR DESCRIPTION
This fixes #1951. The problem was that the message "As you touch..." behaved in the same way as NPC dialogue (it disappeared and should not be stored as the last real chat line), but we did not detect it as such.

This entire code is somewhat finicky, but I believe this is a robust enough fix.

Also fixed so last real chat line (and others) get reset when reconnecting.

Also added junit test junk files to .gitignore...