### PR TITLE
fix: Make price parsing much less memory intensive

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/game/AmplifierAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/AmplifierAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.AmplifierItem;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.utils.MathUtils;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -17,7 +16,7 @@ public final class AmplifierAnnotator extends GameItemAnnotator {
     private static final Pattern AMPLIFIER_PATTERN = Pattern.compile("^§bCorkian Amplifier (I{1,3})$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher ampMatcher = name.getMatcher(AMPLIFIER_PATTERN);
         if (!ampMatcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/CharmAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/CharmAnnotator.java
@@ -7,7 +7,6 @@ package com.wynntils.models.items.annotators.game;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.GameItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -16,7 +15,7 @@ public final class CharmAnnotator extends GameItemAnnotator {
     private static final Pattern CHARM_PATTERN = Pattern.compile("^§[5abcdef](Charm of the (?<Type>\\w+))$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(CHARM_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedConsumableAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedConsumableAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.wynnitem.parsing.WynnItemParseResult;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import com.wynntils.utils.type.CappedValue;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -19,7 +18,7 @@ public final class CraftedConsumableAnnotator extends GameItemAnnotator {
     private static final Pattern CRAFTED_CONSUMABLE_PATTERN = Pattern.compile("^§3(.*)§b \\[(\\d+)/(\\d+)\\]$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(CRAFTED_CONSUMABLE_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/CraftedGearAnnotator.java
@@ -7,7 +7,6 @@ package com.wynntils.models.items.annotators.game;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.GameItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -16,7 +15,7 @@ public final class CraftedGearAnnotator extends GameItemAnnotator {
     private static final Pattern CRAFTED_GEAR_PATTERN = Pattern.compile("^§3(.*)§b \\[\\d{1,3}%\\]$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(CRAFTED_GEAR_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/DungeonKeyAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/DungeonKeyAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.dungeon.type.Dungeon;
 import com.wynntils.models.items.items.game.DungeonKeyItem;
 import com.wynntils.models.items.items.game.GameItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +17,7 @@ public final class DungeonKeyAnnotator extends GameItemAnnotator {
             Pattern.compile("^(?:§[46])*(?:Broken )?(?:Corrupted )?(.+) Key$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher keyMatcher = name.getMatcher(DUNGEON_KEY_PATTERN);
         if (!keyMatcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.emeralds.type.EmeraldUnits;
 import com.wynntils.models.items.items.game.EmeraldItem;
 import com.wynntils.models.items.items.game.GameItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -17,7 +16,7 @@ public final class EmeraldAnnotator extends GameItemAnnotator {
     private static final Pattern EMERALD_PATTERN = Pattern.compile("^§a(Liquid )?Emerald( Block)?$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         EmeraldUnits unit = EmeraldUnits.fromItemType(itemStack.getItem());
         if (unit == null) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldPouchAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/EmeraldPouchAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.models.items.items.game.EmeraldPouchItem;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.mc.LoreUtils;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -22,7 +21,7 @@ public final class EmeraldPouchAnnotator extends GameItemAnnotator {
             Pattern.compile("§6§l([\\d\\s]+)" + EmeraldUnits.EMERALD.getSymbol() + ".*");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         // Checks for normal emerald pouch (diamond axe) and emerald pouch pickup texture (gold shovel)
         if (itemStack.getItem() != Items.DIAMOND_AXE && itemStack.getItem() != Items.GOLDEN_SHOVEL) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GameItemAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GameItemAnnotator.java
@@ -4,56 +4,77 @@
  */
 package com.wynntils.models.items.annotators.game;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.ItemAnnotation;
 import com.wynntils.handlers.item.ItemAnnotator;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.utils.mc.LoreUtils;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.world.item.ItemStack;
 
 public abstract class GameItemAnnotator implements ItemAnnotator {
+    private static final int TRADE_MARKET_PRICE_LINE = 1;
     private static final Pattern PRICE_STR = Pattern.compile("§6Price:");
 
     // Test suite: https://regexr.com/7lh2b
     private static final Pattern PRICE_PATTERN = Pattern.compile(
             "§[67] - (?:§f(?<amount>[\\d,]+) §7x )?§(?:(?:(?:c✖|a✔) §f)|f)(?<price>[\\d,]+)§7²(?: .+)?");
 
-    public abstract GameItem getAnnotation(
-            ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice);
+    public abstract GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice);
 
     @Override
     public final ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
-        List<StyledText> lore = LoreUtils.getLore(itemStack);
-        int emeraldPrice = parsePrice(lore);
+        int emeraldPrice = parsePrice(itemStack);
 
-        return getAnnotation(itemStack, name, lore, emeraldPrice);
+        return getAnnotation(itemStack, name, emeraldPrice);
     }
 
-    private int parsePrice(List<StyledText> lore) {
-        boolean foundPrice = false;
-        for (StyledText loreLine : lore) {
-            if (loreLine.matches(PRICE_STR)) {
-                foundPrice = true;
-                continue;
-            }
+    private int parsePrice(ItemStack itemStack) {
+        // Optimization: Only check known line numbers for the price,
+        //               this will save us a lot of memory
+        ListTag loreTag = LoreUtils.getLoreTag(itemStack);
 
-            if (foundPrice) {
-                Matcher matcher = loreLine.getMatcher(PRICE_PATTERN);
-                if (matcher.matches()) {
-                    return Integer.parseInt(matcher.group("price").replaceAll(",", ""));
-                } else {
-                    WynntilsMod.warn("Found price line, but could not match price pattern." + loreLine);
-                }
+        // If the lore tag is null, there is no price
+        if (loreTag == null) return 0;
 
-                // We are done either way
-                break;
+        StyledText priceLoreLine = null;
+
+        // Check the trade market price line first
+        int lineToCheck = TRADE_MARKET_PRICE_LINE;
+        if (loreTag.size() > lineToCheck + 1) {
+            StyledText line = StyledText.fromJson(loreTag.getString(lineToCheck));
+
+            if (line.matches(PRICE_STR) && loreTag.size() > lineToCheck + 1) {
+                priceLoreLine = StyledText.fromJson(loreTag.getString(lineToCheck + 1));
             }
         }
 
+        // If we didn't find the price line, check the normal price line
+        if (priceLoreLine == null) {
+            lineToCheck = loreTag.size() - 2;
+
+            // Lore is too short to contain a price line
+            if (lineToCheck < 0) return 0;
+
+            StyledText line = StyledText.fromJson(loreTag.getString(lineToCheck));
+
+            if (line.matches(PRICE_STR) && loreTag.size() > lineToCheck + 1) {
+                priceLoreLine = StyledText.fromJson(loreTag.getString(lineToCheck + 1));
+            }
+        }
+
+        // If we still didn't find the price line, return 0
+        if (priceLoreLine == null) return 0;
+
+        StyledText loreLine = LoreUtils.getLoreLine(itemStack, lineToCheck + 1);
+        Matcher matcher = loreLine.getMatcher(PRICE_PATTERN);
+        if (matcher.matches()) {
+            return Integer.parseInt(matcher.group("price").replaceAll(",", ""));
+        }
+
+        // There might be a non-emerald price, just return 0
         return 0;
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GatheringToolAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GatheringToolAnnotator.java
@@ -22,7 +22,7 @@ public final class GatheringToolAnnotator extends GameItemAnnotator {
     private static final Pattern DURABILITY_PATTERN = Pattern.compile("\\[(\\d+)/(\\d+) Durability\\]");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(GATHERING_TOOL_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.GearItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -20,7 +19,7 @@ public final class GearAnnotator extends GameItemAnnotator {
             Pattern.compile("^(?:§f⬡ )?(?<rarity>§[5abcdef])(?<unidentified>Unidentified )?(?:Shiny )?(?<name>.+)$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(GEAR_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearBoxAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearBoxAnnotator.java
@@ -11,7 +11,6 @@ import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.GearBoxItem;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.type.RangedValue;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -22,7 +21,7 @@ public final class GearBoxAnnotator extends GameItemAnnotator {
     private static final Pattern LEVEL_RANGE_PATTERN = Pattern.compile("^§a- §7Lv\\. Range: §f(\\d+)-(\\d+)$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         if (!(itemStack.getItem() == Items.STONE_SHOVEL
                 && itemStack.getDamageValue() >= 1
                 && itemStack.getDamageValue() <= 6)) return null;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/HorseAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/HorseAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.HorseItem;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.type.CappedValue;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -24,7 +23,7 @@ public final class HorseAnnotator extends GameItemAnnotator {
     private static final Pattern HORSE_NAME_PATTERN = Pattern.compile("^§7Name: (.+)$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         if (itemStack.getItem() != Items.SADDLE) return null;
         Matcher matcher = name.getMatcher(HORSE_PATTERN);
         if (!matcher.matches()) return null;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.ingredients.type.IngredientInfo;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.IngredientItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -21,7 +20,7 @@ public final class IngredientAnnotator extends GameItemAnnotator {
             Pattern.compile("^§7(.+?)(?:§[3567])? \\[§([8bde])✫(§8)?✫(§8)?✫§[3567]\\]$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(INGREDIENT_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/InsulatorAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/InsulatorAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.InsulatorItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
@@ -18,7 +17,7 @@ public class InsulatorAnnotator extends GameItemAnnotator {
     private static final Pattern INSULATOR_PATTERN = Pattern.compile("^§(.)Corkian Insulator$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(INSULATOR_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MaterialAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MaterialAnnotator.java
@@ -9,7 +9,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.MaterialItem;
 import com.wynntils.models.profession.type.MaterialProfile;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +17,7 @@ public final class MaterialAnnotator extends GameItemAnnotator {
     private static final Pattern MATERIAL_PATTERN = Pattern.compile("^§f(.*) ([^ ]+)§6 \\[§e✫((?:§8)?✫(?:§8)?)✫§6\\]$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(MATERIAL_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MiscAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MiscAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.MiscItem;
 import com.wynntils.utils.mc.LoreUtils;
-import java.util.List;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +17,7 @@ public final class MiscAnnotator extends GameItemAnnotator {
     private static final StyledText QUEST_ITEM = StyledText.fromString("§cQuest Item");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         ListTag loreTag = LoreUtils.getLoreTag(itemStack);
         if (loreTag == null) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MultiHealthPotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MultiHealthPotionAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.MultiHealthPotionItem;
 import com.wynntils.utils.type.CappedValue;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +17,7 @@ public final class MultiHealthPotionAnnotator extends GameItemAnnotator {
             Pattern.compile("^§c\\[\\+(\\d+) ❤\\] §dPotions of Healing §4\\[(\\d+)/(\\d+)\\]$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(MULTI_HEALTH_POTION_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/PotionAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/PotionAnnotator.java
@@ -12,7 +12,6 @@ import com.wynntils.models.items.items.game.PotionItem;
 import com.wynntils.models.wynnitem.parsing.WynnItemParseResult;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import com.wynntils.utils.type.CappedValue;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -25,7 +24,7 @@ public final class PotionAnnotator extends GameItemAnnotator {
     private static final Pattern SKILL_PATTERN = Pattern.compile("^§[2ebcf][✤✦❉✹❋] (.*)§a \\[(\\d+)/(\\d+)\\]$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(POTION_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/PowderAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/PowderAnnotator.java
@@ -11,7 +11,6 @@ import com.wynntils.models.elements.type.PowderTierInfo;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.PowderItem;
 import com.wynntils.utils.MathUtils;
-import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,7 +21,7 @@ public final class PowderAnnotator extends GameItemAnnotator {
             Pattern.compile("^§[2ebcf8].? ?(Earth|Thunder|Water|Fire|Air) Powder ([IV]{1,3})$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(POWDER_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/SimulatorAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/SimulatorAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.SimulatorItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
@@ -18,7 +17,7 @@ public class SimulatorAnnotator extends GameItemAnnotator {
     private static final Pattern SIMULATOR_PATTERN = Pattern.compile("^§(.)Corkian Simulator$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(SIMULATOR_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/TeleportScrollAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/TeleportScrollAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.models.items.items.game.TeleportScrollItem;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.wynn.WynnUtils;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,7 +21,7 @@ public final class TeleportScrollAnnotator extends GameItemAnnotator {
     private static final Pattern TELEPORT_LOCATION_PATTERN = Pattern.compile("§3- §7Teleports to: §f(.*)");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher nameMatcher = name.getMatcher(TELEPORT_SCROLL_PATTERN);
         if (!nameMatcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/TomeAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/TomeAnnotator.java
@@ -8,7 +8,6 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.rewards.type.TomeType;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,7 +19,7 @@ public final class TomeAnnotator extends GameItemAnnotator {
             "^§[5abcdef]((?<Variant>[\\w']+)? ?Tome of (?<Type>\\w+))(?:( Mastery( (?<Tier>[IVX]{1,4}))?))?$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         if (itemStack.getItem() != Items.ENCHANTED_BOOK) return null;
         Matcher matcher = name.getMatcher(TOME_PATTERN);
         if (!matcher.matches()) return null;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/TrinketAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/TrinketAnnotator.java
@@ -10,7 +10,6 @@ import com.wynntils.models.items.items.game.GameItem;
 import com.wynntils.models.items.items.game.TrinketItem;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.type.CappedValue;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,7 +20,7 @@ public final class TrinketAnnotator extends GameItemAnnotator {
     private static final Pattern TRINKET_LORE_PATTERN = Pattern.compile("^§7Right-Click to (use|toggle)$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         Matcher matcher = name.getMatcher(TRINKET_PATTERN);
         if (!matcher.matches()) return null;
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/UnknownGearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/UnknownGearAnnotator.java
@@ -9,7 +9,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.items.items.game.GameItem;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +17,7 @@ public final class UnknownGearAnnotator extends GameItemAnnotator {
     private static final Pattern UNKNOWN_GEAR_PATTERN = Pattern.compile("^§[5abcdef](.*)$");
 
     @Override
-    public GameItem getAnnotation(ItemStack itemStack, StyledText name, List<StyledText> lore, int emeraldPrice) {
+    public GameItem getAnnotation(ItemStack itemStack, StyledText name, int emeraldPrice) {
         GearType gearType = GearType.fromItemStack(itemStack);
         if (gearType == null) return null;
 


### PR DESCRIPTION
This is not perfect. But it makes reduces 2GB/s allocation to around 400MB/s (with 200MB/s as a baseline). That makes it costy, but fully playable. I will think of a better solution, but we might have to wait for the next version change (as 1.20.3 changes component serializing heavily, I would assume the item lore json -> component deserialization is going to be much faster).