### PR TITLE
fix: Fix some specific lootrun tasks not getting parsed in Sky (and MH?)

### DIFF
--- a/common/src/main/java/com/wynntils/models/lootrun/particle/LootrunTaskParticleVerifier.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/particle/LootrunTaskParticleVerifier.java
@@ -94,6 +94,6 @@ public class LootrunTaskParticleVerifier implements ParticleVerifier {
     }
 
     private static boolean isParticlePrecise(Position addedPosition) {
-        return Math.abs(addedPosition.x() % 1) == 0.5d && Math.abs(addedPosition.z() % 1) == 0.5d;
+        return Math.abs(addedPosition.x() % 0.5d) == 0 && Math.abs(addedPosition.z() % 0.5d) == 0;
     }
 }


### PR DESCRIPTION
Seems like Sky has some weird cases..