### PR TITLE
[ci skip] fix: Update ContentBookDumpFeature for dumping 2.0.4 data

### DIFF
--- a/common/src/main/java/com/wynntils/features/debug/ContentBookDumpFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ContentBookDumpFeature.java
@@ -42,6 +42,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
 import net.minecraft.network.chat.Component;
@@ -78,7 +79,14 @@ public class ContentBookDumpFeature extends Feature {
     public void onSetSpawn(SetSpawnEvent event) {
         if (currentlyTracking == null) return;
 
-        Location currentTracker = Models.Activity.ACTIVITY_MARKER_PROVIDER.getSpawnLocation();
+        Optional<Location> spawnLocationOpt = Models.Activity.ACTIVITY_MARKER_PROVIDER.getSpawnLocation();
+        if (spawnLocationOpt.isEmpty()) {
+            WynntilsMod.error("Could not get spawn location for " + currentlyTracking.name());
+            return;
+        }
+
+        Location currentTracker = spawnLocationOpt.get();
+
         if (lastTrackedLocation != currentTracker && currentTracker != null) {
             currentDump.remove(currentlyTracking);
 
@@ -110,9 +118,15 @@ public class ContentBookDumpFeature extends Feature {
                     .map(DumpableActivityInfo::fromActivityInfo)
                     .toList());
 
-            filterEntriesNeedingManualTracking();
+            Models.Activity.scanContentBook(ActivityType.TERRITORIAL_DISCOVERY, (activityInfos2, progress2) -> {
+                currentDump.addAll(activityInfos2.stream()
+                        .map(DumpableActivityInfo::fromActivityInfo)
+                        .toList());
 
-            trackManually();
+                filterEntriesNeedingManualTracking();
+
+                trackManually();
+            });
         });
     }
 
@@ -146,7 +160,8 @@ public class ContentBookDumpFeature extends Feature {
 
         // Track the activity
         currentlyTracking = info;
-        lastTrackedLocation = Models.Activity.ACTIVITY_MARKER_PROVIDER.getSpawnLocation();
+        lastTrackedLocation =
+                Models.Activity.ACTIVITY_MARKER_PROVIDER.getSpawnLocation().orElse(null);
         WynntilsMod.info("Tracking " + info.name());
         Models.Activity.startTracking(info.name(), info.type());
     }

--- a/common/src/main/java/com/wynntils/models/activities/markers/ActivityMarkerProvider.java
+++ b/common/src/main/java/com/wynntils/models/activities/markers/ActivityMarkerProvider.java
@@ -15,6 +15,7 @@ import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.Texture;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ActivityMarkerProvider implements MarkerProvider<MarkerPoi> {
@@ -41,8 +42,8 @@ public class ActivityMarkerProvider implements MarkerProvider<MarkerPoi> {
                                 Texture.QUESTS_SCROLL_ICON));
     }
 
-    public Location getSpawnLocation() {
-        return spawnInfo.location();
+    public Optional<Location> getSpawnLocation() {
+        return spawnInfo == null ? Optional.empty() : Optional.ofNullable(spawnInfo.location());
     }
 
     public void setTrackedActivityLocation(Location trackedActivityLocation, BeaconColor beaconColor) {


### PR DESCRIPTION
This should make content book dumping work for 2.0.4. 

I've already went ahead and updated all of our repositories with the new data:
https://github.com/Wynntils/Data-Storage/pull/41
https://github.com/Wynntils/WynntilsWebsite-API/pull/145
https://github.com/Wynntils/Reference/pull/28

I am also planning to add a few new POIs to the map with this system soon.