### PR TITLE
fix: properly position item tooltips when applying custom scaling

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/TooltipFittingFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/TooltipFittingFeature.java
@@ -123,6 +123,8 @@ public class TooltipFittingFeature extends Feature {
             Vector2i vector2i = new Vector2i(mouseX, mouseY).add(12, -12);
             this.positionTooltip(screenWidth, screenHeight, vector2i, (int) (tooltipWidth * scaleFactor), (int)
                     (tooltipHeight * scaleFactor));
+
+            vector2i.div(scaleFactor); // scale mouse position so tooltip is rendered at the proper location
             return vector2i;
         }
 


### PR DESCRIPTION
Simple one-line fix. IIRC 1.19's tooltip code handled the tooltip location separately, but in 1.20 it is done after we apply our scaling, so the mouse coordinates have to be scaled accordingly