### PR TITLE
fix: Fix territory held times being displayed wrongly

### DIFF
--- a/common/src/main/java/com/wynntils/models/territories/profile/TerritoryProfile.java
+++ b/common/src/main/java/com/wynntils/models/territories/profile/TerritoryProfile.java
@@ -23,8 +23,7 @@ import net.minecraft.core.Position;
 
 public class TerritoryProfile {
     private static final SimpleDateFormatter DATE_FORMATTER = new SimpleDateFormatter();
-    private static final SimpleDateFormat DATE_FORMAT =
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS", Locale.ROOT);
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT);
 
     private final String name;
     private final String friendlyName;


### PR DESCRIPTION
The issue was an incorrect date format string converting "720" MS to 720 seconds, offsetting by large amounts of time..