### PR TITLE
fix: Experimental fix for crashes when preloading a corrupted resource pack

### DIFF
--- a/common/src/main/java/com/wynntils/services/resourcepack/ResourcePackService.java
+++ b/common/src/main/java/com/wynntils/services/resourcepack/ResourcePackService.java
@@ -5,6 +5,7 @@
 package com.wynntils.services.resourcepack;
 
 import com.google.common.hash.Hashing;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Service;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
@@ -90,6 +91,17 @@ public final class ResourcePackService extends Service {
         Pack pack = getPackForHash(requestedPreloadHash.get());
         if (pack == null) {
             // File is missing, forget about it
+            requestedPreloadHash.store("");
+            return;
+        }
+
+        try {
+            // If the pack is corrupted, this will throw an exception
+            pack.open();
+        } catch (Throwable t) {
+            WynntilsMod.warn("Failed to open preloaded resource pack", t);
+
+            // File is corrupted, don't try to load it again
             requestedPreloadHash.store("");
             return;
         }


### PR DESCRIPTION
This should fix the cases where we try to preload a texture pack, but the pack is corrupted, and the crash log contains a "vanilla" crash, as our way of injection makes it so the mod does not appear in the stack-trace of actually loading the texture pack. This is because we only set the server-resource-pack for Minecraft, and Minecraft will happily try to load it during the boot