### PR TITLE
fix: Player name not rendering with Wynntils marker disabled

### DIFF
--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -166,21 +166,21 @@ public class CustomNametagRendererFeature extends Feature {
                     new CustomNametag(accountType.getComponent(), customNametagScale.get() * ACCOUNT_TYPE_MULTIPLIER));
         }
 
-        if (!showWynntilsMarker.get()) return;
-
         // Add an appropriate Wynntils marker
         Component realName = event.getDisplayName();
-        Component vanillaNametag;
+        Component vanillaNametag = realName;
 
-        StyledText styledText = StyledText.fromComponent(realName);
-        if (styledText.getString(PartStyle.StyleType.NONE).startsWith("[")) {
-            vanillaNametag = Component.literal(WYNNTILS_LOGO)
-                    .withStyle(ChatFormatting.DARK_GRAY)
-                    .append(realName);
-        } else {
-            vanillaNametag = Component.literal(WYNNTILS_LOGO + " ")
-                    .withStyle(ChatFormatting.GRAY)
-                    .append(realName);
+        if (showWynntilsMarker.get()) {
+            StyledText styledText = StyledText.fromComponent(realName);
+            if (styledText.getString(PartStyle.StyleType.NONE).startsWith("[")) {
+                vanillaNametag = Component.literal(WYNNTILS_LOGO)
+                        .withStyle(ChatFormatting.DARK_GRAY)
+                        .append(realName);
+            } else {
+                vanillaNametag = Component.literal(WYNNTILS_LOGO + " ")
+                        .withStyle(ChatFormatting.GRAY)
+                        .append(realName);
+            }
         }
         nametags.add(new CustomNametag(vanillaNametag, 1f));
     }


### PR DESCRIPTION
Think someone reported the donator tag was hiding names before but I assume they had the marker disabled and this was the reason for it

![Marker](https://github.com/Wynntils/Artemis/assets/8337467/b54e1217-3e70-4406-829b-bbc290080000)
