### PR TITLE
chore: remove Debugify from the incompatible mod list (experimentally)

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -3,7 +3,6 @@
     "Team Wynntils"
   ],
   "breaks": {
-    "debugify": "*",
     "exordium": "*",
     "memoryleakfix": "<1.1.2"
   },

--- a/quilt/src/main/resources/quilt.mod.json
+++ b/quilt/src/main/resources/quilt.mod.json
@@ -6,10 +6,6 @@
   "quilt_loader": {
     "breaks": [
       {
-        "id": "debugify",
-        "versions": "*"
-      },
-      {
         "id": "exordium",
         "versions": "*"
       },


### PR DESCRIPTION
Debugify seems to not break anymore and thus the break should be removed

i found it by helping a user within the FO server
i told them to replace the fabric loader overrides we use for FO and instead use a custom one where i remove the break on debugify from wynntils
they told it worked and they didn't seem to have the issue that existed in 1.19.3 that i found by looking in the other wynntils repo
(them)
![image](https://github.com/Wynntils/Artemis/assets/49841713/1c09e0fb-c78a-425e-bb03-9f697240641e)
(me)
![image](https://github.com/Wynntils/Artemis/assets/49841713/f3a8a8a2-15fc-47be-adb8-826f93c0c0fd)
(them)
![image](https://github.com/Wynntils/Artemis/assets/49841713/3a526abb-1492-4176-816d-0d9c58ed5ae0)
(me)
![image](https://github.com/Wynntils/Artemis/assets/49841713/d7213cdd-fa5d-487f-9b3d-e6e1584e69fb)
(still me)
![image](https://github.com/Wynntils/Artemis/assets/49841713/d8575ea3-4834-4cf2-801e-400ba770cc52)
(them)
![image](https://github.com/Wynntils/Artemis/assets/49841713/50ff660b-8845-40fb-8ec0-35cad8a2fe98)
(still them)
![image](https://github.com/Wynntils/Artemis/assets/49841713/b0c3548d-e03a-4359-b959-0406d9c8057b)

here is a log of them successfully joining the server with wynntils, debugify and the break override : https://mclo.gs/1lRnWyz