### PR TITLE
fix: Revert game message dialogue handling

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -367,7 +367,7 @@ public final class ChatHandler extends Handler {
         // But it can weirdly enough actually also be a foreground NPC chat message, or
         // a game message; similar to a dialogue but not uttered by an NPC.
         RecipientType recipientType = getRecipientType(styledText, MessageType.FOREGROUND);
-        if (recipientType == RecipientType.NPC || recipientType == RecipientType.GAME_MESSAGE) {
+        if (recipientType == RecipientType.NPC) {
             // In this case, do *not* save this as last chat, since it will soon disappear
             // from history!
             postNpcDialogue(List.of(message), NpcDialogueType.CONFIRMATIONLESS, false);
@@ -399,7 +399,7 @@ public final class ChatHandler extends Handler {
         WynntilsMod.info("[CHAT] " + styledText.getString().replace("§", "&"));
         RecipientType recipientType = getRecipientType(styledText, messageType);
 
-        if (recipientType == RecipientType.NPC || recipientType == RecipientType.GAME_MESSAGE) {
+        if (recipientType == RecipientType.NPC) {
             if (shouldSeparateNPC()) {
                 postNpcDialogue(List.of(message), NpcDialogueType.CONFIRMATIONLESS, false);
                 // We need to cancel the original chat event, if any


### PR DESCRIPTION
I don't mean to push this through just when magicus is away, but it has been unaddressed for a while now. This makes item bombs, crates, and certain other system messages become dialogue, which breaks things such as claiming item bombs. We should revisit in the future, probably with a hardcoded list of dialogue, since there is no way to differentiate between the different types of messages.