### PR TITLE
fix: Detect soul points in hunted

### DIFF
--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -204,9 +204,7 @@ public final class CharacterModel extends Model {
 
         Matcher veteran = LoreUtils.matchLoreLine(rankSubscriptionItem, 0, VETERAN_PATTERN);
 
-        if (veteran.matches()) {
-            isVeteran = true;
-        }
+        isVeteran = veteran.matches();
 
         Matcher status = LoreUtils.matchLoreLine(rankSubscriptionItem, 0, SILVERBULL_PATTERN);
         if (!status.matches()) {

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -49,6 +49,8 @@ public final class CharacterModel extends Model {
     // Test suite: https://regexr.com/7irg0
     private static final Pattern SILVERBULL_DURATION_PATTERN = Pattern.compile(
             "§7Expiration: §f(?:(?<weeks>\\d+) weeks?)? ?(?:(?<days>\\d+) days?)? ?(?:(?<hours>\\d+) hours?)?");
+    // Test suite: https://regexr.com/7ntns
+    private static final Pattern VETERAN_PATTERN = Pattern.compile("§7Rank: §[6dba]Vet");
 
     private static final int RANK_SUBSCRIPTION_INFO_SLOT = 0;
     private static final int CHARACTER_INFO_SLOT = 7;
@@ -68,6 +70,8 @@ public final class CharacterModel extends Model {
     private ClassType classType;
     private boolean reskinned;
     private int level;
+
+    private boolean isVeteran = false;
 
     @Persisted
     public final Storage<Long> silverbullExpiresAt = new Storage<>(0L);
@@ -115,6 +119,10 @@ public final class CharacterModel extends Model {
         if (!hasCharacter) return "-";
 
         return id;
+    }
+
+    public boolean isVeteran() {
+        return isVeteran;
     }
 
     @SubscribeEvent
@@ -193,6 +201,12 @@ public final class CharacterModel extends Model {
 
     private void parseCratesBombsCosmeticsContainer(ContainerContent container) {
         ItemStack rankSubscriptionItem = container.items().get(RANK_SUBSCRIPTION_INFO_SLOT);
+
+        Matcher veteran = LoreUtils.matchLoreLine(rankSubscriptionItem, 0, VETERAN_PATTERN);
+
+        if (veteran.matches()) {
+            isVeteran = true;
+        }
 
         Matcher status = LoreUtils.matchLoreLine(rankSubscriptionItem, 0, SILVERBULL_PATTERN);
         if (!status.matches()) {

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -95,11 +95,11 @@ public final class CharacterStatsModel extends Model {
      */
     private int getCurrentSoulPoints() {
         ItemStack soulPoints = McUtils.inventory().getItem(8);
-        if (soulPoints.getItem() != Items.NETHER_STAR) {
-            return -1;
+        if (soulPoints.getItem() == Items.NETHER_STAR || soulPoints.getItem() == Items.DIAMOND_AXE) {
+            return soulPoints.getCount();
         }
 
-        return soulPoints.getCount();
+        return -1;
     }
 
     public CappedValue getSoulPoints() {

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -81,7 +81,10 @@ public final class CharacterStatsModel extends Model {
      * Return the maximum number of soul points the character can currently have
      */
     private int getMaxSoulPoints() {
-        // FIXME: If player is veteran, we should always return 15
+        if (Models.Character.isVeteran()) {
+            return 15;
+        }
+
         int maxIfNotVeteran =
                 10 + MathUtils.clamp(Models.CombatXp.getCombatLevel().current() / 15, 0, 5);
         if (getCurrentSoulPoints() > maxIfNotVeteran) {


### PR DESCRIPTION
![image](https://github.com/Wynntils/Artemis/assets/8337467/026f1735-740b-4ba1-bdec-9961f22ce05c)
![image2](https://github.com/Wynntils/Artemis/assets/8337467/6d0c879c-b684-48c8-a261-da4369ea90df)

Diamond axe is used for a lot of items, so potentially in the future we could detect if the player is in hunted mode and then determine if soul points are a nether star or diamond axe. Also noticed the fixme for veteran soul points so thought I'd add that too, though I can't verify for certain the non champion vet colours