### PR TITLE
feat: Add universal support for encoding byte arrays

### DIFF
--- a/common/src/main/java/com/wynntils/core/encoding/EncodedByteBuffer.java
+++ b/common/src/main/java/com/wynntils/core/encoding/EncodedByteBuffer.java
@@ -4,25 +4,114 @@
  */
 package com.wynntils.core.encoding;
 
-// byte[] <-> UTF-16, Base64, etc.
-public final class EncodedByteBuffer {
-    private byte[] bytes;
+import com.wynntils.utils.type.UnsignedByte;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
 
-    private EncodedByteBuffer(byte[] bytes) {
+/**
+ * A buffer of bytes that can be encoded and decoded to various formats.
+ */
+public final class EncodedByteBuffer {
+    private static final int PRIVATE_USE_AREA_A_START = 0xF0000;
+    private static final int PRIVATE_USE_AREA_B_START = 0x100000;
+
+    private UnsignedByte[] bytes;
+
+    private EncodedByteBuffer(UnsignedByte[] bytes) {
         this.bytes = bytes;
     }
 
-    public static EncodedByteBuffer fromBytes(byte[] bytes) {
+    public static EncodedByteBuffer fromBytes(UnsignedByte[] bytes) {
         return new EncodedByteBuffer(bytes);
     }
 
     public static EncodedByteBuffer fromUtf16String(String string) {
-        // UTF-16 -> byte extraction
-        return null;
+        List<UnsignedByte> bytes = new ArrayList<>();
+
+        int[] codePoints = string.codePoints().toArray();
+
+        for (int codePoint : codePoints) {
+            // Special cases
+            if (codePoint >= PRIVATE_USE_AREA_B_START) {
+                // Single byte
+                int singleByteOffset = PRIVATE_USE_AREA_B_START + (255 << 8);
+                if (codePoint >= singleByteOffset) {
+                    int actualValue = codePoint - singleByteOffset;
+                    bytes.add(UnsignedByte.of((byte) actualValue));
+
+                    assert actualValue <= 255 : "Invalid code point: " + codePoint;
+                    continue;
+                }
+
+                // Two bytes
+                int values = codePoint - PRIVATE_USE_AREA_B_START;
+
+                UnsignedByte firstByte = UnsignedByte.of((byte) 255);
+                UnsignedByte secondByte = UnsignedByte.of((byte) (254 + (values & 0xFF)));
+
+                bytes.add(firstByte);
+                bytes.add(secondByte);
+
+                // Only 0x100000-0x100001 are used
+                assert codePoint < 0x100002 : "Invalid code point: " + codePoint;
+                continue;
+            }
+
+            // Normal case
+            int values = codePoint - PRIVATE_USE_AREA_A_START;
+
+            UnsignedByte firstByte = UnsignedByte.of((byte) (values >> 8));
+            UnsignedByte secondByte = UnsignedByte.of((byte) (values & 0xFF));
+
+            bytes.add(firstByte);
+            bytes.add(secondByte);
+
+            // Only 0xF0000-0xFFFFD are used
+            assert codePoint < 0xFFFFE : "Invalid code point: " + codePoint;
+        }
+
+        return fromBytes(bytes.toArray(new UnsignedByte[0]));
     }
 
     public static EncodedByteBuffer fromBase64String(String string) {
-        // Base64 -> byte extraction
-        return null;
+        byte[] decodedBytes = Base64.getDecoder().decode(string);
+        UnsignedByte[] bytes = UnsignedByte.of(decodedBytes);
+        return fromBytes(bytes);
+    }
+
+    public String toUtf16String() {
+        StringBuilder builder = new StringBuilder(bytes.length / 2 + bytes.length % 2);
+
+        // 2 byte -> UTF-16
+        for (int i = 0; i < bytes.length - 1; i += 2) {
+            int codePoint;
+
+            // 0xFFFE-0xFFFF are using private use area B
+            if (bytes[i].value() == 255 && bytes[i + 1].value() >= 254) {
+                codePoint = PRIVATE_USE_AREA_B_START + (bytes[i + 1].value() - 254);
+            } else {
+                codePoint = PRIVATE_USE_AREA_A_START + (bytes[i].value() << 8 | bytes[i + 1].value());
+            }
+
+            builder.appendCodePoint(codePoint);
+        }
+
+        // Handle leftover byte
+        if (bytes.length % 2 == 1) {
+            // Odd number of bytes, so we add a padding character
+            builder.appendCodePoint(PRIVATE_USE_AREA_B_START + (255 << 8) + bytes[bytes.length - 1].value());
+        }
+
+        return builder.toString();
+    }
+
+    public String toBase64String() {
+        byte[] bytes = UnsignedByte.toPrimitive(this.bytes);
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    public UnsignedByte[] getBytes() {
+        return bytes;
     }
 }

--- a/common/src/main/java/com/wynntils/models/gear/encoding/GearEncoder.java
+++ b/common/src/main/java/com/wynntils/models/gear/encoding/GearEncoder.java
@@ -4,9 +4,11 @@
  */
 package com.wynntils.models.gear.encoding;
 
+import com.wynntils.utils.EncodedByteBuffer;
+
 /**
  * This class is responsible for encoding gear data into a byte array,
  * which can be used further encode the gear into a string
- * using {@link com.wynntils.core.encoding.EncodedByteBuffer}.
+ * using {@link EncodedByteBuffer}.
  */
 public class GearEncoder {}

--- a/common/src/main/java/com/wynntils/utils/EncodedByteBuffer.java
+++ b/common/src/main/java/com/wynntils/utils/EncodedByteBuffer.java
@@ -2,7 +2,7 @@
  * Copyright © Wynntils 2023.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
-package com.wynntils.core.encoding;
+package com.wynntils.utils;
 
 import com.wynntils.utils.type.UnsignedByte;
 import java.util.ArrayList;

--- a/common/src/main/java/com/wynntils/utils/type/UnsignedByte.java
+++ b/common/src/main/java/com/wynntils/utils/type/UnsignedByte.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.type;
+
+import java.util.Objects;
+
+public final class UnsignedByte {
+    private final short value;
+
+    private UnsignedByte(byte value) {
+        this.value = (short) (value & 0xFF);
+    }
+
+    public static UnsignedByte of(byte value) {
+        return new UnsignedByte(value);
+    }
+
+    public static UnsignedByte[] of(byte[] values) {
+        UnsignedByte[] result = new UnsignedByte[values.length];
+
+        for (int i = 0; i < values.length; i++) {
+            result[i] = of(values[i]);
+        }
+
+        return result;
+    }
+
+    public static byte[] toPrimitive(UnsignedByte[] values) {
+        byte[] result = new byte[values.length];
+
+        for (int i = 0; i < values.length; i++) {
+            // Convert unsigned bytes to signed bytes
+            result[i] = (byte) values[i].value();
+        }
+
+        return result;
+    }
+
+    public static short[] asShort(UnsignedByte[] values) {
+        short[] result = new short[values.length];
+
+        for (int i = 0; i < values.length; i++) {
+            // Convert unsigned bytes to signed bytes
+            result[i] = values[i].value();
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns the value of this {@link UnsignedByte} as an int.
+     * @return the value of this {@link UnsignedByte} as an int, in the range 0 to 255
+     */
+    public short value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UnsignedByte that = (UnsignedByte) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "UnsignedByte{" + value + '}';
+    }
+}

--- a/fabric/src/test/java/TestEncodedByteBuffer.java
+++ b/fabric/src/test/java/TestEncodedByteBuffer.java
@@ -2,7 +2,7 @@
  * Copyright © Wynntils 2023.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
-import com.wynntils.core.encoding.EncodedByteBuffer;
+import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.type.UnsignedByte;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;

--- a/fabric/src/test/java/TestEncodedByteBuffer.java
+++ b/fabric/src/test/java/TestEncodedByteBuffer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.wynntils.core.encoding.EncodedByteBuffer;
+import com.wynntils.utils.type.UnsignedByte;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestEncodedByteBuffer {
+    @BeforeAll
+    public static void setup() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    public void simpleByteArray_toUtf16Works() {
+        UnsignedByte[] bytes = UnsignedByte.of(new byte[] {(byte) 214, 121, 11, 49, 43, 75});
+
+        String result = EncodedByteBuffer.fromBytes(bytes).toUtf16String();
+
+        // Expected: "\uFD679\uF0B31\uF2B4B"
+        final String expected = Character.toString(0xFD679) + Character.toString(0xF0B31) + Character.toString(0xF2B4B);
+
+        Assertions.assertEquals(expected, result, "toUtf16String() did not return the correct string");
+    }
+
+    @Test
+    public void highBytes_toUtf16Works() {
+        UnsignedByte[] bytes = UnsignedByte.of(
+                new byte[] {(byte) 255, (byte) 254, (byte) 255, (byte) 255, 0, (byte) 255, (byte) 255, 0});
+
+        String result = EncodedByteBuffer.fromBytes(bytes).toUtf16String();
+
+        // Expected: "\u100000\u100001\uF00FF\uFFF00"
+        final String expected = Character.toString(0x100000)
+                + Character.toString(0x100001)
+                + Character.toString(0xF00FF)
+                + Character.toString(0xFFF00);
+
+        Assertions.assertEquals(expected, result, "toUtf16String() did not return the correct string");
+    }
+
+    @Test
+    public void paddingByte_toUtf16Works() {
+        UnsignedByte[] bytes = UnsignedByte.of(new byte[] {(byte) 255, (byte) 254, (byte) 255, (byte) 255, 2});
+
+        String result = EncodedByteBuffer.fromBytes(bytes).toUtf16String();
+
+        // Expected: "\u100000\u100001\u10FF02"
+        final String expected =
+                Character.toString(0x100000) + Character.toString(0x100001) + Character.toString(0x10FF02);
+
+        Assertions.assertEquals(expected, result, "toUtf16String() did not return the correct string");
+    }
+
+    @Test
+    public void simpleDecoding_fromUtf16Works() {
+        String string = Character.toString(0xFD239) + Character.toString(0xF0F51) + Character.toString(0xFDD5B);
+
+        UnsignedByte[] result = EncodedByteBuffer.fromUtf16String(string).getBytes();
+
+        UnsignedByte[] expected = UnsignedByte.of(new byte[] {(byte) 210, 57, 15, 81, (byte) 221, 91});
+
+        Assertions.assertArrayEquals(expected, result, "fromUtf16String() did not return the correct byte array");
+    }
+
+    @Test
+    public void highBytes_fromUtf16Works() {
+        String string = Character.toString(0x100000) + Character.toString(0x100001) + Character.toString(0xF00FF);
+
+        UnsignedByte[] result = EncodedByteBuffer.fromUtf16String(string).getBytes();
+
+        UnsignedByte[] expected =
+                UnsignedByte.of(new byte[] {(byte) 255, (byte) 254, (byte) 255, (byte) 255, 0, (byte) 255});
+
+        Assertions.assertArrayEquals(expected, result, "fromUtf16String() did not return the correct byte array");
+    }
+
+    @Test
+    public void padding_fromUtf16Works() {
+        String string = Character.toString(0x100000) + Character.toString(0x100001) + Character.toString(0x10FF02);
+
+        UnsignedByte[] result = EncodedByteBuffer.fromUtf16String(string).getBytes();
+
+        UnsignedByte[] expected = UnsignedByte.of(new byte[] {(byte) 255, (byte) 254, (byte) 255, (byte) 255, 2});
+
+        Assertions.assertArrayEquals(expected, result, "fromUtf16String() did not return the correct byte array");
+    }
+}

--- a/fabric/src/test/java/TestUnsignedByte.java
+++ b/fabric/src/test/java/TestUnsignedByte.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.wynntils.utils.type.UnsignedByte;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestUnsignedByte {
+    @BeforeAll
+    public static void setup() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    public void simpleByteArray_toUnsignedByteWorks() {
+        UnsignedByte[] bytes = UnsignedByte.of(new byte[] {(byte) 214, 121, 11, 49, 43, 75});
+
+        short[] result = UnsignedByte.asShort(bytes);
+
+        final short[] expected = {214, 121, 11, 49, 43, 75};
+
+        Assertions.assertArrayEquals(expected, result, "toUnsignedByte() did not return the correct string");
+    }
+
+    @Test
+    public void simpleByteArray_toPrimitiveWorks() {
+        UnsignedByte[] bytes = UnsignedByte.of(new byte[] {(byte) 214, 121, 11, 49, 43, 75});
+
+        byte[] result = UnsignedByte.toPrimitive(bytes);
+
+        final byte[] expected = {(byte) 214, 121, 11, 49, 43, 75};
+
+        Assertions.assertArrayEquals(expected, result, "toPrimitive() did not return the correct string");
+    }
+}


### PR DESCRIPTION
EncodedByteBuffer is can be used for encoding and kind of byte[] data into formats like UTF-16 and base64. This is used as the base for the new gear chat encoding.