### PR TITLE
fix: Fix chat items not displaying "static" stats

### DIFF
--- a/common/src/main/java/com/wynntils/models/gear/GearChatEncoding.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearChatEncoding.java
@@ -156,7 +156,12 @@ public class GearChatEncoding {
         for (StatType statType : sortedStats) {
             StatPossibleValues possibleValues = gearInfo.getPossibleValues(statType);
 
-            if (possibleValues.isPreIdentified()) continue;
+            // Pre-identified stats are not encoded, but need to be added
+            if (possibleValues.isPreIdentified()) {
+                identifications.add(
+                        Models.Stat.buildActualValue(statType, possibleValues.baseValue(), 0, possibleValues));
+                continue;
+            }
 
             if (counter >= ids.length) return null; // some kind of mismatch, abort
 


### PR DESCRIPTION
The problem was introduced when migrating to V3 API, since the API doesn't only differentiate between pre-identified items and non-pre-identified items, but we can also tell the difference between pre-identified and non-pre-identified stats. That meant that we skipped encoding those "static" values in the chat encoding, but we never added them back when decoding.

Sharing items with static stats did not work before, so I won't try to fix it here, with backwards compatibility (sharing items is still backwards compatible, but won't display static stats). The shared items should now display correctly on new clients, while the new system is being worked on.