### PR TITLE
fix: Fix item screenshots not accounting for a component's style properly

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
@@ -98,7 +98,7 @@ public class ItemScreenshotFeature extends Feature {
         // width calculation
         int width = 0;
         for (Component c : tooltip) {
-            int w = font.width(c.getString());
+            int w = font.width(c);
             if (w > width) {
                 width = w;
             }


### PR DESCRIPTION
(Obviously fake items, were used, to test this).

Before:
![2023-12-09_20 17 15-Pickpocket's_Tome_of_Lootrun_Mastery](https://github.com/Wynntils/Artemis/assets/49001742/6df15c1b-cbc0-4e0d-bb8b-780114b8d2a8)

After:
![2023-12-09_20 19 09-Pickpocket's_Tome_of_Lootrun_Mastery](https://github.com/Wynntils/Artemis/assets/49001742/d07757c4-0163-44b9-967f-597983343e16)
