### PR TITLE
refactor: Treat SkillStatType as a regular stat

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/tooltip/gear/GearTooltipHeader.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/gear/GearTooltipHeader.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Style;
 
 public final class GearTooltipHeader {
     public static List<Component> buildTooltip(GearInfo gearInfo, GearInstance gearInstance, boolean hideUnidentified) {
@@ -116,30 +115,7 @@ public final class GearTooltipHeader {
             header.add(Component.literal(""));
         }
 
-        // skill bonuses
-        List<Pair<Skill, Integer>> skillBonuses = gearInfo.fixedStats().skillBonuses();
-        if (!skillBonuses.isEmpty()) {
-            for (Skill skill : Models.Element.getGearSkillOrder()) {
-                int skillBonusValue = gearInfo.fixedStats().getSkillBonus(skill);
-                if (skillBonusValue == 0) continue;
-
-                Component line = buildSkillBonusLine(skill, skillBonusValue);
-                header.add(line);
-            }
-            header.add(Component.literal(""));
-        }
-
         return header;
-    }
-
-    private static Component buildSkillBonusLine(Skill skill, int value) {
-        boolean isGood = (value > 0);
-
-        MutableComponent skillBonusLine = Component.literal(StringUtils.toSignedString(value))
-                .withStyle(Style.EMPTY.withColor(isGood ? ChatFormatting.GREEN : ChatFormatting.RED));
-        skillBonusLine.append(Component.literal(" " + skill.getDisplayName()).withStyle(ChatFormatting.GRAY));
-
-        return skillBonusLine;
     }
 
     private static MutableComponent buildRequirementLine(String requirementName, boolean fulfilled) {

--- a/common/src/main/java/com/wynntils/models/rewards/TomeInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/rewards/TomeInfoRegistry.java
@@ -14,7 +14,6 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.net.Download;
 import com.wynntils.core.net.UrlId;
-import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearDropRestrictions;
 import com.wynntils.models.gear.type.GearMetaInfo;
 import com.wynntils.models.gear.type.GearRestrictions;
@@ -115,11 +114,10 @@ public class TomeInfoRegistry {
             TomeRequirements requirements = parseTomeRequirements(json);
 
             JsonObject identifications = JsonUtils.getNullableJsonObject(json, "identifications");
-            List<Pair<Skill, Integer>> skillBonuses = parseSkillBonuses(identifications);
 
             List<Pair<StatType, StatPossibleValues>> variableStats = parseVariableStats(json);
 
-            return new TomeInfo(displayName, type, variant, tier, metaInfo, requirements, skillBonuses, variableStats);
+            return new TomeInfo(displayName, type, variant, tier, metaInfo, requirements, variableStats);
         }
 
         private GearMetaInfo parseMetaInfo(JsonObject json, String name, String apiName, TomeType type) {

--- a/common/src/main/java/com/wynntils/models/rewards/type/TomeInfo.java
+++ b/common/src/main/java/com/wynntils/models/rewards/type/TomeInfo.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.models.rewards.type;
 
-import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearMetaInfo;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.rewards.TomeType;
@@ -22,7 +21,6 @@ public record TomeInfo(
         GearTier tier,
         GearMetaInfo metaInfo,
         TomeRequirements requirements,
-        List<Pair<Skill, Integer>> skillBonuses,
         List<Pair<StatType, StatPossibleValues>> variableStats) {
     public StatPossibleValues getPossibleValues(StatType statType) {
         return this.variableStats().stream()

--- a/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
@@ -8,6 +8,7 @@ import com.wynntils.models.stats.builders.MiscStatKind;
 import com.wynntils.models.stats.type.DamageStatType;
 import com.wynntils.models.stats.type.DefenceStatType;
 import com.wynntils.models.stats.type.MiscStatType;
+import com.wynntils.models.stats.type.SkillStatType;
 import com.wynntils.models.stats.type.SpellStatType;
 import com.wynntils.models.stats.type.StatListDelimiter;
 import com.wynntils.models.stats.type.StatListOrdering;
@@ -151,20 +152,22 @@ public final class StatListOrderer {
             MiscStatKind.LOOT_QUALITY);
 
     public static Map<StatListOrdering, List<StatType>> createOrderingMap(
+            List<SkillStatType> skillStats,
             List<MiscStatType> miscStats,
             List<DefenceStatType> defenceStats,
             List<DamageStatType> damageStats,
             List<SpellStatType> spellStats) {
         return Map.of(
                 StatListOrdering.DEFAULT,
-                createDefaultOrdering(miscStats, defenceStats, damageStats, spellStats),
+                createDefaultOrdering(skillStats, miscStats, defenceStats, damageStats, spellStats),
                 StatListOrdering.WYNNCRAFT,
-                createWynncraftOrdering(miscStats, defenceStats, damageStats, spellStats),
+                createWynncraftOrdering(skillStats, miscStats, defenceStats, damageStats, spellStats),
                 StatListOrdering.LEGACY,
-                createLegacyOrdering(miscStats, defenceStats, damageStats, spellStats));
+                createLegacyOrdering(skillStats, miscStats, defenceStats, damageStats, spellStats));
     }
 
     private static List<StatType> createDefaultOrdering(
+            List<SkillStatType> skillStats,
             List<MiscStatType> miscStats,
             List<DefenceStatType> defenceStats,
             List<DamageStatType> damageStats,
@@ -172,6 +175,8 @@ public final class StatListOrderer {
         List<StatType> defaultOrdering = new ArrayList<>();
 
         // Default ordering is a lightly curated version of the Wynncraft vanilla ordering
+        defaultOrdering.addAll(skillStats);
+        defaultOrdering.add(new StatListDelimiter());
         defaultOrdering.addAll(miscStats);
         defaultOrdering.add(new StatListDelimiter());
         defaultOrdering.addAll(defenceStats);
@@ -183,6 +188,7 @@ public final class StatListOrderer {
     }
 
     private static List<StatType> createWynncraftOrdering(
+            List<SkillStatType> skillStats,
             List<MiscStatType> miscStats,
             List<DefenceStatType> defenceStats,
             List<DamageStatType> damageStats,
@@ -190,6 +196,8 @@ public final class StatListOrderer {
         List<StatType> wynncraftOrdering = new ArrayList<>();
 
         // Wynncraft order seem to have grown a bit haphazardly
+        wynncraftOrdering.addAll(skillStats);
+        wynncraftOrdering.add(new StatListDelimiter());
         addMiscStats(wynncraftOrdering, miscStats, WYNNCRAFT_MISC_ORDER_1);
         wynncraftOrdering.add(new StatListDelimiter());
         wynncraftOrdering.addAll(damageStats);
@@ -226,11 +234,13 @@ public final class StatListOrderer {
     }
 
     private static List<StatType> createLegacyOrdering(
+            List<SkillStatType> skillStats,
             List<MiscStatType> miscStats,
             List<DefenceStatType> defenceStats,
             List<DamageStatType> damageStats,
             List<SpellStatType> spellStats) {
         List<StatType> allStats = new ArrayList<>();
+        allStats.addAll(skillStats);
         allStats.addAll(miscStats);
         allStats.addAll(defenceStats);
         allStats.addAll(damageStats);

--- a/common/src/main/java/com/wynntils/models/stats/StatModel.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatModel.java
@@ -35,25 +35,22 @@ public final class StatModel extends Model {
     private final List<StatType> statTypeRegistry = new ArrayList<>();
     private final StatLookupTable statTypeLookup = new StatLookupTable();
     private final Map<StatListOrdering, List<StatType>> orderingLists;
-    private final List<SkillStatType> skillStats;
 
     public StatModel() {
         super(List.of());
 
         // First build stats of all kinds
+        List<SkillStatType> skillStats = buildStats(new SkillStatBuilder());
         List<MiscStatType> miscStats = buildStats(new MiscStatBuilder());
         List<DefenceStatType> defenceStats = buildStats(new DefenceStatBuilder());
         List<DamageStatType> damageStats = buildStats(new DamageStatBuilder());
         List<SpellStatType> spellStats = buildStats(new SpellStatBuilder());
 
-        // Skill stats is special, they are not variable for gear
-        skillStats = buildStats(new SkillStatBuilder());
-
         // Then put them all in the registry
-        initRegistry(miscStats, defenceStats, damageStats, spellStats);
+        initRegistry(skillStats, miscStats, defenceStats, damageStats, spellStats);
 
         // Finally create ordered lists for sorting
-        orderingLists = StatListOrderer.createOrderingMap(miscStats, defenceStats, damageStats, spellStats);
+        orderingLists = StatListOrderer.createOrderingMap(skillStats, miscStats, defenceStats, damageStats, spellStats);
     }
 
     public StatActualValue buildActualValue(
@@ -73,19 +70,11 @@ public final class StatModel extends Model {
             if (statType.getInternalRollName().equals(id)) return statType;
         }
 
-        for (StatType statType : skillStats) {
-            if (statType.getInternalRollName().equals(id)) return statType;
-        }
-
         return null;
     }
 
     public StatType fromApiRollId(String id) {
         for (StatType statType : statTypeRegistry) {
-            if (statType.getApiName().equals(id)) return statType;
-        }
-
-        for (StatType statType : skillStats) {
             if (statType.getApiName().equals(id)) return statType;
         }
 
@@ -129,10 +118,12 @@ public final class StatModel extends Model {
     }
 
     private void initRegistry(
+            List<SkillStatType> skillStats,
             List<MiscStatType> miscStats,
             List<DefenceStatType> defenceStats,
             List<DamageStatType> damageStats,
             List<SpellStatType> spellStats) {
+        statTypeRegistry.addAll(skillStats);
         statTypeRegistry.addAll(miscStats);
         statTypeRegistry.addAll(defenceStats);
         statTypeRegistry.addAll(damageStats);

--- a/common/src/main/java/com/wynntils/models/stats/type/FixedStats.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/FixedStats.java
@@ -5,7 +5,6 @@
 package com.wynntils.models.stats.type;
 
 import com.wynntils.models.elements.type.Element;
-import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearAttackSpeed;
 import com.wynntils.models.gear.type.GearMajorId;
 import com.wynntils.utils.type.Pair;
@@ -15,18 +14,7 @@ import java.util.Optional;
 
 public record FixedStats(
         int healthBuff,
-        List<Pair<Skill, Integer>> skillBonuses,
         Optional<GearAttackSpeed> attackSpeed,
         Optional<GearMajorId> majorIds,
         List<Pair<DamageType, RangedValue>> damages,
-        List<Pair<Element, Integer>> defences) {
-    public int getSkillBonus(Skill skill) {
-        for (Pair<Skill, Integer> skillBonusValue : skillBonuses) {
-            if (skillBonusValue.key() == skill) {
-                return skillBonusValue.value();
-            }
-        }
-
-        return 0;
-    }
-}
+        List<Pair<Element, Integer>> defences) {}

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -10,7 +10,6 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.elements.type.Powder;
-import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.stats.StatCalculator;
@@ -192,9 +191,6 @@ public final class WynnItemParser {
 
                 StatType statType = Models.Stat.fromDisplayName(statDisplayName, unit);
                 if (statType == null) {
-                    // Skill bonuses looks like stats when parsing, ignore them
-                    if (Skill.isSkill(statDisplayName)) continue;
-
                     WynntilsMod.warn(
                             "Item " + itemStack.getHoverName() + " has unknown identified stat " + statDisplayName);
                     continue;

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillStatProvider.java
@@ -6,9 +6,10 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.items.WynnItem;
-import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import com.wynntils.models.stats.type.SkillStatType;
+import com.wynntils.models.stats.type.StatActualValue;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
-import com.wynntils.utils.type.Pair;
 import java.util.List;
 
 public class SkillStatProvider extends ItemStatProvider<Integer> {
@@ -30,11 +31,11 @@ public class SkillStatProvider extends ItemStatProvider<Integer> {
 
     @Override
     public List<Integer> getValue(WynnItem wynnItem) {
-        if (!(wynnItem instanceof GearItem gearItem)) return List.of();
+        if (!(wynnItem instanceof IdentifiableItemProperty identifiableItemProperty)) return List.of();
 
-        return gearItem.getGearInfo().fixedStats().skillBonuses().stream()
-                .filter(pair -> pair.key() == skill)
-                .map(Pair::value)
+        return identifiableItemProperty.getIdentifications().stream()
+                .filter(id -> id.statType() instanceof SkillStatType)
+                .map(StatActualValue::value)
                 .toList();
     }
 }


### PR DESCRIPTION
This refactor is not only needed for the gear encoding, I think it makes a lot of sense. I can see why skills were handled specially, as a fixed stat, but I think it is really obvious from this PR that it needed too much special handling, for no real benefit. Now that the V3 API makes it easy to tell the difference between "pre-identified" and not "pre-identified" stats, we can move skill stats back to every other stat. (Legacy API only had a difference between "pre-identified" items)