### PR TITLE
feat: allows packs to be applied on top of wynn

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/AutoApplyResourcePackFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/AutoApplyResourcePackFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.mc.event.PackGetFixedPositionEvent;
 import com.wynntils.mc.event.ResourcePackEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -27,5 +28,10 @@ public class AutoApplyResourcePackFeature extends Feature {
             // Use this resource pack as our preloaded pack
             Services.ResourcePack.setRequestedPreloadHash(packHash);
         }
+    }
+
+    @SubscribeEvent
+    public void onResourcePackFixedPosition(PackGetFixedPositionEvent event) {
+        if (event.getPack().getId().equals("server")) event.setFixedPosition(false);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/PackGetFixedPositionEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PackGetFixedPositionEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraftforge.eventbus.api.Event;
+
+public class PackGetFixedPositionEvent extends Event {
+    private final Pack pack;
+    private boolean fixedPosition;
+
+    public PackGetFixedPositionEvent(Pack pack, boolean fixedPosition) {
+        this.pack = pack;
+        this.fixedPosition = fixedPosition;
+    }
+
+    public Pack getPack() {
+        return pack;
+    }
+
+    public boolean isFixedPosition() {
+        return fixedPosition;
+    }
+
+    public void setFixedPosition(boolean fixedPosition) {
+        this.fixedPosition = fixedPosition;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/PackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/PackMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Managers;
+import com.wynntils.core.consumers.features.FeatureManager;
+import com.wynntils.core.events.MixinHelper;
+import com.wynntils.features.utilities.AutoApplyResourcePackFeature;
+import com.wynntils.utils.mc.McUtils;
+import net.minecraft.server.packs.repository.Pack;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Pack.class)
+public abstract class PackMixin {
+    @Shadow
+    public abstract String getId();
+
+    @Shadow @Final private boolean fixedPosition;
+
+    @Redirect(method = "*",at = @At(target="Lnet/minecraft/server/packs/repository/Pack;fixedPosition:Z",value = "FIELD",opcode = Opcodes.GETFIELD))
+    private boolean onGetFixedPosition(Pack pack){
+        boolean enabled = Managers.Feature.getFeatureInstance(AutoApplyResourcePackFeature.class).isEnabled();
+        if(enabled){
+            if(pack.getId().equals("server")){
+                return false;
+            }
+        }
+        return this.fixedPosition;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/PackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/PackMixin.java
@@ -4,19 +4,14 @@
  */
 package com.wynntils.mc.mixin;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
-import com.wynntils.core.consumers.features.FeatureManager;
-import com.wynntils.core.events.MixinHelper;
 import com.wynntils.features.utilities.AutoApplyResourcePackFeature;
-import com.wynntils.utils.mc.McUtils;
 import net.minecraft.server.packs.repository.Pack;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Pack.class)
@@ -24,13 +19,22 @@ public abstract class PackMixin {
     @Shadow
     public abstract String getId();
 
-    @Shadow @Final private boolean fixedPosition;
+    @Shadow
+    @Final
+    private boolean fixedPosition;
 
-    @Redirect(method = "*",at = @At(target="Lnet/minecraft/server/packs/repository/Pack;fixedPosition:Z",value = "FIELD",opcode = Opcodes.GETFIELD))
-    private boolean onGetFixedPosition(Pack pack){
-        boolean enabled = Managers.Feature.getFeatureInstance(AutoApplyResourcePackFeature.class).isEnabled();
-        if(enabled){
-            if(pack.getId().equals("server")){
+    @Redirect(
+            method = "*",
+            at =
+                    @At(
+                            target = "Lnet/minecraft/server/packs/repository/Pack;fixedPosition:Z",
+                            value = "FIELD",
+                            opcode = Opcodes.GETFIELD))
+    private boolean onGetFixedPosition(Pack pack) {
+        boolean enabled = Managers.Feature.getFeatureInstance(AutoApplyResourcePackFeature.class)
+                .isEnabled();
+        if (enabled) {
+            if (pack.getId().equals("server")) {
                 return false;
             }
         }

--- a/common/src/main/java/com/wynntils/mc/mixin/PackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/PackMixin.java
@@ -4,8 +4,8 @@
  */
 package com.wynntils.mc.mixin;
 
-import com.wynntils.core.components.Managers;
-import com.wynntils.features.utilities.AutoApplyResourcePackFeature;
+import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.PackGetFixedPositionEvent;
 import net.minecraft.server.packs.repository.Pack;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
@@ -31,13 +31,8 @@ public abstract class PackMixin {
                             value = "FIELD",
                             opcode = Opcodes.GETFIELD))
     private boolean onGetFixedPosition(Pack pack) {
-        boolean enabled = Managers.Feature.getFeatureInstance(AutoApplyResourcePackFeature.class)
-                .isEnabled();
-        if (enabled) {
-            if (pack.getId().equals("server")) {
-                return false;
-            }
-        }
-        return this.fixedPosition;
+        PackGetFixedPositionEvent event = new PackGetFixedPositionEvent(pack, this.fixedPosition);
+        MixinHelper.postAlways(event);
+        return event.isFixedPosition();
     }
 }

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -47,7 +47,8 @@
     "accessors.ItemStackInfoAccessor",
     "accessors.LerpingBossEventAccessor",
     "accessors.MinecraftAccessor",
-    "accessors.OptionsAccessor"
+    "accessors.OptionsAccessor",
+    "PackMixin"
   ],
   "compatibilityLevel": "JAVA_17",
   "injectors": {


### PR DESCRIPTION
part 1/2 for #1791 
allows packs to be applied on top of wynncraft textures.
 "Using Wynntils auto-apply RPs, it would apply them on top of the wynntils one, which is not even possible using other mods currently."

I'm working on part 2/2 to actually auto apply resource packs.