### PR TITLE
chore: Add framework for unit testing of regexes

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/AbilityTreeAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/AbilityTreeAnnotator.java
@@ -20,7 +20,7 @@ public final class AbilityTreeAnnotator implements ItemAnnotator {
 
     // Deals with the reset button in the ability tree screen
     private static final StyledText TREE_ABILITY_POINTS_NAME = StyledText.fromString("§3§lAbility Points");
-    // Test suite: https://regexr.com/7h12b
+    // Test method: AbilityTreeAnnotator_TREE_ABILITY_POINTS_PATTERN
     private static final Pattern TREE_ABILITY_POINTS_PATTERN =
             Pattern.compile("^§b✦ Available Points: §f(\\d+)§7/\\d+$");
 

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © Wynntils 2023.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
+import java.lang.reflect.Field;
+import java.util.regex.Pattern;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestRegex {
+    @BeforeAll
+    public static void setup() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    public static final class PatternTester {
+        private final Class<?> clazz;
+        private final String fieldName;
+        private final Pattern pattern;
+
+        public PatternTester(Class<?> clazz, String fieldName) {
+            this.clazz = clazz;
+            this.fieldName = fieldName;
+            Pattern pattern = null;
+
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                pattern = (Pattern) field.get(null);
+            } catch (NoSuchFieldException e) {
+                Assertions.fail("Pattern field " + clazz.getSimpleName() + "." + fieldName + " does not exist");
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+            this.pattern = pattern;
+        }
+
+        public void shouldMatch(String s) {
+            Assertions.assertTrue(
+                    pattern.matcher(s).matches(),
+                    "Regex failure: " + clazz.getSimpleName() + "." + fieldName + " should have matched " + s
+                            + ", but it did not.");
+        }
+
+        public void shouldNotMatch(String s) {
+            Assertions.assertFalse(
+                    pattern.matcher(s).matches(),
+                    "Regex failure: " + clazz.getSimpleName() + "." + fieldName + " should NOT have matched " + s
+                            + ", but it did.");
+        }
+    }
+
+    @Test
+    public void AbilityTreeAnnotator_TREE_ABILITY_POINTS_PATTERN() {
+        PatternTester p = new PatternTester(AbilityTreeAnnotator.class, "TREE_ABILITY_POINTS_PATTERN");
+        p.shouldMatch("§b✦ Available Points: §f0§7/45");
+    }
+}


### PR DESCRIPTION
I've been thinking about this for a long time, to have a simple way to store our regex test strings in the code base, and run them as unit tests. 

Here is a framework for doing that, and one test converted from regexr.com. Once this gets integrated, it's a bit of a copy/paste chore to move the remaining tests from regexr.com into the code base. Maybe we have some willing interns that could take that upon themselves? :-)