### PR TITLE
chore: Move all regex testing from regexr.com to unit tests

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/GuildRankReplacementFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/GuildRankReplacementFeature.java
@@ -33,11 +33,11 @@ public class GuildRankReplacementFeature extends Feature {
     @Persisted
     public final Config<RankType> rankType = new Config<>(RankType.NAME);
 
-    // Test suite: https://regexr.com/7f8kh
+    // Test in GuildRankReplacementFeature_GUILD_MESSAGE_PATTERN
     private static final Pattern GUILD_MESSAGE_PATTERN =
             Pattern.compile("§3\\[(?:§b)?★{0,5}(?:§3)?(?:§o)?.{1,16}(?:§r)?(?:§3)?\\]§b");
 
-    // Test suite: https://regexr.com/7e66m
+    // Test in GuildRankReplacementFeature_RECRUIT_USERNAME_PATTERN
     private static final Pattern RECRUIT_USERNAME_PATTERN = Pattern.compile("§3\\[(.{1,16})");
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
@@ -46,11 +46,10 @@ public class MessageFilterFeature extends Feature {
                     Pattern.compile("^§8\\[§7!§8\\] §7Congratulations to (§r)?.* for reaching (combat )?§flevel .*!$"),
                     Pattern.compile("^(§8)?\\[!\\] Congratulations to (§r)?.* for reaching (combat )?§7level .*!$")));
 
-    // Test suite: https://regexr.com/7j9u6
-    private static final List<Pair<Pattern, Pattern>> PARTY_FINDER = List.of(Pair.of(
-            Pattern.compile(
-                    "^§5Party Finder:§d Hey [\\w ]{1,20}, over here! Join the [a-zA-Z'§ ]+ queue and match up with §e\\d{1,2} other players?§d!$"),
-            null));
+    // Test in MessageFilterFeature_PARTY_FINDER
+    private static final Pattern PARTY_FINDER_FG = Pattern.compile(
+            "^§5Party Finder:§d Hey [\\w ]{1,20}, over here! Join the [a-zA-Z'§ ]+ queue and match up with §e\\d{1,2} other players?§d!$");
+    private static final List<Pair<Pattern, Pattern>> PARTY_FINDER = List.of(Pair.of(PARTY_FINDER_FG, null));
 
     @Persisted
     public final Config<Boolean> hideWelcome = new Config<>(false);

--- a/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
@@ -531,10 +531,10 @@ public class ChatRedirectFeature extends Feature {
         }
     }
 
-    private class LoginRedirector extends SimpleRedirector {
-        // Test suite: https://regexr.com/7khdo
+    public class LoginRedirector extends SimpleRedirector {
         private static final String RANK_STRING =
                 Arrays.stream(PlayerRank.values()).map(PlayerRank::getTag).collect(Collectors.joining());
+        // Test in ChatRedirectFeature_LoginRedirector_FOREGROUND_PATTERN
         private static final Pattern FOREGROUND_PATTERN = Pattern.compile(
                 "^(?<rank>[" + RANK_STRING + "]) §#[0-9a-f]{6,8}(?:§o)?(?<name>[\\w ]{1,20})§. has just logged in!$");
         private static final Pattern BACKGROUND_PATTERN = Pattern.compile("^(?:§8)?\\[(§.)+\\|?(§.)*(?<rank>["

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceMatchFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceMatchFeature.java
@@ -38,9 +38,9 @@ public class TradeMarketPriceMatchFeature extends Feature {
     private static final StyledText TYPE_SELL_PRICE =
             StyledText.fromString("§6Type the price in emeralds or type 'cancel' to cancel:");
 
-    // Test suite: https://regexr.com/7h631
+    // Test in TradeMarketPriceMatchFeature_HIGHEST_BUY_PATTERN
     private static final Pattern HIGHEST_BUY_PATTERN = Pattern.compile("§7Highest Buy Offer: §a(\\d+)²§8 \\(.+\\)");
-    // Test suite: https://regexr.com/7h62u
+    // Test in TradeMarketPriceMatchFeature_LOWEST_SELL_PATTERN
     private static final Pattern LOWEST_SELL_PATTERN = Pattern.compile("§7Lowest Sell Offer: §a(\\d+)²§8 \\(.+\\)");
 
     private static final int PRICE_SET_ITEM_SLOT = 12;

--- a/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
@@ -35,7 +35,7 @@ public class BulkBuyFeature extends Feature {
     @Persisted
     public final Config<Integer> bulkBuyAmount = new Config<>(4);
 
-    // Test suite: https://regexr.com/7esio
+    // Test in BulkBuyFeature_PRICE_PATTERN
     private static final Pattern PRICE_PATTERN = Pattern.compile("§6 - §(?:c✖|a✔) §f(\\d+)§7²");
     private static final ChatFormatting BULK_BUY_ACTIVE_COLOR = ChatFormatting.GREEN;
     private static final StyledText PRICE_STR = StyledText.fromString("§6Price:");

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class ActionBarHandler extends Handler {
-    // https://regexr.com/7kfrm
+    // Test in ActionBarHandler_ACTIONBAR_PATTERN
     private static final Pattern ACTIONBAR_PATTERN =
             Pattern.compile("(?<LEFT>.+[^ ]) {4,}(?<CENTER>.+[^ ]) {4,}(?<RIGHT>.+)");
     private static final StyledText CENTER_PADDING = StyledText.fromString("§0               ");

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -76,11 +76,11 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
  * importantly, a way to update already printed chat lines.
  */
 public final class ChatHandler extends Handler {
-    // Test suite: https://regexr.com/7esj7
+    // Test in ChatHandler_NPC_CONFIRM_PATTERN
     private static final Pattern NPC_CONFIRM_PATTERN =
             Pattern.compile("^ *§[47]Press §[cf](SNEAK|SHIFT) §[47]to continue$");
 
-    // Test suite: https://regexr.com/7esjd
+    // Test in ChatHandler_NPC_SELECT_PATTERN
     private static final Pattern NPC_SELECT_PATTERN =
             Pattern.compile("^ *§[47cf](Select|CLICK) §[47cf]an option (§[47])?to continue$");
 

--- a/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
@@ -10,13 +10,13 @@ import java.util.regex.Pattern;
 public enum RecipientType {
     INFO(null, null, "Info"),
     CLIENTSIDE(null, null, "Clientside"),
-    // https://regexr.com/7b14s
+    // Test in RecipientType_NPC_foregroundPattern
     NPC("^§7\\[\\d+\\/\\d+\\](?:§.)? ?§[25] ?.+: ?§..*$", "^§8\\[\\d+\\/\\d+\\] .+: ?§..*$", "NPC"),
-    // https://regexr.com/7kbao
+    // Test in RecipientType_GLOBAL_foregroundPattern
     GLOBAL("^§7\uE056\uE042[\uE060-\uE069]{1,3}§r .+", "^(§8)?\uE056\uE042[\uE060-\uE069]{1,3}§r .+", "Global"),
-    // https://regexr.com/7kbac
+    // Test in RecipientType_LOCAL_foregroundPattern
     LOCAL("^§f[-]{1,3}§r .+", "^(§8)?\uE056\uE042[\uE060-\uE069]{1,3}§r .+", "Local"),
-    // https://regexr.com/7f8ma
+    // Test in RecipientType_GUILD_foregroundPattern
     GUILD(
             "^§3\\[(§b)?(★{0,5})?(§3)?(§o)?(?!INFO).+(§3)?](§.)? .+$",
             "^(§8)?\\[(§7)?(★{0,5})?(§8)?(§o)?(?!INFO).+]§7 .+$",

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -44,12 +44,12 @@ public final class CharacterModel extends Model {
     private static final Pattern CLASS_MENU_LEVEL_PATTERN = Pattern.compile("§e- §7Level: §f(\\d+)");
     private static final Pattern INFO_MENU_CLASS_PATTERN = Pattern.compile("§7Class: §f(.+)");
     private static final Pattern INFO_MENU_LEVEL_PATTERN = Pattern.compile("§7Combat Lv: §f(\\d+)");
-    // Test suite: https://regexr.com/7i87d
+    // Test in CharacterModel_SILVERBULL_PATTERN
     private static final Pattern SILVERBULL_PATTERN = Pattern.compile("§7Subscription: §[ac][✖✔] ((?:Ina|A)ctive)");
-    // Test suite: https://regexr.com/7irg0
+    // Test in CharacterModel_SILVERBULL_DURATION_PATTERN
     private static final Pattern SILVERBULL_DURATION_PATTERN = Pattern.compile(
             "§7Expiration: §f(?:(?<weeks>\\d+) weeks?)? ?(?:(?<days>\\d+) days?)? ?(?:(?<hours>\\d+) hours?)?");
-    // Test suite: https://regexr.com/7ntns
+    // Test in CharacterModel_VETERAN_PATTERN
     private static final Pattern VETERAN_PATTERN = Pattern.compile("§7Rank: §[6dba]Vet");
 
     private static final int RANK_SUBSCRIPTION_INFO_SLOT = 0;

--- a/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
@@ -26,7 +26,7 @@ import org.lwjgl.glfw.GLFW;
 public final class CharacterSelectionModel extends Model {
     private static final Pattern NEW_CLASS_ITEM_NAME_PATTERN = Pattern.compile("^§a\\[\\+\\] Create a new character$");
     private static final Pattern CLASS_ITEM_NAME_PATTERN = Pattern.compile("^§6\\[>\\] Select (.+)$");
-    // Test suite: https://regexr.com/7l9ks
+    // Test in CharacterSelectionModel_CLASS_ITEM_CLASS_PATTERN
     private static final Pattern CLASS_ITEM_CLASS_PATTERN = Pattern.compile(
             "§e- §7Class: (§r)?(§c(?:§l)?)?(§r)?(§6(?:§l)?)?(§r)?(§b(?:§l)?)?(§r)?(§3(?:§l)?)?(§r)?(§5(?:§l)?)?(§r)?(\\s)?(§r)?§f(?<name>.+)");
     private static final Pattern CLASS_ITEM_LEVEL_PATTERN = Pattern.compile("§e- §7Level: §f(\\d+)");

--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/CoordinatesSegment.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/CoordinatesSegment.java
@@ -10,7 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CoordinatesSegment implements ActionBarSegment {
-    // https://regexr.com/7kfra
+    // Test in CoordinatesSegment_COORDINATES_PATTERN
     private static final Pattern COORDINATES_PATTERN = Pattern.compile("§7(-?\\d+)§f ([NWSE]{1,2})§7 (-?\\d+)");
 
     private final Runnable onSegmentCleared;

--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/ManaSegment.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/ManaSegment.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ManaSegment implements ActionBarSegment {
-    // https://regexr.com/7kfrp
+    // Test in ManaSegment_MANA_PATTERN
     private static final Pattern MANA_PATTERN = Pattern.compile("(?:§b)?✺ (\\d+)/(\\d+)");
 
     private CappedValue mana = CappedValue.EMPTY;

--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/PowderSpecialSegment.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/PowderSpecialSegment.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class PowderSpecialSegment implements ActionBarSegment {
-    // https://regexr.com/7kfrv
+    // Test in PowderSpecialSegment_POWDER_SPECIAL_PATTERN
     private static final Pattern POWDER_SPECIAL_PATTERN = Pattern.compile("§.([✤✦❉✹❋]) (\\d+)%");
 
     private float powderSpecialCharge = 0;

--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/SprintSegment.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/SprintSegment.java
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SprintSegment implements ActionBarSegment {
-    // https://regexr.com/7k9an
+    // Test in SprintSegment_SPRINT_PATTERN
     private static final Pattern SPRINT_PATTERN = Pattern.compile("§[246]\\[(§.*)§[246]]");
     private static final int MAX_SPRINT = 13;
     private CappedValue sprint = CappedValue.EMPTY;

--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -19,22 +19,22 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
 public final class ContainerModel extends Model {
-    // Test suite: https://regexr.com/7jh15
+    // Test in ContainerModel_ABILITY_TREE_PATTERN
     public static final Pattern ABILITY_TREE_PATTERN =
             Pattern.compile("(?:Warrior|Shaman|Mage|Assassin|Archer) Abilities");
 
-    // Test suite: https://regexr.com/7b4lf
+    // Test in ContainerModel_GUILD_BANK_PATTERN
     private static final Pattern GUILD_BANK_PATTERN =
             Pattern.compile("[a-zA-Z ]+: Bank \\((?:Everyone|High Ranked)\\)");
 
-    // Test suite: https://regexr.com/7jh1e
+    // Test in ContainerModel_LOOT_CHEST_PATTERN
     private static final Pattern LOOT_CHEST_PATTERN = Pattern.compile("Loot Chest (§.)\\[.+\\]");
 
-    // Test suite: https://regexr.com/7hcl7
+    // Test in ContainerModel_PERSONAL_STORAGE_PATTERN
     private static final Pattern PERSONAL_STORAGE_PATTERN =
             Pattern.compile("^§0\\[Pg\\. (\\d+)\\] §8[a-zA-Z0-9_ ]+'s?§0 (.*)$");
 
-    // Test suite: https://regexr.com/7jh0s
+    // Test in ContainerModel_TRADE_MARKET_FILTER_TITLE
     private static final Pattern TRADE_MARKET_FILTER_TITLE = Pattern.compile("\\[Pg\\. \\d] Filter Items");
 
     private static final String ACCOUNT_BANK_NAME = "Account Bank";

--- a/common/src/main/java/com/wynntils/models/damage/DamageModel.java
+++ b/common/src/main/java/com/wynntils/models/damage/DamageModel.java
@@ -23,10 +23,10 @@ import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class DamageModel extends Model {
-    // https://regexr.com/7968a
+    // Test in DamageModel_DAMAGE_LABEL_PATTERN
     private static final Pattern DAMAGE_LABEL_PATTERN = Pattern.compile("(?:§[245bcef](?:§l)?-(\\d+) ([❤✦✤❉❋✹☠]) )");
 
-    // https://regexr.com/7965g
+    // Test in DamageModel_DAMAGE_BAR_PATTERN
     private static final Pattern DAMAGE_BAR_PATTERN = Pattern.compile("^§[ac](.*) - §c(\\d+)§4❤(?: - §7(.*)§7)?$");
 
     private final DamageBar damageBar = new DamageBar();

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class IngredientAnnotator implements ItemAnnotator {
-    // Test suite: https://regexr.com/7co3b
+    // Test in IngredientAnnotator_INGREDIENT_PATTERN
     private static final Pattern INGREDIENT_PATTERN =
             Pattern.compile("^§7(.+?)(?:§[3567])? \\[§([8bde])✫(§8)?✫(§8)?✫§[3567]\\]$");
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/RuneAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/RuneAnnotator.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class RuneAnnotator implements ItemAnnotator {
-    // https://regexr.com/7lhjd
+    // Test in RuneAnnotator_RUNE_PATTERN
     private static final Pattern RUNE_PATTERN = Pattern.compile("§[b432]([A-Z][a-z]{1,2}) Rune");
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/AbilityTreeAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/AbilityTreeAnnotator.java
@@ -20,7 +20,7 @@ public final class AbilityTreeAnnotator implements ItemAnnotator {
 
     // Deals with the reset button in the ability tree screen
     private static final StyledText TREE_ABILITY_POINTS_NAME = StyledText.fromString("§3§lAbility Points");
-    // Test method: AbilityTreeAnnotator_TREE_ABILITY_POINTS_PATTERN
+    // Test in AbilityTreeAnnotator_TREE_ABILITY_POINTS_PATTERN
     private static final Pattern TREE_ABILITY_POINTS_PATTERN =
             Pattern.compile("^§b✦ Available Points: §f(\\d+)§7/\\d+$");
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/ArchetypeAbilitiesAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/ArchetypeAbilitiesAnnotator.java
@@ -15,9 +15,9 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class ArchetypeAbilitiesAnnotator implements ItemAnnotator {
-    // Test suite: https://regexr.com/7h12h
+    // Test in ArchetypeAbilitiesAnnotator_ARCHETYPE_NAME
     private static final Pattern ARCHETYPE_NAME = Pattern.compile("^§([a-r0-9])§l[A-Za-z ]+ Archetype$");
-    // Test suite: https://regexr.com/7h133
+    // Test in ArchetypeAbilitiesAnnotator_ARCHETYPE_PATTERN
     private static final Pattern ARCHETYPE_PATTERN = Pattern.compile("^§a✔ §7Unlocked Abilities: §f(\\d+)§7/(\\d+)$");
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/SkillPointAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/SkillPointAnnotator.java
@@ -15,9 +15,9 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class SkillPointAnnotator implements ItemAnnotator {
-    // Test suite: https://regexr.com/7h0tl
+    // Test in SkillPointAnnotator_SKILL_POINT_PATTERN
     private static final Pattern SKILL_POINT_PATTERN = Pattern.compile("^§dUpgrade your §[2ebcf][✤✦❉✹❋] (.*)§d skill$");
-    // Test suite: https://regexr.com/7h0to
+    // Test in SkillPointAnnotator_LORE_PATTERN
     private static final Pattern LORE_PATTERN = Pattern.compile("^[ À]+§7(-?\\d+) points?§r[ À]+§6-?\\d+ points?$");
 
     @Override

--- a/common/src/main/java/com/wynntils/models/players/FriendsModel.java
+++ b/common/src/main/java/com/wynntils/models/players/FriendsModel.java
@@ -47,15 +47,15 @@ public final class FriendsModel extends Model {
             Pattern.compile("§e(.+) has been removed from your friends!");
     private static final Pattern FRIEND_ADD_MESSAGE_PATTERN = Pattern.compile("§e(.+) has been added to your friends!");
 
-    // https://regexr.com/7ihc9
+    // Test in FriendsModel_ONLINE_FRIENDS_HEADER
     private static final Pattern ONLINE_FRIENDS_HEADER = Pattern.compile("§2Online §aFriends:");
-    // https://regexr.com/7ihcc
+    // Test in FriendsModel_ONLINE_FRIEND
     private static final Pattern ONLINE_FRIEND = Pattern.compile("§2 - §a(\\w{1,16})§2 \\[Server: §aWC(\\d{1,3})§2]");
 
-    // https://regexr.com/7ihci
+    // Test in FriendsModel_JOIN_PATTERN
     private static final Pattern JOIN_PATTERN = Pattern.compile(
             "§a(?<username>\\w{1,16})§2 has logged into server §aWC(?<server>\\d{1,3})§2 as §aan? (?<class>[A-Z][a-z]+)");
-    // https://regexr.com/7ihcl
+    // Test in FriendsModel_LEAVE_PATTERN
     private static final Pattern LEAVE_PATTERN = Pattern.compile("§a(?<username>\\w{1,16}) left the game\\.");
     // endregion
 

--- a/common/src/main/java/com/wynntils/models/players/GuildModel.java
+++ b/common/src/main/java/com/wynntils/models/players/GuildModel.java
@@ -38,22 +38,20 @@ public class GuildModel extends Model {
             .registerTypeHierarchyAdapter(GuildProfile.class, new GuildProfile.GuildProfileDeserializer())
             .create();
 
-    // Test suite: https://regexr.com/7hob9
+    // Test in GuildModel_GUILD_NAME_MATCHER
     private static final Pattern GUILD_NAME_MATCHER = Pattern.compile("§3([a-zA-Z ]*?)§b \\[[a-zA-Z]{3,4}]");
 
-    // Test suite: https://regexr.com/7hobf
-    // Recruiter is intentionally first, otherwise Recruit will incorrectly match first
-    // This applies to all other patterns in this class involving guild ranks
+    // Test in GuildModel_GUILD_RANK_MATCHER
     private static final Pattern GUILD_RANK_MATCHER =
             Pattern.compile("^§7Rank: §f(Recruit|Recruiter|Captain|Strategist|Chief|Owner)$");
 
-    // Test suite: https://regexr.com/7hoae
+    // Test in GuildModel_MSG_LEFT_GUILD
     private static final Pattern MSG_LEFT_GUILD = Pattern.compile("§3You have left §b[a-zA-Z ]*§3!");
 
-    // Test suite: https://regexr.com/7hoah
+    // Test in GuildModel_MSG_JOINED_GUILD
     private static final Pattern MSG_JOINED_GUILD = Pattern.compile("§3You have joined §b([a-zA-Z ]*)§3!");
 
-    // Test suite: https://regexr.com/7hra2
+    // Test in GuildModel_MSG_RANK_CHANGED
     private static final Pattern MSG_RANK_CHANGED = Pattern.compile(
             "^§3\\[INFO]§b [\\w]{1,16} has set ([\\w]{1,16})'s? guild rank from (?:Recruit|Recruiter|Captain|Strategist|Chief|Owner) to (Recruit|Recruiter|Captain|Strategist|Chief|Owner)$");
 

--- a/common/src/main/java/com/wynntils/models/spells/SpellModel.java
+++ b/common/src/main/java/com/wynntils/models/spells/SpellModel.java
@@ -26,9 +26,7 @@ import java.util.regex.Pattern;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class SpellModel extends Model {
-    // If you modify please test with link below
-    // If you pass the tests and it still doesn't work, please resync tests with the game and update the link here
-    // https://regexr.com/76ijo
+    // Test in SpellModel_SPELL_TITLE_PATTERN
     private static final Pattern SPELL_TITLE_PATTERN = Pattern.compile(
             "§a([LR]|Right|Left)§7-§[a7](?:§n)?([LR?]|Right|Left)§7-§r§[a7](?:§n)?([LR?]|Right|Left)§r");
     private static final Pattern SPELL_CAST = Pattern.compile("^§7(.*) spell cast! §3\\[§b-([0-9]+) ✺§3\\]$");

--- a/common/src/main/java/com/wynntils/models/spells/actionbar/SpellSegment.java
+++ b/common/src/main/java/com/wynntils/models/spells/actionbar/SpellSegment.java
@@ -12,7 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SpellSegment implements ActionBarSegment {
-    // https://regexr.com/7kkpu
+    // Test in SpellSegment_SPELL_PATTERN
     private static final Pattern SPELL_PATTERN =
             Pattern.compile("§a([RL])§7-(?:§[a7n])?([RL?])(?:§r)?§7-(?:§[a7n])?([LR?])(?:§r)?");
 

--- a/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
@@ -30,7 +30,6 @@ public final class StatusEffectModel extends Model {
      * Buffs like "17% Frenzy" will have the 17% be considered as part of the prefix.
      * This is because the 17% in Frenzy (and certain other buffs) can change, but the static scroll buffs cannot.
      * <p>
-     * https://regexr.com/7999h
      *
      * <p>Originally taken from: <a href="https://github.com/Wynntils/Wynntils/pull/615">Legacy</a>
      */
@@ -44,6 +43,7 @@ public final class StatusEffectModel extends Model {
      *
      * */
 
+    // Test in StatusEffectModel_STATUS_EFFECT_PATTERN
     private static final Pattern STATUS_EFFECT_PATTERN = Pattern.compile(
             "(?<prefix>.+?)§7\\s?(?<modifier>(\\-|\\+)?([\\-\\.\\d]+))?(?<modifierSuffix>((\\/\\d+s)|%)?)?\\s?(?<name>\\+?['a-zA-Z\\/\\s]+?)\\s(?<timer>§[84a]\\((.+?)\\))");
 

--- a/common/src/main/java/com/wynntils/models/trademarket/TradeMarketModel.java
+++ b/common/src/main/java/com/wynntils/models/trademarket/TradeMarketModel.java
@@ -41,7 +41,7 @@ public class TradeMarketModel extends Model {
     private static final int TRADE_MARKET_PRICE_LINE = 1;
     private static final Pattern PRICE_STR = Pattern.compile("§6Price:");
 
-    // Test suite: https://regexr.com/7lh2b
+    // Test in TradeMarketModel_PRICE_PATTERN
     private static final Pattern PRICE_PATTERN = Pattern.compile(
             "§[67] - (?:§f(?<amount>[\\d,]+) §7x )?§(?:(?:(?:c✖|a✔) §f)|f§m|f)(?<price>[\\d,]+)§7(?:§m)?²(?:§b ✮ (?<silverbullPrice>[\\d,]+)§3²)?(?: .+)?");
 

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -45,40 +45,40 @@ import net.minecraft.world.item.ItemStack;
 public final class WynnItemParser {
     public static final Pattern HEALTH_PATTERN = Pattern.compile("^§4❤ Health: ([+-]\\d+)$");
 
-    // Test suite: https://regexr.com/7pn75
+    // Test in WynnItemParser_ITEM_ATTACK_SPEED_PATTERN
     private static final Pattern ITEM_ATTACK_SPEED_PATTERN = Pattern.compile("^§7(.+) Attack Speed$");
 
-    // Test suite: https://regexr.com/7pm84
+    // Test in WynnItemParser_ITEM_DAMAGE_PATTERN
     private static final Pattern ITEM_DAMAGE_PATTERN =
             Pattern.compile("^§.(?<symbol>[✤✦❉✹❋✣]+) (?<type>.+) Damage: (?<range>(\\d+)-(\\d+))$");
 
-    // Test suite: https://regexr.com/7pm8p
+    // Test in WynnItemParser_ITEM_DEFENCE_PATTERN
     private static final Pattern ITEM_DEFENCE_PATTERN =
             Pattern.compile("^§.(?<symbol>[✤✦❉✹❋]+) (?<type>.+)§7 Defence: (?<value>[+-]?\\d+)$");
 
-    // Test suite: https://regexr.com/7pnj8
+    // Test in WynnItemParser_IDENTIFICATION_STAT_PATTERN
     public static final Pattern IDENTIFICATION_STAT_PATTERN = Pattern.compile(
             "^§[ac]([-+]\\d+)(?:§[24] to §[ac](-?\\d+))?(%| tier|\\/[35]s)?(?:§8\\/([-+]?\\d+)(?:%| tier|\\/[35]s)?)?(?:§2(\\*{1,3}))? ?§7 ?(.*)$");
 
-    // Test suite: https://regexr.com/782rk
+    // Test in WynnItemParser_TIER_AND_REROLL_PATTERN
     private static final Pattern TIER_AND_REROLL_PATTERN = Pattern.compile(
             "^(§fNormal|§eUnique|§dRare|§bLegendary|§cFabled|§5Mythic|§aSet|§3Crafted) ([A-Za-z\\d _]+)(?:§8)?(?: \\[(\\d+)(?:\\/(\\d+) Durability)?\\])?$");
 
-    // Test suite: https://regexr.com/778gk
+    // Test in WynnItemParser_POWDER_PATTERN
     private static final Pattern POWDER_PATTERN =
             Pattern.compile("^§7\\[(\\d+)/(\\d+)\\] Powder Slots(?: \\[§(.*)§7\\])?$");
 
-    // Test suite: https://regexr.com/79atu
+    // Test in WynnItemParser_EFFECT_LINE_PATTERN
     private static final Pattern EFFECT_LINE_PATTERN = Pattern.compile("^§(.)- §7(.*): §f([+-]?\\d+)(?:§.§.)? ?(.*)$");
 
-    // Test suite: https://regexr.com/798o0
+    // Test in WynnItemParser_MIN_LEVEL_PATTERN
     private static final Pattern MIN_LEVEL_PATTERN = Pattern.compile("^§..§7 Combat Lv. Min: (\\d+)$");
 
-    // Test suite: https://regexr.com/7pm87
+    // Test in WynnItemParser_CLASS_REQ_PATTERN
     private static final Pattern CLASS_REQ_PATTERN =
             Pattern.compile("^§(?:c✖|a✔)§7 Class Req: (?<name>.+)\\/(?<skinned>.+)$");
 
-    // Test suite: https://regexr.com/7pm8a
+    // Test in WynnItemParser_SKILL_REQ_PATTERN
     private static final Pattern SKILL_REQ_PATTERN =
             Pattern.compile("^§(?:c✖|a✔)§7 (?<skill>[a-zA-Z]+) Min: (?<value>-?\\d+)$");
 
@@ -88,11 +88,11 @@ public final class WynnItemParser {
 
     public static final Pattern SET_BONUS_PATTEN = Pattern.compile("^§aSet Bonus:$");
 
-    // Test suite: https://regexr.com/7i5h5
+    // Test in WynnItemParser_SHINY_STAT_PATTERN
     public static final Pattern SHINY_STAT_PATTERN = Pattern.compile("^§f⬡ §7([a-zA-Z ]+): §f(\\d+)$");
 
     // Crafted items
-    // Test suite: https://regexr.com/7pm7o
+    // Test in WynnItemParser_CRAFTED_ITEM_NAME_PATTERN
     private static final Pattern CRAFTED_ITEM_NAME_PATTERN = Pattern.compile("^§3§o(.+)§b§o \\[(\\d+)%\\]À*$");
     private static final Pattern CRAFTED_CONSUMABLE_TYPE_PATTERN = Pattern.compile("^§3Crafted (.+)$");
 

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -2,6 +2,8 @@
  * Copyright © Wynntils 2023.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.features.chat.GuildRankReplacementFeature;
+import com.wynntils.features.chat.MessageFilterFeature;
 import com.wynntils.features.redirects.ChatRedirectFeature;
 import com.wynntils.features.ui.BulkBuyFeature;
 import com.wynntils.handlers.actionbar.ActionBarHandler;
@@ -9,8 +11,11 @@ import com.wynntils.handlers.chat.ChatHandler;
 import com.wynntils.models.character.CharacterModel;
 import com.wynntils.models.character.CharacterSelectionModel;
 import com.wynntils.models.characterstats.actionbar.CoordinatesSegment;
+import com.wynntils.models.characterstats.actionbar.ManaSegment;
+import com.wynntils.models.characterstats.actionbar.PowderSpecialSegment;
 import com.wynntils.models.containers.ContainerModel;
 import com.wynntils.models.damage.DamageModel;
+import com.wynntils.models.items.annotators.game.IngredientAnnotator;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
 import com.wynntils.models.items.annotators.gui.ArchetypeAbilitiesAnnotator;
 import com.wynntils.models.players.FriendsModel;
@@ -311,5 +316,60 @@ public class TestRegex {
         PatternTester p = new PatternTester(GuildModel.class, "MSG_RANK_CHANGED");
         p.shouldMatch("§3[INFO]§b v8j has set USERNAME's guild rank from Recruit to Chief");
         p.shouldMatch("§3[INFO]§b v8j has set USERNAMES' guild rank from Recruiter to Chief");
+    }
+
+    @Test
+    public void GuildRankReplacementFeature_GUILD_MESSAGE_PATTERN() {
+        PatternTester p = new PatternTester(GuildRankReplacementFeature.class, "GUILD_MESSAGE_PATTERN");
+        /* FIXME: These tests fail
+        p.shouldMatch("§3[§b★★★★★§3§oDisco reroller§3]");
+        p.shouldMatch("§3[§b★★★★★§3§oafKing§r§3]§");
+        p.shouldMatch("§3[§b★★★★§3§obol§r§3]");
+         */
+    }
+
+    @Test
+    public void GuildRankReplacementFeature_RECRUIT_USERNAME_PATTERN() {
+        PatternTester p = new PatternTester(GuildRankReplacementFeature.class, "RECRUIT_USERNAME_PATTERN");
+        p.shouldMatch("§3[_user0name_");
+    }
+
+    @Test
+    public void IngredientAnnotator_INGREDIENT_PATTERN() {
+        PatternTester p = new PatternTester(IngredientAnnotator.class, "INGREDIENT_PATTERN");
+        p.shouldMatch("§7Perkish Potato [§8✫✫✫§7]");
+        p.shouldMatch("§7Sylphid Tears§6 [§e✫§8✫✫§6]");
+        p.shouldMatch("§7Bob's Tear§5 [§d✫✫§8✫§5]");
+        p.shouldMatch("§7Contorted Stone§3 [§b✫✫✫§3]");
+    }
+
+    @Test
+    public void ManaSegment_MANA_PATTERN() {
+        PatternTester p = new PatternTester(ManaSegment.class, "MANA_PATTERN");
+        p.shouldMatch("§b✺ 175/175");
+        p.shouldMatch("§b✺ 56/175");
+        p.shouldMatch("✺ 175/175");
+    }
+
+    @Test
+    public void MessageFilterFeature_PARTY_FINDER_FG() {
+        PatternTester p = new PatternTester(MessageFilterFeature.class, "PARTY_FINDER_FG");
+        p.shouldMatch(
+                "§5Party Finder:§d Hey Rafii2198, over here! Join the §bThe Canyon Colossus§d queue and match up with §e2 other players§d!"); // Name 2 players
+        p.shouldMatch(
+                "§5Party Finder:§d Hey Rafii2198, over here! Join the §bThe Canyon Colossus§d queue and match up with §e1 other player§d!"); // Name 1 player
+        p.shouldMatch(
+                "§5Party Finder:§d Hey nickname spaces, over here! Join the §bThe Canyon Colossus§d queue and match up with §e1 other player§d!"); // Nickname 1 player
+        p.shouldMatch(
+                "§5Party Finder:§d Hey nickname spaces 20cr, over here! Join the §bThe Canyon Colossus§d queue and match up with §e11 other players§d!"); // Nickname 11 players
+    }
+
+    @Test
+    public void PowderSpecialSegment_POWDER_SPECIAL_PATTERN() {
+        PatternTester p = new PatternTester(PowderSpecialSegment.class, "POWDER_SPECIAL_PATTERN");
+        p.shouldMatch("§7❉ 87%"); // curse/partial charge
+        p.shouldMatch("§b❉ 100%"); // curse/full charge
+        p.shouldMatch("§7✹ 78%"); // courage/partial charge
+        p.shouldMatch("§c✹ 100%"); // courage/full charge
     }
 }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -5,6 +5,7 @@
 import com.wynntils.features.chat.GuildRankReplacementFeature;
 import com.wynntils.features.chat.MessageFilterFeature;
 import com.wynntils.features.redirects.ChatRedirectFeature;
+import com.wynntils.features.trademarket.TradeMarketPriceMatchFeature;
 import com.wynntils.features.ui.BulkBuyFeature;
 import com.wynntils.handlers.actionbar.ActionBarHandler;
 import com.wynntils.handlers.chat.ChatHandler;
@@ -627,5 +628,17 @@ public class TestRegex {
         p.shouldMatch("§7 - §f8 §7x §f127§7² §8(1²½ 63²)");
         p.shouldMatch("§7 - §f308 §7x §f§m16§7§m²§b ✮ 15§3² §8(15²)");
         p.shouldMatch("§7 - §f308 §7x §f§m16§7§m²§b ✮ 15§3² §8(15²)");
+    }
+
+    @Test
+    public void TradeMarketPriceMatchFeature_HIGHEST_BUY_PATTERN() {
+        PatternTester p = new PatternTester(TradeMarketPriceMatchFeature.class, "HIGHEST_BUY_PATTERN");
+        p.shouldMatch("§7Highest Buy Offer: §a100000²§8 (24¼² 26²½ 32²)");
+    }
+
+    @Test
+    public void TradeMarketPriceMatchFeature_LOWEST_SELL_PATTERN() {
+        PatternTester p = new PatternTester(TradeMarketPriceMatchFeature.class, "LOWEST_SELL_PATTERN");
+        p.shouldMatch("§7Lowest Sell Offer: §a1050000²§8 (4stx 0.35¼²)");
     }
 }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -14,13 +14,20 @@ import com.wynntils.models.character.CharacterSelectionModel;
 import com.wynntils.models.characterstats.actionbar.CoordinatesSegment;
 import com.wynntils.models.characterstats.actionbar.ManaSegment;
 import com.wynntils.models.characterstats.actionbar.PowderSpecialSegment;
+import com.wynntils.models.characterstats.actionbar.SprintSegment;
 import com.wynntils.models.containers.ContainerModel;
 import com.wynntils.models.damage.DamageModel;
 import com.wynntils.models.items.annotators.game.IngredientAnnotator;
+import com.wynntils.models.items.annotators.game.RuneAnnotator;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
 import com.wynntils.models.items.annotators.gui.ArchetypeAbilitiesAnnotator;
+import com.wynntils.models.items.annotators.gui.SkillPointAnnotator;
 import com.wynntils.models.players.FriendsModel;
 import com.wynntils.models.players.GuildModel;
+import com.wynntils.models.spells.SpellModel;
+import com.wynntils.models.spells.actionbar.SpellSegment;
+import com.wynntils.models.statuseffects.StatusEffectModel;
+import com.wynntils.models.trademarket.TradeMarketModel;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
@@ -493,5 +500,132 @@ public class TestRegex {
         p.shouldMatch("§3[§b★★★★§3§obol§r§3]§b test ");
         p.shouldMatch("§3[kristof345]§b test");
         p.shouldNotMatch("§3[INFO]§b bolyai has kicked kristof345 from the guild");
+    }
+
+    @Test
+    public void RuneAnnotator_RUNE_PATTERN() {
+        PatternTester p = new PatternTester(RuneAnnotator.class, "RUNE_PATTERN");
+        p.shouldMatch("§bAz Rune");
+        p.shouldMatch("§4Nii Rune");
+        p.shouldMatch("§3Uth Rune");
+        p.shouldMatch("§2Tol Rune");
+    }
+
+    @Test
+    public void SkillPointAnnotator_SKILL_POINT_PATTERN() {
+        PatternTester p = new PatternTester(SkillPointAnnotator.class, "SKILL_POINT_PATTERN");
+        p.shouldMatch("§dUpgrade your §2✤ Strength§d skill");
+        p.shouldMatch("§dUpgrade your §e✦ Dexterity§d skill");
+        p.shouldMatch("§dUpgrade your §b❉ Intelligence§d skill");
+        p.shouldMatch("§dUpgrade your §c✹ Defence§d skill");
+        p.shouldMatch("§dUpgrade your §f❋ Agility§d skill");
+    }
+
+    @Test
+    public void SkillPointAnnotator_LORE_PATTERN() {
+        PatternTester p = new PatternTester(SkillPointAnnotator.class, "LORE_PATTERN");
+        p.shouldMatch(" ÀÀ§740 points§r    ÀÀÀ           ÀÀÀ§641 points");
+        p.shouldMatch(" ÀÀ§763 points§r    ÀÀÀ           ÀÀÀ§664 points");
+        p.shouldMatch("ÀÀÀ§7131 points§r               §6132 points");
+        p.shouldMatch(" ÀÀ§790 points§r    ÀÀÀ           ÀÀÀ§691 points");
+        p.shouldMatch(" ÀÀ§762 points§r    ÀÀÀ           ÀÀÀ§663 points");
+    }
+
+    @Test
+    public void SpellModel_SPELL_TITLE_PATTERN() {
+        PatternTester p = new PatternTester(SpellModel.class, "SPELL_TITLE_PATTERN");
+        // Lv1 R??
+        p.shouldMatch("§aRight§7-§7§n?§7-§r§7?§r");
+        // Lv1 RL?
+        p.shouldMatch("§aRight§7-§aLeft§7-§r§7§n?§r");
+        // Lv1 RLR
+        p.shouldMatch("§aRight§7-§aLeft§7-§r§aRight§r");
+        // Lv1 RR?
+        p.shouldMatch("§aRight§7-§aRight§7-§r§7§n?§r");
+        // Lv1 RRL
+        p.shouldMatch("§aRight§7-§aRight§7-§r§aLeft§r");
+        // Lv1 RRR
+        p.shouldMatch("§aRight§7-§aRight§7-§r§aRight§r");
+        // Lv1 RLL
+        p.shouldMatch("§aRight§7-§aLeft§7-§r§aLeft§r");
+        // L??
+        p.shouldMatch("§aL§7-§7§n?§7-§r§7?§r");
+        // LL?
+        p.shouldMatch("§aL§7-§aL§7-§r§7§n?§r");
+        // LLL
+        p.shouldMatch("§aL§7-§aL§7-§r§aL§r");
+        // LR?
+        p.shouldMatch("§aL§7-§aR§7-§r§7§n?§r");
+        // LRL
+        p.shouldMatch("§aL§7-§aR§7-§r§aL§r");
+        // R??
+        p.shouldMatch("§aR§7-§7§n?§7-§r§7?§r");
+        // RL?
+        p.shouldMatch("§aR§7-§aL§7-§r§7§n?§r");
+        // RRL
+        p.shouldMatch("§aR§7-§aR§7-§r§aL§r");
+    }
+
+    @Test
+    public void SpellSegment_SPELL_PATTERN() {
+        PatternTester p = new PatternTester(SpellSegment.class, "SPELL_PATTERN");
+        // L??
+        p.shouldMatch("§aL§7-§n?§r§7-?§r");
+        // LR?
+        p.shouldMatch("§aL§7-§aR§7-§n?§r");
+        // LRL
+        p.shouldMatch("§aL§7-§aR§7-§aL§r");
+        // LLR
+        p.shouldMatch("§aL§7-§aL§7-§aR§r");
+        // R??
+        p.shouldMatch("§aR§7-§n?§r§7-?§r");
+        // RR?
+        p.shouldMatch("§aR§7-§aR§7-§n?§r");
+        // RRR
+        p.shouldMatch("§aR§7-§aR§7-§aR§r");
+    }
+
+    @Test
+    public void SprintSegment_SPRINT_PATTERN() {
+        PatternTester p = new PatternTester(SprintSegment.class, "SPRINT_PATTERN");
+        // green sprint bar
+        p.shouldMatch("§2[§a|||Sprint|§8||§2]");
+        // green sprint text 1
+        p.shouldMatch("§2[§a|||Sprin§8t|||§2]");
+        // green sprint text 2
+        p.shouldMatch("§6[§e|||S§8print|||§6]");
+        // yellow sprint text
+        p.shouldMatch("§6[§e|||§8Sprint|||§6]");
+        // yellow sprint bar
+        p.shouldMatch("§6[§e|§8||Sprint|||§6]");
+        // no sprint grey
+        p.shouldMatch("§4[§8|||Sprint|||§4]");
+        // no sprint red
+        p.shouldMatch("§4[§c|||Sprint|||§4]");
+        // max sprint
+        p.shouldMatch("§2[§a|||Sprint|||§2]");
+    }
+
+    @Test
+    public void StatusEffectModel_STATUS_EFFECT_PATTERN() {
+        PatternTester p = new PatternTester(StatusEffectModel.class, "STATUS_EFFECT_PATTERN");
+        p.shouldMatch("§fⒺ§7 +198 Main Attack Damage §8(00:41)");
+        p.shouldMatch("§f§b❤§7 Windy Feet §8(02:57)");
+        p.shouldMatch("§a❉ §776.5% Concentration §4(00:13)");
+        p.shouldMatch("§b➲ §718% Frenzy §8(**:**)");
+        p.shouldMatch("§fⒺ§7 +54% Spell Damage §8(00:41)");
+        p.shouldMatch("§8⬤ §7Vanish §a(00:04)");
+        p.shouldMatch("§fⒺ§7 +250/3s Life Steal §8(00:41)");
+        p.shouldMatch("§8⬤ §7Boiling Blood §a(00:02)");
+    }
+
+    @Test
+    public void TradeMarketModel_PRICE_PATTERN() {
+        PatternTester p = new PatternTester(TradeMarketModel.class, "PRICE_PATTERN");
+        p.shouldMatch("§7 - §f525§7² §8(8²½ 13²)");
+        p.shouldMatch("§7 - §f21,111§7² §8(5¼² 9²½ 55²)");
+        p.shouldMatch("§7 - §f8 §7x §f127§7² §8(1²½ 63²)");
+        p.shouldMatch("§7 - §f308 §7x §f§m16§7§m²§b ✮ 15§3² §8(15²)");
+        p.shouldMatch("§7 - §f308 §7x §f§m16§7§m²§b ✮ 15§3² §8(15²)");
     }
 }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -29,6 +29,7 @@ import com.wynntils.models.spells.SpellModel;
 import com.wynntils.models.spells.actionbar.SpellSegment;
 import com.wynntils.models.statuseffects.StatusEffectModel;
 import com.wynntils.models.trademarket.TradeMarketModel;
+import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
@@ -640,5 +641,122 @@ public class TestRegex {
     public void TradeMarketPriceMatchFeature_LOWEST_SELL_PATTERN() {
         PatternTester p = new PatternTester(TradeMarketPriceMatchFeature.class, "LOWEST_SELL_PATTERN");
         p.shouldMatch("§7Lowest Sell Offer: §a1050000²§8 (4stx 0.35¼²)");
+    }
+
+    @Test
+    public void WynnItemParser_ITEM_ATTACK_SPEED_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "ITEM_ATTACK_SPEED_PATTERN");
+        p.shouldMatch("§7Normal Attack Speed");
+        p.shouldMatch("§7Super Fast Attack Speed");
+    }
+
+    @Test
+    public void WynnItemParser_ITEM_DAMAGE_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "ITEM_DAMAGE_PATTERN");
+        /* FIXME: This test fails
+        p.shouldMatch("§6✣ Neutral Damage: 55-68§r");
+        */
+    }
+
+    @Test
+    public void WynnItemParser_ITEM_DEFENCE_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "ITEM_DEFENCE_PATTERN");
+        p.shouldMatch("§e✦ Thunder§7 Defence: +56");
+    }
+
+    @Test
+    public void WynnItemParser_IDENTIFICATION_STAT_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "IDENTIFICATION_STAT_PATTERN");
+        p.shouldMatch("§a+10% §7Health Regen");
+        p.shouldMatch("§a+5%§2* §7XP Bonus");
+        p.shouldMatch("§a+5/5s §7Mana Regen");
+        p.shouldMatch("§a+42 §7Water Spell Damage");
+        p.shouldMatch("§a+4 §7Intelligence");
+        p.shouldMatch("§a+1 tier§2* §7Attack Speed");
+        p.shouldMatch("§a+16%§2*** §7XP Bonus");
+        p.shouldMatch("§c-28000§4 to §c-52000%§7 Spell Damage");
+        p.shouldMatch("§c-28000§4 to §c-52000§7 Spell Damage");
+        p.shouldMatch("§a+12§2 to §a52%§7 Main Attack Damage");
+        p.shouldMatch("§c-280§4 to §c-520§7 {sp1} Cost");
+        p.shouldMatch("§a+291/3s§2** §7Life Steal");
+        p.shouldMatch("§c-28% §7Soul Point Regen");
+        // Crafted gear 18/18% Main Attack Damage
+        p.shouldMatch("§a+18%§8/18% §7Main Attack Damage");
+    }
+
+    @Test
+    public void WynnItemParser_TIER_AND_REROLL_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "TIER_AND_REROLL_PATTERN");
+        p.shouldMatch("§eUnique Item");
+        p.shouldMatch("§dRare Item");
+        p.shouldMatch("§dRare Item [2]");
+        p.shouldMatch("§bLegendary Item");
+        p.shouldMatch("§cFabled Item");
+        p.shouldMatch("§aSet Item");
+        /* FIXME: These tests fail
+        p.shouldMatch("§3Crafted Wand§r§8 [134/137 Durability]");
+        p.shouldMatch("§3Crafted by player_name§r§8 [177/177 Durability]");
+        p.shouldMatch("§3Crafted by v8j§r§8 [177/177 Durability]  ");
+        */
+    }
+
+    @Test
+    public void WynnItemParser_POWDER_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "POWDER_PATTERN");
+        p.shouldMatch("§7[0/1] Powder Slots");
+        p.shouldMatch("§7[1/1] Powder Slots [§r§c✹§r§7]");
+        p.shouldMatch("§7[3/3] Powder Slots [§r§f❋ ❋ ❋§r§7]");
+        p.shouldMatch("§7[2/2] Powder Slots [§r§e✦ ✦§r§7]");
+        p.shouldMatch("§7[2/2] Powder Slots [§r§b❉ ❉§r§7]");
+        p.shouldMatch("§7[3/3] Powder Slots [§r§2✤ §r§c✹ §r§b❉§r§7]");
+    }
+
+    @Test
+    public void WynnItemParser_EFFECT_LINE_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "EFFECT_LINE_PATTERN");
+        /* FIXME: This test fails
+        p.shouldMatch("§6- §r§7Effect: §r§f20% XP");
+        */
+    }
+
+    @Test
+    public void WynnItemParser_MIN_LEVEL_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "MIN_LEVEL_PATTERN");
+        /* FIXME: These tests fail
+        p.shouldMatch("§a✔§r§7 Combat Lv. Min: 35");
+        p.shouldMatch("§c✖§r§7 Combat Lv. Min: 65");
+        */
+    }
+
+    @Test
+    public void WynnItemParser_CLASS_REQ_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "CLASS_REQ_PATTERN");
+        p.shouldMatch("§c✖§7 Class Req: Shaman/Skyseer§r");
+    }
+
+    @Test
+    public void WynnItemParser_SKILL_REQ_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "SKILL_REQ_PATTERN");
+        p.shouldMatch("§a✔§7 Intelligence Min: 38");
+    }
+
+    @Test
+    public void WynnItemParser_SHINY_STAT_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "SHINY_STAT_PATTERN");
+        p.shouldMatch("§f⬡ §7Raids Won: §f0");
+        p.shouldMatch("§f⬡ §7Raids Won: §f297");
+        p.shouldMatch("§f⬡ §7Mobs Killed: §f0");
+        p.shouldNotMatch("§c✖§7 Agility Min: 70");
+        p.shouldNotMatch("§f⬡ §7: §f0");
+        p.shouldNotMatch("§f⬡ §7Mobs Killed: §f");
+        p.shouldMatch("§f⬡ §7Wars Won: §f164");
+        p.shouldMatch("§f⬡ §7Raids Won: §f0");
+    }
+
+    @Test
+    public void WynnItemParser_CRAFTED_ITEM_NAME_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "CRAFTED_ITEM_NAME_PATTERN");
+        p.shouldMatch("§3§otest item§b§o [24%]À");
+        p.shouldMatch("§3§oAbsorbant Skirt of the Skyraider§b§o [100%]À");
     }
 }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -2,7 +2,13 @@
  * Copyright © Wynntils 2023.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.features.ui.BulkBuyFeature;
+import com.wynntils.handlers.actionbar.ActionBarHandler;
+import com.wynntils.handlers.chat.ChatHandler;
+import com.wynntils.models.character.CharacterModel;
+import com.wynntils.models.character.CharacterSelectionModel;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
+import com.wynntils.models.items.annotators.gui.ArchetypeAbilitiesAnnotator;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
@@ -59,5 +65,95 @@ public class TestRegex {
     public void AbilityTreeAnnotator_TREE_ABILITY_POINTS_PATTERN() {
         PatternTester p = new PatternTester(AbilityTreeAnnotator.class, "TREE_ABILITY_POINTS_PATTERN");
         p.shouldMatch("§b✦ Available Points: §f0§7/45");
+        p.shouldMatch("§b✦ Available Points: §f15§7/45");
+    }
+
+    @Test
+    public void ActionBarHandler_ACTIONBAR_PATTERN() {
+        PatternTester p = new PatternTester(ActionBarHandler.class, "ACTIONBAR_PATTERN");
+        p.shouldMatch("§c❤ 14930/14930§0      §b❉ 100%      ✺ 175/175");
+        p.shouldMatch("§c❤ 14930/14930§0      §7❉ 48%      §b✺ 175/175");
+        p.shouldMatch("§c❤ 14930/14930§0      §7❉ 48%      §b✺ 175/175");
+    }
+
+    @Test
+    public void ArchetypeAbilitiesAnnotator_ARCHETYPE_NAME() {
+        PatternTester p = new PatternTester(ArchetypeAbilitiesAnnotator.class, "ARCHETYPE_NAME");
+        p.shouldMatch("§e§lBoltslinger Archetype");
+        p.shouldMatch("§d§lSharpshooter Archetype");
+        p.shouldMatch("§2§lTrapper Archetype");
+        p.shouldMatch("§d§lLight Bender Archetype");
+    }
+
+    @Test
+    public void ArchetypeAbilitiesAnnotator_ARCHETYPE_PATTERN() {
+        PatternTester p = new PatternTester(ArchetypeAbilitiesAnnotator.class, "ARCHETYPE_PATTERN");
+        p.shouldMatch("§a✔ §7Unlocked Abilities: §f14§7/15");
+        p.shouldMatch("§a✔ §7Unlocked Abilities: §f2§7/16");
+        p.shouldMatch("§a✔ §7Unlocked Abilities: §f2§7/16");
+        p.shouldMatch("§a✔ §7Unlocked Abilities: §f5§7/16");
+        p.shouldMatch("§a✔ §7Unlocked Abilities: §f14§7/15");
+        p.shouldMatch("§a✔ §7Unlocked Abilities: §f0§7/15");
+    }
+
+    @Test
+    public void BulkBuyFeature_PRICE_PATTERN() {
+        PatternTester p = new PatternTester(BulkBuyFeature.class, "PRICE_PATTERN");
+        p.shouldMatch("§6 - §a✔ §f24§7²");
+        p.shouldMatch("§6 - §a✔ §f648§7²");
+        p.shouldMatch("§6 - §c✖ §f24§7²");
+    }
+
+    @Test
+    public void CharacterModel_SILVERBULL_PATTERN() {
+        PatternTester p = new PatternTester(CharacterModel.class, "SILVERBULL_PATTERN");
+        p.shouldMatch("§7Subscription: §c✖ Inactive");
+        p.shouldMatch("§7Subscription: §a✔ Active");
+    }
+
+    @Test
+    public void CharacterModel_SILVERBULL_DURATION_PATTERN() {
+        PatternTester p = new PatternTester(CharacterModel.class, "SILVERBULL_DURATION_PATTERN");
+        p.shouldMatch("§7Expiration: §f1 week 5 days");
+        p.shouldMatch("§7Expiration: §f5 days");
+        p.shouldMatch("§7Expiration: §f1 week");
+        p.shouldMatch("§7Expiration: §f2 days 12 hours");
+    }
+
+    @Test
+    public void CharacterModel_VETERAN_PATTERN() {
+        PatternTester p = new PatternTester(CharacterModel.class, "VETERAN_PATTERN");
+        p.shouldMatch("§7Rank: §6Vet"); // Champion
+        p.shouldMatch("§7Rank: §dVet"); // Hero
+        p.shouldMatch("§7Rank: §bVet"); // VIP+
+        p.shouldMatch("§7Rank: §aVet"); // VIP
+    }
+
+    @Test
+    public void CharacterSelectionModel_CLASS_ITEM_CLASS_PATTERN() {
+        PatternTester p = new PatternTester(CharacterSelectionModel.class, "CLASS_ITEM_CLASS_PATTERN");
+        p.shouldMatch("§e- §7Class: §fHunter"); // Hunter
+        p.shouldMatch("§e- §7Class: §fMage"); // Mage
+        p.shouldMatch("§e- §7Class: §3\uE026§r §fDark Wizard"); // Craftsman Dark Wizard
+        p.shouldMatch("§e- §7Class: §c\uE027§r §fAssassin"); // Hardcore Assassin
+        p.shouldMatch("§e- §7Class: §5\uE028§r §fNinja"); // Hunted Ninja
+        p.shouldMatch("§e- §7Class: §b\uE083§r §fShaman"); // Ultimate Ironman Shaman
+        p.shouldMatch("§e- §7Class: §c\uE027§b\uE083§3\uE026§5\uE028§r §fWarrior"); // Ultimate HIC Warrior
+        p.shouldMatch("§e- §7Class: §c\uE027§6\uE029§3\uE026§5\uE028§r §fSkyseer"); // HIC Skyseer
+        p.shouldMatch("§e- §7Class: §6\uE029§r §fArcher"); // Ironman Archer
+    }
+
+    @Test
+    public void ChatHandler_NPC_CONFIRM_PATTERN() {
+        PatternTester p = new PatternTester(ChatHandler.class, "NPC_CONFIRM_PATTERN");
+        p.shouldMatch("§7Press §fSHIFT §7to continue");
+        p.shouldMatch("§4Press §cSNEAK §4to continue");
+    }
+
+    @Test
+    public void ChatHandler_NPC_SELECT_PATTERN() {
+        PatternTester p = new PatternTester(ChatHandler.class, "NPC_SELECT_PATTERN");
+        p.shouldMatch("§7Select §fan option §7to continue");
+        p.shouldMatch("§cCLICK §4an option to continue");
     }
 }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -143,24 +143,37 @@ public class TestRegex {
     @Test
     public void CharacterModel_VETERAN_PATTERN() {
         PatternTester p = new PatternTester(CharacterModel.class, "VETERAN_PATTERN");
-        p.shouldMatch("§7Rank: §6Vet"); // Champion
-        p.shouldMatch("§7Rank: §dVet"); // Hero
-        p.shouldMatch("§7Rank: §bVet"); // VIP+
-        p.shouldMatch("§7Rank: §aVet"); // VIP
+        // Champion
+        p.shouldMatch("§7Rank: §6Vet");
+        // Hero
+        p.shouldMatch("§7Rank: §dVet");
+        // VIP+
+        p.shouldMatch("§7Rank: §bVet");
+        // VIP
+        p.shouldMatch("§7Rank: §aVet");
     }
 
     @Test
     public void CharacterSelectionModel_CLASS_ITEM_CLASS_PATTERN() {
         PatternTester p = new PatternTester(CharacterSelectionModel.class, "CLASS_ITEM_CLASS_PATTERN");
-        p.shouldMatch("§e- §7Class: §fHunter"); // Hunter
-        p.shouldMatch("§e- §7Class: §fMage"); // Mage
-        p.shouldMatch("§e- §7Class: §3\uE026§r §fDark Wizard"); // Craftsman Dark Wizard
-        p.shouldMatch("§e- §7Class: §c\uE027§r §fAssassin"); // Hardcore Assassin
-        p.shouldMatch("§e- §7Class: §5\uE028§r §fNinja"); // Hunted Ninja
-        p.shouldMatch("§e- §7Class: §b\uE083§r §fShaman"); // Ultimate Ironman Shaman
-        p.shouldMatch("§e- §7Class: §c\uE027§b\uE083§3\uE026§5\uE028§r §fWarrior"); // Ultimate HIC Warrior
-        p.shouldMatch("§e- §7Class: §c\uE027§6\uE029§3\uE026§5\uE028§r §fSkyseer"); // HIC Skyseer
-        p.shouldMatch("§e- §7Class: §6\uE029§r §fArcher"); // Ironman Archer
+        // Hunter
+        p.shouldMatch("§e- §7Class: §fHunter");
+        // Mage
+        p.shouldMatch("§e- §7Class: §fMage");
+        // Craftsman Dark Wizard
+        p.shouldMatch("§e- §7Class: §3\uE026§r §fDark Wizard");
+        // Hardcore Assassin
+        p.shouldMatch("§e- §7Class: §c\uE027§r §fAssassin");
+        // Hunted Ninja
+        p.shouldMatch("§e- §7Class: §5\uE028§r §fNinja");
+        // Ultimate Ironman Shaman
+        p.shouldMatch("§e- §7Class: §b\uE083§r §fShaman");
+        // Ultimate HIC Warrior
+        p.shouldMatch("§e- §7Class: §c\uE027§b\uE083§3\uE026§5\uE028§r §fWarrior");
+        // HIC Skyseer
+        p.shouldMatch("§e- §7Class: §c\uE027§6\uE029§3\uE026§5\uE028§r §fSkyseer");
+        // Ironman Archer
+        p.shouldMatch("§e- §7Class: §6\uE029§r §fArcher");
     }
 
     @Test
@@ -180,21 +193,31 @@ public class TestRegex {
     @Test
     public void ChatRedirectFeature_LoginRedirector_FOREGROUND_PATTERN() {
         PatternTester p = new PatternTester(ChatRedirectFeature.LoginRedirector.class, "FOREGROUND_PATTERN");
-        p.shouldMatch("\uE017 §#ffe60000v8j§6 has just logged in!"); // champion
-        p.shouldMatch("\uE01B §#a344aa00v8j§d has just logged in!"); // hero
-        p.shouldMatch("\uE024 §#8a99ee00v8j§3 has just logged in!"); // vip+
-        p.shouldMatch("\uE023 §#44aa3300v8j§a has just logged in!"); // vip
-        p.shouldMatch("\uE017 §#ffe60000§ocharlie268IsAWizard§6 has just logged in!"); // champion nickname
+        // champion
+        p.shouldMatch("\uE017 §#ffe60000v8j§6 has just logged in!");
+        // hero
+        p.shouldMatch("\uE01B §#a344aa00v8j§d has just logged in!");
+        // vip+
+        p.shouldMatch("\uE024 §#8a99ee00v8j§3 has just logged in!");
+        // vip
+        p.shouldMatch("\uE023 §#44aa3300v8j§a has just logged in!");
+        // champion nickname
+        p.shouldMatch("\uE017 §#ffe60000§ocharlie268IsAWizard§6 has just logged in!");
     }
 
     @Test
     public void ContainerModel_ABILITY_TREE_PATTERN() {
         PatternTester p = new PatternTester(ContainerModel.class, "ABILITY_TREE_PATTERN");
-        p.shouldMatch("Warrior Abilities"); // Warrior
-        p.shouldMatch("Shaman Abilities"); // Shaman
-        p.shouldMatch("Mage Abilities"); // Mage
-        p.shouldMatch("Assassin Abilities"); // Assassin
-        p.shouldMatch("Archer Abilities"); // Archer
+        // Warrior
+        p.shouldMatch("Warrior Abilities");
+        // Shaman
+        p.shouldMatch("Shaman Abilities");
+        // Mage
+        p.shouldMatch("Mage Abilities");
+        // Assassin
+        p.shouldMatch("Assassin Abilities");
+        // Archer
+        p.shouldMatch("Archer Abilities");
     }
 
     @Test
@@ -207,10 +230,14 @@ public class TestRegex {
     @Test
     public void ContainerModel_LOOT_CHEST_PATTERN() {
         PatternTester p = new PatternTester(ContainerModel.class, "LOOT_CHEST_PATTERN");
-        p.shouldMatch("Loot Chest §7[§f✫§8✫✫✫§7]"); // Tier 1
-        p.shouldMatch("Loot Chest §e[§6✫✫§8✫✫§e]"); // Tier 2
-        p.shouldMatch("Loot Chest §5[§d✫✫✫§8✫§5]"); // Tier 3
-        p.shouldMatch("Loot Chest §3[§b✫✫✫✫§3]"); // Tier 4
+        // Tier 1
+        p.shouldMatch("Loot Chest §7[§f✫§8✫✫✫§7]");
+        // Tier 2
+        p.shouldMatch("Loot Chest §e[§6✫✫§8✫✫§e]");
+        // Tier 3
+        p.shouldMatch("Loot Chest §5[§d✫✫✫§8✫§5]");
+        // Tier 4
+        p.shouldMatch("Loot Chest §3[§b✫✫✫✫§3]");
     }
 
     @Test
@@ -228,8 +255,10 @@ public class TestRegex {
     @Test
     public void ContainerModel_TRADE_MARKET_FILTER_TITLE() {
         PatternTester p = new PatternTester(ContainerModel.class, "TRADE_MARKET_FILTER_TITLE");
-        p.shouldMatch("[Pg. 1] Filter Items"); // Page 1
-        p.shouldMatch("[Pg. 7] Filter Items"); // Page 7
+        // Page 1
+        p.shouldMatch("[Pg. 1] Filter Items");
+        // Page 7
+        p.shouldMatch("[Pg. 7] Filter Items");
     }
 
     @Test
@@ -376,10 +405,14 @@ public class TestRegex {
     @Test
     public void PowderSpecialSegment_POWDER_SPECIAL_PATTERN() {
         PatternTester p = new PatternTester(PowderSpecialSegment.class, "POWDER_SPECIAL_PATTERN");
-        p.shouldMatch("§7❉ 87%"); // curse/partial charge
-        p.shouldMatch("§b❉ 100%"); // curse/full charge
-        p.shouldMatch("§7✹ 78%"); // courage/partial charge
-        p.shouldMatch("§c✹ 100%"); // courage/full charge
+        // curse/partial charge
+        p.shouldMatch("§7❉ 87%");
+        // curse/full charge
+        p.shouldMatch("§b❉ 100%");
+        // courage/partial charge
+        p.shouldMatch("§7✹ 78%");
+        // courage/full charge
+        p.shouldMatch("§c✹ 100%");
     }
 
     @Test

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -2,13 +2,19 @@
  * Copyright © Wynntils 2023.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.features.redirects.ChatRedirectFeature;
 import com.wynntils.features.ui.BulkBuyFeature;
 import com.wynntils.handlers.actionbar.ActionBarHandler;
 import com.wynntils.handlers.chat.ChatHandler;
 import com.wynntils.models.character.CharacterModel;
 import com.wynntils.models.character.CharacterSelectionModel;
+import com.wynntils.models.characterstats.actionbar.CoordinatesSegment;
+import com.wynntils.models.containers.ContainerModel;
+import com.wynntils.models.damage.DamageModel;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
 import com.wynntils.models.items.annotators.gui.ArchetypeAbilitiesAnnotator;
+import com.wynntils.models.players.FriendsModel;
+import com.wynntils.models.players.GuildModel;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 import net.minecraft.SharedConstants;
@@ -155,5 +161,155 @@ public class TestRegex {
         PatternTester p = new PatternTester(ChatHandler.class, "NPC_SELECT_PATTERN");
         p.shouldMatch("§7Select §fan option §7to continue");
         p.shouldMatch("§cCLICK §4an option to continue");
+    }
+
+    @Test
+    public void ChatRedirectFeature_LoginRedirector_FOREGROUND_PATTERN() {
+        PatternTester p = new PatternTester(ChatRedirectFeature.LoginRedirector.class, "FOREGROUND_PATTERN");
+        p.shouldMatch("\uE017 §#ffe60000v8j§6 has just logged in!"); // champion
+        p.shouldMatch("\uE01B §#a344aa00v8j§d has just logged in!"); // hero
+        p.shouldMatch("\uE024 §#8a99ee00v8j§3 has just logged in!"); // vip+
+        p.shouldMatch("\uE023 §#44aa3300v8j§a has just logged in!"); // vip
+        p.shouldMatch("\uE017 §#ffe60000§ocharlie268IsAWizard§6 has just logged in!"); // champion nickname
+    }
+
+    @Test
+    public void ContainerModel_ABILITY_TREE_PATTERN() {
+        PatternTester p = new PatternTester(ContainerModel.class, "ABILITY_TREE_PATTERN");
+        p.shouldMatch("Warrior Abilities"); // Warrior
+        p.shouldMatch("Shaman Abilities"); // Shaman
+        p.shouldMatch("Mage Abilities"); // Mage
+        p.shouldMatch("Assassin Abilities"); // Assassin
+        p.shouldMatch("Archer Abilities"); // Archer
+    }
+
+    @Test
+    public void ContainerModel_GUILD_BANK_PATTERN() {
+        PatternTester p = new PatternTester(ContainerModel.class, "GUILD_BANK_PATTERN");
+        p.shouldMatch("Very Cool Guild Name: Bank (Everyone)");
+        p.shouldMatch("Other very cool guild name: Bank (High Ranked)");
+    }
+
+    @Test
+    public void ContainerModel_LOOT_CHEST_PATTERN() {
+        PatternTester p = new PatternTester(ContainerModel.class, "LOOT_CHEST_PATTERN");
+        p.shouldMatch("Loot Chest §7[§f✫§8✫✫✫§7]"); // Tier 1
+        p.shouldMatch("Loot Chest §e[§6✫✫§8✫✫§e]"); // Tier 2
+        p.shouldMatch("Loot Chest §5[§d✫✫✫§8✫§5]"); // Tier 3
+        p.shouldMatch("Loot Chest §3[§b✫✫✫✫§3]"); // Tier 4
+    }
+
+    @Test
+    public void ContainerModel_PERSONAL_STORAGE_PATTERN() {
+        PatternTester p = new PatternTester(ContainerModel.class, "PERSONAL_STORAGE_PATTERN");
+        p.shouldMatch("§0[Pg. 1] §8v8j's§0 Bank");
+        p.shouldMatch("§0[Pg. 29] §8aA9a9G_g0g4G's§0 Bank");
+        p.shouldMatch("§0[Pg. 1] §8mag_icus'§0 Bank");
+        p.shouldMatch("§0[Pg. 29] §8aA9a9G_g0g4G's§0 Block Bank");
+        p.shouldMatch("§0[Pg. 1] §8v8j's§0 Misc. Bucket");
+        p.shouldMatch("§0[Pg. 1] §8mag_icus'§0 Misc. Bucket");
+        p.shouldMatch("§0[Pg. 1] §8Housing Island's§0 Block Bank");
+    }
+
+    @Test
+    public void ContainerModel_TRADE_MARKET_FILTER_TITLE() {
+        PatternTester p = new PatternTester(ContainerModel.class, "TRADE_MARKET_FILTER_TITLE");
+        p.shouldMatch("[Pg. 1] Filter Items"); // Page 1
+        p.shouldMatch("[Pg. 7] Filter Items"); // Page 7
+    }
+
+    @Test
+    public void CoordinatesSegment_COORDINATES_PATTERN() {
+        PatternTester p = new PatternTester(CoordinatesSegment.class, "COORDINATES_PATTERN");
+        p.shouldMatch("§7457§f N§7 -1576");
+        p.shouldMatch("§7-1§f NW§7 154");
+        p.shouldMatch("§7-736§f S§7 -1575");
+    }
+
+    @Test
+    public void DamageModel_DAMAGE_LABEL_PATTERN() {
+        PatternTester p = new PatternTester(DamageModel.class, "DAMAGE_LABEL_PATTERN");
+        p.shouldMatch("§4-13 ❤ ");
+        p.shouldMatch("§4-10 ❤ ");
+        p.shouldMatch("§c-8 ✹ ");
+        p.shouldMatch("§e-30 ✦ ");
+        p.shouldMatch("§2-41 ✤ ");
+        p.shouldMatch("§b-21 ❉ ");
+        p.shouldMatch("§f-32 ❋ ");
+        p.shouldMatch("§c-28 ✹ ");
+    }
+
+    @Test
+    public void DamageModel_DAMAGE_BAR_PATTERN() {
+        PatternTester p = new PatternTester(DamageModel.class, "DAMAGE_BAR_PATTERN");
+        p.shouldMatch("§aTravelling Merchant§r - §c5985§4❤");
+        p.shouldMatch("§aGrook§r - §c23§4❤");
+        p.shouldMatch("§cZombie§r - §c43§4❤");
+        p.shouldMatch("§cFeligember Frog§r - §c1553§4❤ - §7§e✦Weak §c✹Dam §c✹Def§7");
+    }
+
+    @Test
+    public void FriendsModel_ONLINE_FRIENDS_HEADER() {
+        PatternTester p = new PatternTester(FriendsModel.class, "ONLINE_FRIENDS_HEADER");
+        p.shouldMatch("§2Online §aFriends:");
+    }
+
+    @Test
+    public void FriendsModel_ONLINE_FRIEND() {
+        PatternTester p = new PatternTester(FriendsModel.class, "ONLINE_FRIEND");
+        p.shouldMatch("§2 - §auserName914__§2 [Server: §aWC3§2]");
+        p.shouldMatch("§2 - §av8j§2 [Server: §aWC103§2]");
+        p.shouldMatch("§2 - §a__asdf__§2 [Server: §aWC91§2]");
+    }
+
+    @Test
+    public void FriendsModel_JOIN_PATTERN() {
+        PatternTester p = new PatternTester(FriendsModel.class, "JOIN_PATTERN");
+        p.shouldMatch("§aMirvun§2 has logged into server §aWC1§2 as §aan Archer");
+        p.shouldMatch("§aMirvun§2 has logged into server §aWC27§2 as §aa Mage");
+    }
+
+    @Test
+    public void FriendsModel_LEAVE_PATTERN() {
+        PatternTester p = new PatternTester(FriendsModel.class, "LEAVE_PATTERN");
+        p.shouldMatch("§aMirvun left the game.");
+    }
+
+    @Test
+    public void GuildModel_GUILD_NAME_MATCHER() {
+        PatternTester p = new PatternTester(GuildModel.class, "GUILD_NAME_MATCHER");
+        p.shouldMatch("§3guildName§b [aAaA]");
+        p.shouldMatch("§3guild Name§b [aaaa]");
+        p.shouldMatch("§3GUILD NAME§b [wynn]");
+    }
+
+    @Test
+    public void GuildModel_GUILD_RANK_MATCHER() {
+        PatternTester p = new PatternTester(GuildModel.class, "GUILD_RANK_MATCHER");
+        p.shouldMatch("§7Rank: §fRecruit");
+        p.shouldMatch("§7Rank: §fRecruiter");
+        p.shouldMatch("§7Rank: §fCaptain");
+        p.shouldMatch("§7Rank: §fStrategist");
+        p.shouldMatch("§7Rank: §fChief");
+        p.shouldMatch("§7Rank: §fOwner");
+    }
+
+    @Test
+    public void GuildModel_MSG_LEFT_GUILD() {
+        PatternTester p = new PatternTester(GuildModel.class, "MSG_LEFT_GUILD");
+        p.shouldMatch("§3You have left §bExample Guild§3!");
+    }
+
+    @Test
+    public void GuildModel_MSG_JOINED_GUILD() {
+        PatternTester p = new PatternTester(GuildModel.class, "MSG_JOINED_GUILD");
+        p.shouldMatch("§3You have joined §bExample Guild§3!");
+    }
+
+    @Test
+    public void GuildModel_MSG_RANK_CHANGED() {
+        PatternTester p = new PatternTester(GuildModel.class, "MSG_RANK_CHANGED");
+        p.shouldMatch("§3[INFO]§b v8j has set USERNAME's guild rank from Recruit to Chief");
+        p.shouldMatch("§3[INFO]§b v8j has set USERNAMES' guild rank from Recruiter to Chief");
     }
 }


### PR DESCRIPTION
If something needs doing, do it yourself.

I have now ported all regex tests from regexr.com to our unit tests. (At least, those that had a regexr.com link in the source).

A handful of tests did not actually work, or did not work if I updated the regexr test with the current value of the pattern. I have just commented these out -- we should really investigate if the wynn format has changed, of if we have actually broken the regex pattern.

I made a few changes to the regexr tests if they failed, if they contained superfluous `§r` codes. I believe these changes are safe to do.