### PR TITLE
chore: Don't run tests on "build"

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildDependents -x spotlessCheck
+          arguments: buildDependents -x spotlessCheck -x test
 
       - name: Upload files to release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildDependents -x spotlessCheck
+          arguments: buildDependents -x spotlessCheck -x test
 
       - name: Test with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pre-alpha-release.yml
+++ b/.github/workflows/pre-alpha-release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildDependents -x spotlessCheck
+          arguments: buildDependents -x spotlessCheck -x test
 
       - name: Upload files to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Turns out we already ran tests, when we built the mod. I've made sure we only run them separately now. (2 second runtime for tests was a little suspicious)