### PR TITLE
fix: Vanilla actionbar formatting [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -19,6 +19,7 @@ import java.util.regex.Matcher;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class ActionBarHandler extends Handler {
+    private static final String VANILLA_PADDING = "\\s{4,}";
     private static final StyledText CENTER_PADDING = StyledText.fromString("§0               ");
     private static final String STANDARD_PADDING = "    ";
 
@@ -52,7 +53,7 @@ public final class ActionBarHandler extends Handler {
         }
         previousRawContent = content;
 
-        StyledText[] contentGroups = content.split(" {4,}");
+        StyledText[] contentGroups = content.split(VANILLA_PADDING);
 
         // Create map of position -> matching part of the content
         Map<ActionBarPosition, StyledText> positionMatches = new EnumMap<>(ActionBarPosition.class);

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -73,7 +73,6 @@ public final class ActionBarHandler extends Handler {
 
         StyledText newContentBuilder = StyledText.EMPTY;
         // vanilla segments have three spaces between each segment, regardless of content
-        //
         if (!lastSegments.get(ActionBarPosition.LEFT).isHidden()) {
             newContentBuilder = newContentBuilder.append(positionMatches.get(ActionBarPosition.LEFT));
         }

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.handlers.actionbar;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handler;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
@@ -57,8 +58,27 @@ public final class ActionBarHandler extends Handler {
 
         // Create map of position -> matching part of the content
         Map<ActionBarPosition, StyledText> positionMatches = new EnumMap<>(ActionBarPosition.class);
-        Arrays.stream(ActionBarPosition.values())
-                .forEach(pos -> positionMatches.put(pos, contentGroups[pos.ordinal()]));
+        switch (positionMatches.size()) {
+            case 3:
+                // normal case
+                Arrays.stream(ActionBarPosition.values())
+                        .forEach(pos -> positionMatches.put(pos, contentGroups[pos.ordinal()]));
+                break;
+            case 2:
+                // missing center
+                WynntilsMod.warn("Only 2 segments in action bar: " + content);
+                positionMatches.put(ActionBarPosition.LEFT, contentGroups[0]);
+                positionMatches.put(ActionBarPosition.RIGHT, contentGroups[1]);
+                break;
+            case 1:
+                // only center
+                WynntilsMod.warn("Only 1 segment in action bar: " + content);
+                positionMatches.put(ActionBarPosition.CENTER, contentGroups[0]);
+                break;
+            default:
+                WynntilsMod.warn("0 or more than 3 segments in action bar: " + content);
+                return;
+        }
 
         Arrays.stream(ActionBarPosition.values()).forEach(pos -> processPosition(pos, positionMatches));
 

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -58,7 +58,7 @@ public final class ActionBarHandler extends Handler {
 
         // Create map of position -> matching part of the content
         Map<ActionBarPosition, StyledText> positionMatches = new EnumMap<>(ActionBarPosition.class);
-        switch (positionMatches.size()) {
+        switch (contentGroups.length) {
             case 3:
                 // normal case
                 Arrays.stream(ActionBarPosition.values())

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class ActionBarHandler extends Handler {

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.handlers.actionbar;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handler;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
@@ -18,15 +17,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraft.ChatFormatting;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public final class ActionBarHandler extends Handler {
-    // Test in ActionBarHandler_ACTIONBAR_PATTERN
-    private static final Pattern ACTIONBAR_PATTERN =
-            Pattern.compile("(?<LEFT>.+[^ ]) {4,}(?<CENTER>.+[^ ]) {4,}(?<RIGHT>.+)");
     private static final StyledText CENTER_PADDING = StyledText.fromString("§0               ");
-    private static final String STANDARD_PADDING = "   ";
+    private static final String STANDARD_PADDING = "    ";
 
     private static final Map<ActionBarPosition, List<ActionBarSegment>> ALL_SEGMENTS = Map.of(
             ActionBarPosition.LEFT,
@@ -58,16 +53,12 @@ public final class ActionBarHandler extends Handler {
         }
         previousRawContent = content;
 
-        Matcher matcher = content.getMatcher(ACTIONBAR_PATTERN);
-        if (!matcher.matches()) {
-            WynntilsMod.warn("ActionBarHandler pattern failed to match: " + content);
-            return;
-        }
+        StyledText[] contentGroups = content.split(" {4,}");
 
         // Create map of position -> matching part of the content
         Map<ActionBarPosition, StyledText> positionMatches = new EnumMap<>(ActionBarPosition.class);
         Arrays.stream(ActionBarPosition.values())
-                .forEach(pos -> positionMatches.put(pos, StyledText.fromString(matcher.group(pos.name()))));
+                .forEach(pos -> positionMatches.put(pos, contentGroups[pos.ordinal()]));
 
         Arrays.stream(ActionBarPosition.values()).forEach(pos -> processPosition(pos, positionMatches));
 
@@ -85,15 +76,7 @@ public final class ActionBarHandler extends Handler {
             newContentBuilder = newContentBuilder.append(CENTER_PADDING);
         }
         if (!lastSegments.get(ActionBarPosition.RIGHT).isHidden()) {
-            StyledText right = positionMatches.get(ActionBarPosition.RIGHT);
-
-            // Rare case where the user has 100% curse charge, which makes StyledText remove the color code
-            // For mana, since it is the same color as the curse charge. So we add it back here
-            if (!right.startsWith(ChatFormatting.AQUA.toString())) {
-                right = StyledText.fromString(ChatFormatting.AQUA + right.getString());
-            }
-
-            newContentBuilder = newContentBuilder.append(right);
+            newContentBuilder = newContentBuilder.append(positionMatches.get(ActionBarPosition.RIGHT));
         }
         newContentBuilder = newContentBuilder.trim(); // In case either left or right is hidden
         previousProcessedContent = newContentBuilder;

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -7,7 +7,6 @@ import com.wynntils.features.chat.MessageFilterFeature;
 import com.wynntils.features.redirects.ChatRedirectFeature;
 import com.wynntils.features.trademarket.TradeMarketPriceMatchFeature;
 import com.wynntils.features.ui.BulkBuyFeature;
-import com.wynntils.handlers.actionbar.ActionBarHandler;
 import com.wynntils.handlers.chat.ChatHandler;
 import com.wynntils.handlers.chat.type.RecipientType;
 import com.wynntils.models.character.CharacterModel;

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -98,14 +98,6 @@ public class TestRegex {
     }
 
     @Test
-    public void ActionBarHandler_ACTIONBAR_PATTERN() {
-        PatternTester p = new PatternTester(ActionBarHandler.class, "ACTIONBAR_PATTERN");
-        p.shouldMatch("§c❤ 14930/14930§0      §b❉ 100%      ✺ 175/175");
-        p.shouldMatch("§c❤ 14930/14930§0      §7❉ 48%      §b✺ 175/175");
-        p.shouldMatch("§c❤ 14930/14930§0      §7❉ 48%      §b✺ 175/175");
-    }
-
-    @Test
     public void ArchetypeAbilitiesAnnotator_ARCHETYPE_NAME() {
         PatternTester p = new PatternTester(ArchetypeAbilitiesAnnotator.class, "ARCHETYPE_NAME");
         p.shouldMatch("§e§lBoltslinger Archetype");


### PR DESCRIPTION
So in the first one, the padding is missing and the mana turns a weird color when curse is charged to full. Both are fixed here. Padding of 3 spaces taken from vanilla Wynn.

![2024-01-12_02-19-57.gif](https://donkeyblaster.tk/uploads/2024-01-12_02-19-57.gif)

![2024-01-12_02-18-16.gif](https://donkeyblaster.tk/uploads/2024-01-12_02-18-16.gif)

Delayed because very few people use vanilla actionbar and this doesn't actually hide any information, just looks better