### PR TITLE
fix: Use proper hooks for enabling/disabling Discord RPC, refactor territory checking [ci skip]

### DIFF
--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -126,6 +126,11 @@ public class DiscordRichPresenceFeature extends Feature {
     }
 
     @Override
+    protected void onConfigUpdate(Config<?> config) {
+        tryUpdateDisplayedInfo();
+    }
+
+    @Override
     public void onEnable() {
         // This isReady() check is required for Linux to not crash on config change.
         if (!Services.Discord.isReady()) {
@@ -133,9 +138,18 @@ public class DiscordRichPresenceFeature extends Feature {
             if (!Services.Discord.load()) {
                 // happens when wrong version of GLIBC is installed and Discord SDK fails to load
                 Managers.Feature.crashFeature(this);
+            } else {
+                tryUpdateDisplayedInfo();
             }
         }
+    }
 
+    @Override
+    public void onDisable() {
+        Services.Discord.unload();
+    }
+
+    private void tryUpdateDisplayedInfo() {
         if (!Models.WorldState.onWorld() && Services.Discord.isReady()) return;
 
         if (displayLocation.get()) {
@@ -159,10 +173,5 @@ public class DiscordRichPresenceFeature extends Feature {
         } else {
             Services.Discord.setState("");
         }
-    }
-
-    @Override
-    public void onDisable() {
-        Services.Discord.unload();
     }
 }

--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features;
@@ -126,42 +126,43 @@ public class DiscordRichPresenceFeature extends Feature {
     }
 
     @Override
-    protected void onConfigUpdate(Config<?> config) {
-        if (this.isEnabled()) {
-            // This isReady() check is required for Linux to not crash on config change.
-            if (!Services.Discord.isReady()) {
-                // Even though this is in the onConfigUpdate method, it is how the library is first loaded on launch
-                if (!Services.Discord.load()) {
-                    // happens when wrong version of GLIBC is installed and Discord SDK fails to load
-                    Managers.Feature.crashFeature(this);
-                }
+    public void onEnable() {
+        // This isReady() check is required for Linux to not crash on config change.
+        if (!Services.Discord.isReady()) {
+            // Even though this is in the onConfigUpdate method, it is how the library is first loaded on launch
+            if (!Services.Discord.load()) {
+                // happens when wrong version of GLIBC is installed and Discord SDK fails to load
+                Managers.Feature.crashFeature(this);
             }
+        }
 
-            if (!Models.WorldState.onWorld() && Services.Discord.isReady()) return;
+        if (!Models.WorldState.onWorld() && Services.Discord.isReady()) return;
 
-            if (displayLocation.get()) {
-                if (lastTerritoryProfile == null) {
-                    stopTerritoryCheck = false;
-                    checkTerritory();
-                }
-            } else {
-                stopTerritoryCheck = true;
-                Services.Discord.setDetails("");
-            }
-
-            if (displayCharacterInfo.get()) {
-                displayCharacterDetails();
-            } else {
-                Services.Discord.setWynncraftLogo();
-            }
-
-            if (displayWorld.get()) {
-                Services.Discord.setState(Models.WorldState.getCurrentWorldName());
-            } else {
-                Services.Discord.setState("");
+        if (displayLocation.get()) {
+            if (lastTerritoryProfile == null) {
+                stopTerritoryCheck = false;
+                checkTerritory();
             }
         } else {
-            Services.Discord.unload();
+            stopTerritoryCheck = true;
+            Services.Discord.setDetails("");
         }
+
+        if (displayCharacterInfo.get()) {
+            displayCharacterDetails();
+        } else {
+            Services.Discord.setWynncraftLogo();
+        }
+
+        if (displayWorld.get()) {
+            Services.Discord.setState(Models.WorldState.getCurrentWorldName());
+        } else {
+            Services.Discord.setState("");
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        Services.Discord.unload();
     }
 }

--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -109,6 +109,7 @@ public class DiscordRichPresenceFeature extends Feature {
             if (!Services.Discord.load()) {
                 // happens when wrong version of GLIBC is installed and Discord SDK fails to load
                 Managers.Feature.crashFeature(this);
+                return;
             }
         }
 


### PR DESCRIPTION
Previously we called `DiscordService#load` for every config change, even if it was necessary. This is partially because `DiscordService#isReady` will always be false if Discord is closed. These new hooks will run iff we changed the enabled/disabled state of the feature (+on startup, if the feature is enabled). This makes config related operations much faster (as I noticed that `/config` commands hang the game for seconds...).

I would like to request help with testing some platforms, @JamieCallan117, @DonkeyBlaster. Please tick the table below if you found the feature working on the platform (please do an enable/disable cycle, start with a disabled state, run `/config reload`).

| OS | Test |
|--------|--------|
| MacOS (arch) | &check; |
| Linux - Ubuntu |  ? |
| Linux - Arch | &check; |
| Windows | &check;  |