### PR TITLE
chore: Bump Kir-Antipov/mc-publish@v3.3.0 to re-enable releases to Modrinth/Curseforge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           name: build
 
-      - uses: Kir-Antipov/mc-publish@v3.2
+      - uses: Kir-Antipov/mc-publish@v3.3.0
         with:
           modrinth-id: dU5Gb9Ab
           modrinth-featured: true


### PR DESCRIPTION
Old versions got added an extra .0, so there is no version "v3.2", only "v.3.2.0". Thanks, I guess..