### PR TITLE
fix: Sort worlds using their start time [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/ServerListModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/ServerListModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds;
@@ -46,7 +46,7 @@ public final class ServerListModel extends Model {
 
     public List<String> getServersSortedOnUptime() {
         return getServers().stream()
-                .sorted(Comparator.comparing(profile -> getServer(profile).getUptime()))
+                .sorted(Comparator.comparingLong(profile -> -getServer(profile).getFirstSeen()))
                 .toList();
     }
 


### PR DESCRIPTION
Previously it would sort using the human-readable format which led to worlds with 10+ hour uptimes appearing out of order.

|Before|After|
|---|---|
|![world list showing two worlds with 10 and 11 hour uptimes at the top of the list](https://github.com/Wynntils/Artemis/assets/71361356/ff6ae110-ae8c-4a7b-b72b-ce7a5ad6c1c5)|![world list showing a world with an 11 hour uptime at the bottom of the list](https://github.com/Wynntils/Artemis/assets/71361356/fa7566b2-93d4-4e10-a19a-8a043c718e9b)|
