### PR TITLE
fix: Fix TradeMarketScreen crashing the game if the user closes an ItemSharingScreen

### DIFF
--- a/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
@@ -119,7 +119,6 @@ public final class ItemSharingScreen extends WynntilsScreen {
 
     @Override
     public void onClose() {
-        super.onClose();
         McUtils.mc().setScreen(previousScreen);
     }
 


### PR DESCRIPTION
Turns out `super.onClose` was called in `ItemSharingScreen` for some reason, making the it close trading screen container, and crashing the game. 