### PR TITLE
refactor: Make TranscribeMessagesFeature use StyledText to produce a translator-friendly output [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.utilities;
@@ -23,12 +23,12 @@ import com.wynntils.models.wynnalphabet.type.TranscribeCondition;
 import com.wynntils.utils.colors.ColorChatFormatting;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.IterationDecision;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.Style;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -57,7 +57,6 @@ public class TranscribeMessagesFeature extends Feature {
     public final Config<ColorChatFormatting> wynnicColor = new Config<>(ColorChatFormatting.DARK_GREEN);
 
     private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*[\\]:]\\s?");
-    private static final Pattern WYNNIC_NUMBER_PATTERN = Pattern.compile("[⑴-⑿]+");
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onChat(ChatMessageReceivedEvent event) {
@@ -115,10 +114,54 @@ public class TranscribeMessagesFeature extends Feature {
 
     private StyledText getStyledTextWithTranscription(
             StyledText original, boolean transcribeWynnic, boolean transcribeGavellian, boolean npcDialogue) {
-        ChatFormatting defaultColor = npcDialogue
-                ? ColorChatFormatting.GREEN.getChatFormatting()
-                : ColorChatFormatting.WHITE.getChatFormatting();
+        if (!transcribeWynnic && !transcribeGavellian) return original;
 
+        StyledText transcribedStyledText = original;
+
+        if (transcribeWynnic) {
+            // Wynnic numbers are transcribed first
+            transcribedStyledText = transcribeStyledText(
+                    transcribedStyledText,
+                    Models.WynnAlphabet::getWynnicNumberMatcher,
+                    (partToBeTranslated) -> Models.WynnAlphabet.transcribeMessageFromWynnAlphabet(
+                            partToBeTranslated,
+                            WynnAlphabet.WYNNIC,
+                            coloredTranscriptions.get(),
+                            wynnicColor.get().getChatFormatting(),
+                            npcDialogue || showTooltip.get()));
+
+            // Wynnic characters are transcribed second
+            transcribedStyledText = transcribeStyledText(
+                    transcribedStyledText,
+                    Models.WynnAlphabet::getWynnicCharacterMatcher,
+                    (partToBeTranslated) -> Models.WynnAlphabet.transcribeMessageFromWynnAlphabet(
+                            partToBeTranslated,
+                            WynnAlphabet.WYNNIC,
+                            coloredTranscriptions.get(),
+                            wynnicColor.get().getChatFormatting(),
+                            npcDialogue || showTooltip.get()));
+        }
+
+        if (transcribeGavellian) {
+            // Lastly, Gavellian characters are transcribed
+            transcribedStyledText = transcribeStyledText(
+                    transcribedStyledText,
+                    Models.WynnAlphabet::getGavellianCharacterMatcher,
+                    (partToBeTranslated) -> Models.WynnAlphabet.transcribeMessageFromWynnAlphabet(
+                            partToBeTranslated,
+                            WynnAlphabet.GAVELLIAN,
+                            coloredTranscriptions.get(),
+                            gavellianColor.get().getChatFormatting(),
+                            npcDialogue || showTooltip.get()));
+        }
+
+        return transcribedStyledText;
+    }
+
+    private StyledText transcribeStyledText(
+            StyledText original,
+            Function<String, Matcher> matcherFunction,
+            Function<StyledTextPart, StyledTextPart> transcriptorFunction) {
         return original.iterateBackwards((part, changes) -> {
             String partText = part.getString(null, PartStyle.StyleType.NONE);
             String transcriptedText = partText;
@@ -127,55 +170,50 @@ public class TranscribeMessagesFeature extends Feature {
                 return IterationDecision.BREAK;
             }
 
-            if (transcribeWynnic) {
-                Matcher numMatcher = WYNNIC_NUMBER_PATTERN.matcher(partText);
+            List<StyledTextPart> newParts = new ArrayList<>();
 
-                if (coloredTranscriptions.get()) {
-                    transcriptedText =
-                            numMatcher.replaceAll(match -> wynnicColor.get().getChatFormatting()
-                                    + String.valueOf(Models.WynnAlphabet.wynnicNumToInt(match.group()))
-                                    + ColorChatFormatting.WHITE.getChatFormatting());
-                } else {
-                    transcriptedText = numMatcher.replaceAll(
-                            match -> String.valueOf(Models.WynnAlphabet.wynnicNumToInt(match.group())));
-                }
+            newParts = translatePartUsingMatcher(part, matcherFunction, transcriptorFunction, newParts);
 
-                transcriptedText = Models.WynnAlphabet.transcribeMessageFromWynnAlphabet(
-                        transcriptedText,
-                        WynnAlphabet.WYNNIC,
-                        coloredTranscriptions.get(),
-                        wynnicColor.get().getChatFormatting(),
-                        defaultColor);
-            }
-
-            if (transcribeGavellian) {
-                transcriptedText = Models.WynnAlphabet.transcribeMessageFromWynnAlphabet(
-                        transcriptedText,
-                        WynnAlphabet.GAVELLIAN,
-                        coloredTranscriptions.get(),
-                        gavellianColor.get().getChatFormatting(),
-                        defaultColor);
-            }
-
-            StyledTextPart newPart;
-
-            if (transcribeGavellian || transcribeWynnic) {
-                String text = showTooltip.get() ? partText : transcriptedText;
-                Component hoverComponent = (npcDialogue || showTooltip.get())
-                        ? Component.literal(transcriptedText)
-                        : Component.translatable("feature.wynntils.transcribeMessages.transcribedFrom", partText);
-                Style style = Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent));
-
-                newPart = new StyledTextPart(text, style, null, Style.EMPTY);
-            } else {
-                newPart = part;
+            // If the part was not changed, we don't need to add it to the changes
+            if (newParts.isEmpty()) {
+                return IterationDecision.CONTINUE;
             }
 
             changes.remove(part);
-            changes.add(newPart);
+            changes.addAll(newParts);
 
             return IterationDecision.CONTINUE;
         });
+    }
+
+    private List<StyledTextPart> translatePartUsingMatcher(
+            StyledTextPart part,
+            Function<String, Matcher> matcherFunction,
+            Function<StyledTextPart, StyledTextPart> transcriptorFunction,
+            List<StyledTextPart> newParts) {
+        String partText = part.getString(null, PartStyle.StyleType.NONE);
+
+        Matcher numMatcher = matcherFunction.apply(partText);
+
+        while (numMatcher.find()) {
+            if (numMatcher.start() > 0) {
+                String preNum = partText.substring(0, numMatcher.start());
+                newParts.add(new StyledTextPart(preNum, part.getPartStyle().getStyle(), null, Style.EMPTY));
+            }
+
+            StyledTextPart partToBeTranslated =
+                    new StyledTextPart(numMatcher.group(), part.getPartStyle().getStyle(), null, Style.EMPTY);
+            newParts.add(transcriptorFunction.apply(partToBeTranslated));
+
+            partText = partText.substring(numMatcher.end());
+            numMatcher = matcherFunction.apply(partText);
+        }
+
+        if (!partText.isEmpty()) {
+            newParts.add(new StyledTextPart(partText, part.getPartStyle().getStyle(), null, Style.EMPTY));
+        }
+
+        return newParts;
     }
 
     private static class WynnTranscriptedNpcDialogEvent extends NpcDialogEvent {

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1180,7 +1180,7 @@
   "feature.wynntils.transcribeMessages.transcribeCondition.name": "Transcribe Condition",
   "feature.wynntils.transcribeMessages.transcribeNpcs.description": "Transcribe NPC dialogue containing Gavellian and Wynnic?",
   "feature.wynntils.transcribeMessages.transcribeNpcs.name": "Transcribe NPC dialogue",
-  "feature.wynntils.transcribeMessages.transcribedFrom": "Transcribed from Gavellian/Wynnic, %s",
+  "feature.wynntils.transcribeMessages.transcribedFrom": "Transcribed from %s, %s",
   "feature.wynntils.transcribeMessages.wynnicColor.description": "What color should Wynnic transcriptions be?",
   "feature.wynntils.transcribeMessages.wynnicColor.name": "Wynnic Color",
   "feature.wynntils.translation.description": "Adds the ability to translate Wynntils to your language.",


### PR DESCRIPTION
... and also reduce code duplication, make it easier to add new languages, and make sure to use separate components, so we can add custom hover effects for each part.

Translators cannot make sense of the previous transcription mode, as it does not use `StyledText` parts, and just injects text coloring.

## Old transcriptor
![image](https://github.com/Wynntils/Artemis/assets/49001742/07e30319-8189-403f-8579-703026e96948)

#### String output
**NPC:** 
`[1/1] ???: §2h§a§2a§a§2s§a §2s§a§2o§a§2m§a§2e§a§2o§a§2n§a§2e§a §2e§a§2n§a§2t§a§2e§a§2r§a§2e§a§2d§a §2t§a§2h§a§2e§a §2s§a§2a§a§2n§a§2c§a§2t§a§2u§a§2m§a§2?§a §2i§a §2d§a§2i§a§2d§a §2n§a§2o§a§2t§a §2t§a§2h§a§2i§a§2n§a§2k§a §2t§a§2h§a§2e§a §2b§a§2i§a§2n§a§2d§a§2i§a§2n§a§2g§a§2s§a §2w§a§2o§a§2u§a§2l§a§2d§a §2a§a§2l§a§2l§a§2o§a§2w§a §2e§a§2n§a§2t§a§2r§a§2y§a §2t§a§2o§a §2a§a§2n§a§2y§a§2o§a§2n§a§2e§a §2f§a§2r§a§2o§a§2m§a §2t§a§2h§a§2e§a §2o§a§2u§a§2t§a§2s§a§2i§a§2d§a§2e§a§2.§a §2r§a§2e§a§2v§a§2e§a§2a§a§2l§a §2y§a§2o§a§2u§a§2r§a§2s§a§2e§a§2l§a§2f§a §2i§a§2n§a§2t§a§2r§a§2u§a§2d§a§2e§a§2r§a§2!§a`

**Player:**
`§dh§f§de§f§dl§f§dl§f§do§f, i am testing §2g§f§2a§f§2v§f§2e§f§2l§f§2l§f§2i§f§2a§f§2n§f and §dw§f§dy§f§dn§f§dn§f§di§f§dc§f transcription, attempt §21§f `

## New transcriptor
![image](https://github.com/Wynntils/Artemis/assets/49001742/25e9c535-ad5a-46f3-be77-f4b9196a18ee)

#### String output
**NPC:** 
`§7[1/1] §2???: has§a §2someone§a §2entered§a §2the§a §2sanctum?§a §2i§a §2did§a §2not§a §2think§a §2the§a §2bindings§a §2would§a §2allow§a §2entry§a §2to§a §2anyone§a §2from§a §2the§a §2outside.§a §2reveal§a §2yourself§a §2intruder!`

**Player:**
`§7[§e§obol§7] §dhello§f, i am testing §2gavellian§f and §dwynnic§f transcription, attempt §21§f`
