### PR TITLE
feat: Add support for events in string-parsed StyledTexts [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/text/PartStyle.java
+++ b/common/src/main/java/com/wynntils/core/text/PartStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.text;
@@ -160,7 +160,7 @@ public final class PartStyle {
                 styleString
                         .append(STYLE_PREFIX)
                         .append("[")
-                        .append(owner.getParent().addClickEvent(clickEvent))
+                        .append(owner.getParent().getClickEventIndex(clickEvent))
                         .append("]");
             }
 
@@ -169,7 +169,7 @@ public final class PartStyle {
                 styleString
                         .append(STYLE_PREFIX)
                         .append("<")
-                        .append(owner.getParent().addHoverEvent(hoverEvent))
+                        .append(owner.getParent().getHoverEventIndex(hoverEvent))
                         .append(">");
             }
         }

--- a/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
+++ b/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.text;
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 
@@ -54,9 +56,24 @@ public final class StyledTextPart {
 
         boolean nextIsFormatting = false;
 
+        // []
+        boolean clickEventPrefix = false;
+        // <>
+        boolean hoverEventPrefix = false;
+        String eventIndexString = "";
+
         for (char current : codedString.toCharArray()) {
             if (nextIsFormatting) {
                 nextIsFormatting = false;
+
+                if (current == '[') {
+                    clickEventPrefix = true;
+                    continue;
+                }
+                if (current == '<') {
+                    hoverEventPrefix = true;
+                    continue;
+                }
 
                 ChatFormatting formatting = ChatFormatting.getByCode(current);
 
@@ -69,9 +86,13 @@ public final class StyledTextPart {
                 // We already had some text with the current style
                 // Append it before modifying the style
                 if (!currentString.isEmpty()) {
-                    // We might have lost an event, so we need to add it back
-                    currentStyle =
-                            currentStyle.withClickEvent(style.getClickEvent()).withHoverEvent(style.getHoverEvent());
+                    if (style != Style.EMPTY) {
+                        // We might have lost an event, so we need to add it back
+                        currentStyle = currentStyle
+                                .withClickEvent(style.getClickEvent())
+                                .withHoverEvent(style.getHoverEvent());
+                    }
+                    // But if the style is empty, we might have parsed events from the string itself
 
                     parts.add(new StyledTextPart(currentString.toString(), currentStyle, null, parentStyle));
 
@@ -91,6 +112,47 @@ public final class StyledTextPart {
                 continue;
             }
 
+            // If we are parsing an event, handle it
+            if (clickEventPrefix || hoverEventPrefix) {
+                if (Character.isDigit(current)) {
+                    eventIndexString += current;
+                    continue;
+                }
+
+                if (clickEventPrefix && current == ']') {
+                    ClickEvent clickEvent = parent.getClickEvent(Integer.parseInt(eventIndexString));
+
+                    if (clickEvent != null) {
+                        currentStyle = currentStyle.withClickEvent(clickEvent);
+                        clickEventPrefix = false;
+                        eventIndexString = "";
+                        continue;
+                    }
+                }
+
+                if (hoverEventPrefix && current == '>') {
+                    HoverEvent hoverEvent = parent.getHoverEvent(Integer.parseInt(eventIndexString));
+
+                    if (hoverEvent != null) {
+                        currentStyle = currentStyle.withHoverEvent(hoverEvent);
+                        hoverEventPrefix = false;
+                        eventIndexString = "";
+                        continue;
+                    }
+                }
+
+                // The event was not formatted properly, so add it as a string
+                currentString.append(clickEventPrefix ? '[' : '<');
+                currentString.append(eventIndexString);
+                currentString.append(current);
+
+                // Reset the related variables
+                clickEventPrefix = false;
+                hoverEventPrefix = false;
+                eventIndexString = "";
+                continue;
+            }
+
             if (current == ChatFormatting.PREFIX_CODE) {
                 nextIsFormatting = true;
                 continue;
@@ -101,8 +163,11 @@ public final class StyledTextPart {
 
         // Check if we have some text left
         if (!currentString.isEmpty()) {
-            // We might have lost an event, so we need to add it back
-            currentStyle = currentStyle.withClickEvent(style.getClickEvent()).withHoverEvent(style.getHoverEvent());
+            if (style != Style.EMPTY) {
+                // We might have lost an event, so we need to add it back
+                currentStyle =
+                        currentStyle.withClickEvent(style.getClickEvent()).withHoverEvent(style.getHoverEvent());
+            }
             parts.add(new StyledTextPart(currentString.toString(), currentStyle, null, parentStyle));
         }
 


### PR DESCRIPTION
This should allow us to reconstruct fully working clickable/hoverable components after translation.

Also reworked how events are collected. Previously, it was only collected, when we ran `getString(INCLUDE_EVENTS)`.

I can't justify doing that, it was really stupid. In fact, I am glad I had to be the one to track it down. To be clear, this caused the events not be collected, unless a text was printed as text, which the `toString` method gladly does. This left me wondering why debug mode works, and production-run does not. Let me tell you the obvious: the debugger runs `toString`...

## EDIT:
I've realised that our support for events is pretty low, as we have never used them in production code before. I've added logic to make events inherit like other styles elements, like bold, so they don't get added for every part, like they used to, but only get "repeated" on reset.