### PR TITLE
fix: fix lootrun started message not matching the coordinate pattern [skip ci]

### DIFF
--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2186,7 +2186,7 @@
   "service.wynntils.itemFilter.stat.uses.description": "Uses left of the item",
   "service.wynntils.itemFilter.unknownStat": "%s: unknown stat",
   "service.wynntils.lootrunPaths.lootrunCouldNotBeLoaded": "Lootrun \"%s\" could not be loaded.",
-  "service.wynntils.lootrunPaths.lootrunStart": "Lootrun starts at %s %s %s.",
+  "service.wynntils.lootrunPaths.lootrunStart": "Lootrun starts at [%s %s %s].",
   "service.wynntils.updates.result.error": "Error applying Wynntils/Artemis update.",
   "service.wynntils.updates.result.latest": "Wynntils/Artemis is already on latest version.",
   "service.wynntils.updates.result.pending": "Update was already downloaded. It will apply on shutdown.",


### PR DESCRIPTION
fix: "%s %s %s." doesn't match LocationUtils.STRICT_COORDINATE_PATTERN

![image](https://github.com/Wynntils/Artemis/assets/24792782/5491d2bc-fb7e-4272-a4ad-4a482a9ffe08)
