### PR TITLE
fix: Incorrect price lines on certain bulk buyable items [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -91,8 +91,8 @@ public class BulkBuyFeature extends Feature {
             if (!priceMatcher.find()) continue;
 
             int newPrice = Integer.parseInt(priceMatcher.group(1)) * bulkBuyAmount.get();
-            StyledText newLine = StyledText.fromString(oldLine.getString()
-                    .replace(priceMatcher.group(1), BULK_BUY_ACTIVE_COLOR + Integer.toString(newPrice)));
+            StyledText newLine = StyledText.fromString(oldLine.getString())
+                    .replaceFirst(priceMatcher.group(1), BULK_BUY_ACTIVE_COLOR + Integer.toString(newPrice));
             if (newPrice > Models.Emerald.getAmountInInventory()) {
                 newLine = StyledText.fromString(
                         newLine.getString().replace("a✔", "c✖")); // Replace green checkmark with red x


### PR DESCRIPTION
If the price matched any color code in the price line, the entire thing would be replaced with the price*4 since .replace() does a replace all. StyledText parses first now so color codes aren't replaced.