### PR TITLE
feat: Migrate to wiki.gg [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/activities/quests/QuestModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/quests/QuestModel.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -34,7 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class QuestModel extends Model {
     private static final String MINI_QUEST_PREFIX = "Mini-Quest - ";
-    private static final Pattern WIKI_APOSTROPHE = Pattern.compile("&#039;");
+    private static final String WIKI_APOSTROPHE = "&#039;";
 
     private List<QuestInfo> quests = List.of();
     private List<QuestInfo> miniQuests = List.of();
@@ -138,9 +137,11 @@ public final class QuestModel extends Model {
             ApiResponse apiResponse =
                     Managers.Net.callApi(UrlId.API_WIKI_QUEST_PAGE_QUERY, Map.of("name", questInfo.getName()));
             apiResponse.handleJsonArray(json -> {
-                String pageTitle = WIKI_APOSTROPHE
-                        .matcher(json.get(0).getAsJsonObject().get("_pageTitle").getAsString())
-                        .replaceAll("'");
+                String pageTitle = json.get(0)
+                        .getAsJsonObject()
+                        .get("_pageTitle")
+                        .getAsString()
+                        .replace(WIKI_APOSTROPHE, "'");
                 Managers.Net.openLink(UrlId.LINK_WIKI_LOOKUP, Map.of("title", pageTitle));
             });
         }

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": 10
+    "version": 11
   },
   {
     "id": "apiAthenaAuthPublicKey",

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -61,7 +61,7 @@
     ],
     "encoding": "wiki",
     "id": "apiWikiDiscoveryQuery",
-    "url": "https://wynncraft.gamepedia.com/api.php?action=parse&format=json&prop=wikitext&section=0&redirects=true&page=%{name}"
+    "url": "https://wynncraft.wiki.gg/api.php?action=parse&format=json&prop=wikitext&section=0&page=%{name}"
   },
   {
     "arguments": [
@@ -69,7 +69,7 @@
     ],
     "encoding": "cargo",
     "id": "apiWikiQuestPageQuery",
-    "url": "https://wynncraft.fandom.com/index.php?title=Special:CargoExport&format=json&tables=Quests&fields=Quests._pageTitle&where=Quests.name=%{name}"
+    "url": "https://wynncraft.wiki.gg/index.php?title=Special:CargoExport&tables=Quests&&fields=Quests._pageTitle&where=Quests.name+%3D+%{name}&order+by=&limit=2000&format=json"
   },
   {
     "id": "dataAthenaGuildList",
@@ -222,7 +222,7 @@
     ],
     "encoding": "wiki",
     "id": "linkWikiLookup",
-    "url": "https://wynncraft.fandom.com/wiki/%{title}"
+    "url": "https://wynncraft.wiki.gg/wiki/%{title}"
   },
   {
     "arguments": [


### PR DESCRIPTION
All works as far as I can tell.

Unfortunately wiki.gg encodes the `'` in the quest list so that has to be changed back. [Fandom list](https://wynncraft.fandom.com/index.php?title=Special:CargoExport&format=json&tables=Quests&fields=Quests._pageTitle) [wiki.gg list](https://wynncraft.wiki.gg/index.php?title=Special:CargoExport&tables=Quests&&fields=Quests._pageTitle&order+by=&limit=2000&format=json)