### PR TITLE
fix: fix item data failing to load if ItemObtainType is unknown

### DIFF
--- a/common/src/main/java/com/wynntils/models/wynnitem/AbstractItemInfoDeserializer.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/AbstractItemInfoDeserializer.java
@@ -171,13 +171,20 @@ public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserialize
         if (dropMeta.has("type")) {
             JsonElement type = dropMeta.get("type");
 
-            // The type can be either a string or an array of strings
-            if (type.isJsonArray()) {
-                for (JsonElement typeElement : type.getAsJsonArray()) {
-                    types.add(ItemObtainType.fromApiName(typeElement.getAsString()));
+            // The type can be either a string or an array of string
+            try {
+                if (type.isJsonArray()) {
+                    for (JsonElement typeElement : type.getAsJsonArray()) {
+                        types.add(ItemObtainType.fromApiName(typeElement.getAsString()));
+                    }
+                } else {
+                    types.add(ItemObtainType.fromApiName(type.getAsString()));
                 }
-            } else {
-                types.add(ItemObtainType.fromApiName(type.getAsString()));
+            } catch (Exception e) {
+                WynntilsMod.warn(
+                        "Failed to parse obtain types for " + json.get("name").getAsString());
+                WynntilsMod.warn("Obtain types: " + type.toString());
+                return List.of();
             }
         }
 

--- a/common/src/main/java/com/wynntils/models/wynnitem/type/ItemObtainType.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/type/ItemObtainType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.wynnitem.type;
@@ -10,6 +10,7 @@ public enum ItemObtainType {
     // From Wynncraft API
     LOOT_CHEST("lootchest", "Tier III/IV Loot Chest"), // lootchests (implies t3 or t4, afaict)
     NORMAL_MOB_DROP("normal", "Unspecified Mob Drop"), // mob drops (and any loot chest, afaict)
+    MINIBOSS("miniboss", "Miniboss"), // miniboss
     CHALLENGE("challenge", "Challenge"), // at the moment, only Legendary Island
     EVENT("event", "Event"), // like Bonfire, Heroes, etc.
     LOOTRUN("lootrun", "Lootrun"), // lootrun


### PR DESCRIPTION
Sadly this was an overlook, so people are going to have to update for the item ids to show up..