### PR TITLE
fix: Fix item record crashing if there is a faulty item, fix item saving mode

### DIFF
--- a/common/src/main/java/com/wynntils/screens/itemsharing/SavedItemsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/itemsharing/SavedItemsScreen.java
@@ -71,6 +71,10 @@ public final class SavedItemsScreen extends WynntilsContainerScreen<SavedItemsMe
     @Override
     protected void doInit() {
         super.doInit();
+
+        // If our encoding breaks for some reason, we need to clean up the item record to prevent crashes
+        Services.ItemRecord.cleanupItemRecord();
+
         this.leftPos = (this.width - Texture.ITEM_RECORD.width()) / 2;
         this.topPos = (this.height - Texture.ITEM_RECORD.height()) / 2;
 

--- a/common/src/main/java/com/wynntils/services/itemrecord/type/SavedItem.java
+++ b/common/src/main/java/com/wynntils/services/itemrecord/type/SavedItem.java
@@ -22,11 +22,14 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 public record SavedItem(String base64, Set<String> categories, ItemStack itemStack) implements Comparable<SavedItem> {
+    // This is the encoding settings used to encode the item when it was saved
+    // We cannot let users not save extended identification and share item name as it would break the item if the API
+    // changes
+    private static final EncodingSettings SAVED_ITEM_ENCODING_SETTINGS = new EncodingSettings(true, true);
+
     public static SavedItem create(WynnItem wynnItem, Set<String> categories, ItemStack itemStack) {
-        EncodingSettings encodingSettings = new EncodingSettings(
-                Models.ItemEncoding.extendedIdentificationEncoding.get(), Models.ItemEncoding.shareItemName.get());
         ErrorOr<EncodedByteBuffer> errorOrEncodedByteBuffer =
-                Models.ItemEncoding.encodeItem(wynnItem, encodingSettings);
+                Models.ItemEncoding.encodeItem(wynnItem, SAVED_ITEM_ENCODING_SETTINGS);
 
         if (errorOrEncodedByteBuffer.hasError()) {
             throw new IllegalArgumentException(

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2189,6 +2189,7 @@
   "service.wynntils.itemFilter.stat.tradeAmount.description": "Amount of the item",
   "service.wynntils.itemFilter.stat.uses.description": "Uses left of the item",
   "service.wynntils.itemFilter.unknownStat": "%s: unknown stat",
+  "service.wynntils.itemRecord.cleanupComplete": "Item record cleanup complete. Removed %d faulty records. Readded %d records that can now be decoded.",
   "service.wynntils.lootrunPaths.lootrunCouldNotBeLoaded": "Lootrun \"%s\" could not be loaded.",
   "service.wynntils.lootrunPaths.lootrunStart": "Lootrun starts at [%s %s %s].",
   "service.wynntils.updates.result.error": "Error applying Wynntils/Artemis update.",


### PR DESCRIPTION

This PR adds the proper save flags for saved items, which is extended encoding. We did not do this previously, slowly breaking the saved items with API changes. Unfortunately, we cannot make the item record keep up with item changes, all items in there need to be saved as-is at the time of recording. I've also added a fallback cleanup mechanism for the future, quarantining faulty items and trying to re-add items that parse (after a patch or other change).