### PR TITLE
fix: Loadouts misalignment and disappearing when deleting [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
@@ -487,6 +487,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
 
     public void doScroll(double scrollAmount) {
         int scrollableWidgets = Math.max(0, loadoutWidgets.size() - MAX_LOADOUTS_PER_PAGE);
+        if (scrollableWidgets == 0) return;
         float scrollableRatio = (float) scrollableWidgets / loadoutWidgets.size();
         float maxScrollOffset = (4 * (loadoutWidgets.size() - 1) - 43) / scrollableRatio;
         scrollPercent = (float) Math.max(0, Math.min(scrollableRatio, scrollPercent - scrollAmount / 50));

--- a/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
@@ -255,7 +255,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                             poseStack,
                             StyledText.fromString(summaryParts.get(i).key().get()),
                             dividedWidth * 35,
-                            dividedHeight * (11 + i * 2),
+                            dividedHeight * (10 + i * 2),
                             CommonColors.WHITE,
                             HorizontalAlignment.LEFT,
                             VerticalAlignment.BOTTOM,
@@ -284,7 +284,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                             dividedHeight * 23,
                             CommonColors.WHITE,
                             HorizontalAlignment.LEFT,
-                            VerticalAlignment.BOTTOM,
+                            VerticalAlignment.MIDDLE,
                             TextShadow.NORMAL);
         }
         // endregion

--- a/common/src/main/java/com/wynntils/screens/skillpointloadouts/widgets/LoadoutWidget.java
+++ b/common/src/main/java/com/wynntils/screens/skillpointloadouts/widgets/LoadoutWidget.java
@@ -18,6 +18,8 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.Pair;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
@@ -30,6 +32,7 @@ public class LoadoutWidget extends AbstractWidget {
     private final String name;
     private final SavableSkillPointSet loadout;
     private final SkillPointLoadoutsScreen parent;
+    private final List<String> gearNames = new ArrayList<>();
 
     public LoadoutWidget(
             int x,
@@ -45,6 +48,11 @@ public class LoadoutWidget extends AbstractWidget {
         this.name = name;
         this.loadout = loadout;
         this.parent = parent;
+        if (loadout.weapon() != null) {
+            gearNames.add(loadout.weapon());
+        }
+        gearNames.addAll(loadout.armourNames());
+        gearNames.addAll(loadout.accessoryNames());
     }
 
     @Override
@@ -69,12 +77,11 @@ public class LoadoutWidget extends AbstractWidget {
         }
 
         int nameYOffset = 2;
-        if (loadout.isBuild()) {
+        if (loadout.isBuild()) { // Renders list of weapon, armour, and accessories under name for build loadouts
             nameYOffset = 3;
             String text = RenderedStringUtils.getMaxFittingText(
-                    String.join(
-                            ", ", (loadout.armourNames().isEmpty() ? loadout.accessoryNames() : loadout.armourNames())),
-                    this.getWidth(),
+                    String.join(", ", gearNames),
+                    dividedWidth * 19,
                     FontRenderer.getInstance().getFont());
             FontRenderer.getInstance()
                     .renderText(


### PR DESCRIPTION
![image](https://github.com/Wynntils/Artemis/assets/57310593/9bc1e58e-4bf1-43c3-9850-ec221b086ee4)

They also display weapons now as shown