### PR TITLE
fix: Make blocks_above_ground function handle an edge-case hang

### DIFF
--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -91,7 +91,7 @@ public final class CharacterStatsModel extends Model {
             endY--;
 
             // stop checking beyond the minimum build height as there will never be any blocks below it
-            if (endY < McUtils.mc().level.getMinBuildHeight()) break;
+            if (endY < McUtils.mc().level.getMinBuildHeight()) return -1;
         }
 
         // add the floor height to the result to account for half-blocks

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -90,9 +90,8 @@ public final class CharacterStatsModel extends Model {
                 .isAir()) {
             endY--;
 
-            if (endY < -64) {
-                break;
-            }
+            // stop checking beyond the minimum build height as there will never be any blocks below it
+            if (endY < McUtils.mc().level.getMinBuildHeight()) break;
         }
 
         // add the floor height to the result to account for half-blocks

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -89,6 +89,10 @@ public final class CharacterStatsModel extends Model {
                         McUtils.player().blockPosition().getZ()))
                 .isAir()) {
             endY--;
+
+            if (endY < -64) {
+                break;
+            }
         }
 
         // add the floor height to the result to account for half-blocks


### PR DESCRIPTION
Some situations where it would previously enter an infinite loop are:
- when you're above the void in sky islands
- when you're entering or leaving a housing balloon
- using teleport scrolls