### PR TITLE
fix: Use proper url encoding [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/utils/StringUtils.java
+++ b/common/src/main/java/com/wynntils/utils/StringUtils.java
@@ -1,10 +1,10 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils;
 
-import java.net.URLEncoder;
+import com.google.common.net.UrlEscapers;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
@@ -68,7 +68,7 @@ public final class StringUtils {
     }
 
     public static String encodeUrl(String url) {
-        return URLEncoder.encode(url, StandardCharsets.UTF_8);
+        return UrlEscapers.urlFragmentEscaper().escape(url);
     }
 
     public static String createSlug(String input) {

--- a/common/src/main/java/com/wynntils/utils/StringUtils.java
+++ b/common/src/main/java/com/wynntils/utils/StringUtils.java
@@ -68,7 +68,7 @@ public final class StringUtils {
     }
 
     public static String encodeUrl(String url) {
-        return UrlEscapers.urlFragmentEscaper().escape(url);
+        return UrlEscapers.urlPathSegmentEscaper().escape(url);
     }
 
     public static String createSlug(String input) {

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -85,7 +85,7 @@
   },
   {
     "id": "dataStaticAbilities",
-    "md5": "986503d68ae7433ab125366f382cb914",
+    "md5": "fd5e9a5b76988ae00265695ee90d622a",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Reference/abilities.json"
   },
   {


### PR DESCRIPTION
The previous method encoded the string by the `application/x-www-form-urlencoded` standard, which differs from the HTML specification, so spaces were encoded as "+" instead of "%20" which caused issues when using V3 Wynncraft API.