### PR TITLE
feat: Introduce provider types for ItemStatProviders and SearchableContainers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -39,14 +39,12 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.SearchWidget;
-import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.wynn.ContainerUtils;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -259,7 +257,7 @@ public class ContainerSearchFeature extends Feature {
                     renderY - 20,
                     175,
                     20,
-                    List.of(ItemProviderType.GENERIC),
+                    currentContainer.supportedProviderTypes(),
                     false,
                     query -> {
                         lastSearchQuery = query;

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -39,7 +39,7 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.SearchWidget;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
@@ -259,7 +259,7 @@ public class ContainerSearchFeature extends Feature {
                     renderY - 20,
                     175,
                     20,
-                    List.of(ItemFilterType.GENERIC),
+                    List.of(ItemProviderType.GENERIC),
                     false,
                     query -> {
                         lastSearchQuery = query;

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -39,12 +39,14 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.SearchWidget;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.wynn.ContainerUtils;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -257,6 +259,7 @@ public class ContainerSearchFeature extends Feature {
                     renderY - 20,
                     175,
                     20,
+                    List.of(ItemFilterType.GENERIC),
                     false,
                     query -> {
                         lastSearchQuery = query;

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -14,11 +14,9 @@ import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerCloseEvent;
-import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.mc.event.ContainerSetSlotEvent;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
-import com.wynntils.mc.event.InventoryMouseClickedEvent;
 import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.mc.extension.ScreenExtension;
@@ -39,16 +37,13 @@ import com.wynntils.models.containers.type.wynncontainers.PetMenuContainer;
 import com.wynntils.models.containers.type.wynncontainers.ScrapMenuContainer;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
-import com.wynntils.screens.base.widgets.ItemSearchHelperWidget;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.SearchWidget;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
-import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.wynn.ContainerUtils;
 import java.util.Locale;
 import java.util.Map;
@@ -133,7 +128,6 @@ public class ContainerSearchFeature extends Feature {
     private long guildBankLastSearch = 0;
 
     private SearchWidget lastSearchWidget;
-    private ItemSearchHelperWidget lastItemSearchHelperWidget;
     private SearchableContainerProperty currentContainer;
     private boolean autoSearching = false;
     private ItemSearchQuery lastSearchQuery;
@@ -151,22 +145,6 @@ public class ContainerSearchFeature extends Feature {
         if (currentContainer == null) return;
 
         addWidgets(((AbstractContainerScreen<ChestMenu>) screen), renderX, renderY);
-    }
-
-    // This might not be needed in 1.20
-    // Render the tooltip last
-    @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onContainerRender(ContainerRenderEvent event) {
-        if (lastItemSearchHelperWidget == null) return;
-
-        if (lastItemSearchHelperWidget.isHovered()) {
-            event.getGuiGraphics()
-                    .renderComponentTooltip(
-                            FontRenderer.getInstance().getFont(),
-                            lastItemSearchHelperWidget.getTooltipLines(),
-                            event.getMouseX(),
-                            event.getMouseY());
-        }
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)
@@ -201,7 +179,6 @@ public class ContainerSearchFeature extends Feature {
     public void onContainerClose(ContainerCloseEvent.Post event) {
         lastSearchWidget = null;
         lastSearchQuery = null;
-        lastItemSearchHelperWidget = null;
         currentContainer = null;
         autoSearching = false;
         guildBankLastSearch = 0;
@@ -227,16 +204,6 @@ public class ContainerSearchFeature extends Feature {
         }
 
         tryAutoSearch(abstractContainerScreen);
-    }
-
-    @SubscribeEvent
-    public void onInventoryMouseClick(InventoryMouseClickedEvent event) {
-        if (lastItemSearchHelperWidget == null) return;
-
-        if (lastItemSearchHelperWidget.mouseClicked(event.getMouseX(), event.getMouseY(), event.getButton())) {
-            event.setCanceled(true);
-            return;
-        }
     }
 
     private void tryAutoSearch(AbstractContainerScreen<?> abstractContainerScreen) {
@@ -304,16 +271,6 @@ public class ContainerSearchFeature extends Feature {
             lastSearchWidget = searchWidget;
 
             screen.addRenderableWidget(lastSearchWidget);
-
-            lastItemSearchHelperWidget = new ItemSearchHelperWidget(
-                    renderX + screen.imageWidth - 11,
-                    renderY - 14,
-                    Texture.INFO.width() / 3,
-                    Texture.INFO.height() / 3,
-                    Texture.INFO,
-                    true);
-
-            screen.addRenderableWidget(lastItemSearchHelperWidget);
         } else {
             SearchWidget searchWidget = new SearchWidget(
                     renderX + screen.imageWidth - 175,

--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -7,7 +7,7 @@ package com.wynntils.models.containers;
 import com.wynntils.core.components.Model;
 import com.wynntils.mc.event.ScreenClosedEvent;
 import com.wynntils.mc.event.ScreenInitEvent;
-import com.wynntils.models.containers.type.WynncraftContainer;
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.wynncontainers.AbilityTreeContainer;
 import com.wynntils.models.containers.type.wynncontainers.AccountBankContainer;
 import com.wynntils.models.containers.type.wynncontainers.BlockBankContainer;
@@ -50,8 +50,8 @@ public final class ContainerModel extends Model {
     public static final String COSMETICS_MENU_NAME = "Crates, Bombs & Cosmetics";
     public static final String MASTERY_TOMES_NAME = "Mastery Tomes";
 
-    private static final List<WynncraftContainer> containerTypes = new ArrayList<>();
-    private WynncraftContainer currentContainer = null;
+    private static final List<AbstractWynncraftContainer> containerTypes = new ArrayList<>();
+    private AbstractWynncraftContainer currentContainer = null;
 
     public ContainerModel() {
         super(List.of());
@@ -65,7 +65,7 @@ public final class ContainerModel extends Model {
 
         if (!(e.getScreen() instanceof AbstractContainerScreen<?> screen)) return;
 
-        for (WynncraftContainer container : containerTypes) {
+        for (AbstractWynncraftContainer container : containerTypes) {
             if (container.isScreen(screen)) {
                 currentContainer = container;
                 currentContainer.setContainerId(screen.getMenu().containerId);
@@ -79,7 +79,7 @@ public final class ContainerModel extends Model {
         currentContainer = null;
     }
 
-    public WynncraftContainer getCurrentContainer() {
+    public AbstractWynncraftContainer getCurrentContainer() {
         return currentContainer;
     }
 
@@ -113,7 +113,7 @@ public final class ContainerModel extends Model {
         registerWynncraftContainer(new TradeMarketSecondaryContainer());
     }
 
-    private void registerWynncraftContainer(WynncraftContainer container) {
+    private void registerWynncraftContainer(AbstractWynncraftContainer container) {
         containerTypes.add(container);
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/AbstractWynncraftContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/AbstractWynncraftContainer.java
@@ -8,24 +8,27 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import net.minecraft.client.gui.screens.Screen;
 
-public abstract class WynncraftContainer {
+public abstract class AbstractWynncraftContainer implements ContainerProperty {
     private final Predicate<Screen> screenPredicate;
 
     private int containerId;
 
-    protected WynncraftContainer(Pattern titlePattern) {
+    protected AbstractWynncraftContainer(Pattern titlePattern) {
         this.screenPredicate =
                 screen -> titlePattern.matcher(screen.getTitle().getString()).matches();
     }
 
+    @Override
     public void setContainerId(int containerId) {
         this.containerId = containerId;
     }
 
+    @Override
     public int getContainerId() {
         return containerId;
     }
 
+    @Override
     public boolean isScreen(Screen screen) {
         return screenPredicate.test(screen);
     }

--- a/common/src/main/java/com/wynntils/models/containers/type/ContainerProperty.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/ContainerProperty.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.type;
+
+import net.minecraft.client.gui.screens.Screen;
+
+/**
+ * Marker interface for properties that are used in containers.
+ */
+public interface ContainerProperty {
+    /**
+     * Sets the container ID.
+     *
+     * @param containerId The container ID.
+     */
+    void setContainerId(int containerId);
+
+    /**
+     * Gets the container ID.
+     *
+     * @return The container ID.
+     */
+    int getContainerId();
+
+    /**
+     * Checks if the screen is the container.
+     *
+     * @param screen The screen to check.
+     * @return True if the screen is the container, false otherwise.
+     */
+    boolean isScreen(Screen screen);
+}

--- a/common/src/main/java/com/wynntils/models/containers/type/FullscreenContainerProperty.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/FullscreenContainerProperty.java
@@ -4,4 +4,9 @@
  */
 package com.wynntils.models.containers.type;
 
-public interface FullscreenContainerProperty {}
+/**
+ * Marker interface for properties that are used in fullscreen containers.
+ * These containers are displayed in the entire screen,
+ * and temporarily replace the user's inventory.
+ */
+public interface FullscreenContainerProperty extends ContainerProperty {}

--- a/common/src/main/java/com/wynntils/models/containers/type/PersonalStorageContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/PersonalStorageContainer.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.models.containers.type;
 
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class PersonalStorageContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -48,7 +50,7 @@ public class PersonalStorageContainer extends AbstractWynncraftContainer impleme
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return true;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of(ItemProviderType.GENERIC);
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/PersonalStorageContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/PersonalStorageContainer.java
@@ -5,6 +5,7 @@
 package com.wynntils.models.containers.type;
 
 import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -51,6 +52,6 @@ public class PersonalStorageContainer extends AbstractWynncraftContainer impleme
 
     @Override
     public List<ItemProviderType> supportedProviderTypes() {
-        return List.of(ItemProviderType.GENERIC);
+        return Arrays.stream(ItemProviderType.values()).toList();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/PersonalStorageContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/PersonalStorageContainer.java
@@ -6,7 +6,7 @@ package com.wynntils.models.containers.type;
 
 import java.util.regex.Pattern;
 
-public class PersonalStorageContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class PersonalStorageContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a <§2<§a<§2<§a<");
 

--- a/common/src/main/java/com/wynntils/models/containers/type/RewardContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/RewardContainer.java
@@ -6,7 +6,7 @@ package com.wynntils.models.containers.type;
 
 import java.util.regex.Pattern;
 
-public class RewardContainer extends WynncraftContainer {
+public class RewardContainer extends AbstractWynncraftContainer {
     protected RewardContainer(Pattern titlePattern) {
         super(titlePattern);
     }

--- a/common/src/main/java/com/wynntils/models/containers/type/ScrollableContainerProperty.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/ScrollableContainerProperty.java
@@ -9,7 +9,10 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 
-public interface ScrollableContainerProperty {
+/**
+ * Marker interface for properties that are used in containers that can be scrolled.
+ */
+public interface ScrollableContainerProperty extends ContainerProperty {
     Pattern getNextItemPattern();
 
     Pattern getPreviousItemPattern();

--- a/common/src/main/java/com/wynntils/models/containers/type/SearchableContainerProperty.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/SearchableContainerProperty.java
@@ -4,6 +4,10 @@
  */
 package com.wynntils.models.containers.type;
 
+/**
+ * Represents a container that can be searched. These containers are scrollable,
+ * and have a defined bounds where the content can appear.
+ */
 public interface SearchableContainerProperty extends ScrollableContainerProperty {
     ContainerBounds getBounds();
 

--- a/common/src/main/java/com/wynntils/models/containers/type/SearchableContainerProperty.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/SearchableContainerProperty.java
@@ -4,6 +4,9 @@
  */
 package com.wynntils.models.containers.type;
 
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
+
 /**
  * Represents a container that can be searched. These containers are scrollable,
  * and have a defined bounds where the content can appear.
@@ -11,5 +14,14 @@ package com.wynntils.models.containers.type;
 public interface SearchableContainerProperty extends ScrollableContainerProperty {
     ContainerBounds getBounds();
 
-    boolean supportsAdvancedSearch();
+    /**
+     * Returns the supported provider types for this container.
+     * If basic search should be used, return an empty list.
+     * @return The supported provider types or an empty list if basic search should be used.
+     */
+    List<ItemProviderType> supportedProviderTypes();
+
+    default boolean supportsAdvancedSearch() {
+        return !supportedProviderTypes().isEmpty();
+    }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/AbilityTreeContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/AbilityTreeContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.FullscreenContainerProperty;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class AbilityTreeContainer extends WynncraftContainer
+public class AbilityTreeContainer extends AbstractWynncraftContainer
         implements ScrollableContainerProperty, FullscreenContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("(?:Warrior|Shaman|Mage|Assassin|Archer) Abilities");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/BlockBankContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/BlockBankContainer.java
@@ -19,6 +19,6 @@ public class BlockBankContainer extends PersonalStorageContainer {
 
     @Override
     public List<ItemProviderType> supportedProviderTypes() {
-        return List.of(ItemProviderType.COUNTED);
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/BlockBankContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/BlockBankContainer.java
@@ -6,6 +6,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 
 import com.wynntils.models.containers.type.PersonalStorageContainer;
 import com.wynntils.models.containers.type.PersonalStorageType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class BlockBankContainer extends PersonalStorageContainer {
@@ -16,7 +18,7 @@ public class BlockBankContainer extends PersonalStorageContainer {
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of(ItemProviderType.COUNTED);
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/CharacterInfoContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/CharacterInfoContainer.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
-import com.wynntils.models.containers.type.WynncraftContainer;
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import java.util.regex.Pattern;
 
-public class CharacterInfoContainer extends WynncraftContainer {
+public class CharacterInfoContainer extends AbstractWynncraftContainer {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Character Info");
 
     public CharacterInfoContainer() {

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ContentBookContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ContentBookContainer.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.FullscreenContainerProperty;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class ContentBookContainer extends WynncraftContainer
+public class ContentBookContainer extends AbstractWynncraftContainer
         implements SearchableContainerProperty, FullscreenContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("§f\uE000\uE072");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Scroll Down");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ContentBookContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ContentBookContainer.java
@@ -8,6 +8,8 @@ import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.FullscreenContainerProperty;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class ContentBookContainer extends AbstractWynncraftContainer
@@ -46,7 +48,7 @@ public class ContentBookContainer extends AbstractWynncraftContainer
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildBankContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildBankContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class GuildBankContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class GuildBankContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile(".+: Bank \\(.+\\)");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§a§lNext Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§a§lPrevious Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildBankContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildBankContainer.java
@@ -8,6 +8,7 @@ import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
 import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -47,6 +48,6 @@ public class GuildBankContainer extends AbstractWynncraftContainer implements Se
 
     @Override
     public List<ItemProviderType> supportedProviderTypes() {
-        return List.of(ItemProviderType.GENERIC);
+        return Arrays.stream(ItemProviderType.values()).toList();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildBankContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildBankContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class GuildBankContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class GuildBankContainer extends AbstractWynncraftContainer implements Se
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return true;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of(ItemProviderType.GENERIC);
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildMemberListContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildMemberListContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class GuildMemberListContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class GuildMemberListContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile(".+: Members");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§a§lNext Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§a§lPrevious Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildMemberListContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildMemberListContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class GuildMemberListContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class GuildMemberListContainer extends AbstractWynncraftContainer impleme
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildTerritoriesContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildTerritoriesContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class GuildTerritoriesContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class GuildTerritoriesContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile(".+: Territories");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§a§lNext Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§a§lPrevious Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildTerritoriesContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/GuildTerritoriesContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class GuildTerritoriesContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class GuildTerritoriesContainer extends AbstractWynncraftContainer implem
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingJukeboxContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingJukeboxContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class HousingJukeboxContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class HousingJukeboxContainer extends AbstractWynncraftContainer implemen
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingJukeboxContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingJukeboxContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class HousingJukeboxContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class HousingJukeboxContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Select Songs");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Previous Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingListContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingListContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class HousingListContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class HousingListContainer extends AbstractWynncraftContainer implements 
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingListContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/HousingListContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class HousingListContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class HousingListContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Available Islands");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Previous Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/JukeboxContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/JukeboxContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class JukeboxContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class JukeboxContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Player's Jukebox");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Previous Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/JukeboxContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/JukeboxContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class JukeboxContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class JukeboxContainer extends AbstractWynncraftContainer implements Sear
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/LobbyContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/LobbyContainer.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class LobbyContainer extends WynncraftContainer implements ScrollableContainerProperty {
+public class LobbyContainer extends AbstractWynncraftContainer implements ScrollableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Wynncraft Servers");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a <§2<§a<§2<§a<");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/PetMenuContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/PetMenuContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class PetMenuContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class PetMenuContainer extends AbstractWynncraftContainer implements Sear
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/PetMenuContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/PetMenuContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class PetMenuContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class PetMenuContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Pet Menu");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a <§2<§a<§2<§a<");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ScrapMenuContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ScrapMenuContainer.java
@@ -4,12 +4,12 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class ScrapMenuContainer extends WynncraftContainer implements SearchableContainerProperty {
+public class ScrapMenuContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Scrap Rewards");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Previous Page");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ScrapMenuContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/ScrapMenuContainer.java
@@ -7,6 +7,8 @@ package com.wynntils.models.containers.type.wynncontainers;
 import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ContainerBounds;
 import com.wynntils.models.containers.type.SearchableContainerProperty;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class ScrapMenuContainer extends AbstractWynncraftContainer implements SearchableContainerProperty {
@@ -44,7 +46,7 @@ public class ScrapMenuContainer extends AbstractWynncraftContainer implements Se
     }
 
     @Override
-    public boolean supportsAdvancedSearch() {
-        return false;
+    public List<ItemProviderType> supportedProviderTypes() {
+        return List.of();
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/SeaskipperContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/SeaskipperContainer.java
@@ -4,10 +4,10 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
-import com.wynntils.models.containers.type.WynncraftContainer;
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import java.util.regex.Pattern;
 
-public class SeaskipperContainer extends WynncraftContainer {
+public class SeaskipperContainer extends AbstractWynncraftContainer {
     private static final Pattern TITLE_PATTERN = Pattern.compile("V.S.S. Seaskipper");
 
     public SeaskipperContainer() {

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/TradeMarketFiltersContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/TradeMarketFiltersContainer.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class TradeMarketFiltersContainer extends WynncraftContainer implements ScrollableContainerProperty {
+public class TradeMarketFiltersContainer extends AbstractWynncraftContainer implements ScrollableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("\\[Pg\\. \\d] Filter Items");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Forward to §fPage \\d+");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Back to §fPage \\d+");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/TradeMarketPrimaryContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/TradeMarketPrimaryContainer.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class TradeMarketPrimaryContainer extends WynncraftContainer implements ScrollableContainerProperty {
+public class TradeMarketPrimaryContainer extends AbstractWynncraftContainer implements ScrollableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Trade Market");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a <§2<§a<§2<§a<");

--- a/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/TradeMarketSecondaryContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/type/wynncontainers/TradeMarketSecondaryContainer.java
@@ -4,11 +4,11 @@
  */
 package com.wynntils.models.containers.type.wynncontainers;
 
+import com.wynntils.models.containers.type.AbstractWynncraftContainer;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
-import com.wynntils.models.containers.type.WynncraftContainer;
 import java.util.regex.Pattern;
 
-public class TradeMarketSecondaryContainer extends WynncraftContainer implements ScrollableContainerProperty {
+public class TradeMarketSecondaryContainer extends AbstractWynncraftContainer implements ScrollableContainerProperty {
     private static final Pattern TITLE_PATTERN = Pattern.compile("Search Results");
     private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a >§2>§a>§2>§a>");
     private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§f§lPage \\d+§a <§2<§a<§2<§a<");

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
@@ -5,7 +5,7 @@
 package com.wynntils.screens.base.widgets;
 
 import com.wynntils.core.components.Services;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.services.itemfilter.type.StatFilter;
 import com.wynntils.services.itemfilter.type.StatFilterFactory;
@@ -21,7 +21,7 @@ import org.lwjgl.glfw.GLFW;
 public class ItemSearchHelperWidget extends BasicTexturedButton {
     private static final int ELEMENTS_PER_PAGE = 4;
 
-    private final List<ItemFilterType> supportedFilterTypes;
+    private final List<ItemProviderType> supportedProviderTypes;
     private final List<List<Component>> tooltipPages = new ArrayList<>();
 
     private int page = 0;
@@ -33,9 +33,9 @@ public class ItemSearchHelperWidget extends BasicTexturedButton {
             int height,
             Texture texture,
             boolean scaleTexture,
-            List<ItemFilterType> supportedFilterTypes) {
+            List<ItemProviderType> supportedProviderTypes) {
         super(x, y, width, height, texture, (b) -> {}, List.of(), scaleTexture);
-        this.supportedFilterTypes = supportedFilterTypes;
+        this.supportedProviderTypes = supportedProviderTypes;
 
         generateTooltipPages();
     }
@@ -96,8 +96,8 @@ public class ItemSearchHelperWidget extends BasicTexturedButton {
         // Stats
         counter = 0;
         List<ItemStatProvider<?>> itemStatProviders = Services.ItemFilter.getItemStatProviders().stream()
-                .filter(itemStatProvider -> supportedFilterTypes.contains(ItemFilterType.GENERIC)
-                        || itemStatProvider.getFilterTypes().stream().anyMatch(supportedFilterTypes::contains))
+                .filter(itemStatProvider -> supportedProviderTypes.contains(ItemProviderType.GENERIC)
+                        || itemStatProvider.getFilterTypes().stream().anyMatch(supportedProviderTypes::contains))
                 .toList();
         for (ItemStatProvider<?> itemStatProvider : itemStatProviders) {
             currentTooltip.add(Component.empty());

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
@@ -5,6 +5,7 @@
 package com.wynntils.screens.base.widgets;
 
 import com.wynntils.core.components.Services;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.services.itemfilter.type.StatFilter;
 import com.wynntils.services.itemfilter.type.StatFilterFactory;
@@ -20,12 +21,21 @@ import org.lwjgl.glfw.GLFW;
 public class ItemSearchHelperWidget extends BasicTexturedButton {
     private static final int ELEMENTS_PER_PAGE = 4;
 
+    private final List<ItemFilterType> supportedFilterTypes;
     private final List<List<Component>> tooltipPages = new ArrayList<>();
 
     private int page = 0;
 
-    public ItemSearchHelperWidget(int x, int y, int width, int height, Texture texture, boolean scaleTexture) {
+    public ItemSearchHelperWidget(
+            int x,
+            int y,
+            int width,
+            int height,
+            Texture texture,
+            boolean scaleTexture,
+            List<ItemFilterType> supportedFilterTypes) {
         super(x, y, width, height, texture, (b) -> {}, List.of(), scaleTexture);
+        this.supportedFilterTypes = supportedFilterTypes;
 
         generateTooltipPages();
     }
@@ -85,7 +95,10 @@ public class ItemSearchHelperWidget extends BasicTexturedButton {
 
         // Stats
         counter = 0;
-        List<ItemStatProvider<?>> itemStatProviders = Services.ItemFilter.getItemStatProviders();
+        List<ItemStatProvider<?>> itemStatProviders = Services.ItemFilter.getItemStatProviders().stream()
+                .filter(itemStatProvider -> supportedFilterTypes.contains(ItemFilterType.GENERIC)
+                        || itemStatProvider.getFilterTypes().stream().anyMatch(supportedFilterTypes::contains))
+                .toList();
         for (ItemStatProvider<?> itemStatProvider : itemStatProviders) {
             currentTooltip.add(Component.empty());
             currentTooltip.add(Component.literal(itemStatProvider.getName() + ": ")

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchHelperWidget.java
@@ -96,7 +96,7 @@ public class ItemSearchHelperWidget extends BasicTexturedButton {
         // Stats
         counter = 0;
         List<ItemStatProvider<?>> itemStatProviders = Services.ItemFilter.getItemStatProviders().stream()
-                .filter(itemStatProvider -> supportedProviderTypes.contains(ItemProviderType.GENERIC)
+                .filter(itemStatProvider -> supportedProviderTypes.contains(ItemProviderType.ALL)
                         || itemStatProvider.getFilterTypes().stream().anyMatch(supportedProviderTypes::contains))
                 .toList();
         for (ItemStatProvider<?> itemStatProvider : itemStatProviders) {

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
@@ -8,6 +8,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.base.TextboxScreen;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -16,6 +17,7 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.Pair;
+import java.util.List;
 import java.util.function.Consumer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
@@ -24,6 +26,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
 
 public class ItemSearchWidget extends SearchWidget {
+    private final List<ItemFilterType> supportedFilterTypes;
     private final boolean supportsSorting;
     private final ItemSearchHelperWidget helperWidget;
 
@@ -36,12 +39,20 @@ public class ItemSearchWidget extends SearchWidget {
             int y,
             int width,
             int height,
+            List<ItemFilterType> supportedFilterTypes,
             boolean supportsSorting,
             Consumer<ItemSearchQuery> onSearchQueryUpdateConsumer,
             TextboxScreen textboxScreen) {
         super(x, y, width, height, null, textboxScreen);
+        this.supportedFilterTypes = supportedFilterTypes;
         this.helperWidget = new ItemSearchHelperWidget(
-                x + width - 14, y + 6, Texture.INFO.width() / 3, Texture.INFO.height() / 3, Texture.INFO, true);
+                x + width - 14,
+                y + 6,
+                Texture.INFO.width() / 3,
+                Texture.INFO.height() / 3,
+                Texture.INFO,
+                true,
+                supportedFilterTypes);
         this.supportsSorting = supportsSorting;
         this.onSearchQueryUpdateConsumer = onSearchQueryUpdateConsumer;
         this.searchQuery = Services.ItemFilter.createSearchQuery("", supportsSorting);

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base.widgets;
@@ -11,6 +11,7 @@ import com.wynntils.screens.base.TextboxScreen;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
@@ -18,11 +19,13 @@ import com.wynntils.utils.type.Pair;
 import java.util.function.Consumer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
 
 public class ItemSearchWidget extends SearchWidget {
     private final boolean supportsSorting;
+    private final ItemSearchHelperWidget helperWidget;
 
     private ItemSearchQuery searchQuery;
 
@@ -37,9 +40,31 @@ public class ItemSearchWidget extends SearchWidget {
             Consumer<ItemSearchQuery> onSearchQueryUpdateConsumer,
             TextboxScreen textboxScreen) {
         super(x, y, width, height, null, textboxScreen);
+        this.helperWidget = new ItemSearchHelperWidget(
+                x + width - 14, y + 6, Texture.INFO.width() / 3, Texture.INFO.height() / 3, Texture.INFO, true);
         this.supportsSorting = supportsSorting;
         this.onSearchQueryUpdateConsumer = onSearchQueryUpdateConsumer;
         this.searchQuery = Services.ItemFilter.createSearchQuery("", supportsSorting);
+    }
+
+    @Override
+    public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        super.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
+
+        helperWidget.render(guiGraphics, mouseX, mouseY, partialTick);
+        if (helperWidget.isMouseOver(mouseX, mouseY)) {
+            guiGraphics.renderComponentTooltip(
+                    FontRenderer.getInstance().getFont(), helperWidget.getTooltipLines(), mouseX, mouseY);
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (helperWidget.mouseClicked(mouseX, mouseY, button)) {
+            return true;
+        }
+
+        return super.mouseClicked(mouseX, mouseY, button);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
@@ -8,7 +8,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.base.TextboxScreen;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -26,7 +26,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
 
 public class ItemSearchWidget extends SearchWidget {
-    private final List<ItemFilterType> supportedFilterTypes;
+    private final List<ItemProviderType> supportedProviderTypes;
     private final boolean supportsSorting;
     private final ItemSearchHelperWidget helperWidget;
 
@@ -39,12 +39,12 @@ public class ItemSearchWidget extends SearchWidget {
             int y,
             int width,
             int height,
-            List<ItemFilterType> supportedFilterTypes,
+            List<ItemProviderType> supportedProviderTypes,
             boolean supportsSorting,
             Consumer<ItemSearchQuery> onSearchQueryUpdateConsumer,
             TextboxScreen textboxScreen) {
         super(x, y, width, height, null, textboxScreen);
-        this.supportedFilterTypes = supportedFilterTypes;
+        this.supportedProviderTypes = supportedProviderTypes;
         this.helperWidget = new ItemSearchHelperWidget(
                 x + width - 14,
                 y + 6,
@@ -52,10 +52,10 @@ public class ItemSearchWidget extends SearchWidget {
                 Texture.INFO.height() / 3,
                 Texture.INFO,
                 true,
-                supportedFilterTypes);
+                supportedProviderTypes);
         this.supportsSorting = supportsSorting;
         this.onSearchQueryUpdateConsumer = onSearchQueryUpdateConsumer;
-        this.searchQuery = Services.ItemFilter.createSearchQuery("", supportsSorting, supportedFilterTypes);
+        this.searchQuery = Services.ItemFilter.createSearchQuery("", supportsSorting, supportedProviderTypes);
     }
 
     @Override
@@ -191,7 +191,7 @@ public class ItemSearchWidget extends SearchWidget {
 
     @Override
     protected void onUpdate(String text) {
-        searchQuery = Services.ItemFilter.createSearchQuery(text, supportsSorting, supportedFilterTypes);
+        searchQuery = Services.ItemFilter.createSearchQuery(text, supportsSorting, supportedProviderTypes);
         onSearchQueryUpdateConsumer.accept(searchQuery);
 
         if (searchQuery.errors().isEmpty()) {

--- a/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/ItemSearchWidget.java
@@ -55,7 +55,7 @@ public class ItemSearchWidget extends SearchWidget {
                 supportedFilterTypes);
         this.supportsSorting = supportsSorting;
         this.onSearchQueryUpdateConsumer = onSearchQueryUpdateConsumer;
-        this.searchQuery = Services.ItemFilter.createSearchQuery("", supportsSorting);
+        this.searchQuery = Services.ItemFilter.createSearchQuery("", supportsSorting, supportedFilterTypes);
     }
 
     @Override
@@ -191,7 +191,7 @@ public class ItemSearchWidget extends SearchWidget {
 
     @Override
     protected void onUpdate(String text) {
-        searchQuery = Services.ItemFilter.createSearchQuery(text, supportsSorting);
+        searchQuery = Services.ItemFilter.createSearchQuery(text, supportsSorting, supportedFilterTypes);
         onSearchQueryUpdateConsumer.accept(searchQuery);
 
         if (searchQuery.errors().isEmpty()) {

--- a/common/src/main/java/com/wynntils/screens/base/widgets/SearchWidget.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/SearchWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base.widgets;

--- a/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
@@ -7,7 +7,6 @@ package com.wynntils.screens.guides;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.screens.base.WynntilsListScreen;
 import com.wynntils.screens.base.widgets.BackButton;
-import com.wynntils.screens.base.widgets.ItemSearchHelperWidget;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.PageSelectorButton;
 import com.wynntils.screens.base.widgets.WynntilsButton;
@@ -16,8 +15,6 @@ import com.wynntils.utils.render.Texture;
 import net.minecraft.network.chat.Component;
 
 public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends WynntilsListScreen<E, B> {
-    private WynntilsButton helperButton;
-
     protected WynntilsGuideScreen(Component component) {
         super(component);
 
@@ -29,15 +26,6 @@ public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends W
     @Override
     protected void doInit() {
         super.doInit();
-
-        helperButton = new ItemSearchHelperWidget(
-                Texture.CONTENT_BOOK_BACKGROUND.width() - 17,
-                -19,
-                (int) (Texture.INFO.width() / 1.7f),
-                (int) (Texture.INFO.height() / 1.7f),
-                Texture.INFO,
-                true);
-        this.addRenderableWidget(helperButton);
 
         this.addRenderableWidget(new BackButton(
                 (int) ((Texture.CONTENT_BOOK_BACKGROUND.width() / 2f - 16) / 2f),
@@ -73,19 +61,6 @@ public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends W
         }
 
         reloadElementsList(itemSearchWidget.getSearchQuery());
-    }
-
-    @Override
-    public boolean doMouseClicked(double mouseX, double mouseY, int button) {
-        final float translationX = getTranslationX();
-        final float translationY = getTranslationY();
-
-        // Don't want right click clearing the text input
-        if (helperButton != null && helperButton.mouseClicked(mouseX - translationX, mouseY - translationY, button)) {
-            return false;
-        }
-
-        return super.doMouseClicked(mouseX, mouseY, button);
     }
 
     protected abstract void reloadElementsList(ItemSearchQuery searchQuery);

--- a/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
@@ -10,14 +10,14 @@ import com.wynntils.screens.base.widgets.BackButton;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.PageSelectorButton;
 import com.wynntils.screens.base.widgets.WynntilsButton;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.render.Texture;
 import java.util.List;
 import net.minecraft.network.chat.Component;
 
 public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends WynntilsListScreen<E, B> {
-    protected WynntilsGuideScreen(Component component, List<ItemFilterType> supportedFilterTypes) {
+    protected WynntilsGuideScreen(Component component, List<ItemProviderType> supportedProviderTypes) {
         super(component);
 
         // Override the search widget with our own
@@ -26,7 +26,7 @@ public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends W
                 -22,
                 Texture.CONTENT_BOOK_BACKGROUND.width(),
                 20,
-                supportedFilterTypes,
+                supportedProviderTypes,
                 true,
                 q -> reloadElements(),
                 this);

--- a/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/WynntilsGuideScreen.java
@@ -10,17 +10,26 @@ import com.wynntils.screens.base.widgets.BackButton;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.PageSelectorButton;
 import com.wynntils.screens.base.widgets.WynntilsButton;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.render.Texture;
+import java.util.List;
 import net.minecraft.network.chat.Component;
 
 public abstract class WynntilsGuideScreen<E, B extends WynntilsButton> extends WynntilsListScreen<E, B> {
-    protected WynntilsGuideScreen(Component component) {
+    protected WynntilsGuideScreen(Component component, List<ItemFilterType> supportedFilterTypes) {
         super(component);
 
         // Override the search widget with our own
         this.searchWidget = new ItemSearchWidget(
-                0, -22, Texture.CONTENT_BOOK_BACKGROUND.width(), 20, true, q -> reloadElements(), this);
+                0,
+                -22,
+                Texture.CONTENT_BOOK_BACKGROUND.width(),
+                20,
+                supportedFilterTypes,
+                true,
+                q -> reloadElements(),
+                this);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.charm;
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -30,7 +31,9 @@ public final class WynntilsCharmGuideScreen
     private List<GuideCharmItemStack> allCharmItems = List.of();
 
     private WynntilsCharmGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.charmGuide.name"));
+        super(
+                Component.translatable("screens.wynntils.wynntilsGuides.charmGuide.name"),
+                List.of(ItemFilterType.GEAR, ItemFilterType.GEAR_INSTANCE));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
@@ -33,7 +33,7 @@ public final class WynntilsCharmGuideScreen
     private WynntilsCharmGuideScreen() {
         super(
                 Component.translatable("screens.wynntils.wynntilsGuides.charmGuide.name"),
-                List.of(ItemProviderType.GEAR, ItemProviderType.GEAR_INSTANCE));
+                List.of(ItemProviderType.GENERIC, ItemProviderType.GEAR, ItemProviderType.GEAR_INSTANCE));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
@@ -9,7 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -33,7 +33,7 @@ public final class WynntilsCharmGuideScreen
     private WynntilsCharmGuideScreen() {
         super(
                 Component.translatable("screens.wynntils.wynntilsGuides.charmGuide.name"),
-                List.of(ItemFilterType.GEAR, ItemFilterType.GEAR_INSTANCE));
+                List.of(ItemProviderType.GEAR, ItemProviderType.GEAR_INSTANCE));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.gear;
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -29,7 +30,7 @@ public final class WynntilsItemGuideScreen extends WynntilsGuideScreen<GuideGear
     private List<GuideGearItemStack> allGearItems = List.of();
 
     private WynntilsItemGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"), List.of(ItemFilterType.GEAR));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
@@ -30,7 +30,9 @@ public final class WynntilsItemGuideScreen extends WynntilsGuideScreen<GuideGear
     private List<GuideGearItemStack> allGearItems = List.of();
 
     private WynntilsItemGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"), List.of(ItemProviderType.GEAR));
+        super(
+                Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"),
+                List.of(ItemProviderType.GENERIC, ItemProviderType.GEAR));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
@@ -9,7 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -30,7 +30,7 @@ public final class WynntilsItemGuideScreen extends WynntilsGuideScreen<GuideGear
     private List<GuideGearItemStack> allGearItems = List.of();
 
     private WynntilsItemGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"), List.of(ItemFilterType.GEAR));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.itemGuide.name"), List.of(ItemProviderType.GEAR));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.ingredient;
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -31,7 +32,9 @@ public final class WynntilsIngredientGuideScreen
     private List<GuideIngredientItemStack> allIngredientItems = List.of();
 
     private WynntilsIngredientGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.ingredientGuide.name"));
+        super(
+                Component.translatable("screens.wynntils.wynntilsGuides.ingredientGuide.name"),
+                List.of(ItemFilterType.INGREDIENT));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
@@ -34,7 +34,7 @@ public final class WynntilsIngredientGuideScreen
     private WynntilsIngredientGuideScreen() {
         super(
                 Component.translatable("screens.wynntils.wynntilsGuides.ingredientGuide.name"),
-                List.of(ItemProviderType.INGREDIENT));
+                List.of(ItemProviderType.GENERIC, ItemProviderType.INGREDIENT, ItemProviderType.PROFESSION));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
@@ -9,7 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -34,7 +34,7 @@ public final class WynntilsIngredientGuideScreen
     private WynntilsIngredientGuideScreen() {
         super(
                 Component.translatable("screens.wynntils.wynntilsGuides.ingredientGuide.name"),
-                List.of(ItemFilterType.INGREDIENT));
+                List.of(ItemProviderType.INGREDIENT));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
@@ -30,7 +30,9 @@ public final class WynntilsTomeGuideScreen extends WynntilsGuideScreen<GuideTome
     private List<GuideTomeItemStack> allTomeItems = List.of();
 
     private WynntilsTomeGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.tomeGuide.name"), List.of(ItemProviderType.GEAR));
+        super(
+                Component.translatable("screens.wynntils.wynntilsGuides.tomeGuide.name"),
+                List.of(ItemProviderType.GENERIC, ItemProviderType.GEAR));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
@@ -9,7 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -30,7 +30,7 @@ public final class WynntilsTomeGuideScreen extends WynntilsGuideScreen<GuideTome
     private List<GuideTomeItemStack> allTomeItems = List.of();
 
     private WynntilsTomeGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.tomeGuide.name"), List.of(ItemFilterType.GEAR));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.tomeGuide.name"), List.of(ItemProviderType.GEAR));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.tome;
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.screens.guides.WynntilsGuideScreen;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.FontRenderer;
@@ -29,7 +30,7 @@ public final class WynntilsTomeGuideScreen extends WynntilsGuideScreen<GuideTome
     private List<GuideTomeItemStack> allTomeItems = List.of();
 
     private WynntilsTomeGuideScreen() {
-        super(Component.translatable("screens.wynntils.wynntilsGuides.tomeGuide.name"));
+        super(Component.translatable("screens.wynntils.wynntilsGuides.tomeGuide.name"), List.of(ItemFilterType.GEAR));
     }
 
     public static Screen create() {

--- a/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
+++ b/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
@@ -24,6 +24,7 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import java.util.Arrays;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
@@ -89,7 +90,7 @@ public class TradeMarketSearchResultScreen extends WynntilsContainerScreen<Chest
                 renderY,
                 175,
                 20,
-                List.of(ItemProviderType.GENERIC),
+                Arrays.stream(ItemProviderType.values()).toList(),
                 true,
                 (query) -> {
                     saveSearchFilter(query);

--- a/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
+++ b/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.trademarket;
@@ -100,15 +100,6 @@ public class TradeMarketSearchResultScreen extends WynntilsContainerScreen<Chest
         // On reloads, this should not change anything
         itemSearchWidget.setTextBoxInput(Models.TradeMarket.getLastSearchFilter());
 
-        WynntilsButton helperButton = new ItemSearchHelperWidget(
-                renderX + 160,
-                renderY + 4,
-                (int) (Texture.INFO.width() / 2f),
-                (int) (Texture.INFO.height() / 2f),
-                Texture.INFO,
-                true);
-        this.addRenderableWidget(helperButton);
-
         WynntilsButton backButton = new BasicTexturedButton(
                 renderX - Texture.CONTAINER_SIDEBAR.width() / 2 - 2,
                 renderY + Texture.CONTAINER_SIDEBAR.height(),
@@ -160,10 +151,10 @@ public class TradeMarketSearchResultScreen extends WynntilsContainerScreen<Chest
 
         updateItems();
 
-        renderables.forEach(c -> c.render(guiGraphics, mouseX, mouseY, partialTick));
-
         super.doRender(guiGraphics, mouseX, mouseY, partialTick);
         renderScrollButton(poseStack);
+
+        renderables.forEach(c -> c.render(guiGraphics, mouseX, mouseY, partialTick));
 
         // Render item tooltip
         super.renderTooltip(guiGraphics, mouseX, mouseY);

--- a/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
+++ b/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
@@ -16,6 +16,7 @@ import com.wynntils.screens.base.widgets.ItemSearchHelperWidget;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.trademarket.widgets.PresetButton;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CustomColor;
@@ -88,6 +89,7 @@ public class TradeMarketSearchResultScreen extends WynntilsContainerScreen<Chest
                 renderY,
                 175,
                 20,
+                List.of(ItemFilterType.GENERIC),
                 true,
                 (query) -> {
                     saveSearchFilter(query);

--- a/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
+++ b/common/src/main/java/com/wynntils/screens/trademarket/TradeMarketSearchResultScreen.java
@@ -16,7 +16,7 @@ import com.wynntils.screens.base.widgets.ItemSearchHelperWidget;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
 import com.wynntils.screens.base.widgets.WynntilsButton;
 import com.wynntils.screens.trademarket.widgets.PresetButton;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemSearchQuery;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CustomColor;
@@ -89,7 +89,7 @@ public class TradeMarketSearchResultScreen extends WynntilsContainerScreen<Chest
                 renderY,
                 175,
                 20,
-                List.of(ItemFilterType.GENERIC),
+                List.of(ItemProviderType.GENERIC),
                 true,
                 (query) -> {
                     saveSearchFilter(query);

--- a/common/src/main/java/com/wynntils/services/itemfilter/ItemFilterService.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/ItemFilterService.java
@@ -326,7 +326,7 @@ public class ItemFilterService extends Service {
     private ErrorOr<ItemStatProvider<?>> getItemStatProvider(
             String name, List<ItemProviderType> supportedProviderTypes) {
         Optional<ItemStatProvider<?>> itemStatProviderOpt = itemStatProviders.stream()
-                .filter(provider -> supportedProviderTypes.contains(ItemProviderType.GENERIC)
+                .filter(provider -> supportedProviderTypes.contains(ItemProviderType.ALL)
                         || provider.getFilterTypes().stream().anyMatch(supportedProviderTypes::contains))
                 .filter(filter ->
                         filter.getName().equals(name) || filter.getAliases().contains(name))

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ActualStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ActualStatProvider.java
@@ -13,7 +13,7 @@ import com.wynntils.models.items.items.game.IngredientItem;
 import com.wynntils.models.stats.type.StatActualValue;
 import com.wynntils.models.stats.type.StatPossibleValues;
 import com.wynntils.models.stats.type.StatType;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.services.itemfilter.type.StatValue;
 import com.wynntils.utils.type.Pair;
@@ -52,8 +52,8 @@ public class ActualStatProvider extends ItemStatProvider<StatValue> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR, ItemFilterType.GEAR_INSTANCE, ItemFilterType.INGREDIENT);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR, ItemProviderType.GEAR_INSTANCE, ItemProviderType.INGREDIENT);
     }
 
     private List<StatValue> handleIngredientItem(IngredientItem ingredientItem) {

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ActualStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ActualStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -13,6 +13,7 @@ import com.wynntils.models.items.items.game.IngredientItem;
 import com.wynntils.models.stats.type.StatActualValue;
 import com.wynntils.models.stats.type.StatPossibleValues;
 import com.wynntils.models.stats.type.StatType;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.services.itemfilter.type.StatValue;
 import com.wynntils.utils.type.Pair;
@@ -48,6 +49,11 @@ public class ActualStatProvider extends ItemStatProvider<StatValue> {
         }
 
         return List.of();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR, ItemFilterType.GEAR_INSTANCE, ItemFilterType.INGREDIENT);
     }
 
     private List<StatValue> handleIngredientItem(IngredientItem ingredientItem) {

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/CountedItemStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/CountedItemStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.CountedItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class CountedItemStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.COUNTED);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.COUNTED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/CountedItemStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/CountedItemStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.CountedItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class CountedItemStatProvider extends ItemStatProvider<Integer> {
         if (!(wynnItem instanceof CountedItemProperty countedItemProperty)) return List.of();
 
         return List.of(countedItemProperty.getCount());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.COUNTED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/DurabilityStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/DurabilityStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.DurableItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.utils.type.CappedValue;
 import java.util.List;
@@ -20,7 +20,7 @@ public class DurabilityStatProvider extends ItemStatProvider<CappedValue> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.DURABLE);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.DURABLE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/DurabilityStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/DurabilityStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.DurableItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.utils.type.CappedValue;
 import java.util.List;
@@ -16,5 +17,10 @@ public class DurabilityStatProvider extends ItemStatProvider<CappedValue> {
         if (!(wynnItem instanceof DurableItemProperty durableItemProperty)) return List.of();
 
         return List.of(durableItemProperty.getDurability());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.DURABLE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/EmeraldValueStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/EmeraldValueStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.EmeraldValuedItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class EmeraldValueStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.VALUED);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/EmeraldValueStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/EmeraldValueStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.EmeraldValuedItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class EmeraldValueStatProvider extends ItemStatProvider<Integer> {
         if (!(wynnItem instanceof EmeraldValuedItemProperty emeraldValuedItemProperty)) return List.of();
 
         return List.of(emeraldValuedItemProperty.getEmeraldValue());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/FavoriteStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/FavoriteStatProvider.java
@@ -7,6 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.core.components.Services;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.NamedItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -18,6 +19,11 @@ public class FavoriteStatProvider extends ItemStatProvider<Boolean> {
         }
 
         return List.of(false);
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GENERIC);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/FavoriteStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/FavoriteStatProvider.java
@@ -7,7 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.core.components.Services;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.NamedItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -22,8 +22,8 @@ public class FavoriteStatProvider extends ItemStatProvider<Boolean> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GENERIC);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GENERIC);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearRestrictionStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearRestrictionStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class GearRestrictionStatProvider extends ItemStatProvider<String> {
         if (!(wynnItem instanceof GearItem gearItem)) return List.of();
 
         return List.of(gearItem.getItemInfo().metaInfo().restrictions().name());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearRestrictionStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearRestrictionStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class GearRestrictionStatProvider extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearTypeStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearTypeStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.GearTypeItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class GearTypeStatProvider extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearTypeStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/GearTypeStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.GearTypeItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class GearTypeStatProvider extends ItemStatProvider<String> {
         if (!(wynnItem instanceof GearTypeItemProperty gearTypeItemProperty)) return List.of();
 
         return List.of(gearTypeItemProperty.getGearType().name());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/HealthStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/HealthStatProvider.java
@@ -7,7 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.CraftedGearItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +27,7 @@ public class HealthStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR, ItemFilterType.GEAR_INSTANCE);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR, ItemProviderType.GEAR_INSTANCE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/HealthStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/HealthStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -7,6 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.CraftedGearItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.Collections;
 import java.util.List;
@@ -23,5 +24,10 @@ public class HealthStatProvider extends ItemStatProvider<Integer> {
         }
 
         return List.of();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR, ItemFilterType.GEAR_INSTANCE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ItemTypeStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ItemTypeStatProvider.java
@@ -1,10 +1,11 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -12,5 +13,10 @@ public class ItemTypeStatProvider extends ItemStatProvider<String> {
     @Override
     public List<String> getValue(WynnItem wynnItem) {
         return List.of(wynnItem.getClass().getSimpleName().replace("Item", ""));
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GENERIC);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ItemTypeStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ItemTypeStatProvider.java
@@ -5,7 +5,7 @@
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -16,7 +16,7 @@ public class ItemTypeStatProvider extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GENERIC);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GENERIC);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/LevelStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/LevelStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.LeveledItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,8 +19,8 @@ public class LevelStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GENERIC);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GENERIC);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/LevelStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/LevelStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.LeveledItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,6 +16,11 @@ public class LevelStatProvider extends ItemStatProvider<Integer> {
         if (!(wynnItem instanceof LeveledItemProperty levelItemProperty)) return List.of();
 
         return List.of(levelItemProperty.getLevel());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GENERIC);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/MajorIdStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/MajorIdStatProvider.java
@@ -7,7 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.gear.type.GearMajorId;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -22,7 +22,7 @@ public class MajorIdStatProvider extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/MajorIdStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/MajorIdStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -7,6 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.gear.type.GearMajorId;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -18,5 +19,10 @@ public class MajorIdStatProvider extends ItemStatProvider<String> {
         return gearItem.getItemInfo().fixedStats().majorIds().stream()
                 .map(GearMajorId::name)
                 .toList();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/OverallStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/OverallStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -7,6 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 import java.util.Optional;
@@ -25,5 +26,10 @@ public class OverallStatProvider extends ItemStatProvider<Integer> {
         }
 
         return List.of();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR_INSTANCE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/OverallStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/OverallStatProvider.java
@@ -7,7 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +29,7 @@ public class OverallStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR_INSTANCE);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR_INSTANCE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PowderSlotsStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PowderSlotsStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class PowderSlotsStatProvider extends ItemStatProvider<Integer> {
         if (!(wynnItem instanceof GearItem gearItem)) return List.of();
 
         return List.of(gearItem.getItemInfo().powderSlots());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PowderSlotsStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PowderSlotsStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class PowderSlotsStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PriceStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PriceStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -8,6 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.trademarket.type.TradeMarketPriceInfo;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -26,5 +27,10 @@ public class PriceStatProvider extends ItemStatProvider<Integer> {
 
         // Silverbull price is the normal price if the item is not discounted
         return List.of(priceInfo.silverbullPrice());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PriceStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/PriceStatProvider.java
@@ -8,7 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.trademarket.type.TradeMarketPriceInfo;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -30,7 +30,7 @@ public class PriceStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.VALUED);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ProfessionStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ProfessionStatProvider.java
@@ -7,7 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.ProfessionItemProperty;
 import com.wynntils.models.profession.type.ProfessionType;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -22,8 +22,8 @@ public class ProfessionStatProvider extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.PROFESSION);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.PROFESSION);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ProfessionStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/ProfessionStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -7,6 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.ProfessionItemProperty;
 import com.wynntils.models.profession.type.ProfessionType;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -18,6 +19,11 @@ public class ProfessionStatProvider extends ItemStatProvider<String> {
         return professionItemProperty.getProfessionTypes().stream()
                 .map(ProfessionType::getDisplayName)
                 .toList();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.PROFESSION);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/QualityTierStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/QualityTierStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.QualityTierItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class QualityTierStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.INGREDIENT, ItemFilterType.MATERIAL);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.INGREDIENT, ItemProviderType.MATERIAL);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/QualityTierStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/QualityTierStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.QualityTierItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class QualityTierStatProvider extends ItemStatProvider<Integer> {
         if (!(wynnItem instanceof QualityTierItemProperty qualityTierItemProperty)) return List.of();
 
         return List.of(qualityTierItemProperty.getQualityTier());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.INGREDIENT, ItemFilterType.MATERIAL);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/RarityStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/RarityStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.GearTierItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class RarityStatProvider extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/RarityStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/RarityStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.GearTierItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class RarityStatProvider extends ItemStatProvider<String> {
         if (!(wynnItem instanceof GearTierItemProperty gearTierItemProperty)) return List.of();
 
         return List.of(gearTierItemProperty.getGearTier().getName());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillReqStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillReqStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -7,6 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.utils.type.Pair;
 import java.util.List;
@@ -36,5 +37,10 @@ public class SkillReqStatProvider extends ItemStatProvider<Integer> {
                 .filter(pair -> pair.key() == skill)
                 .map(Pair::value)
                 .toList();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillReqStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillReqStatProvider.java
@@ -7,7 +7,7 @@ package com.wynntils.services.itemfilter.statproviders;
 import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.utils.type.Pair;
 import java.util.List;
@@ -40,7 +40,7 @@ public class SkillReqStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GEAR);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -9,6 +9,7 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.stats.type.SkillStatType;
 import com.wynntils.models.stats.type.StatActualValue;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -37,5 +38,11 @@ public class SkillStatProvider extends ItemStatProvider<Integer> {
                 .filter(id -> id.statType() instanceof SkillStatType)
                 .map(StatActualValue::value)
                 .toList();
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        // Skill stats are either fixed in gear
+        return List.of(ItemFilterType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/SkillStatProvider.java
@@ -9,7 +9,7 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.stats.type.SkillStatType;
 import com.wynntils.models.stats.type.StatActualValue;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -41,8 +41,8 @@ public class SkillStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
+    public List<ItemProviderType> getFilterTypes() {
         // Skill stats are either fixed in gear
-        return List.of(ItemFilterType.GEAR);
+        return List.of(ItemProviderType.GEAR);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TargetStatProperty.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TargetStatProperty.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.TargetedItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class TargetStatProperty extends ItemStatProvider<String> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.GENERIC);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.GENERIC);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TargetStatProperty.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TargetStatProperty.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.TargetedItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class TargetStatProperty extends ItemStatProvider<String> {
         if (!(wynnItem instanceof TargetedItemProperty targetedItemProperty)) return List.of();
 
         return List.of(targetedItemProperty.getTarget());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.GENERIC);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TierStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TierStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.NumberedTierItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class TierStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.TIERED);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.TIERED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TierStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TierStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.NumberedTierItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -15,5 +16,10 @@ public class TierStatProvider extends ItemStatProvider<Integer> {
         if (!(wynnItem instanceof NumberedTierItemProperty numberedTierItemProperty)) return List.of();
 
         return List.of(numberedTierItemProperty.getTier());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.TIERED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TotalPriceStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TotalPriceStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -8,6 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.trademarket.type.TradeMarketPriceInfo;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -25,5 +26,10 @@ public class TotalPriceStatProvider extends ItemStatProvider<Integer> {
         }
 
         return List.of(priceInfo.totalPrice());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TotalPriceStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TotalPriceStatProvider.java
@@ -8,7 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.trademarket.type.TradeMarketPriceInfo;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class TotalPriceStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.VALUED);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TradeAmountStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TradeAmountStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
@@ -8,6 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.trademarket.type.TradeMarketPriceInfo;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -25,5 +26,10 @@ public class TradeAmountStatProvider extends ItemStatProvider<Integer> {
         }
 
         return List.of(priceInfo.amount());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TradeAmountStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/TradeAmountStatProvider.java
@@ -8,7 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.trademarket.type.TradeMarketPriceInfo;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class TradeAmountStatProvider extends ItemStatProvider<Integer> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.VALUED);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.VALUED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/UsesStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/UsesStatProvider.java
@@ -21,6 +21,6 @@ public class UsesStatProvider extends ItemStatProvider<CappedValue> {
 
     @Override
     public List<ItemProviderType> getFilterTypes() {
-        return List.of(ItemProviderType.DURABLE);
+        return List.of(ItemProviderType.COUNTED);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/UsesStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/UsesStatProvider.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.UsesItemProperty;
+import com.wynntils.services.itemfilter.type.ItemFilterType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.utils.type.CappedValue;
 import java.util.List;
@@ -16,5 +17,10 @@ public class UsesStatProvider extends ItemStatProvider<CappedValue> {
         if (!(wynnItem instanceof UsesItemProperty usesItemProperty)) return List.of();
 
         return List.of(usesItemProperty.getUses());
+    }
+
+    @Override
+    public List<ItemFilterType> getFilterTypes() {
+        return List.of(ItemFilterType.DURABLE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/UsesStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/UsesStatProvider.java
@@ -6,7 +6,7 @@ package com.wynntils.services.itemfilter.statproviders;
 
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.properties.UsesItemProperty;
-import com.wynntils.services.itemfilter.type.ItemFilterType;
+import com.wynntils.services.itemfilter.type.ItemProviderType;
 import com.wynntils.services.itemfilter.type.ItemStatProvider;
 import com.wynntils.utils.type.CappedValue;
 import java.util.List;
@@ -20,7 +20,7 @@ public class UsesStatProvider extends ItemStatProvider<CappedValue> {
     }
 
     @Override
-    public List<ItemFilterType> getFilterTypes() {
-        return List.of(ItemFilterType.DURABLE);
+    public List<ItemProviderType> getFilterTypes() {
+        return List.of(ItemProviderType.DURABLE);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemfilter/type/ItemFilterType.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/type/ItemFilterType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.itemfilter.type;
+
+/**
+ * Represents the type of item filter.
+ * Item filter types are used to determine if the current container supports the filter.
+ * An item filter can have multiple types, but it must have at least one.
+ */
+public enum ItemFilterType {
+    /**
+     * A generic item filter. If this is present, the filter can be used for any item.
+     */
+    GENERIC,
+
+    /**
+     * A filter for gear items.
+     */
+    GEAR,
+
+    /**
+     * A filter for gear items, where identified gear instances are present.
+     */
+    GEAR_INSTANCE,
+
+    /**
+     * A filter for ingredients.
+     */
+    INGREDIENT,
+
+    /**
+     * A filter for materials.
+     */
+    MATERIAL,
+
+    /**
+     * A filter for priced items, or for items, that have an emerald value.
+     */
+    VALUED,
+
+    /**
+     * A filter for items that have counts, such as stacks of items.
+     */
+    COUNTED,
+
+    /**
+     * A filter for items that have tiers.
+     */
+    TIERED,
+
+    /**
+     * A filter for items that have durability or have uses.
+     */
+    DURABLE,
+
+    /**
+     * A filter for items that have a profession.
+     */
+    PROFESSION
+}

--- a/common/src/main/java/com/wynntils/services/itemfilter/type/ItemProviderType.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/type/ItemProviderType.java
@@ -11,7 +11,12 @@ package com.wynntils.services.itemfilter.type;
  */
 public enum ItemProviderType {
     /**
-     * A generic item filter. If this is present, the filter can be used for any item.
+     * A filter for all items. If this is present, the filter can be used for any item.
+     */
+    ALL,
+
+    /**
+     * A generic item filter. For providers that do not fit into any other category.
      */
     GENERIC,
 

--- a/common/src/main/java/com/wynntils/services/itemfilter/type/ItemProviderType.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/type/ItemProviderType.java
@@ -5,11 +5,11 @@
 package com.wynntils.services.itemfilter.type;
 
 /**
- * Represents the type of item filter.
- * Item filter types are used to determine if the current container supports the filter.
- * An item filter can have multiple types, but it must have at least one.
+ * Represents the type of item provider.
+ * Item provider types are used to determine if the current container supports the filter.
+ * An item provider can have multiple types, but it must have at least one.
  */
-public enum ItemFilterType {
+public enum ItemProviderType {
     /**
      * A generic item filter. If this is present, the filter can be used for any item.
      */

--- a/common/src/main/java/com/wynntils/services/itemfilter/type/ItemProviderType.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/type/ItemProviderType.java
@@ -41,7 +41,7 @@ public enum ItemProviderType {
     VALUED,
 
     /**
-     * A filter for items that have counts, such as stacks of items.
+     * A filter for items that have counts or uses, such as stacks of items.
      */
     COUNTED,
 
@@ -51,7 +51,7 @@ public enum ItemProviderType {
     TIERED,
 
     /**
-     * A filter for items that have durability or have uses.
+     * A filter for items that have durability.
      */
     DURABLE,
 

--- a/common/src/main/java/com/wynntils/services/itemfilter/type/ItemStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/type/ItemStatProvider.java
@@ -34,7 +34,7 @@ public abstract class ItemStatProvider<T extends Comparable<T>> implements Trans
      * Returns the type of filter this stat provider is for.
      * @return The type of filter this stat provider is for
      */
-    public abstract List<ItemFilterType> getFilterTypes();
+    public abstract List<ItemProviderType> getFilterTypes();
 
     public Class<T> getType() {
         return (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass()).getActualTypeArguments()[0];

--- a/common/src/main/java/com/wynntils/services/itemfilter/type/ItemStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/type/ItemStatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.itemfilter.type;
@@ -29,6 +29,12 @@ public abstract class ItemStatProvider<T extends Comparable<T>> implements Trans
      * @return The value of the stat for the given item
      */
     public abstract List<T> getValue(WynnItem wynnItem);
+
+    /**
+     * Returns the type of filter this stat provider is for.
+     * @return The type of filter this stat provider is for
+     */
+    public abstract List<ItemFilterType> getFilterTypes();
 
     public Class<T> getType() {
         return (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass()).getActualTypeArguments()[0];


### PR DESCRIPTION
The filter types introduced here are debatable, but the main point of this PR is adding support for special filter types for specific containers (like territory management item filters, or guild member filters). However, I find it logical that containers know what provider types they want to use, and I prefer this over providers knowing what screens they "support". 

The types itself are only used by the helper widget now, and the filter UI, when it's finished. The ItemFilterService also filters the providers by the supported types.