### PR TITLE
fix: Make Wynntils much smarter about user info requests to greatly reduce Athena load

### DIFF
--- a/common/src/main/java/com/wynntils/models/players/PlayerModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PlayerModel.java
@@ -52,7 +52,8 @@ public final class PlayerModel extends Model {
     private final Map<UUID, Integer> ghosts = new ConcurrentHashMap<>();
     private final Map<UUID, String> nameMap = new ConcurrentHashMap<>();
 
-    // Count of errors in the last minute, to avoid spamming the API
+    // The size of this set is the count of errors in the last ERROR_TIMEOUT_MINUTE minutes.
+    // This is used to avoid spamming the API.
     private final TimedSet<Object> errors =
             new TimedSet<>(ERROR_TIMEOUT_MINUTE, TimeUnit.MINUTES, true, ConcurrentHashMap::newKeySet);
     private final Map<UUID, Integer> userFailures = new ConcurrentHashMap<>();
@@ -161,8 +162,8 @@ public final class PlayerModel extends Model {
                 json -> {
                     if (json.has("message") && json.get("message").getAsString().equals(ATHENA_USER_NOT_FOUND)) {
                         // This user does not exist in our database, stop requesting it
-                        fetching.remove(uuid);
                         usersWithoutWynntilsAccount.add(uuid);
+                        fetching.remove(uuid);
                         return;
                     }
 

--- a/common/src/main/java/com/wynntils/models/players/PlayerModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PlayerModel.java
@@ -191,7 +191,7 @@ public final class PlayerModel extends Model {
     }
 
     private void saveUserFailures(UUID uuid, String userName) {
-        userFailures.computeIfAbsent(uuid, k -> 0);
+        userFailures.putIfAbsent(uuid, 0);
         userFailures.compute(uuid, (k, v) -> v + 1);
 
         // Only log the error once

--- a/common/src/main/java/com/wynntils/models/players/PlayerModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PlayerModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.players;
@@ -120,7 +120,10 @@ public final class PlayerModel extends Model {
     }
 
     private void loadUser(UUID uuid, String userName) {
+        // Avoid fetching the same user multiple times
         if (fetching.contains(uuid)) return;
+        if (users.containsKey(uuid)) return;
+
         if (errorCount >= MAX_ERRORS) {
             // Athena is having problems, skip this
             return;

--- a/common/src/main/java/com/wynntils/models/players/PlayerModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PlayerModel.java
@@ -145,7 +145,8 @@ public final class PlayerModel extends Model {
         if (fetching.contains(uuid)) return;
         if (users.containsKey(uuid) || usersWithoutWynntilsAccount.contains(uuid)) return;
 
-        if (errors.size() >= MAX_ERRORS) {
+        // Call getEntries to clear old entries
+        if (errors.getEntries().size() >= MAX_ERRORS) {
             // Athena is having problems, skip this
             return;
         }
@@ -194,7 +195,8 @@ public final class PlayerModel extends Model {
         userFailures.compute(uuid, (k, v) -> v + 1);
 
         // Only log the error once
-        if (errors.size() == MAX_ERRORS) {
+        // Call getEntries to clear old entries
+        if (errors.getEntries().size() == MAX_ERRORS) {
             WynntilsMod.error("Athena user lookup has repeating failures. Disabling future lookups temporarily.");
         }
 

--- a/common/src/main/java/com/wynntils/utils/type/TimedSet.java
+++ b/common/src/main/java/com/wynntils/utils/type/TimedSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;
@@ -11,11 +11,12 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class TimedSet<T> implements Iterable<T> {
-    private final Set<TimedEntry> entries = new HashSet<>();
+    private final Set<TimedEntry> entries;
 
     private final long timeJump;
     private final boolean autoClear;
@@ -23,6 +24,13 @@ public class TimedSet<T> implements Iterable<T> {
     public TimedSet(long duration, TimeUnit unit, boolean autoClear) {
         timeJump = unit.toMillis(duration);
         this.autoClear = autoClear;
+        entries = new HashSet<>();
+    }
+
+    public TimedSet(long duration, TimeUnit unit, boolean autoClear, Supplier<Set<TimedEntry>> setSupplier) {
+        timeJump = unit.toMillis(duration);
+        this.autoClear = autoClear;
+        entries = setSupplier.get();
     }
 
     public TimedSet(long duration, TimeUnit unit) {


### PR DESCRIPTION
## Important
Please review this PR ASAP, but let me merge it, and release it with an announcement. From the limited logs we have about Athena, we think that the major performance hit Athena's been taking recently is due to this route. This PR should reduce requests by 2/3x, meaning, we should get much, much less requests per minute (I don't have exact numbers, but thousands less..).

## The changes

This PR should make error handling of user requests much better, fix some bugs where players got stuck in a fetching state, and make sure that we do the least amount of requests possible. 

Here is the data I recorded pre- and post- fix, it can be seen that we load the same amount of users, in around 2/3 times less requests. The duplication rate is also 0, meaning we don't do any unnecessary calls, for failed users, but we also don't refetch user data we already have.

```
Pre-fix:

[10:15:21] [Render thread/INFO] (wynntils) PlayerModel: 19 users loaded, 0 ghosts, 0 errors, 0 user failures.
[10:15:21] [Render thread/INFO] (wynntils) PlayerModel: 165 fetches, 111 unique users, duplication rate: 0.49x

[10:16:21] [Render thread/INFO] (wynntils) PlayerModel: 28 users loaded, 27 ghosts, 0 errors, 0 user failures.
[10:16:21] [Render thread/INFO] (wynntils) PlayerModel: 241 fetches, 145 unique users, duplication rate: 0.66x

Post-fix:

[10:10:43] [Render thread/INFO] (wynntils) PlayerModel: 15 users loaded, 8 ghosts, 0 errors, 0 user failures.
[10:10:43] [Render thread/INFO] (wynntils) PlayerModel: 54 fetches, 53 unique users, duplication rate: 0.02x

[10:11:50] [Render thread/INFO] (wynntils) PlayerModel: 29 users loaded, 29 ghosts, 0 errors, 0 user failures.
[10:11:50] [Render thread/INFO] (wynntils) PlayerModel: 120 fetches, 120 unique users, duplication rate: 0.0x
```

#### What the data means
users loaded = wynntils user profiles loaded
ghosts = player ghosts we found, irrelevant to athena
fetches = number of requests to athena
unique users = loaded users that either have an wynntils profile, or not

## Left to do
We still run some requests for NPC players. Sadly, I can see no way of filtering them out currently. I'll think about if we can fix that issue, but this change should be enough for now.

#### Edit
We now have a way to filter out NPCs, starting Wynncraft 2.1. The code is already implemented here, for the future.