### PR TITLE
fix: Fix minimap disabling/crashing when changing the minimap's configs

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -100,7 +100,12 @@ public class MinimapOverlay extends Overlay {
 
     public void setZoomLevel(float level) {
         // Clamp zoom levels to allowed interval
-        zoomLevel.setValue(MathUtils.clamp(level, 1, MapRenderer.ZOOM_LEVELS));
+        float clampedLevel = MathUtils.clamp(level, 1, MapRenderer.ZOOM_LEVELS);
+
+        // If the level is the same, do nothing (avoid recursion loop)
+        if (clampedLevel == zoomLevel.get()) return;
+
+        zoomLevel.setValue(clampedLevel);
     }
 
     public void adjustZoomLevel(int delta) {


### PR DESCRIPTION
The overlook happened from me when reviewing https://github.com/Wynntils/Artemis/pull/2373/commits/f5101064c4b0ca80532b9d93fc5632e3151760a1. The check to make sure we don't recurse in the configs were removed, because I did not explicitly comment why it was there in the first place, and @magicus thought it could be clean up.