### PR TITLE
fix: Fix crops resource name causing TerritoryAnnotator to crash [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/territories/TerritoryInfo.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryInfo.java
@@ -129,7 +129,7 @@ public class TerritoryInfo {
                 case ORE -> resourceColors.add(CustomColor.fromHSV(0, 0.3f, 1f, 1));
                 case FISH -> resourceColors.add(CustomColor.fromHSV(0.5f, 0.6f, 0.9f, 1));
                 case WOOD -> resourceColors.add(CustomColor.fromHSV(1 / 3f, 0.6f, 0.9f, 1));
-                case CROP -> resourceColors.add(CustomColor.fromHSV(1 / 6f, 0.6f, 0.9f, 1));
+                case CROPS -> resourceColors.add(CustomColor.fromHSV(1 / 6f, 0.6f, 0.9f, 1));
             }
         }
     }

--- a/common/src/main/java/com/wynntils/models/territories/type/GuildResource.java
+++ b/common/src/main/java/com/wynntils/models/territories/type/GuildResource.java
@@ -11,7 +11,7 @@ public enum GuildResource {
     ORE(ChatFormatting.WHITE, "Ore", "Ⓑ"),
     WOOD(ChatFormatting.GOLD, "Wood", "Ⓒ"),
     FISH(ChatFormatting.AQUA, "Fish", "Ⓚ"),
-    CROP(ChatFormatting.YELLOW, "Crop", "Ⓙ");
+    CROPS(ChatFormatting.YELLOW, "Crops", "Ⓙ");
 
     private final ChatFormatting color;
     private final String name;


### PR DESCRIPTION
Snippet of the problematic item log `"text":"Ⓙ +4320 Crops per Hour"`