### PR TITLE
fix: Detect flying chests correctly

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/containers/reward/FlyingChestContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/reward/FlyingChestContainer.java
@@ -7,7 +7,7 @@ package com.wynntils.models.containers.containers.reward;
 import java.util.regex.Pattern;
 
 public class FlyingChestContainer extends RewardContainer {
-    private static final Pattern TITLE_PATTERN = Pattern.compile("Flying Chest");
+    private static final Pattern TITLE_PATTERN = Pattern.compile("Flying Chest Rewards");
 
     public FlyingChestContainer() {
         super(TITLE_PATTERN);


### PR DESCRIPTION
![image](https://github.com/Wynntils/Artemis/assets/8337467/d9b4e89b-50bd-4230-a6d5-0254bfc95cdb)
