### PR TITLE
perf: Optimize ItemHandler lore soft matching

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.item;
@@ -29,9 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;


### PR DESCRIPTION
With this PR, I am starting a new branch, to collect some performance patches, I'll be working on in the upcoming days.

# Test
Join the same 5 classes, in order, then open the trade market, and scroll 10 pages.

# Results
| Type | Old | New |
|--------|--------|--------|
| Memory | 525 MB | 0 B (-100%) |
| CPU | 146 | 1 (-99.3%) |

# Verification
Ran the old and new algorithm side-by-side, performed the same tests as the benchmark, no assertions triggered (the two methods produced identical results).