### PR TITLE
fix: Make GuildAttackTimerModel use string territory names instead of profiles

### DIFF
--- a/common/src/main/java/com/wynntils/models/territories/TerritoryAttackTimer.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryAttackTimer.java
@@ -5,20 +5,19 @@
 package com.wynntils.models.territories;
 
 import com.wynntils.core.components.Models;
-import com.wynntils.models.territories.profile.TerritoryProfile;
 import com.wynntils.models.territories.type.GuildResourceValues;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 
-public record TerritoryAttackTimer(TerritoryProfile territoryProfile, long timerEnd) {
+public record TerritoryAttackTimer(String territoryName, long timerEnd) {
     public String asString() {
         Optional<GuildResourceValues> defense = defense();
         ChatFormatting defenseColor =
                 defense.isEmpty() ? ChatFormatting.GRAY : defense.get().getDefenceColor();
         String defenseString = defense.isEmpty() ? "Unknown" : defense.get().getAsString();
 
-        return ChatFormatting.GRAY + territoryProfile.getFriendlyName() + defenseColor + " (" + defenseString + ")"
-                + ChatFormatting.AQUA + " " + timerString();
+        return ChatFormatting.GRAY + territoryName + defenseColor + " (" + defenseString + ")" + ChatFormatting.AQUA
+                + " " + timerString();
     }
 
     public int getMinutesRemaining() {
@@ -38,6 +37,6 @@ public record TerritoryAttackTimer(TerritoryProfile territoryProfile, long timer
     }
 
     public Optional<GuildResourceValues> defense() {
-        return Models.GuildAttackTimer.getDefenseForTerritory(territoryProfile);
+        return Models.GuildAttackTimer.getDefenseForTerritory(territoryName);
     }
 }

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -74,11 +74,9 @@ public final class TerritoryModel extends Model {
      * @param excludedTerritories Territories to exclude from the search
      * @return The territory profile, or null if not found
      */
-    public TerritoryProfile getTerritoryProfileFromShortName(
-            String shortName, Collection<TerritoryProfile> excludedTerritories) {
+    public TerritoryProfile getTerritoryProfileFromShortName(String shortName, Collection<String> excludedTerritories) {
         return territoryProfileMap.values().stream()
-                .filter(profile -> excludedTerritories.stream()
-                        .noneMatch(ex -> ex.getName().equals(profile.getName())))
+                .filter(profile -> excludedTerritories.stream().noneMatch(ex -> ex.equals(profile.getName())))
                 .filter(profile -> profile.getName().startsWith(shortName))
                 .min(Comparator.comparing(TerritoryProfile::getName))
                 .orElse(null);


### PR DESCRIPTION
It is not correct to use profiles, as they can vary when guilds take territories. Also added a fail-safe if a timer is refunded, but the scoreboard is not updated fast enough. In reality, this might not even be needed, but there is no harm in keeping it.