### PR TITLE
fix: Fix territory connections not working due to some connections not being displayed as bidirectional [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementHolder.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementHolder.java
@@ -408,7 +408,7 @@ public class TerritoryManagementHolder extends WrappedScreenHolder<TerritoryMana
     }
 
     private void updateRenderedItems() {
-        territoryConnections = Models.Territory.getUnconnectedTerritories(
+        territoryConnections = Models.Territory.getTerritoryConnections(
                 territories.values().stream().map(Pair::b).collect(Collectors.toList()));
 
         // Update the rendered territory items


### PR DESCRIPTION


Wynn moment... This bug is still present. In fact, I've already experienced this, when I made the first guild map for the guild update, at beta #1.