### PR TITLE
feat: Click territory pois to set marker on guild map [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -23,6 +23,7 @@ import com.wynntils.services.map.type.TerritoryDefenseFilterType;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.MapRenderer;
 import com.wynntils.utils.render.RenderUtils;
@@ -41,6 +42,7 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
+import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
 public final class GuildMapScreen extends AbstractMapScreen {
@@ -285,6 +287,15 @@ public final class GuildMapScreen extends AbstractMapScreen {
                 Models.Marker.USER_WAYPOINTS_PROVIDER.removeLocation(
                         hovered.getLocation().asLocation());
                 return true;
+            } else if (hovered instanceof TerritoryPoi) {
+                McUtils.playSoundUI(SoundEvents.EXPERIENCE_ORB_PICKUP);
+
+                // If shift is not held down, clear all waypoints to only have the new one
+                if (!KeyboardUtils.isShiftDown()) {
+                    Models.Marker.USER_WAYPOINTS_PROVIDER.removeAllLocations();
+                }
+
+                Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(new Location(hovered.getLocation()));
             }
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_MIDDLE) {
             setCompassToMouseCoords(mouseX, mouseY);

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -396,7 +396,7 @@ public final class MainMapScreen extends AbstractMapScreen {
             if (hovered != null && !(hovered instanceof TerritoryPoi)) {
                 McUtils.playSoundUI(SoundEvents.EXPERIENCE_ORB_PICKUP);
 
-                // If shift is not held down, clear all waypoints to only add have the new one
+                // If shift is not held down, clear all waypoints to only have the new one
                 if (!KeyboardUtils.isShiftDown()) {
                     Models.Marker.USER_WAYPOINTS_PROVIDER.removeAllLocations();
                 }


### PR DESCRIPTION
Apparently the unlimited middle clicks on guild map was useful for setting markers for territories not yet under attack