### PR TITLE
fix: Fix PlayerCommand not using the correct date format [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/commands/PlayerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/PlayerCommand.java
@@ -12,8 +12,9 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.commands.Command;
 import com.wynntils.models.players.type.WynnPlayerInfo;
-import com.wynntils.utils.SimpleDateFormatter;
+import com.wynntils.utils.LongDateFormatter;
 import com.wynntils.utils.mc.McUtils;
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -28,7 +29,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 
 public class PlayerCommand extends Command {
-    private static final SimpleDateFormatter DATE_FORMATTER = new SimpleDateFormatter();
+    private static final DateFormat DATE_FORMATTER = new LongDateFormatter();
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT);
     private static final SuggestionProvider<CommandSourceStack> PLAYER_NAME_SUGGESTION_PROVIDER =
             (context, builder) -> SharedSuggestionProvider.suggest(Models.Player.getAllPlayerNames(), builder);

--- a/common/src/main/java/com/wynntils/utils/LongDateFormatter.java
+++ b/common/src/main/java/com/wynntils/utils/LongDateFormatter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils;
+
+import com.google.common.collect.ImmutableMap;
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.ParsePosition;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+import java.util.TimeZone;
+
+public class LongDateFormatter extends DateFormat {
+    private static final Map<Integer, String> MAPPINGS = ImmutableMap.of(
+            Calendar.YEAR, "y",
+            Calendar.MONTH, "mo",
+            Calendar.DAY_OF_MONTH, "d",
+            Calendar.HOUR_OF_DAY, "h",
+            Calendar.MINUTE, "m",
+            Calendar.SECOND, "s");
+
+    public LongDateFormatter() {
+        setCalendar(Calendar.getInstance());
+        setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Override
+    public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
+        calendar.setTime(date);
+        StringBuffer sb = new StringBuffer();
+
+        MAPPINGS.forEach((key, value) -> {
+            int count = calendar.get(key);
+
+            if (key == Calendar.YEAR) {
+                count -= 1970;
+            } else if (key == Calendar.DAY_OF_MONTH) {
+                count--;
+            }
+
+            if (count > 0) {
+                sb.append(count).append(value).append(" ");
+            }
+        });
+
+        return sb;
+    }
+
+    @Override
+    public Date parse(String source, ParsePosition pos) {
+        throw new UnsupportedOperationException("Parsing relative time is not supported.");
+    }
+}


### PR DESCRIPTION
The day itself might be off by a day.. Currently we use "dynamic" months, not the regular 30 day months. I guess this is a way to do it...