### PR TITLE
fix: Don't parse three consecutive 0's as coordinates [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
@@ -16,7 +16,7 @@ public final class LocationUtils {
             "\\s*(?<x>[-+]?\\d{1,6})(?:\\.\\d+)?([^0-9.+-]{1,5}(?<y>[-+]?\\d{1,3})(?:\\.\\d+)?)?[^0-9.+-]{1,5}(?<z>[-+]?\\d{1,6})(?:\\.\\d+)?\\s*");
 
     private static final Pattern STRICT_COORDINATE_PATTERN = Pattern.compile(
-            "(?:^|\\s|\\[)\\s*([-+]?\\d{1,6}(?:[\\s,]{0,2}[-+]?\\d{1,3}(?:[\\s,]{0,2}[-+]?\\d{1,6})?)?)\\s*(?:\\]|\\s+|$)");
+            "(?:^|\\s|\\[)\\s*([-+]?(?:[1-9]{1,6}|0{1,2})(?:[\\s,]{0,2}[-+]?\\d{1,3}(?:[\\s,]{0,2}[-+]?(?:[1-9]{1,6}|0{1,2}))?)?)\\s*(?:\\]|\\s+|$)");
 
     public static Optional<Location> parseFromString(String locString) {
         Matcher matcher = COORDINATE_PATTERN.matcher(locString);

--- a/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/LocationUtils.java
@@ -16,7 +16,7 @@ public final class LocationUtils {
             "\\s*(?<x>[-+]?\\d{1,6})(?:\\.\\d+)?([^0-9.+-]{1,5}(?<y>[-+]?\\d{1,3})(?:\\.\\d+)?)?[^0-9.+-]{1,5}(?<z>[-+]?\\d{1,6})(?:\\.\\d+)?\\s*");
 
     private static final Pattern STRICT_COORDINATE_PATTERN = Pattern.compile(
-            "(?:^|\\s|\\[)\\s*([-+]?(?:[1-9]{1,6}|0{1,2})(?:[\\s,]{0,2}[-+]?\\d{1,3}(?:[\\s,]{0,2}[-+]?(?:[1-9]{1,6}|0{1,2}))?)?)\\s*(?:\\]|\\s+|$)");
+            "(?:^|\\s|\\[)\\s*([-+]?\\d{1,5}(?:[\\s,]{1,2}[-+]?\\d{1,3})?(?:[\\s,]{1,2}[-+]?(?:[1-9]\\d{0,4}|\\d{0,4}[1-9]|0)))\\s*(?:\\]|\\s+|$)");
 
     public static Optional<Location> parseFromString(String locString) {
         Matcher matcher = COORDINATE_PATTERN.matcher(locString);

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -32,10 +32,9 @@ import com.wynntils.models.statuseffects.StatusEffectModel;
 import com.wynntils.models.trademarket.TradeMarketModel;
 import com.wynntils.models.war.bossbar.WarTowerBar;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
+import com.wynntils.utils.wynn.LocationUtils;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
-
-import com.wynntils.utils.wynn.LocationUtils;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -34,6 +34,8 @@ import com.wynntils.models.war.bossbar.WarTowerBar;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
+
+import com.wynntils.utils.wynn.LocationUtils;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
@@ -355,6 +357,27 @@ public class TestRegex {
         p.shouldMatch("§7Sylphid Tears§6 [§e✫§8✫✫§6]");
         p.shouldMatch("§7Bob's Tear§5 [§d✫✫§8✫§5]");
         p.shouldMatch("§7Contorted Stone§3 [§b✫✫✫§3]");
+    }
+
+    @Test
+    public void LocationUtils_STRICT_COORDINATE_PATTERN() {
+        PatternTester p = new PatternTester(LocationUtils.class, "STRICT_COORDINATE_PATTERN");
+        System.out.println(p.pattern.pattern());
+        p.shouldMatch("10, 14, -1945");
+        p.shouldMatch("10591, 106, 20489");
+        p.shouldMatch("[200, 0, 0]");
+        p.shouldMatch("102, 100, 102");
+        p.shouldMatch("1002, 100, 1002");
+        p.shouldMatch("10002, 100, 10002");
+        p.shouldMatch("0, 0, 0");
+        p.shouldMatch("0, 0");
+        p.shouldNotMatch("100");
+        p.shouldNotMatch("0");
+        p.shouldNotMatch("200,000");
+        p.shouldNotMatch("195,000,000");
+        p.shouldNotMatch("20,000");
+        p.shouldNotMatch("2,000");
+        p.shouldNotMatch("");
     }
 
     @Test


### PR DESCRIPTION
This goes with the assumption that no one will ever type `200,000,000` for the coordinates `200,0,0`. Instead of parsing to coordinates, when we see three consecutive zeros, ignore and assume it is a regular number instead.
200,00,00 still is parsed to coordinates since that's not a valid way to write 2 million.

This is the only change I made, if it's easier to review this way
![image](https://github.com/Wynntils/Artemis/assets/57310593/0a2964d5-c291-46e0-87b1-8b833e7b8985)
