### PR TITLE
fix: Some lootrun drops not included in box possibilities [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/wynnitem/type/ItemObtainType.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/type/ItemObtainType.java
@@ -39,6 +39,7 @@ public enum ItemObtainType {
             NORMAL_MOB_DROP,
             BOSS_ALTAR,
             MINIBOSS,
+            LOOTRUN, // some items are boxed, some are not
             DUNGEON_RAIN,
             FORGERY_CHEST,
             RAID,


### PR DESCRIPTION
Apparently some lootrun-exclusive rewards are boxes and some are shown as an Unidentified Item.
![image](https://github.com/Wynntils/Artemis/assets/57310593/96cef587-f128-4540-a88c-92a74ec9b9b5)
