### PR TITLE
fix: Fix transcription tooltip option not working correctly [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -68,7 +68,7 @@ public class TranscribeMessagesFeature extends Feature {
 
         StyledText modified = getStyledTextWithTranscription(styledText, transcribeWynnic, transcribeGavellian, false);
 
-        if (styledText.getString().equalsIgnoreCase(modified.getString())) return;
+        if (styledText.equals(modified)) return;
 
         event.setMessage(modified.getComponent());
     }

--- a/common/src/main/java/com/wynntils/models/wynnalphabet/WynnAlphabetModel.java
+++ b/common/src/main/java/com/wynntils/models/wynnalphabet/WynnAlphabetModel.java
@@ -9,8 +9,6 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
-import com.wynntils.models.activities.discoveries.DiscoveryInfo;
-import com.wynntils.models.activities.type.ActivitySortOrder;
 import com.wynntils.models.wynnalphabet.type.TranscribeCondition;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.McUtils;
@@ -19,10 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
@@ -58,8 +54,6 @@ public class WynnAlphabetModel extends Model {
     private static final Map<Character, Character> wynnicToEnglishMap = new HashMap<>();
     private static final Pattern BRACKET_PATTERN = Pattern.compile("(\\[\\[.*\\]\\])|(<<.*>>)");
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
-    private static final String GAVELLIAN_TRANSCRIBER_DISCOVERY = "Ne du Valeos du Ellach";
-    private static final String WYNNIC_TRANSCRIBER_DISCOVERY = "Wynn Plains Monument";
     private static final StyledText GAVELLIAN_TRANSCRIBER = StyledText.fromString("§rHigh Gavellian Transcriber");
     private static final StyledText WYNNIC_TRANSCRIBER = StyledText.fromString("§fAncient Wynnic Transcriber");
 
@@ -253,9 +247,6 @@ public class WynnAlphabetModel extends Model {
             case TRANSCRIBER -> alphabet == WynnAlphabet.WYNNIC
                     ? hasTranscriber(WynnAlphabet.WYNNIC)
                     : hasTranscriber(WynnAlphabet.GAVELLIAN);
-            case DISCOVERY -> alphabet == WynnAlphabet.WYNNIC
-                    ? hasCompletedDiscovery(WynnAlphabet.WYNNIC)
-                    : hasCompletedDiscovery(WynnAlphabet.GAVELLIAN);
             default -> true;
         };
     }
@@ -349,21 +340,6 @@ public class WynnAlphabetModel extends Model {
         }
 
         return false;
-    }
-
-    private boolean hasCompletedDiscovery(WynnAlphabet discoveryToCheck) {
-        Stream<DiscoveryInfo> discoveryInfoStream =
-                Models.Discovery.getAllCompletedDiscoveries(ActivitySortOrder.ALPHABETIC);
-
-        String nameToFind = discoveryToCheck == WynnAlphabet.WYNNIC
-                ? WYNNIC_TRANSCRIBER_DISCOVERY
-                : GAVELLIAN_TRANSCRIBER_DISCOVERY;
-
-        Optional<DiscoveryInfo> foundDiscoveryInfo = discoveryInfoStream
-                .filter(discoveryInfo -> discoveryInfo.getName().equals(nameToFind))
-                .findFirst();
-
-        return foundDiscoveryInfo.map(DiscoveryInfo::isDiscovered).orElse(false);
     }
 
     public void setSelectedAlphabet(WynnAlphabet selectedAlphabet) {

--- a/common/src/main/java/com/wynntils/models/wynnalphabet/WynnAlphabetModel.java
+++ b/common/src/main/java/com/wynntils/models/wynnalphabet/WynnAlphabetModel.java
@@ -90,7 +90,7 @@ public class WynnAlphabetModel extends Model {
 
         PartStyle partStyle = originalPart.getPartStyle();
 
-        if (useColors) {
+        if (useColors && !originalTextAsTooltip) {
             partStyle = partStyle.withColor(colorToUse);
         }
 
@@ -105,7 +105,8 @@ public class WynnAlphabetModel extends Model {
                         originalString);
         partStyle = partStyle.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent));
 
-        return new StyledTextPart(transcriptedString, partStyle.getStyle(), null, Style.EMPTY);
+        return new StyledTextPart(
+                originalTextAsTooltip ? originalString : transcriptedString, partStyle.getStyle(), null, Style.EMPTY);
     }
 
     public String transcribeBracketedText(String message) {

--- a/common/src/main/java/com/wynntils/models/wynnalphabet/type/TranscribeCondition.java
+++ b/common/src/main/java/com/wynntils/models/wynnalphabet/type/TranscribeCondition.java
@@ -1,12 +1,11 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.wynnalphabet.type;
 
 public enum TranscribeCondition {
     ALWAYS,
-    DISCOVERY,
     TRANSCRIBER,
     NEVER
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1275,7 +1275,7 @@
   "feature.wynntils.transcribeMessages.showTooltip.name": "Show Transcription Tooltip",
   "feature.wynntils.transcribeMessages.transcribeChat.description": "Transcribe chat messages containing Gavellian and Wynnic?",
   "feature.wynntils.transcribeMessages.transcribeChat.name": "Transcribe chat messages",
-  "feature.wynntils.transcribeMessages.transcribeCondition.description": "When should Gavellian and Wynnic be transcribed? Discovery - Once you have completed the discovery for the transcriber. Transcriber - If you have the transcriber in your inventory.",
+  "feature.wynntils.transcribeMessages.transcribeCondition.description": "When should Gavellian and Wynnic be transcribed? Transcriber - If you have the transcriber in your inventory.",
   "feature.wynntils.transcribeMessages.transcribeCondition.name": "Transcribe Condition",
   "feature.wynntils.transcribeMessages.transcribeNpcs.description": "Transcribe NPC dialogue containing Gavellian and Wynnic?",
   "feature.wynntils.transcribeMessages.transcribeNpcs.name": "Transcribe NPC dialogue",


### PR DESCRIPTION
Currently Wynnic/Gavellian text is always transcribed and coloured regardless of the tooltip config when it should only change the actual text if the tooltip config is disabled.

Discovery condition was removed as since the model is almost always out of date due to it taking significantly longer to query the content book it was basically never working.