### PR TITLE
fix: Don't overwrite current world name when entering housing [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/PerCharacterGuildContributionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/PerCharacterGuildContributionFeature.java
@@ -7,7 +7,6 @@ package com.wynntils.features.utilities;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
-import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
@@ -39,26 +38,17 @@ public class PerCharacterGuildContributionFeature extends Feature {
     public final Config<Boolean> hideContributionMessage = new Config<>(true);
 
     private boolean waitingForCommandResponse = false;
-    private String currentCharacterId = "";
 
     @SubscribeEvent
     public void onCharacterChange(CharacterUpdateEvent e) {
         if (Models.Guild.getGuildName().isEmpty()) return;
-        if (currentCharacterId.equals(Models.Character.getId())) return;
 
-        currentCharacterId = Models.Character.getId();
-
-        int amountToContribute = characterContributions.get().getOrDefault(currentCharacterId, -1);
+        int amountToContribute = characterContributions.get().getOrDefault(Models.Character.getId(), -1);
 
         if (amountToContribute != -1) {
             waitingForCommandResponse = true;
             Handlers.Command.queueCommand("guild xp " + amountToContribute);
         }
-    }
-
-    @SubscribeEvent
-    public void disconnected(WynncraftConnectionEvent.Disconnected e) {
-        currentCharacterId = "";
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -37,9 +37,11 @@ public final class WorldStateModel extends Model {
 
     private StyledText currentTabListFooter = StyledText.EMPTY;
     private String currentWorldName = "";
+    private String currentHousingName = "";
     private long serverJoinTimestamp = 0;
     private boolean onBetaServer;
     private boolean hasJoinedAnyWorld = false;
+    private boolean onHousing = false;
 
     public WorldStateModel() {
         super(List.of());
@@ -49,6 +51,10 @@ public final class WorldStateModel extends Model {
 
     public boolean onWorld() {
         return currentState == WorldState.WORLD;
+    }
+
+    public boolean onHousing() {
+        return onHousing;
     }
 
     public boolean isInStream() {
@@ -147,18 +153,20 @@ public final class WorldStateModel extends Model {
         Component displayName = e.getDisplayName();
         StyledText name = StyledText.fromComponent(displayName);
         Matcher m = name.getMatcher(WORLD_NAME);
-        if (setWorldIfMatched(m)) return;
+        if (setWorldIfMatched(m, false)) return;
         // must check in this order as housing name regex matches anything that WORLD_NAME would match, housing names
         // need to exclude world names.
         Matcher housingNameMatcher = name.getMatcher(HOUSING_NAME);
-        setWorldIfMatched(housingNameMatcher);
+        setWorldIfMatched(housingNameMatcher, true);
     }
 
-    private boolean setWorldIfMatched(Matcher m) {
+    private boolean setWorldIfMatched(Matcher m, boolean housing) {
         if (m.find()) {
-            String worldName = m.group(1);
+            String worldName = housing ? currentWorldName : m.group(1);
             setState(WorldState.WORLD, worldName, !hasJoinedAnyWorld);
             hasJoinedAnyWorld = true;
+            onHousing = housing;
+            currentHousingName = onHousing ? m.group(1) : "";
             return true;
         }
         return false;
@@ -169,6 +177,10 @@ public final class WorldStateModel extends Model {
      */
     public String getCurrentWorldName() {
         return currentWorldName;
+    }
+
+    public String getCurrentHousingName() {
+        return currentHousingName;
     }
 
     public long getServerJoinTimestamp() {

--- a/common/src/main/java/com/wynntils/overlays/CustomPlayerListOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/CustomPlayerListOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays;
@@ -113,7 +113,10 @@ public class CustomPlayerListOverlay extends Overlay {
         float categoryStart = getRenderY() + 18;
         renderCategoryTitle(poseStack, "Friends", currentDist, categoryStart);
         currentDist += DISTANCE_BETWEEN_CATEGORIES;
-        renderCategoryTitle(poseStack, Models.WorldState.getCurrentWorldName(), currentDist, categoryStart);
+        String worldCategory = Models.WorldState.onHousing()
+                ? Models.WorldState.getCurrentHousingName()
+                : Models.WorldState.getCurrentWorldName();
+        renderCategoryTitle(poseStack, worldCategory, currentDist, categoryStart);
         currentDist += DISTANCE_BETWEEN_CATEGORIES;
         renderCategoryTitle(poseStack, "Party", currentDist, categoryStart);
         currentDist += DISTANCE_BETWEEN_CATEGORIES;


### PR DESCRIPTION
Should fix the minor issue from https://github.com/Wynntils/Artemis/issues/2388 but doesn't fix the main issue.