### PR TITLE
fix: Fix DeathCoordinatesFeature sending both the Wynn and the custom message [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/DeathCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/DeathCoordinatesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -13,11 +13,13 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.StyledTextUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 @ConfigCategory(Category.CHAT)
 public class DeathCoordinatesFeature extends Feature {
-    @SubscribeEvent
+    // Lowest as this will always cancel the event
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onCharacterDeath(CharacterDeathEvent e) {
         StyledText deathMessage =
                 StyledText.fromComponent(Component.translatable("feature.wynntils.deathCoordinates.diedAt")
@@ -25,5 +27,7 @@ public class DeathCoordinatesFeature extends Feature {
         deathMessage = deathMessage.appendPart(StyledTextUtils.createLocationPart(e.getLocation()));
 
         McUtils.player().sendSystemMessage(deathMessage.getComponent());
+
+        e.setCanceled(true);
     }
 }

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -167,7 +167,12 @@ public final class CharacterModel extends Model {
     public void onChatReceived(ChatMessageReceivedEvent e) {
         if (!e.getStyledText().matches(WYNN_DEATH_MESSAGE)) return;
         lastDeathLocation = Location.containing(lastPositionBeforeTeleport);
-        WynntilsMod.postEvent(new CharacterDeathEvent(lastDeathLocation));
+        CharacterDeathEvent deathEvent = new CharacterDeathEvent(lastDeathLocation);
+        WynntilsMod.postEvent(deathEvent);
+
+        if (deathEvent.isCanceled()) {
+            e.setCanceled(true);
+        }
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -60,7 +60,7 @@ public final class CharacterModel extends Model {
 
     // we need a .* in front because the message may have a custom timestamp prefix (or some other mod could do
     // something weird)
-    private static final Pattern WYNN_DEATH_MESSAGE = Pattern.compile(".* §4§lYou have died\\.\\.\\.");
+    private static final Pattern WYNN_DEATH_MESSAGE = Pattern.compile(".*§4§lYou have died\\.\\.\\.");
     private Position lastPositionBeforeTeleport;
     private Location lastDeathLocation;
 

--- a/common/src/main/java/com/wynntils/models/character/event/CharacterDeathEvent.java
+++ b/common/src/main/java/com/wynntils/models/character/event/CharacterDeathEvent.java
@@ -1,12 +1,14 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.character.event;
 
 import com.wynntils.utils.mc.type.Location;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
+@Cancelable
 public class CharacterDeathEvent extends Event {
     private final Location location;
 


### PR DESCRIPTION
![DeathEvent](https://github.com/Wynntils/Artemis/assets/8337467/9f4f29c2-bbc6-4c1d-a4b0-faaec6af6a13)
