### PR TITLE
fix: Fix ItemGuessFeature tooltip line being fully underlined incorrectly [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
@@ -1,9 +1,10 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.tooltips;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
@@ -73,6 +74,11 @@ public class ItemGuessFeature extends Feature {
             int level = entry.getKey();
             List<MutableComponent> itemsForLevel = entry.getValue();
 
+            if (itemsForLevel.isEmpty()) {
+                WynntilsMod.warn("No items for level " + level + " in gear box " + gearBoxItem.getGearTier() + " "
+                        + gearBoxItem.getLevelRange() + "!");
+            }
+
             MutableComponent guesses = Component.literal("    ");
 
             guesses.append(Component.literal("- ")
@@ -91,12 +97,14 @@ public class ItemGuessFeature extends Feature {
 
             guesses.append(StyledText.fromString("§7: ").getComponent());
 
-            Optional<MutableComponent> itemsComponent = itemsForLevel.stream()
-                    .reduce((i, j) -> i.append(Component.literal(", ").withStyle(ChatFormatting.GRAY))
-                            .append(j));
+            MutableComponent itemsComponent = Component.empty();
+            itemsComponent.append(itemsForLevel.get(0));
+            itemsForLevel.stream().skip(1).forEach(i -> itemsComponent
+                    .append(Component.literal(", ").withStyle(ChatFormatting.GRAY))
+                    .append(i));
 
-            if (itemsComponent.isPresent()) {
-                guesses.append(itemsComponent.get());
+            if (!itemsForLevel.isEmpty()) {
+                guesses.append(itemsComponent);
 
                 addon.add(guesses);
             }

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
@@ -77,6 +77,7 @@ public class ItemGuessFeature extends Feature {
             if (itemsForLevel.isEmpty()) {
                 WynntilsMod.warn("No items for level " + level + " in gear box " + gearBoxItem.getGearTier() + " "
                         + gearBoxItem.getLevelRange() + "!");
+                continue;
             }
 
             MutableComponent guesses = Component.literal("    ");


### PR DESCRIPTION
# Old
![image](https://github.com/Wynntils/Artemis/assets/49001742/f2e6b10a-fb60-4eca-8d6e-3c7935dffdb9)


# Fixed
![image](https://github.com/Wynntils/Artemis/assets/49001742/528fae28-2f58-46c1-bc87-a80bac2aa604)
