### PR TITLE
fix: Parse unidentified shiny items correctly [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.items.annotators.game;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.GameItemAnnotator;
@@ -17,7 +18,7 @@ import net.minecraft.world.item.ItemStack;
 
 public final class GearAnnotator implements GameItemAnnotator {
     private static final Pattern GEAR_PATTERN = Pattern.compile(
-            "^(?<rarity>§[5abcdef])(?<unidentified>Unidentified )?(?:§f⬡ )?(?:§[5abcdef])?(?:Shiny )?(?<name>.+)$");
+            "^(?:(?<unidrarity>§[5abcdef])(?<unidentified>Unidentified ))?(?:§f⬡ )?(?<idrarity>§[5abcdef])?(?:Shiny )?(?<name>.+)$");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
@@ -30,7 +31,22 @@ public final class GearAnnotator implements GameItemAnnotator {
         if (gearInfo == null) return null;
 
         // Verify that rarity matches
-        if (!matcher.group("rarity").equals(gearInfo.tier().getChatFormatting().toString())) return null;
+        // If unidentified and shiny, the rarity is in both groups
+        // If unidentified, the rarity is in unidrarity
+        // If identified, the rarity is in idrarity
+        String unidRarity = matcher.group("unidrarity");
+        if (unidRarity != null
+                && !unidRarity.equals(gearInfo.tier().getChatFormatting().toString())) return null;
+
+        String idRarity = matcher.group("idrarity");
+        if (idRarity != null
+                && !idRarity.equals(gearInfo.tier().getChatFormatting().toString())) return null;
+
+        // We have no rarity information, so we can't determine if the item is gear
+        if (unidRarity == null && idRarity == null) {
+            WynntilsMod.warn("GearAnnotator: No rarity information found in item name: " + name);
+            return null;
+        }
 
         GearInstance gearInstance =
                 matcher.group("unidentified") != null ? null : Models.Gear.parseInstance(gearInfo, itemStack);

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class GearAnnotator implements GameItemAnnotator {
+    // Test in GearAnnotator_GEAR_PATTERN
     private static final Pattern GEAR_PATTERN = Pattern.compile(
             "^(?:(?<unidrarity>§[5abcdef])(?<unidentified>Unidentified ))?(?:§f⬡ )?(?<idrarity>§[5abcdef])?(?:Shiny )?(?<name>.+)$");
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
@@ -16,8 +16,8 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class GearAnnotator implements GameItemAnnotator {
-    private static final Pattern GEAR_PATTERN =
-            Pattern.compile("^(?:§f⬡ )?(?<rarity>§[5abcdef])(?<unidentified>Unidentified )?(?:Shiny )?(?<name>.+)$");
+    private static final Pattern GEAR_PATTERN = Pattern.compile(
+            "^(?<rarity>§[5abcdef])(?<unidentified>Unidentified )?(?:§f⬡ )?(?:§[5abcdef])?(?:Shiny )?(?<name>.+)$");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -18,6 +18,7 @@ import com.wynntils.models.characterstats.actionbar.SprintSegment;
 import com.wynntils.models.containers.BankModel;
 import com.wynntils.models.containers.ContainerModel;
 import com.wynntils.models.damage.DamageModel;
+import com.wynntils.models.items.annotators.game.GearAnnotator;
 import com.wynntils.models.items.annotators.game.IngredientAnnotator;
 import com.wynntils.models.items.annotators.game.RuneAnnotator;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
@@ -737,5 +738,24 @@ public class TestRegex {
         PatternTester p = new PatternTester(GuildSeasonLeaderboardLabelParser.class, "GUILD_SEASON_LEADERBOARD_LABEL");
         p.shouldMatch("§6§l1§7 - §bIdiot Co§d (11 396 656 SR)");
         p.shouldMatch("§62§7 - §bSequoia§d (11 057 047 SR)");
+    }
+
+    @Test
+    public void GearAnnotator_GEAR_PATTERN() {
+        PatternTester p = new PatternTester(GearAnnotator.class, "GEAR_PATTERN");
+
+        // Unidentified
+        p.shouldMatch("§5Unidentified §f⬡ §5Shiny Crusade Sabatons");
+        p.shouldMatch("§5Unidentified §f⬡ §5Shiny Gaia");
+        p.shouldMatch("§5Unidentified Idol");
+        p.shouldMatch("§5Unidentified Nirvana");
+        p.shouldMatch("§bUnidentified Follow the Wind");
+
+        // Identified
+        p.shouldMatch("§5Apocalypse");
+        p.shouldMatch("§cRhythm of the Seasons");
+        p.shouldMatch("§f⬡ §5Shiny Stratiformis");
+        p.shouldMatch("§f⬡ §5Shiny Aftershock");
+        p.shouldMatch("§f⬡ §5Shiny Crusade Sabatons");
     }
 }


### PR DESCRIPTION
I think this is all we need to fix https://github.com/Wynntils/Artemis/issues/2488.

![image](https://github.com/Wynntils/Artemis/assets/49001742/35a7e9ac-358a-4913-8a4f-1c5ece62cda2)