### PR TITLE
feat: Content book QoL changes, speed fixes, (better) partial caching 

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.PlayerInteractEvent;
 import com.wynntils.mc.event.UseItemEvent;
@@ -100,6 +101,35 @@ public class WynntilsContentBookFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> cancelAllQueriesOnScreenClose = new Config<>(true);
+
+    // WynntilsQuestBookScreen storages
+    @Persisted
+    public final Storage<Boolean> questsSelected = new Storage<>(true);
+
+    @Persisted
+    public final Storage<Boolean> miniQuestsSelected = new Storage<>(false);
+
+    // WynntilsDiscoveriesScreen storages
+    // Note: These are intentionally not more advanced types, like Map<DiscoveryType, Boolean>,
+    // to allow easier changes in the future (when more discovery types are added).
+    // TODO: Change this when storage upfixers are implemented
+    @Persisted
+    public final Storage<Boolean> secretsSelected = new Storage<>(true);
+
+    @Persisted
+    public final Storage<Boolean> undiscoveredSecretsSelected = new Storage<>(false);
+
+    @Persisted
+    public final Storage<Boolean> worldSelected = new Storage<>(true);
+
+    @Persisted
+    public final Storage<Boolean> undiscoveredWorldSelected = new Storage<>(false);
+
+    @Persisted
+    public final Storage<Boolean> territorySelected = new Storage<>(true);
+
+    @Persisted
+    public final Storage<Boolean> undiscoveredTerritorySelected = new Storage<>(false);
 
     @SubscribeEvent
     public void onUseItem(UseItemEvent event) {

--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -12,6 +12,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.features.ui.WynntilsContentBookFeature;
 import com.wynntils.handlers.scoreboard.ScoreboardPart;
+import com.wynntils.mc.event.ScreenClosedEvent;
 import com.wynntils.mc.event.SetSpawnEvent;
 import com.wynntils.models.activities.caves.CaveInfo;
 import com.wynntils.models.activities.event.ActivityTrackerUpdatedEvent;
@@ -82,6 +83,7 @@ public final class ActivityModel extends Model {
     private TrackedActivity trackedActivity;
     private List<List<StyledText>> dialogueHistory = List.of();
     private CappedValue overallProgress = CappedValue.EMPTY;
+    private boolean overallProgressOutdated = true;
 
     public ActivityModel(MarkerModel markerModel) {
         super(List.of(markerModel));
@@ -108,6 +110,19 @@ public final class ActivityModel extends Model {
         }
 
         ACTIVITY_MARKER_PROVIDER.setSpawnLocation(spawn);
+    }
+
+    @SubscribeEvent
+    public void onScreenClosed(ScreenClosedEvent event) {
+        // The progress cannot be outdated if we are in the content book
+        // This speeds up navigation in the content book
+        overallProgressOutdated = true;
+    }
+
+    @SubscribeEvent
+    public void onWorldStateChange(WorldStateEvent event) {
+        // We need to rescan the overall progress when the world state changes
+        overallProgressOutdated = true;
     }
 
     public ActivityInfo parseItem(String name, ActivityType type, ItemStack itemStack) {
@@ -326,6 +341,9 @@ public final class ActivityModel extends Model {
     }
 
     public void scanOverallProgress() {
+        if (!overallProgressOutdated) return;
+
+        overallProgressOutdated = false;
         CONTAINER_QUERIES.queryContentBook(
                 ActivityType.RECOMMENDED,
                 (ignored, progress) -> {

--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities;
@@ -98,7 +98,7 @@ public final class ActivityModel extends Model {
             return;
         }
 
-        var player = Location.containing(McUtils.player().position());
+        Location player = Location.containing(McUtils.player().position());
         if (spawn.equals(player)) {
             // Wynncraft "resets" tracking by setting the compass to your current
             // location. In theory, this can fail if you happen to be standing on

--- a/common/src/main/java/com/wynntils/models/activities/caves/CaveModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/caves/CaveModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities.caves;
@@ -18,12 +18,13 @@ import com.wynntils.models.activities.type.ActivityType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class CaveModel extends Model {
-    private List<CaveInfo> caves = new ArrayList<>();
-    private List<StyledText> caveProgress = List.of();
+    private final Map<String, CaveStorage> caveStorage = new HashMap<>();
 
     public CaveModel() {
         super(List.of());
@@ -45,18 +46,21 @@ public class CaveModel extends Model {
             CaveInfo caveInfo = getCaveInfoFromActivity(activity);
             newCaves.add(caveInfo);
         }
-        caves = newCaves;
-        caveProgress = progress;
+        caveStorage.put(
+                Models.Character.getId(),
+                new CaveStorage(Collections.unmodifiableList(newCaves), Collections.unmodifiableList(progress)));
         WynntilsMod.postEvent(new ActivityUpdatedEvent(ActivityType.CAVE));
-        WynntilsMod.info("Updated caves from query, got " + caves.size() + " caves.");
+        WynntilsMod.info("Updated caves from query, got " + newCaves.size() + " caves.");
     }
 
     public Optional<CaveInfo> getCaveInfoFromName(String name) {
-        return caves.stream().filter(cave -> cave.getName().equals(name)).findFirst();
+        return getCavesRaw().stream()
+                .filter(cave -> cave.getName().equals(name))
+                .findFirst();
     }
 
     public List<CaveInfo> getSortedCaves(ActivitySortOrder sortOrder) {
-        return sortCaveInfoList(sortOrder, caves);
+        return sortCaveInfoList(sortOrder, getCavesRaw());
     }
 
     private List<CaveInfo> sortCaveInfoList(ActivitySortOrder sortOrder, List<CaveInfo> caveList) {
@@ -90,7 +94,15 @@ public class CaveModel extends Model {
     }
 
     public List<StyledText> getCaveProgress() {
-        return Collections.unmodifiableList(caveProgress);
+        return Collections.unmodifiableList(caveStorage
+                .getOrDefault(Models.Character.getId(), CaveStorage.EMPTY)
+                .progress());
+    }
+
+    public List<CaveInfo> getCavesRaw() {
+        return Collections.unmodifiableList(caveStorage
+                .getOrDefault(Models.Character.getId(), CaveStorage.EMPTY)
+                .caves());
     }
 
     private CaveInfo getCaveInfoFromActivity(ActivityInfo activity) {
@@ -103,5 +115,9 @@ public class CaveModel extends Model {
                 activity.length().orElse(ActivityLength.SHORT),
                 activity.difficulty().orElse(ActivityDifficulty.EASY),
                 activity.rewards());
+    }
+
+    private record CaveStorage(List<CaveInfo> caves, List<StyledText> progress) {
+        public static final CaveStorage EMPTY = new CaveStorage(List.of(), List.of());
     }
 }

--- a/common/src/main/java/com/wynntils/models/activities/discoveries/DiscoveryModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/discoveries/DiscoveryModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities.discoveries;
@@ -85,14 +85,22 @@ public final class DiscoveryModel extends Model {
         Managers.Net.openLink(UrlId.LINK_WIKI_LOOKUP, Map.of("title", discoveryInfo.getName()));
     }
 
-    private void queryDiscoveries() {
+    private void queryDiscoveries(
+            boolean querySecretDiscoveries, boolean queryWorldDiscoveries, boolean queryTerritoryDiscoveries) {
         WynntilsMod.info("Requesting rescan of discoveries in Content Book");
 
         // This order is a bit arbitrary, but it's the order they appear in the Content Book,
         // so we can use this as a workaround to parse them faster.
-        Models.Activity.scanContentBook(ActivityType.SECRET_DISCOVERY, this::updateSecretDiscoveriesFromQuery);
-        Models.Activity.scanContentBook(ActivityType.WORLD_DISCOVERY, this::updateWorldDiscoveriesFromQuery);
-        Models.Activity.scanContentBook(ActivityType.TERRITORIAL_DISCOVERY, this::updateTerritoryDiscoveriesFromQuery);
+        if (querySecretDiscoveries) {
+            Models.Activity.scanContentBook(ActivityType.SECRET_DISCOVERY, this::updateSecretDiscoveriesFromQuery);
+        }
+        if (queryWorldDiscoveries) {
+            Models.Activity.scanContentBook(ActivityType.WORLD_DISCOVERY, this::updateWorldDiscoveriesFromQuery);
+        }
+        if (queryTerritoryDiscoveries) {
+            Models.Activity.scanContentBook(
+                    ActivityType.TERRITORIAL_DISCOVERY, this::updateTerritoryDiscoveriesFromQuery);
+        }
     }
 
     private void updateTerritoryDiscoveriesFromQuery(List<ActivityInfo> newActivities, List<StyledText> progress) {
@@ -231,8 +239,9 @@ public final class DiscoveryModel extends Model {
         });
     }
 
-    public void reloadDiscoveries() {
-        queryDiscoveries();
+    public void reloadDiscoveries(
+            boolean querySecretDiscoveries, boolean queryWorldDiscoveries, boolean queryTerritoryDiscoveries) {
+        queryDiscoveries(querySecretDiscoveries, queryWorldDiscoveries, queryTerritoryDiscoveries);
     }
 
     public enum DiscoveryOpenAction {

--- a/common/src/main/java/com/wynntils/screens/activities/WynntilsDiscoveriesScreen.java
+++ b/common/src/main/java/com/wynntils/screens/activities/WynntilsDiscoveriesScreen.java
@@ -95,8 +95,7 @@ public final class WynntilsDiscoveriesScreen extends WynntilsListScreen<Discover
 
     @Override
     protected void doInit() {
-        // FIXME: Only query the types of discoveries that are currently being shown
-        Models.Discovery.reloadDiscoveries();
+        Models.Discovery.reloadDiscoveries(isShowingSecrets(), isShowingWorld(), isShowingTerritory());
 
         super.doInit();
 
@@ -119,6 +118,11 @@ public final class WynntilsDiscoveriesScreen extends WynntilsListScreen<Discover
                             Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class).territorySelected;
                     territorySelected.store(!territorySelected.get());
                     reloadElements();
+
+                    // Scan territories, if it's the first time we're showing them
+                    if (territorySelected.get()) {
+                        Models.Discovery.reloadDiscoveries(false, false, true);
+                    }
                 },
                 this::isShowingTerritory));
         filterButtons.add(new FilterButton(
@@ -138,6 +142,11 @@ public final class WynntilsDiscoveriesScreen extends WynntilsListScreen<Discover
                             Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class).worldSelected;
                     worldSelected.store(!worldSelected.get());
                     reloadElements();
+
+                    // Scan world discoveries, if it's the first time we're showing them
+                    if (worldSelected.get()) {
+                        Models.Discovery.reloadDiscoveries(false, true, false);
+                    }
                 },
                 this::isShowingWorld));
         filterButtons.add(new FilterButton(
@@ -157,6 +166,11 @@ public final class WynntilsDiscoveriesScreen extends WynntilsListScreen<Discover
                             Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class).secretsSelected;
                     secretsSelected.store(!secretsSelected.get());
                     reloadElements();
+
+                    // Scan secret discoveries, if it's the first time we're showing them
+                    if (secretsSelected.get()) {
+                        Models.Discovery.reloadDiscoveries(true, false, false);
+                    }
                 },
                 this::isShowingSecrets));
         filterButtons.add(new FilterButton(
@@ -233,7 +247,7 @@ public final class WynntilsDiscoveriesScreen extends WynntilsListScreen<Discover
                 (int) (Texture.RELOAD_ICON_OFFSET.width() / 2 / 1.7f),
                 (int) (Texture.RELOAD_ICON_OFFSET.height() / 1.7f),
                 "discovery",
-                Models.Discovery::reloadDiscoveries));
+                () -> Models.Discovery.reloadDiscoveries(isShowingSecrets(), isShowingWorld(), isShowingTerritory())));
 
         this.addRenderableWidget(new SortOrderWidget(
                 Texture.CONTENT_BOOK_BACKGROUND.width() / 2 + 1,

--- a/common/src/main/java/com/wynntils/screens/activities/WynntilsQuestBookScreen.java
+++ b/common/src/main/java/com/wynntils/screens/activities/WynntilsQuestBookScreen.java
@@ -135,7 +135,6 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
                     reloadElements();
 
                     // Scan quests, if it's the first time we're showing them
-                    // FIXME: Only scan if we're showing quests for the first time
                     if (questsSelected.get()) {
                         Models.Quest.rescanQuestBook(true, false);
                     }
@@ -160,7 +159,6 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
                     reloadElements();
 
                     // Scan mini quests, if it's the first time we're showing them
-                    // FIXME: Only scan if we're showing mini quests for the first time
                     if (miniQuestsSelected.get()) {
                         Models.Quest.rescanQuestBook(false, true);
                     }

--- a/common/src/main/java/com/wynntils/screens/activities/WynntilsQuestBookScreen.java
+++ b/common/src/main/java/com/wynntils/screens/activities/WynntilsQuestBookScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.activities;
@@ -9,6 +9,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
+import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.features.ui.WynntilsContentBookFeature;
 import com.wynntils.mc.event.MenuEvent;
@@ -51,8 +52,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo, QuestButton>
         implements SortableActivityScreen {
     private QuestInfo trackingRequested = null;
-    private boolean showQuests = true;
-    private boolean showMiniQuests = false;
     private ActivitySortOrder activitySortOrder = ActivitySortOrder.LEVEL;
 
     private final List<FilterButton> filterButtons = new ArrayList<>();
@@ -70,8 +69,23 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
         return new WynntilsQuestBookScreen();
     }
 
+    // Called when the screen is closed
     @Override
     public void onClose() {
+        cleanupOnClose();
+
+        super.onClose();
+    }
+
+    // Called when the screen is "overwritten" by another screen
+    @Override
+    public void removed() {
+        cleanupOnClose();
+
+        super.removed();
+    }
+
+    private void cleanupOnClose() {
         WynntilsMod.unregisterEventListener(this);
 
         if (Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class)
@@ -79,8 +93,6 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
                 .get()) {
             Handlers.ContainerQuery.endAllQueries();
         }
-
-        super.onClose();
     }
 
     /** This is called on every resize. Re-registering widgets are required, re-creating them is not.
@@ -88,7 +100,7 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
     @Override
     protected void doInit() {
         if (firstInit) {
-            Models.Quest.rescanQuestBook(true, false);
+            Models.Quest.rescanQuestBook(isShowingQuests(), isShowingMiniQuests());
         }
 
         firstInit = false;
@@ -117,10 +129,18 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
-                    showQuests = !showQuests;
+                    Storage<Boolean> questsSelected =
+                            Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class).questsSelected;
+                    questsSelected.store(!questsSelected.get());
                     reloadElements();
+
+                    // Scan quests, if it's the first time we're showing them
+                    // FIXME: Only scan if we're showing quests for the first time
+                    if (questsSelected.get()) {
+                        Models.Quest.rescanQuestBook(true, false);
+                    }
                 },
-                () -> showQuests));
+                this::isShowingQuests));
         filterButtons.add(new FilterButton(
                 90,
                 142,
@@ -134,15 +154,18 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
                                 .withStyle(ChatFormatting.BOLD)
                                 .withStyle(ChatFormatting.GREEN))),
                 () -> {
-                    showMiniQuests = !showMiniQuests;
+                    Storage<Boolean> miniQuestsSelected =
+                            Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class).miniQuestsSelected;
+                    miniQuestsSelected.store(!miniQuestsSelected.get());
                     reloadElements();
 
-                    if (showMiniQuests) {
-                        // Scan mini quests, we don't do this on init because it's slow
+                    // Scan mini quests, if it's the first time we're showing them
+                    // FIXME: Only scan if we're showing mini quests for the first time
+                    if (miniQuestsSelected.get()) {
                         Models.Quest.rescanQuestBook(false, true);
                     }
                 },
-                () -> showMiniQuests));
+                this::isShowingMiniQuests));
 
         for (FilterButton filterButton : filterButtons) {
             this.addRenderableWidget(filterButton);
@@ -154,7 +177,7 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
                 (int) (Texture.RELOAD_ICON_OFFSET.width() / 2 / 1.7f),
                 (int) (Texture.RELOAD_ICON_OFFSET.height() / 1.7f),
                 "quest",
-                () -> Models.Quest.rescanQuestBook(showQuests, showMiniQuests)));
+                () -> Models.Quest.rescanQuestBook(isShowingQuests(), isShowingMiniQuests())));
         this.addRenderableWidget(new PageSelectorButton(
                 Texture.CONTENT_BOOK_BACKGROUND.width() / 2 + 50 - Texture.FORWARD_ARROW_OFFSET.width() / 2,
                 Texture.CONTENT_BOOK_BACKGROUND.height() - 25,
@@ -368,7 +391,7 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
     }
 
     private List<QuestInfo> getSortedQuests() {
-        return Models.Quest.getSortedQuests(activitySortOrder, showQuests, showMiniQuests);
+        return Models.Quest.getSortedQuests(activitySortOrder, isShowingQuests(), isShowingMiniQuests());
     }
 
     private void setQuests(List<QuestInfo> quests) {
@@ -412,6 +435,18 @@ public final class WynntilsQuestBookScreen extends WynntilsListScreen<QuestInfo,
         this.activitySortOrder = newSortOrder;
         setQuests(getSortedQuests());
         this.setCurrentPage(0);
+    }
+
+    private boolean isShowingQuests() {
+        return Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class)
+                .questsSelected
+                .get();
+    }
+
+    private boolean isShowingMiniQuests() {
+        return Managers.Feature.getFeatureInstance(WynntilsContentBookFeature.class)
+                .miniQuestsSelected
+                .get();
     }
 
     private void addQuestProgressTooltipLines(List<Component> tooltipLines, boolean miniQuestMode) {

--- a/common/src/main/java/com/wynntils/screens/base/WynntilsListScreen.java
+++ b/common/src/main/java/com/wynntils/screens/base/WynntilsListScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base;
@@ -245,7 +245,10 @@ public abstract class WynntilsListScreen<E, B extends WynntilsButton> extends Wy
 
     public void reloadElements() {
         reloadElements(searchWidget.getTextBoxInput());
-        setCurrentPage(0);
+        // Set the current page to the same page, but with the new elements
+        // This will clamp the current page to the new max page
+        // But if the contents are the same, it will not change the page
+        setCurrentPage(getCurrentPage());
     }
 
     @Override


### PR DESCRIPTION
With this PR, we cache all of the currently parsed content book (quests, mini-quests, all discoveries, caves) per character. We can't yet figure out, when to re-parse the book, and when there were no changes, but this PR is a step in the direction for that. Theoretically, we have enough hints in the chat to mark a class outdated, but that is a too complex change here.

All filter buttons are now also saved into storage, to allow for easier usage of the content book. Also, switching from different types of activity screens will now cancel all background queries correctly, avoiding really long wait times.