### PR TITLE
fix: NPC dialogues not getting transcribed [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -118,7 +118,7 @@ public class TranscribeMessagesFeature extends Feature {
                             WynnAlphabet.WYNNIC,
                             coloredTranscriptions.get(),
                             wynnicColor.get().getChatFormatting(),
-                            npcDialogue || showTooltip.get()));
+                            !npcDialogue && showTooltip.get()));
 
             // Wynnic characters are transcribed second
             transcribedStyledText = transcribeStyledText(
@@ -129,7 +129,7 @@ public class TranscribeMessagesFeature extends Feature {
                             WynnAlphabet.WYNNIC,
                             coloredTranscriptions.get(),
                             wynnicColor.get().getChatFormatting(),
-                            npcDialogue || showTooltip.get()));
+                            !npcDialogue && showTooltip.get()));
         }
 
         if (transcribeGavellian) {
@@ -142,7 +142,7 @@ public class TranscribeMessagesFeature extends Feature {
                             WynnAlphabet.GAVELLIAN,
                             coloredTranscriptions.get(),
                             gavellianColor.get().getChatFormatting(),
-                            npcDialogue || showTooltip.get()));
+                            !npcDialogue && showTooltip.get()));
         }
 
         return transcribedStyledText;

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1282,7 +1282,7 @@
   "feature.wynntils.transcribeMessages.gavellianColor.description": "What color should Gavellian transcriptions be?",
   "feature.wynntils.transcribeMessages.gavellianColor.name": "Gavellian Color",
   "feature.wynntils.transcribeMessages.name": "Transcribe Received Messages",
-  "feature.wynntils.transcribeMessages.showTooltip.description": "Hover chat messages to see transcription of message. NPC dialogue containing Gavellian/Wynnic will be sent to chat.",
+  "feature.wynntils.transcribeMessages.showTooltip.description": "Hover chat messages to see transcription of message. NPC dialogue containing Gavellian/Wynnic will always be transcribed.",
   "feature.wynntils.transcribeMessages.showTooltip.name": "Show Transcription Tooltip",
   "feature.wynntils.transcribeMessages.transcribeChat.description": "Transcribe chat messages containing Gavellian and Wynnic?",
   "feature.wynntils.transcribeMessages.transcribeChat.name": "Transcribe chat messages",


### PR DESCRIPTION
This is less than ideal, but the last patch made it so the NPC overlay messages cannot be transcribed at all. Since adapting the code to send a chat message with the transcription (but only when the overlay is enabled, as the other two methods are unaffected) is very hard, I think this is a nice compromise.