### PR TITLE
chore: Add Storage upfixers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
@@ -18,6 +18,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.PersistedOwner;
 import com.wynntils.core.persisted.PersistedValue;
+import com.wynntils.core.persisted.upfixers.UpfixerType;
 import com.wynntils.utils.JsonUtils;
 import com.wynntils.utils.mc.McUtils;
 import java.io.File;
@@ -57,7 +58,7 @@ public final class ConfigManager extends Manager {
         // Now, we have to apply upfixers, before any config loading happens
         // FIXME: Solve generics type issue
         Set<PersistedValue<?>> workaround = new HashSet<>(CONFIGS);
-        if (Managers.Upfixer.runUpfixers(configObject, workaround)) {
+        if (Managers.Upfixer.runUpfixers(configObject, workaround, UpfixerType.CONFIG)) {
             Managers.Json.savePreciousJson(userConfigFile, configObject);
         }
 

--- a/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
@@ -12,13 +12,17 @@ import com.wynntils.core.components.Manager;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.persisted.Persisted;
+import com.wynntils.core.persisted.PersistedValue;
+import com.wynntils.core.persisted.upfixers.UpfixerType;
 import com.wynntils.utils.mc.McUtils;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -37,6 +41,8 @@ public final class StorageManager extends Manager {
     private final Map<String, Storage<?>> storages = new TreeMap<>();
     private final Map<Storage<?>, Type> storageTypes = new HashMap<>();
     private final Map<Storage<?>, Storageable> storageOwner = new HashMap<>();
+
+    private JsonObject storageObject;
 
     private long lastPersisted;
     private boolean scheduledPersist;
@@ -59,6 +65,16 @@ public final class StorageManager extends Manager {
         Managers.Feature.getFeatures().forEach(this::registerStorageable);
 
         readFromJson();
+
+        // Now, we have to apply upfixers, before any storage loading happens
+        // FIXME: Solve generics type issue
+        Set<PersistedValue<?>> workaround = new HashSet<>(storages.values());
+        if (Managers.Upfixer.runUpfixers(storageObject, workaround, UpfixerType.STORAGE)) {
+            Managers.Json.savePreciousJson(userStorageFile, storageObject);
+
+            // Re-read the storage file after upfixing
+            readFromJson();
+        }
 
         storageInitialized = true;
 
@@ -116,12 +132,12 @@ public final class StorageManager extends Manager {
     }
 
     private void readFromJson() {
-        JsonObject storageJson = Managers.Json.loadPreciousJson(userStorageFile);
+        storageObject = Managers.Json.loadPreciousJson(userStorageFile);
         storages.forEach((jsonName, storage) -> {
-            if (!storageJson.has(jsonName)) return;
+            if (!storageObject.has(jsonName)) return;
 
             // read value and update option
-            JsonElement jsonElem = storageJson.get(jsonName);
+            JsonElement jsonElem = storageObject.get(jsonName);
             Object value = Managers.Json.GSON.fromJson(jsonElem, storageTypes.get(storage));
             Managers.Persisted.setRaw(storage, value);
 
@@ -132,6 +148,10 @@ public final class StorageManager extends Manager {
 
     private void writeToJson() {
         JsonObject storageJson = new JsonObject();
+
+        // Save upfixers
+        String upfixerJsonMemberName = Managers.Upfixer.UPFIXER_JSON_MEMBER_NAME;
+        storageJson.add(upfixerJsonMemberName, storageObject.get(upfixerJsonMemberName));
 
         storages.forEach((jsonName, storage) -> {
             try {

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerType.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.persisted.upfixers;
+
+public enum UpfixerType {
+    CONFIG,
+    STORAGE
+}


### PR DESCRIPTION
If I had a dollar, every time we needed storage upfixers... I could probably eat a menu in McDonalds.

Anyways, this was really simple to add, thanks to every previous refactor of the persisted values, by magicus. This will be useful in the future for keeping our code clean, allowing us to do necessary refactors. It'll also be helpful when we are migrating map-data.

The upfixers however can't interact between storage types, you can't move configs to storage. That's a whole different story :).

I've tested this by applying a storage upfixer to a renamed list of crowd sourced data, which is our most complex storage type. I've also tested applying a config upfixer, to make sure they still work.