### PR TITLE
feat: Add option to limit number of leaderboard badges shown [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.players;
@@ -43,6 +43,7 @@ public class CustomNametagRendererFeature extends Feature {
     private static final float ACCOUNT_TYPE_MULTIPLIER = 1.5f;
     private static final float NAMETAG_HEIGHT = 0.25875f;
     private static final float BADGE_MARGIN = 2;
+    private static final int BADGE_SCROLL_SPEED = 40;
     private static final String WYNNTILS_LOGO = "⛨"; // Well, at least it's a shield...
 
     @Persisted
@@ -56,6 +57,9 @@ public class CustomNametagRendererFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> showProfessionBadges = new Config<>(true);
+
+    @Persisted
+    public final Config<Integer> badgeCount = new Config<>(7);
 
     @Persisted
     public final Config<Boolean> showGearOnHover = new Config<>(true);
@@ -213,20 +217,32 @@ public class CustomNametagRendererFeature extends Feature {
 
     private void drawBadges(PlayerNametagRenderEvent event, float height) {
         if (!showProfessionBadges.get()) return;
+        if (badgeCount.get() <= 0) return;
 
-        List<LeaderboardBadge> badges =
+        List<LeaderboardBadge> allBadges =
                 Services.Leaderboard.getBadges(event.getEntity().getUUID());
 
-        if (badges.isEmpty()) return;
+        if (allBadges.isEmpty()) return;
 
-        float totalWidth = LeaderboardBadge.WIDTH * badges.size() + BADGE_MARGIN * (badges.size() - 1);
+        List<LeaderboardBadge> badgesToRender = new ArrayList<>();
+
+        if (badgeCount.get() >= allBadges.size()) {
+            badgesToRender = allBadges;
+        } else {
+            int offset = (McUtils.player().tickCount / BADGE_SCROLL_SPEED) % allBadges.size();
+            for (int i = 0; i < badgeCount.get(); i++) {
+                badgesToRender.add(allBadges.get((i + offset) % allBadges.size()));
+            }
+        }
+
+        float totalWidth = LeaderboardBadge.WIDTH * badgesToRender.size() + BADGE_MARGIN * (badgesToRender.size() - 1);
         float xOffset = -(totalWidth / 2) + LeaderboardBadge.WIDTH / 2F;
         float yOffset = 15F;
         if (height == 0) {
             yOffset += 10F;
         }
 
-        for (LeaderboardBadge badge : badges) {
+        for (LeaderboardBadge badge : badgesToRender) {
             RenderUtils.renderProfessionBadge(
                     event.getPoseStack(),
                     event.getEntityRenderDispatcher(),

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -385,6 +385,8 @@
   "feature.wynntils.customLootrunBeacons.name": "Custom Lootrun Beacons",
   "feature.wynntils.customLootrunBeacons.removeOriginalBeacons.description": "Should the original Wynncraft lootrun beacons be removed?",
   "feature.wynntils.customLootrunBeacons.removeOriginalBeacons.name": "Remove Original Beacons",
+  "feature.wynntils.customNametagRenderer.badgeCount.description": "If badges are enabled, how many should be displayed at a time?",
+  "feature.wynntils.customNametagRenderer.badgeCount.name": "Badges to Display",
   "feature.wynntils.customNametagRenderer.customNametagScale.description": "How large should the extra nametag lines be?",
   "feature.wynntils.customNametagRenderer.customNametagScale.name": "Custom Nametag Scale",
   "feature.wynntils.customNametagRenderer.description": "Adds the ability to render custom nametags.",


### PR DESCRIPTION
Rendering so many at once is it a bit excessive and especially since we'll soon be adding more badges this felt like it should be implemented. I set a default of 7 as I think that's a reasonable amount but it can support anything from 1 to however many badges there are.

It scrolls through the badges every 40 ticks, so it's not like any badges outside of the range aren't viewable.

Default 7
![image](https://github.com/Wynntils/Artemis/assets/8337467/e4d6c6c7-72e9-45d7-a1b0-ef39ecf761d6)
Original 13 for comparison
![image](https://github.com/Wynntils/Artemis/assets/8337467/c6764c85-b36f-468b-a520-8c0d0eb88ea1)


https://github.com/Wynntils/Artemis/assets/8337467/b1b2036a-03a8-4106-a64e-8557d5755415

