### PR TITLE
fix: Fix CustomPlayerListOverlay below the boss bars [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/overlays/CustomPlayerListOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CustomPlayerListOverlayFeature.java
@@ -15,6 +15,8 @@ import com.wynntils.overlays.CustomPlayerListOverlay;
 
 @ConfigCategory(Category.OVERLAYS)
 public class CustomPlayerListOverlayFeature extends Feature {
-    @OverlayInfo(renderType = RenderEvent.ElementType.GUI, renderAt = RenderState.PRE)
+    // This render type is not set to PLAYER_TAB_LIST on purpose,
+    // as we need to do additional rendering before and after the player list is rendered (for animations).
+    @OverlayInfo(renderType = RenderEvent.ElementType.GUI, renderAt = RenderState.POST)
     private final Overlay customPlayerListOverlay = new CustomPlayerListOverlay();
 }

--- a/common/src/main/java/com/wynntils/overlays/CustomPlayerListOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/CustomPlayerListOverlay.java
@@ -5,6 +5,7 @@
 package com.wynntils.overlays;
 
 import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.overlays.Overlay;
@@ -102,6 +103,8 @@ public class CustomPlayerListOverlay extends Overlay {
     }
 
     private void renderPlayerList(PoseStack poseStack, double animation) {
+        RenderSystem.disableDepthTest();
+
         if (animation < 1) {
             RenderUtils.enableScissor(
                     (int) (getRenderX() + ROLL_WIDTH + HALF_WIDTH - HALF_WIDTH * animation),
@@ -139,6 +142,8 @@ public class CustomPlayerListOverlay extends Overlay {
         float middle = getRenderX() + HALF_WIDTH + ROLL_WIDTH;
         renderRoll(poseStack, (float) (middle - ROLL_WIDTH + 2 - HALF_WIDTH * animation));
         renderRoll(poseStack, (float) (middle - 2 + HALF_WIDTH * animation));
+
+        RenderSystem.enableDepthTest();
     }
 
     private void renderRoll(PoseStack poseStack, float xPos) {


### PR DESCRIPTION
# Old
![image](https://github.com/Wynntils/Artemis/assets/49001742/3822130b-4f46-4395-ad1e-b1eaa863d959)

# Fix
![image](https://github.com/Wynntils/Artemis/assets/49001742/79bb25e0-7ab3-4abc-bb90-dbda2e29df8b)
