### PR TITLE
fix: Fix charms being counted as defective, if they had no identifications [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/rewards/type/CharmInstance.java
+++ b/common/src/main/java/com/wynntils/models/rewards/type/CharmInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.rewards.type;
@@ -31,6 +31,6 @@ public record CharmInstance(int rerolls, List<StatActualValue> identifications, 
     }
 
     public boolean isDefective() {
-        return overallQuality.orElse(0.0f) <= 0.0f;
+        return overallQuality.isPresent() && overallQuality.orElse(0.0f) <= 0.0f;
     }
 }


### PR DESCRIPTION
All charms currently have identifications but good to be future proof