### PR TITLE
fix: Remove "Optional" from map level hover

### DIFF
--- a/common/src/main/java/com/wynntils/services/map/pois/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/LabelPoi.java
@@ -137,7 +137,7 @@ public class LabelPoi implements Poi {
                         .renderText(
                                 poseStack,
                                 bufferSource,
-                                StyledText.fromString("[Lv. " + level + "]"),
+                                StyledText.fromString("[Lv. " + level.get() + "]"),
                                 0,
                                 10,
                                 color,

--- a/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
@@ -73,12 +73,18 @@ public class MapDataService extends Service {
         float max = mapVisibility.getMax().get();
         float fade = mapVisibility.getFade().get();
 
+        // Having max larger than min is a way to represent "never show"
+        if (max < min) {
+            return 0f;
+        }
+
         float startFadeIn = min - fade;
         float stopFadeIn = min + fade;
         float startFadeOut = max - fade;
         float stopFadeOut = max + fade;
 
-        // If min or max is at the extremes, do not apply fading
+        // If min or max is at the extremes, do not apply fading.
+        // This is a way of representing "always show".
         if (min <= 1) {
             startFadeIn = 0;
             stopFadeIn = 0;

--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeaturePoiWrapper.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeaturePoiWrapper.java
@@ -180,15 +180,15 @@ public class MapFeaturePoiWrapper implements Poi {
         }
 
         // Draw level, if applicable
-        Optional<Integer> level = attributes.getLevel();
+        int level = attributes.getLevel().get();
         // Show level only for features that are displayed and hovered
         boolean drawLevel = hovered && (drawIcon || drawLabel);
-        if (level.get() >= 1 && drawLevel) {
+        if (level >= 1 && drawLevel) {
             BufferedFontRenderer.getInstance()
                     .renderText(
                             poseStack,
                             bufferSource,
-                            StyledText.fromString("[Lv. " + level.get() + "]"),
+                            StyledText.fromString("[Lv. " + level + "]"),
                             0,
                             yOffset,
                             attributes.getLabelColor().get(),


### PR DESCRIPTION
Unfortunately the changes in Label meant that we print like `[Lv. Optional[10]]` in the label hover.

This was not happening in the new mapdata rendering, but I removed the optional there as well for clarity. I'm also sneaking in a small bug fix for the "never" FixedMapVisibilities.