### PR TITLE
feat: Start using MapData for some providers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -220,7 +220,8 @@ public class WorldWaypointDistanceFeature extends Feature {
                                 false,
                                 scale.get(),
                                 1,
-                                50);
+                                50,
+                                true);
                 bufferSource.endBatch();
                 poseStack.popPose();
             }

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -7,7 +7,6 @@ package com.wynntils.overlays.minimap;
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.overlays.Overlay;
@@ -16,9 +15,7 @@ import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.features.map.MainMapFeature;
 import com.wynntils.services.map.MapTexture;
-import com.wynntils.services.map.pois.PlayerMiniMapPoi;
 import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.map.pois.WaypointPoi;
 import com.wynntils.utils.MathUtils;
@@ -252,20 +249,15 @@ public class MinimapOverlay extends Overlay {
 
         float currentZoom = 1f / zoomRenderScale;
 
-        Stream<? extends Poi> poisToRender = Services.Poi.getServicePois();
+        // Get all MapData features as Pois
+        Stream<? extends Poi> poisToRender = Services.MapData.getFeaturesAsPois();
 
-        poisToRender = Stream.concat(
-                poisToRender,
-                Services.Hades.getHadesUsers()
-                        .filter(user -> (user.isPartyMember() && renderRemotePartyPlayers.get())
-                                || (user.isMutualFriend() && renderRemoteFriendPlayers.get()))
-                        .map(PlayerMiniMapPoi::new));
-
-        poisToRender = Stream.concat(poisToRender, Services.Poi.getCombatPois());
-        poisToRender = Stream.concat(
-                poisToRender, Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get().stream());
+        // Append the pois that are still not converted to MapData
         poisToRender = Stream.concat(poisToRender, Services.Poi.getProvidedCustomPois().stream());
         poisToRender = Stream.concat(poisToRender, Models.Marker.getAllPois());
+        poisToRender = Stream.concat(
+                poisToRender,
+                Services.Hades.getPlayerPois(renderRemotePartyPlayers.get(), renderRemoteFriendPlayers.get()));
 
         MultiBufferSource.BufferSource bufferSource =
                 McUtils.mc().renderBuffers().bufferSource();
@@ -293,7 +285,15 @@ public class MinimapOverlay extends Overlay {
 
             if (BoundingShape.intersects(box, textureBoundingCircle)) {
                 poi.renderAt(
-                        poseStack, bufferSource, poiRenderX, poiRenderZ, false, poiScale.get(), currentZoom, zoomLevel);
+                        poseStack,
+                        bufferSource,
+                        poiRenderX,
+                        poiRenderZ,
+                        false,
+                        poiScale.get(),
+                        currentZoom,
+                        zoomLevel,
+                        false);
             }
         }
 
@@ -365,7 +365,8 @@ public class MinimapOverlay extends Overlay {
                                 false,
                                 poiScale.get(),
                                 1f / zoomRenderScale,
-                                zoomLevel);
+                                zoomLevel,
+                                false);
                 poseStack.popPose();
             } else {
                 waypointPoi.renderAt(
@@ -376,7 +377,8 @@ public class MinimapOverlay extends Overlay {
                         false,
                         poiScale.get(),
                         currentZoom,
-                        zoomLevel);
+                        zoomLevel,
+                        false);
             }
 
             bufferSource.endBatch();

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -179,7 +179,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                     hovered == poi,
                     poiScale,
                     zoomRenderScale,
-                    zoomLevel);
+                    zoomLevel,
+                    true);
         }
 
         bufferSource.endBatch();

--- a/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
@@ -440,7 +440,8 @@ public final class CustomSeaskipperScreen extends AbstractMapScreen {
                         hoveredPoi == poi,
                         poiScale,
                         zoomRenderScale,
-                        zoomLevel);
+                        zoomLevel,
+                        true);
             }
         }
 

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -274,7 +274,8 @@ public final class GuildMapScreen extends AbstractMapScreen {
                     hovered == poi,
                     poiScale,
                     zoomRenderScale,
-                    zoomLevel);
+                    zoomLevel,
+                    true);
         }
 
         bufferSource.endBatch();

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -218,8 +218,8 @@ public final class MainMapScreen extends AbstractMapScreen {
 
             // When in an unmapped area, center to the middle of the map if the feature is enabled
             if (Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                            .centerWhenUnmapped
-                            .get()
+                    .centerWhenUnmapped
+                    .get()
                     && Services.Map.getMapsForBoundingBox(textureBoundingBox).isEmpty()) {
                 centerMapOnWorld();
             }
@@ -234,9 +234,9 @@ public final class MainMapScreen extends AbstractMapScreen {
 
         if (holdingMapKey
                 && !Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                        .openMapKeybind
-                        .getKeyMapping()
-                        .isDown()) {
+                .openMapKeybind
+                .getKeyMapping()
+                .isDown()) {
             this.onClose();
             return;
         }
@@ -297,11 +297,10 @@ public final class MainMapScreen extends AbstractMapScreen {
     }
 
     private void renderPois(PoseStack poseStack, int mouseX, int mouseY) {
-        Stream<? extends Poi> pois = Services.Poi.getServicePois();
+        // Get all MapData features as Pois
+        Stream<? extends Poi> pois = Services.MapData.getFeaturesAsPois();
 
-        pois = Stream.concat(pois, Services.Poi.getCombatPois());
-        pois = Stream.concat(pois, Services.Poi.getLabelPois());
-        pois = Stream.concat(pois, Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get().stream());
+        // Append the pois that are still not converted to MapData
         pois = Stream.concat(pois, Services.Poi.getProvidedCustomPois().stream());
         pois = Stream.concat(pois, Models.Marker.getAllPois());
         pois = Stream.concat(pois, Services.Hades.getPlayerPois());

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -218,8 +218,8 @@ public final class MainMapScreen extends AbstractMapScreen {
 
             // When in an unmapped area, center to the middle of the map if the feature is enabled
             if (Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                    .centerWhenUnmapped
-                    .get()
+                            .centerWhenUnmapped
+                            .get()
                     && Services.Map.getMapsForBoundingBox(textureBoundingBox).isEmpty()) {
                 centerMapOnWorld();
             }
@@ -234,9 +234,9 @@ public final class MainMapScreen extends AbstractMapScreen {
 
         if (holdingMapKey
                 && !Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                .openMapKeybind
-                .getKeyMapping()
-                .isDown()) {
+                        .openMapKeybind
+                        .getKeyMapping()
+                        .isDown()) {
             this.onClose();
             return;
         }
@@ -303,7 +303,15 @@ public final class MainMapScreen extends AbstractMapScreen {
         // Append the pois that are still not converted to MapData
         pois = Stream.concat(pois, Services.Poi.getProvidedCustomPois().stream());
         pois = Stream.concat(pois, Models.Marker.getAllPois());
-        pois = Stream.concat(pois, Services.Hades.getPlayerPois());
+        pois = Stream.concat(
+                pois,
+                Services.Hades.getPlayerPois(
+                        Managers.Feature.getFeatureInstance(MainMapFeature.class)
+                                .renderRemotePartyPlayers
+                                .get(),
+                        Managers.Feature.getFeatureInstance(MainMapFeature.class)
+                                .renderRemoteFriendPlayers
+                                .get()));
 
         if (showTerrs) {
             pois = Stream.concat(pois, Models.Territory.getTerritoryPois().stream());

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -361,7 +361,8 @@ public final class PoiCreationScreen extends AbstractMapScreen implements Textbo
                     hovered == poi,
                     1,
                     zoomRenderScale,
-                    zoomLevel);
+                    zoomLevel,
+                    true);
 
             bufferSource.endBatch();
         }

--- a/common/src/main/java/com/wynntils/services/hades/HadesService.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesService.java
@@ -9,7 +9,6 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Service;
 import com.wynntils.core.components.Services;
-import com.wynntils.features.map.MainMapFeature;
 import com.wynntils.features.players.HadesFeature;
 import com.wynntils.hades.objects.HadesConnection;
 import com.wynntils.hades.protocol.builders.HadesNetworkBuilder;
@@ -61,16 +60,10 @@ public final class HadesService extends Service {
         super(List.of());
     }
 
-    public Stream<PlayerMainMapPoi> getPlayerPois() {
+    public Stream<PlayerMainMapPoi> getPlayerPois(boolean renderRemotePartyPlayers, boolean renderRemoteFriendPlayers) {
         return getHadesUsers()
-                .filter(hadesUser -> (hadesUser.isPartyMember()
-                                && Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                                        .renderRemotePartyPlayers
-                                        .get())
-                        || (hadesUser.isMutualFriend()
-                                && Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                                        .renderRemoteFriendPlayers
-                                        .get()))
+                .filter(hadesUser -> (hadesUser.isPartyMember() && renderRemotePartyPlayers)
+                        || (hadesUser.isMutualFriend() && renderRemoteFriendPlayers))
                 .map(PlayerMainMapPoi::new);
     }
 

--- a/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
@@ -68,7 +68,8 @@ public abstract class IconPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         float modifier = scale;
 
         if (hovered) {

--- a/common/src/main/java/com/wynntils/services/map/pois/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/LabelPoi.java
@@ -102,7 +102,8 @@ public class LabelPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         float alpha = getAlphaFromScale(zoomRenderScale);
         if (alpha < 0.01) {
             return; // small enough alphas are turned into 255

--- a/common/src/main/java/com/wynntils/services/map/pois/PlayerMainMapPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/PlayerMainMapPoi.java
@@ -35,7 +35,8 @@ public class PlayerMainMapPoi extends PlayerPoiBase {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         poseStack.pushPose();
         poseStack.translate(-playerHeadRenderSize / 2f, -playerHeadRenderSize / 2f, 0); // center the player icon
 

--- a/common/src/main/java/com/wynntils/services/map/pois/PlayerMiniMapPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/PlayerMiniMapPoi.java
@@ -32,7 +32,8 @@ public class PlayerMiniMapPoi extends PlayerPoiBase {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         poseStack.pushPose();
         poseStack.translate(-playerHeadRenderSize / 2f, -playerHeadRenderSize / 2f, 0); // center the player icon
 

--- a/common/src/main/java/com/wynntils/services/map/pois/Poi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/Poi.java
@@ -28,7 +28,8 @@ public interface Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel);
+            float zoomLevel,
+            boolean showLabels);
 
     int getWidth(float mapZoom, float scale);
 

--- a/common/src/main/java/com/wynntils/services/map/pois/SeaskipperDestinationPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/SeaskipperDestinationPoi.java
@@ -73,7 +73,8 @@ public class SeaskipperDestinationPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         renderPoi(poseStack, bufferSource, renderX, renderY, zoomRenderScale, true);
     }
 

--- a/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
@@ -77,7 +77,8 @@ public class TerritoryPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         poseStack.pushPose();
         poseStack.translate(0, 0, 100);
 

--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeaturePoiWrapper.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeaturePoiWrapper.java
@@ -106,7 +106,8 @@ public class MapFeaturePoiWrapper implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel) {
+            float zoomLevel,
+            boolean showLabels) {
         float renderScale = hovered ? scale * 1.05f : scale;
         // this is the default alpha for labels
         float hoverAlphaFactor = hovered ? 1f : 0.9f;
@@ -156,7 +157,7 @@ public class MapFeaturePoiWrapper implements Poi {
         // visual glitches
         // Always draw labels for hovered icons, regardless of label visibility rules
         boolean drawLabel = labelAlpha > 0.01 || (drawIcon && hovered);
-        if (!attributes.getLabel().get().isEmpty() && drawLabel) {
+        if (!attributes.getLabel().get().isEmpty() && drawLabel && showLabels) {
             if (drawIcon && hovered) {
                 // If this is hovered, show with full alpha
                 labelAlpha = 1f;


### PR DESCRIPTION
This will switch combat, caves, labels, services and custom waypoints to use the MapData implementation instead, for both the main map and the minimap.

The services and labels are not removed from PoiService since they are still queried by `/location` and `/compass`. We need to address that first.