### PR TITLE
chore: Revert "feat: Start using MapData for some providers [skip ci]" [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -220,8 +220,7 @@ public class WorldWaypointDistanceFeature extends Feature {
                                 false,
                                 scale.get(),
                                 1,
-                                50,
-                                true);
+                                50);
                 bufferSource.endBatch();
                 poseStack.popPose();
             }

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -179,8 +179,7 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                     hovered == poi,
                     poiScale,
                     zoomRenderScale,
-                    zoomLevel,
-                    true);
+                    zoomLevel);
         }
 
         bufferSource.endBatch();

--- a/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
@@ -440,8 +440,7 @@ public final class CustomSeaskipperScreen extends AbstractMapScreen {
                         hoveredPoi == poi,
                         poiScale,
                         zoomRenderScale,
-                        zoomLevel,
-                        true);
+                        zoomLevel);
             }
         }
 

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -274,8 +274,7 @@ public final class GuildMapScreen extends AbstractMapScreen {
                     hovered == poi,
                     poiScale,
                     zoomRenderScale,
-                    zoomLevel,
-                    true);
+                    zoomLevel);
         }
 
         bufferSource.endBatch();

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -297,21 +297,14 @@ public final class MainMapScreen extends AbstractMapScreen {
     }
 
     private void renderPois(PoseStack poseStack, int mouseX, int mouseY) {
-        // Get all MapData features as Pois
-        Stream<? extends Poi> pois = Services.MapData.getFeaturesAsPois();
+        Stream<? extends Poi> pois = Services.Poi.getServicePois();
 
-        // Append the pois that are still not converted to MapData
+        pois = Stream.concat(pois, Services.Poi.getCombatPois());
+        pois = Stream.concat(pois, Services.Poi.getLabelPois());
+        pois = Stream.concat(pois, Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get().stream());
         pois = Stream.concat(pois, Services.Poi.getProvidedCustomPois().stream());
         pois = Stream.concat(pois, Models.Marker.getAllPois());
-        pois = Stream.concat(
-                pois,
-                Services.Hades.getPlayerPois(
-                        Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                                .renderRemotePartyPlayers
-                                .get(),
-                        Managers.Feature.getFeatureInstance(MainMapFeature.class)
-                                .renderRemoteFriendPlayers
-                                .get()));
+        pois = Stream.concat(pois, Services.Hades.getPlayerPois());
 
         if (showTerrs) {
             pois = Stream.concat(pois, Models.Territory.getTerritoryPois().stream());

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -361,8 +361,7 @@ public final class PoiCreationScreen extends AbstractMapScreen implements Textbo
                     hovered == poi,
                     1,
                     zoomRenderScale,
-                    zoomLevel,
-                    true);
+                    zoomLevel);
 
             bufferSource.endBatch();
         }

--- a/common/src/main/java/com/wynntils/services/hades/HadesService.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesService.java
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Service;
 import com.wynntils.core.components.Services;
+import com.wynntils.features.map.MainMapFeature;
 import com.wynntils.features.players.HadesFeature;
 import com.wynntils.hades.objects.HadesConnection;
 import com.wynntils.hades.protocol.builders.HadesNetworkBuilder;
@@ -60,10 +61,16 @@ public final class HadesService extends Service {
         super(List.of());
     }
 
-    public Stream<PlayerMainMapPoi> getPlayerPois(boolean renderRemotePartyPlayers, boolean renderRemoteFriendPlayers) {
+    public Stream<PlayerMainMapPoi> getPlayerPois() {
         return getHadesUsers()
-                .filter(hadesUser -> (hadesUser.isPartyMember() && renderRemotePartyPlayers)
-                        || (hadesUser.isMutualFriend() && renderRemoteFriendPlayers))
+                .filter(hadesUser -> (hadesUser.isPartyMember()
+                                && Managers.Feature.getFeatureInstance(MainMapFeature.class)
+                                        .renderRemotePartyPlayers
+                                        .get())
+                        || (hadesUser.isMutualFriend()
+                                && Managers.Feature.getFeatureInstance(MainMapFeature.class)
+                                        .renderRemoteFriendPlayers
+                                        .get()))
                 .map(PlayerMainMapPoi::new);
     }
 

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -17,6 +17,7 @@ import com.wynntils.core.net.UrlId;
 import com.wynntils.core.net.event.NetResultProcessedEvent;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
+import com.wynntils.services.map.pois.CombatPoi;
 import com.wynntils.services.map.pois.CustomPoi;
 import com.wynntils.services.map.pois.LabelPoi;
 import com.wynntils.services.map.pois.ServicePoi;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -64,6 +66,8 @@ public class PoiService extends Service {
 
     private final Set<LabelPoi> labelPois = new HashSet<>();
     private final Set<ServicePoi> servicePois = new HashSet<>();
+    private final Set<CombatPoi> combatPois = new HashSet<>();
+    private final Set<CombatPoi> cavePois = new HashSet<>();
     private final Map<CustomPoiProvider, List<CustomPoi>> providedCustomPois = new ConcurrentHashMap<>();
 
     @Persisted
@@ -101,9 +105,16 @@ public class PoiService extends Service {
         Download dl = Managers.Net.download(UrlId.DATA_STATIC_CAVE_INFO);
         dl.handleReader(reader -> {
             Type type = new TypeToken<List<CaveProfile>>() {}.getType();
+
             List<CaveProfile> profiles = GSON.fromJson(reader, type);
-            profiles.forEach(
-                    profile -> CombatListProvider.registerFeature(profile.location, CombatKind.CAVES, profile.name));
+
+            cavePois.addAll(profiles.stream()
+                    .map(profile -> {
+                        CombatListProvider.registerFeature(profile.location, CombatKind.CAVES, profile.name);
+                        return new CombatPoi(
+                                PoiLocation.fromLocation(profile.location), profile.name, CombatKind.CAVES);
+                    })
+                    .collect(Collectors.toUnmodifiableSet()));
         });
     }
 
@@ -151,6 +162,10 @@ public class PoiService extends Service {
 
     public Stream<ServicePoi> getServicePois() {
         return servicePois.stream();
+    }
+
+    public Stream<CombatPoi> getCombatPois() {
+        return Stream.concat(combatPois.stream(), cavePois.stream());
     }
 
     public List<CustomPoi> getProvidedCustomPois() {
@@ -217,6 +232,7 @@ public class PoiService extends Service {
                 // We load caves separately... until the refactor
                 if (kind != null && kind != CombatKind.CAVES) {
                     for (CombatProfile profile : combatList.locations) {
+                        combatPois.add(new CombatPoi(profile.coordinates, profile.name, kind));
                         CombatListProvider.registerFeature(new Location(profile.coordinates), kind, profile.name);
                     }
                 } else {

--- a/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
@@ -68,8 +68,7 @@ public abstract class IconPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         float modifier = scale;
 
         if (hovered) {

--- a/common/src/main/java/com/wynntils/services/map/pois/LabelPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/LabelPoi.java
@@ -102,8 +102,7 @@ public class LabelPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         float alpha = getAlphaFromScale(zoomRenderScale);
         if (alpha < 0.01) {
             return; // small enough alphas are turned into 255

--- a/common/src/main/java/com/wynntils/services/map/pois/PlayerMainMapPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/PlayerMainMapPoi.java
@@ -35,8 +35,7 @@ public class PlayerMainMapPoi extends PlayerPoiBase {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         poseStack.pushPose();
         poseStack.translate(-playerHeadRenderSize / 2f, -playerHeadRenderSize / 2f, 0); // center the player icon
 

--- a/common/src/main/java/com/wynntils/services/map/pois/PlayerMiniMapPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/PlayerMiniMapPoi.java
@@ -32,8 +32,7 @@ public class PlayerMiniMapPoi extends PlayerPoiBase {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         poseStack.pushPose();
         poseStack.translate(-playerHeadRenderSize / 2f, -playerHeadRenderSize / 2f, 0); // center the player icon
 

--- a/common/src/main/java/com/wynntils/services/map/pois/Poi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/Poi.java
@@ -28,8 +28,7 @@ public interface Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels);
+            float zoomLevel);
 
     int getWidth(float mapZoom, float scale);
 

--- a/common/src/main/java/com/wynntils/services/map/pois/SeaskipperDestinationPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/SeaskipperDestinationPoi.java
@@ -73,8 +73,7 @@ public class SeaskipperDestinationPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         renderPoi(poseStack, bufferSource, renderX, renderY, zoomRenderScale, true);
     }
 

--- a/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
@@ -77,8 +77,7 @@ public class TerritoryPoi implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         poseStack.pushPose();
         poseStack.translate(0, 0, 100);
 

--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeaturePoiWrapper.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeaturePoiWrapper.java
@@ -106,8 +106,7 @@ public class MapFeaturePoiWrapper implements Poi {
             boolean hovered,
             float scale,
             float zoomRenderScale,
-            float zoomLevel,
-            boolean showLabels) {
+            float zoomLevel) {
         float renderScale = hovered ? scale * 1.05f : scale;
         // this is the default alpha for labels
         float hoverAlphaFactor = hovered ? 1f : 0.9f;
@@ -157,7 +156,7 @@ public class MapFeaturePoiWrapper implements Poi {
         // visual glitches
         // Always draw labels for hovered icons, regardless of label visibility rules
         boolean drawLabel = labelAlpha > 0.01 || (drawIcon && hovered);
-        if (!attributes.getLabel().get().isEmpty() && drawLabel && showLabels) {
+        if (!attributes.getLabel().get().isEmpty() && drawLabel) {
             if (drawIcon && hovered) {
                 // If this is hovered, show with full alpha
                 labelAlpha = 1f;


### PR DESCRIPTION
Reverts Wynntils/Artemis#2536

I've noticed that mapdata rendering performance is a significant problem. The recursive nature of resolving attributes creates a big impact in CPU cycles and memory allocations. There are also some minor visual issues.

I'll go ahead and revert this PR to give us time to fix these issues, without holding back main, or otherwise we wouldn't be able to do any releases, until this problem is fixed.

I'll share profiler data in Discord about the issue, if you have time to take a look, magicus.