### PR TITLE
fix: Make sure StorageManager upfixers run before populating components storages [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
@@ -64,17 +64,9 @@ public final class StorageManager extends Manager {
         // Register all storageables
         Managers.Feature.getFeatures().forEach(this::registerStorageable);
 
+        runUpfixers();
+
         readFromJson();
-
-        // Now, we have to apply upfixers, before any storage loading happens
-        // FIXME: Solve generics type issue
-        Set<PersistedValue<?>> workaround = new HashSet<>(storages.values());
-        if (Managers.Upfixer.runUpfixers(storageObject, workaround, UpfixerType.STORAGE)) {
-            Managers.Json.savePreciousJson(userStorageFile, storageObject);
-
-            // Re-read the storage file after upfixing
-            readFromJson();
-        }
 
         storageInitialized = true;
 
@@ -129,6 +121,20 @@ public final class StorageManager extends Manager {
                 delay,
                 TimeUnit.MILLISECONDS);
         scheduledPersist = true;
+    }
+
+    private void runUpfixers() {
+        storageObject = Managers.Json.loadPreciousJson(userStorageFile);
+
+        // Now, we have to apply upfixers, before any storage loading happens
+        // FIXME: Solve generics type issue
+        Set<PersistedValue<?>> workaround = new HashSet<>(storages.values());
+        if (Managers.Upfixer.runUpfixers(storageObject, workaround, UpfixerType.STORAGE)) {
+            Managers.Json.savePreciousJson(userStorageFile, storageObject);
+
+            // Re-read the storage file after upfixing
+            readFromJson();
+        }
     }
 
     private void readFromJson() {


### PR DESCRIPTION
Previously, upfixers were ran too late, which allowed them to work in cases like field renames, but were too late in cases like field type changes. With these changes, the storage upfixer capabilities should be on-par with config upfixers.

Although storage upfixers are not used at the moment, I've wanted to make sure to correct my previous work here.