### PR TITLE
feat: Add a system for providers to signal when they change

### DIFF
--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -16,6 +16,7 @@ import com.wynntils.models.marker.type.MarkerInfo;
 import com.wynntils.models.territories.profile.TerritoryProfile;
 import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.map.type.ServiceKind;
+import com.wynntils.services.mapdata.MapIconTextureWrapper;
 import com.wynntils.services.mapdata.type.MapLocation;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.McUtils;
@@ -176,7 +177,7 @@ public class CompassCommand extends Command {
         Vec3 currentPosition = McUtils.player().position();
         Optional<MapLocation> closestServiceOptional = Services.MapData.SERVICE_LIST_PROVIDER
                 .getFeatures()
-                .filter(f1 -> f1.getCategoryId().equals("wynntils:service:" + selectedKind.getMapDataId()))
+                .filter(f1 -> f1.getCategoryId().startsWith("wynntils:service:" + selectedKind.getMapDataId()))
                 .map(f -> (MapLocation) f)
                 .min(Comparator.comparingDouble(loc -> currentPosition.distanceToSqr(
                         loc.getLocation().x(),
@@ -193,9 +194,12 @@ public class CompassCommand extends Command {
         MapLocation closestService = closestServiceOptional.get();
 
         Models.Marker.USER_WAYPOINTS_PROVIDER.removeAllLocations();
-        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(closestService.getLocation(), selectedKind.getIcon());
+        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(
+                closestService.getLocation(),
+                new MapIconTextureWrapper(Services.MapData.getIconOrFallback(closestService)));
 
-        MutableComponent response = Component.literal("Compass set to " + selectedKind.getName() + " at ")
+        MutableComponent response = Component.literal("Compass set to "
+                        + Services.MapData.resolveMapAttributes(closestService).label() + " at ")
                 .withStyle(ChatFormatting.AQUA);
         response.append(
                 Component.literal(closestService.getLocation().toString()).withStyle(ChatFormatting.WHITE));

--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.commands;
@@ -174,7 +174,8 @@ public class CompassCommand extends Command {
         if (selectedKind == null) return 0;
 
         Vec3 currentPosition = McUtils.player().position();
-        Optional<MapLocation> closestServiceOptional = Services.MapData.SERVICE_LIST_PROVIDER.getFeatures()
+        Optional<MapLocation> closestServiceOptional = Services.MapData.SERVICE_LIST_PROVIDER
+                .getFeatures()
                 .filter(f1 -> f1.getCategoryId().equals("wynntils:service:" + selectedKind.getMapDataId()))
                 .map(f -> (MapLocation) f)
                 .min(Comparator.comparingDouble(loc -> currentPosition.distanceToSqr(
@@ -192,9 +193,7 @@ public class CompassCommand extends Command {
         MapLocation closestService = closestServiceOptional.get();
 
         Models.Marker.USER_WAYPOINTS_PROVIDER.removeAllLocations();
-        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(
-                closestService.getLocation(),
-                selectedKind.getIcon());
+        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(closestService.getLocation(), selectedKind.getIcon());
 
         MutableComponent response = Component.literal("Compass set to " + selectedKind.getName() + " at ")
                 .withStyle(ChatFormatting.AQUA);

--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -32,10 +32,10 @@ import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.arguments.coordinates.Coordinates;
 import net.minecraft.commands.arguments.coordinates.Vec3Argument;
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.phys.Vec3;
 
 public class CompassCommand extends Command {
     private static final SuggestionProvider<CommandSourceStack> SHARE_TARGET_SUGGESTION_PROVIDER =
@@ -172,15 +172,12 @@ public class CompassCommand extends Command {
         ServiceKind selectedKind = LocateCommand.getServiceKind(context, searchedName);
         if (selectedKind == null) return 0;
 
-        Vec3 currentPosition = McUtils.player().position();
+        Position currentPosition = McUtils.player().position();
         Optional<MapLocation> closestServiceOptional = Services.MapData.SERVICE_LIST_PROVIDER
                 .getFeatures()
                 .filter(f1 -> f1.getCategoryId().startsWith("wynntils:service:" + selectedKind.getMapDataId()))
                 .map(f -> (MapLocation) f)
-                .min(Comparator.comparingDouble(loc -> currentPosition.distanceToSqr(
-                        loc.getLocation().x(),
-                        loc.getLocation().y(),
-                        loc.getLocation().z())));
+                .min(Comparator.comparingDouble(loc -> loc.getLocation().distanceToSqr(currentPosition)));
 
         if (closestServiceOptional.isEmpty()) {
             // This really should not happen...

--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -14,7 +14,6 @@ import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.commands.Command;
 import com.wynntils.models.marker.type.MarkerInfo;
 import com.wynntils.models.territories.profile.TerritoryProfile;
-import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.map.type.ServiceKind;
 import com.wynntils.services.mapdata.MapIconTextureWrapper;
 import com.wynntils.services.mapdata.type.MapLocation;
@@ -23,7 +22,6 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.wynn.LocationUtils;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -210,9 +208,12 @@ public class CompassCommand extends Command {
     private int compassPlace(CommandContext<CommandSourceStack> context) {
         String searchedName = context.getArgument("name", String.class);
 
-        List<Poi> places = new ArrayList<>(Services.Poi.getLabelPois()
-                .filter(poi -> StringUtils.partialMatch(poi.getName(), searchedName))
-                .toList());
+        List<MapLocation> places = Services.MapData.PLACE_LIST_PROVIDER
+                .getFeatures()
+                .map(f -> (MapLocation) f)
+                .filter(loc -> StringUtils.partialMatch(
+                        Services.MapData.resolveMapAttributes(loc).label(), searchedName))
+                .toList();
 
         if (places.isEmpty()) {
             MutableComponent response = Component.literal("Found no places matching '" + searchedName + "'")
@@ -221,19 +222,24 @@ public class CompassCommand extends Command {
             return 0;
         }
 
-        Poi place;
+        MapLocation place;
 
         if (places.size() > 1) {
             // Try to find one with an exact match, to differentiate e.g. "Detlas" from "Detlas Suburbs"
-            Optional<Poi> exactMatch = places.stream()
-                    .filter(poi -> poi.getName().equals(searchedName))
+            Optional<MapLocation> exactMatch = places.stream()
+                    .filter(loc ->
+                            Services.MapData.resolveMapAttributes(loc).label().equals(searchedName))
                     .findFirst();
             if (exactMatch.isEmpty()) {
                 MutableComponent response = Component.literal("Found multiple places matching '" + searchedName
                                 + "', but none matched exactly. Matching: ")
                         .withStyle(ChatFormatting.RED);
-                response.append(Component.literal(
-                        String.join(", ", places.stream().map(Poi::getName).toList())));
+                response.append(Component.literal(String.join(
+                        ", ",
+                        places.stream()
+                                .map(loc -> Services.MapData.resolveMapAttributes(loc)
+                                        .label())
+                                .toList())));
                 context.getSource().sendFailure(response);
                 return 0;
             }
@@ -243,10 +249,11 @@ public class CompassCommand extends Command {
         }
 
         Models.Marker.USER_WAYPOINTS_PROVIDER.removeAllLocations();
-        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(place.getLocation().asLocation());
+        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(place.getLocation());
 
-        MutableComponent response =
-                Component.literal("Compass set to " + place.getName() + " at ").withStyle(ChatFormatting.AQUA);
+        MutableComponent response = Component.literal("Compass set to "
+                        + Services.MapData.resolveMapAttributes(place).label() + " at ")
+                .withStyle(ChatFormatting.AQUA);
         response.append(Component.literal(place.getLocation().toString()).withStyle(ChatFormatting.WHITE));
         context.getSource().sendSuccess(() -> response, false);
         return 1;

--- a/common/src/main/java/com/wynntils/commands/LocateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LocateCommand.java
@@ -151,7 +151,9 @@ public class LocateCommand extends Command {
                 .filter(loc -> StringUtils.partialMatch(
                         Services.MapData.resolveMapAttributes(loc).label(), searchedName))
                 .sorted(Comparator.comparingDouble(loc -> currentPosition.distanceToSqr(
-                        loc.getLocation().x(), loc.getLocation().y(), loc.getLocation().z())))
+                        loc.getLocation().x(),
+                        loc.getLocation().y(),
+                        loc.getLocation().z())))
                 .toList();
 
         if (places.isEmpty()) {

--- a/common/src/main/java/com/wynntils/commands/LocateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LocateCommand.java
@@ -22,10 +22,10 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.core.Position;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.world.phys.Vec3;
 
 public class LocateCommand extends Command {
     public static final SuggestionProvider<CommandSourceStack> SERVICE_SUGGESTION_PROVIDER = (context, builder) ->
@@ -104,16 +104,13 @@ public class LocateCommand extends Command {
         if (selectedKind == null) return 0;
 
         // Only keep the 4 closest results
-        Vec3 currentPosition = McUtils.player().position();
+        Position currentPosition = McUtils.player().position();
 
         List<MapLocation> services = Services.MapData.SERVICE_LIST_PROVIDER
                 .getFeatures()
                 .filter(f1 -> f1.getCategoryId().startsWith("wynntils:service:" + selectedKind.getMapDataId()))
                 .map(f -> (MapLocation) f)
-                .sorted(Comparator.comparingDouble(loc -> currentPosition.distanceToSqr(
-                        loc.getLocation().x(),
-                        loc.getLocation().y(),
-                        loc.getLocation().z())))
+                .sorted(Comparator.comparingDouble(loc -> loc.getLocation().distanceToSqr(currentPosition)))
                 .limit(4)
                 .toList();
 
@@ -143,17 +140,14 @@ public class LocateCommand extends Command {
         String searchedName = context.getArgument("name", String.class);
 
         // Sort in order of closeness to the player
-        Vec3 currentPosition = McUtils.player().position();
+        Position currentPosition = McUtils.player().position();
 
         List<MapLocation> places = Services.MapData.PLACE_LIST_PROVIDER
                 .getFeatures()
                 .map(f -> (MapLocation) f)
                 .filter(loc -> StringUtils.partialMatch(
                         Services.MapData.resolveMapAttributes(loc).label(), searchedName))
-                .sorted(Comparator.comparingDouble(loc -> currentPosition.distanceToSqr(
-                        loc.getLocation().x(),
-                        loc.getLocation().y(),
-                        loc.getLocation().z())))
+                .sorted(Comparator.comparingDouble(loc -> loc.getLocation().distanceToSqr(currentPosition)))
                 .toList();
 
         if (places.isEmpty()) {

--- a/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.map;
 
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
+import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
@@ -21,7 +22,6 @@ import com.wynntils.models.containers.type.LootChestType;
 import com.wynntils.screens.maps.MainMapScreen;
 import com.wynntils.screens.maps.PoiCreationScreen;
 import com.wynntils.services.map.pois.CustomPoi;
-import com.wynntils.services.mapdata.providers.builtin.WaypointsProvider;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
@@ -199,9 +199,6 @@ public class MainMapFeature extends Feature {
     }
 
     public void updateWaypoints() {
-        WaypointsProvider.resetFeatures();
-        customPois.get().forEach(customPoi -> {
-            WaypointsProvider.registerFeature(customPoi);
-        });
+        Services.MapData.WAYPOINTS_PROVIDER.updateWaypoints(customPois.get());
     }
 }

--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -25,6 +25,7 @@ import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.type.AbstractTexture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
@@ -130,7 +131,7 @@ public class WorldWaypointDistanceFeature extends Feature {
             float displayPositionY;
 
             Vec2 intersectPoint = getBoundingIntersectPoint(renderedMarker.screenCoordinates, event.getWindow());
-            Texture icon = renderedMarker.markerInfo.texture();
+            AbstractTexture icon = renderedMarker.markerInfo.texture();
             float[] color = renderedMarker.markerInfo.textureColor().asFloatArray();
             RenderSystem.setShaderColor(color[0], color[1], color[2], 1f);
 

--- a/common/src/main/java/com/wynntils/models/activities/quests/QuestModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/quests/QuestModel.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import net.minecraft.world.phys.Vec3;
+import net.minecraft.core.Position;
 import org.apache.commons.lang3.StringUtils;
 
 public final class QuestModel extends Model {
@@ -213,14 +213,14 @@ public final class QuestModel extends Model {
     }
 
     private static class LocationComparator implements Comparator<QuestInfo> {
-        private final Vec3 playerLocation = McUtils.player().position();
+        private final Position playerLocation = McUtils.player().position();
 
         private double getDistance(Optional<Location> loc) {
             // Quests with no location always counts as closest
             if (loc.isEmpty()) return 0f;
 
             Location location = loc.get();
-            return playerLocation.distanceToSqr(location.toVec3());
+            return location.distanceToSqr(playerLocation);
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -19,7 +19,9 @@ import com.wynntils.handlers.container.type.ContainerContent;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.MenuEvent.MenuClosedEvent;
 import com.wynntils.mc.event.PlayerTeleportEvent;
+import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.character.event.CharacterDeathEvent;
+import com.wynntils.models.character.event.CharacterMovedEvent;
 import com.wynntils.models.character.event.CharacterUpdateEvent;
 import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.containers.ContainerModel;
@@ -64,6 +66,9 @@ public final class CharacterModel extends Model {
     // we need a .* in front because the message may have a custom timestamp prefix (or some other mod could do
     // something weird)
     private static final Pattern WYNN_DEATH_MESSAGE = Pattern.compile(".*§4§lYou have died\\.\\.\\.");
+    public static final int MOVE_CHECK_FREQUENCY = 10;
+    private int moveCheckTicks;
+    private Position currentPosition;
     private Position lastPositionBeforeTeleport;
     private Location lastDeathLocation;
 
@@ -187,6 +192,18 @@ public final class CharacterModel extends Model {
             hasCharacter = true;
             WynntilsMod.postEvent(new CharacterUpdateEvent());
             WynntilsMod.info("Selected character " + getCharacterString());
+        }
+    }
+
+    @SubscribeEvent
+    public void checkPlayerMove(TickEvent e) {
+        if (McUtils.player() == null) return;
+        if (moveCheckTicks++ % MOVE_CHECK_FREQUENCY != 0) return;
+
+        Position newPosition = McUtils.player().position();
+        if (newPosition != currentPosition) {
+            currentPosition = newPosition;
+            WynntilsMod.postEvent(new CharacterMovedEvent(currentPosition));
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/character/event/CharacterMovedEvent.java
+++ b/common/src/main/java/com/wynntils/models/character/event/CharacterMovedEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.character.event;
+
+import net.minecraft.core.Position;
+import net.minecraftforge.eventbus.api.Event;
+
+public class CharacterMovedEvent extends Event {
+    private final Position position;
+
+    public CharacterMovedEvent(Position position) {
+        this.position = position;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/marker/UserWaypointMarkerProvider.java
+++ b/common/src/main/java/com/wynntils/models/marker/UserWaypointMarkerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.marker;
@@ -14,6 +14,7 @@ import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.type.AbstractTexture;
 import com.wynntils.utils.type.Pair;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -22,7 +23,8 @@ import java.util.stream.Stream;
 public class UserWaypointMarkerProvider implements MarkerProvider<WaypointPoi> {
     private final Set<Pair<MarkerInfo, WaypointPoi>> markerInfoSet = new CopyOnWriteArraySet<>();
 
-    public void addLocation(Location location, Texture texture, CustomColor beaconColor, CustomColor textColor) {
+    public void addLocation(
+            Location location, AbstractTexture texture, CustomColor beaconColor, CustomColor textColor) {
         addLocation(new MarkerInfo(
                 "Waypoint", new StaticLocationSupplier(location), texture, beaconColor, textColor, CommonColors.WHITE));
     }
@@ -37,7 +39,7 @@ public class UserWaypointMarkerProvider implements MarkerProvider<WaypointPoi> {
                 CommonColors.WHITE));
     }
 
-    public void addLocation(Location location, Texture texture) {
+    public void addLocation(Location location, AbstractTexture texture) {
         addLocation(new MarkerInfo(
                 "Waypoint",
                 new StaticLocationSupplier(location),

--- a/common/src/main/java/com/wynntils/models/marker/type/MarkerInfo.java
+++ b/common/src/main/java/com/wynntils/models/marker/type/MarkerInfo.java
@@ -1,17 +1,17 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.marker.type;
 
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.type.Location;
-import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.type.AbstractTexture;
 
 public record MarkerInfo(
         String name,
         LocationSupplier locationSupplier,
-        Texture texture,
+        AbstractTexture texture,
         CustomColor beaconColor,
         CustomColor textureColor,
         CustomColor textColor) {

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -18,7 +18,6 @@ import com.wynntils.core.net.event.NetResultProcessedEvent;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.services.map.pois.CustomPoi;
-import com.wynntils.services.map.pois.LabelPoi;
 import com.wynntils.services.map.type.CombatKind;
 import com.wynntils.services.map.type.CustomPoiProvider;
 import com.wynntils.services.map.type.ServiceKind;
@@ -30,13 +29,10 @@ import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.Texture;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class PoiService extends Service {
@@ -61,7 +57,6 @@ public class PoiService extends Service {
             Texture.MINING,
             Texture.WOODCUTTING);
 
-    private final Set<LabelPoi> labelPois = new HashSet<>();
     private final Map<CustomPoiProvider, List<CustomPoi>> providedCustomPois = new ConcurrentHashMap<>();
 
     @Persisted
@@ -143,10 +138,6 @@ public class PoiService extends Service {
         }
     }
 
-    public Stream<LabelPoi> getLabelPois() {
-        return labelPois.stream();
-    }
-
     public List<CustomPoi> getProvidedCustomPois() {
         return customPoiProviders.get().stream()
                 .filter(CustomPoiProvider::isEnabled)
@@ -174,7 +165,6 @@ public class PoiService extends Service {
         dl.handleReader(reader -> {
             PlacesProfile places = GSON.fromJson(reader, PlacesProfile.class);
             for (Label label : places.labels) {
-                labelPois.add(new LabelPoi(label));
                 PlaceListProvider.registerFeature(label);
             }
         });

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -63,7 +63,6 @@ public class PoiService extends Service {
             Texture.WOODCUTTING);
 
     private final Set<LabelPoi> labelPois = new HashSet<>();
-    private final Set<ServicePoi> servicePois = new HashSet<>();
     private final Map<CustomPoiProvider, List<CustomPoi>> providedCustomPois = new ConcurrentHashMap<>();
 
     @Persisted
@@ -149,10 +148,6 @@ public class PoiService extends Service {
         return labelPois.stream();
     }
 
-    public Stream<ServicePoi> getServicePois() {
-        return servicePois.stream();
-    }
-
     public List<CustomPoi> getProvidedCustomPois() {
         return customPoiProviders.get().stream()
                 .filter(CustomPoiProvider::isEnabled)
@@ -196,7 +191,6 @@ public class PoiService extends Service {
                 ServiceKind kind = ServiceKind.fromString(service.type);
                 if (kind != null) {
                     for (PoiLocation location : service.locations) {
-                        servicePois.add(new ServicePoi(location, kind));
                         ServiceListProvider.registerFeature(new Location(location), kind);
                     }
                 } else {

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -19,7 +19,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.services.map.pois.CustomPoi;
 import com.wynntils.services.map.pois.LabelPoi;
-import com.wynntils.services.map.pois.ServicePoi;
 import com.wynntils.services.map.type.CombatKind;
 import com.wynntils.services.map.type.CustomPoiProvider;
 import com.wynntils.services.map.type.ServiceKind;

--- a/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
@@ -12,8 +12,8 @@ import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.render.buffered.BufferedRenderUtils;
+import com.wynntils.utils.render.type.AbstractTexture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
@@ -30,7 +30,7 @@ public abstract class IconPoi implements Poi {
         return (int) (getIcon().height() * scale);
     }
 
-    public abstract Texture getIcon();
+    public abstract AbstractTexture getIcon();
 
     // Returns the minimum zoom where the poi should be rendered with full alpha
     // Return -1 to always render without fading
@@ -76,7 +76,7 @@ public abstract class IconPoi implements Poi {
             modifier *= 1.05;
         }
 
-        Texture icon = getIcon();
+        AbstractTexture icon = getIcon();
 
         float width = icon.width() * modifier;
         float height = icon.height() * modifier;

--- a/common/src/main/java/com/wynntils/services/map/pois/MarkerPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/MarkerPoi.java
@@ -1,25 +1,25 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.map.pois;
 
 import com.wynntils.services.map.type.DisplayPriority;
 import com.wynntils.utils.mc.type.PoiLocation;
-import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.type.AbstractTexture;
 
 public class MarkerPoi extends StaticIconPoi {
     private final String name;
-    private final Texture texture;
+    private final AbstractTexture texture;
 
-    public MarkerPoi(PoiLocation location, String name, Texture texture) {
+    public MarkerPoi(PoiLocation location, String name, AbstractTexture texture) {
         super(location);
         this.name = name;
         this.texture = texture;
     }
 
     @Override
-    public Texture getIcon() {
+    public AbstractTexture getIcon() {
         return texture;
     }
 

--- a/common/src/main/java/com/wynntils/services/map/type/ServiceKind.java
+++ b/common/src/main/java/com/wynntils/services/map/type/ServiceKind.java
@@ -32,7 +32,9 @@ public enum ServiceKind {
     TRADE_MARKET("Trade Market", Texture.TRADE_MARKET, "trade-market"),
     WEAPON_MERCHANT("Weapon Merchant", Texture.WEAPON_MERCHANT, "merchant:weapon"),
     WEAPONSMITHING_STATION("Weaponsmithing Station", Texture.WEAPONSMITHING_STATION, "profession:weaponsmithing"),
-    WOODWORKING_STATION("Woodworking Station", Texture.WOODWORKING_STATION, "profession:woodworking");
+    WOODWORKING_STATION("Woodworking Station", Texture.WOODWORKING_STATION, "profession:woodworking"),
+    MERCHANT("Merchant", null, "merchant"),
+    STATION("Station", null, "profession");
 
     private final String name;
     private final Texture texture;

--- a/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
@@ -6,6 +6,7 @@ package com.wynntils.services.mapdata;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Service;
+import com.wynntils.core.components.Services;
 import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.attributes.type.ResolvedMapAttributes;
@@ -92,6 +93,22 @@ public class MapDataService extends Service {
             Stream<MapIcon> allIcons = getProviders().flatMap(MapDataProvider::getIcons);
             return allIcons.filter(i -> i.getIconId().equals(iconId)).findFirst();
         });
+    }
+
+    public Optional<MapIcon> getIcon(MapFeature feature) {
+        return getIcon(resolveMapAttributes(feature).iconId());
+    }
+
+    public MapIcon getIconOrFallback(String iconId) {
+        return getIcon(iconId)
+                .orElse(Services.MapData.getIcon(MapIconsProvider.FALLBACK_ICON_ID)
+                        .get());
+    }
+
+    public MapIcon getIconOrFallback(MapFeature feature) {
+        return getIcon(feature)
+                .orElse(Services.MapData.getIcon(MapIconsProvider.FALLBACK_ICON_ID)
+                        .get());
     }
 
     // endregion

--- a/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
@@ -33,6 +33,14 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public class MapDataService extends Service {
+    public static final CategoriesProvider CATEGORIES_PROVIDER = new CategoriesProvider();
+    public static final MapIconsProvider MAP_ICONS_PROVIDER = new MapIconsProvider();
+    public static final ServiceListProvider SERVICE_LIST_PROVIDER = new ServiceListProvider();
+    public static final CombatListProvider COMBAT_LIST_PROVIDER = new CombatListProvider();
+    public static final PlaceListProvider PLACE_LIST_PROVIDER = new PlaceListProvider();
+    public static final CharacterProvider CHARACTER_PROVIDER = new CharacterProvider();
+    public static final WaypointsProvider WAYPOINTS_PROVIDER = new WaypointsProvider();
+
     private static final MapDataProvider ONLINE_PLACEHOLDER_PROVIDER = new PlaceholderProvider();
     // FIXME: i18n
     private static final String NAMELESS_CATEGORY = "Category '%s'";
@@ -122,15 +130,15 @@ public class MapDataService extends Service {
 
     private void createBuiltInProviders() {
         // Metadata
-        registerBuiltInProvider(new CategoriesProvider());
-        registerBuiltInProvider(new MapIconsProvider());
+        registerBuiltInProvider(CATEGORIES_PROVIDER);
+        registerBuiltInProvider(MAP_ICONS_PROVIDER);
 
         // Locations
-        registerBuiltInProvider(new ServiceListProvider());
-        registerBuiltInProvider(new CombatListProvider());
-        registerBuiltInProvider(new PlaceListProvider());
-        registerBuiltInProvider(new CharacterProvider());
-        registerBuiltInProvider(new WaypointsProvider());
+        registerBuiltInProvider(SERVICE_LIST_PROVIDER);
+        registerBuiltInProvider(COMBAT_LIST_PROVIDER);
+        registerBuiltInProvider(PLACE_LIST_PROVIDER);
+        registerBuiltInProvider(CHARACTER_PROVIDER);
+        registerBuiltInProvider(WAYPOINTS_PROVIDER);
     }
 
     private void registerBuiltInProvider(BuiltInProvider provider) {
@@ -156,14 +164,17 @@ public class MapDataService extends Service {
     }
 
     private void onProviderChange(MapDataProvidedType mapDataProvidedType) {
-        // FIXME: This is too heavy-handed. We should only invalidate
-        // the actual type that has changed, if it is present in the caches.
-        invalidateAllCaches();
+        if (mapDataProvidedType instanceof MapFeature mapFeature) {
+            resolvedAttributesCache.remove(mapFeature);
+        } else if (mapDataProvidedType instanceof MapIcon mapIcon) {
+            iconCache.remove(mapIcon.getIconId());
+        } else if (mapDataProvidedType instanceof MapCategory mapCategory) {
+            // If this happens, we need to redo everything
+            invalidateAllCaches();
+        }
     }
 
-    public void invalidateAllCaches() {
-        // FIXME: This should not really be exposed. We need a better way to
-        // communicate the need to cache refresh.
+    private void invalidateAllCaches() {
         resolvedAttributesCache.clear();
         iconCache.clear();
     }

--- a/common/src/main/java/com/wynntils/services/mapdata/MapIconTextureWrapper.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapIconTextureWrapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata;
+
+import com.wynntils.services.mapdata.attributes.type.MapIcon;
+import com.wynntils.utils.render.type.AbstractTexture;
+import net.minecraft.resources.ResourceLocation;
+
+public class MapIconTextureWrapper implements AbstractTexture {
+    private final MapIcon mapIcon;
+
+    public MapIconTextureWrapper(MapIcon mapIcon) {
+        this.mapIcon = mapIcon;
+    }
+
+    @Override
+    public ResourceLocation resource() {
+        return mapIcon.getResourceLocation();
+    }
+
+    @Override
+    public int width() {
+        return mapIcon.getWidth();
+    }
+
+    @Override
+    public int height() {
+        return mapIcon.getHeight();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapIcon.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapIcon.java
@@ -4,9 +4,10 @@
  */
 package com.wynntils.services.mapdata.attributes.type;
 
+import com.wynntils.services.mapdata.type.MapDataProvidedType;
 import net.minecraft.resources.ResourceLocation;
 
-public interface MapIcon {
+public interface MapIcon extends MapDataProvidedType {
     String NO_ICON_ID = "none";
 
     String getIconId();

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/MapDataProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/MapDataProvider.java
@@ -6,7 +6,9 @@ package com.wynntils.services.mapdata.providers;
 
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.type.MapCategory;
+import com.wynntils.services.mapdata.type.MapDataProvidedType;
 import com.wynntils.services.mapdata.type.MapFeature;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public interface MapDataProvider {
@@ -15,4 +17,6 @@ public interface MapDataProvider {
     Stream<MapCategory> getCategories();
 
     Stream<MapIcon> getIcons();
+
+    void onChange(Consumer<MapDataProvidedType> callback);
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/BuiltInProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/BuiltInProvider.java
@@ -7,10 +7,16 @@ package com.wynntils.services.mapdata.providers.builtin;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.providers.MapDataProvider;
 import com.wynntils.services.mapdata.type.MapCategory;
+import com.wynntils.services.mapdata.type.MapDataProvidedType;
 import com.wynntils.services.mapdata.type.MapFeature;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public abstract class BuiltInProvider implements MapDataProvider {
+    protected final List<Consumer<MapDataProvidedType>> callbacks = new ArrayList<>();
+
     public abstract String getProviderId();
 
     @Override
@@ -26,5 +32,14 @@ public abstract class BuiltInProvider implements MapDataProvider {
     @Override
     public Stream<MapIcon> getIcons() {
         return Stream.empty();
+    }
+
+    @Override
+    public void onChange(Consumer<MapDataProvidedType> callback) {
+        callbacks.add(callback);
+    }
+
+    protected void notifyCallbacks(MapDataProvidedType type) {
+        callbacks.forEach(c -> c.accept(type));
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CharacterProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CharacterProvider.java
@@ -26,9 +26,7 @@ public class CharacterProvider extends BuiltInProvider {
 
     @SubscribeEvent
     public void onCharacterMove(CharacterMovedEvent e) {
-        // FIXME: Do not do this until we have more selective updating
-        // in MapDataService.
-        // notifyCallbacks(CHARACTER_LOCATION);
+        notifyCallbacks(CHARACTER_LOCATION);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CharacterProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CharacterProvider.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.services.mapdata.providers.builtin;
 
+import com.wynntils.models.character.event.CharacterMovedEvent;
 import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.attributes.type.MapAttributes;
@@ -16,10 +17,19 @@ import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class CharacterProvider extends BuiltInProvider {
-    private static final List<MapFeature> PROVIDED_FEATURES = List.of(new CharacterLocation());
+    public static final CharacterLocation CHARACTER_LOCATION = new CharacterLocation();
+    private static final List<MapFeature> PROVIDED_FEATURES = List.of(CHARACTER_LOCATION);
     private static final List<MapCategory> PROVIDED_CATEGORIES = List.of(new PlayersCategory());
+
+    @SubscribeEvent
+    public void onCharacterMove(CharacterMovedEvent e) {
+        // FIXME: Do not do this until we have more selective updating
+        // in MapDataService.
+        // notifyCallbacks(CHARACTER_LOCATION);
+    }
 
     @Override
     public String getProviderId() {

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.services.mapdata.providers.builtin;
 
-import com.wynntils.core.components.Services;
 import com.wynntils.services.map.pois.CustomPoi;
 import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
@@ -33,12 +32,15 @@ public class WaypointsProvider extends BuiltInProvider {
         return PROVIDED_FEATURES.stream();
     }
 
-    public static void resetFeatures() {
+    public void updateWaypoints(List<CustomPoi> customPois) {
+        PROVIDED_FEATURES.forEach(feature -> notifyCallbacks(feature));
         PROVIDED_FEATURES.clear();
-        Services.MapData.invalidateAllCaches();
+        customPois.forEach(customPoi -> {
+            registerFeature(customPoi);
+        });
     }
 
-    public static void registerFeature(CustomPoi customPoi) {
+    private void registerFeature(CustomPoi customPoi) {
         int tier =
                 switch (customPoi.getIcon()) {
                     case CHEST_T1 -> 1;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
@@ -32,11 +32,11 @@ public class WaypointsProvider extends BuiltInProvider {
         return PROVIDED_FEATURES.stream();
     }
 
-    public void updateWaypoints(List<CustomPoi> customPois) {
+    public void updateWaypoints(List<CustomPoi> waypoints) {
         PROVIDED_FEATURES.forEach(feature -> notifyCallbacks(feature));
         PROVIDED_FEATURES.clear();
-        customPois.forEach(customPoi -> {
-            registerFeature(customPoi);
+        waypoints.forEach(waypoint -> {
+            registerFeature(waypoint);
         });
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.services.mapdata.providers.builtin;
 
+import com.wynntils.core.components.Services;
 import com.wynntils.services.map.pois.CustomPoi;
 import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
@@ -34,6 +35,7 @@ public class WaypointsProvider extends BuiltInProvider {
 
     public static void resetFeatures() {
         PROVIDED_FEATURES.clear();
+        Services.MapData.invalidateAllCaches();
     }
 
     public static void registerFeature(CustomPoi customPoi) {
@@ -48,7 +50,11 @@ public class WaypointsProvider extends BuiltInProvider {
         if (tier == 0) {
             String iconId = MapIconsProvider.getIconIdFromTexture(customPoi.getIcon());
             PROVIDED_FEATURES.add(new WaypointLocation(
-                    customPoi.getLocation().asLocation(), customPoi.getName(), iconId, customPoi.getColor(), customPoi.getVisibility()));
+                    customPoi.getLocation().asLocation(),
+                    customPoi.getName(),
+                    iconId,
+                    customPoi.getColor(),
+                    customPoi.getVisibility()));
         } else {
             PROVIDED_FEATURES.add(new FoundChestLocation(customPoi.getLocation().asLocation(), tier));
         }
@@ -64,7 +70,8 @@ public class WaypointsProvider extends BuiltInProvider {
         private final CustomPoi.Visibility visibility;
         private final int number;
 
-        private WaypointLocation(Location location, String name, String iconId, CustomColor color, CustomPoi.Visibility visibility) {
+        private WaypointLocation(
+                Location location, String name, String iconId, CustomColor color, CustomPoi.Visibility visibility) {
             this.location = location;
             this.name = name;
             this.iconId = iconId;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
@@ -18,6 +18,7 @@ import com.wynntils.core.net.Download;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.providers.MapDataProvider;
 import com.wynntils.services.mapdata.type.MapCategory;
+import com.wynntils.services.mapdata.type.MapDataProvidedType;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.utils.EnumUtils;
 import com.wynntils.utils.JsonUtils;
@@ -36,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public final class JsonProvider implements MapDataProvider {
@@ -151,6 +153,12 @@ public final class JsonProvider implements MapDataProvider {
     @Override
     public Stream<MapIcon> getIcons() {
         return icons.stream();
+    }
+
+    @Override
+    public void onChange(Consumer<MapDataProvidedType> callback) {
+        // The json does not change, as long as we do not implement a
+        // reload of the file, so we do not need to register callbacks.
     }
 
     private static final class CategoryDeserializer implements JsonDeserializer<MapCategory> {

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapCategory.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapCategory.java
@@ -7,7 +7,7 @@ package com.wynntils.services.mapdata.type;
 import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import java.util.Optional;
 
-public interface MapCategory {
+public interface MapCategory extends MapDataProvidedType {
     String getCategoryId();
 
     Optional<String> getName();

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapDataProvidedType.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapDataProvidedType.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.type;
+
+/** Marker interface for types that are provided by a MapDataProvider. */
+public interface MapDataProvidedType {}

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
@@ -8,7 +8,7 @@ import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import java.util.List;
 import java.util.Optional;
 
-public interface MapFeature {
+public interface MapFeature extends MapDataProvidedType {
     // The id should be unique, and track the provenance of the feature
     String getFeatureId();
 

--- a/common/src/main/java/com/wynntils/utils/mc/type/Location.java
+++ b/common/src/main/java/com/wynntils/utils/mc/type/Location.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.mc.type;
@@ -76,6 +76,10 @@ public class Location implements Comparable<Location> {
 
     public boolean equalsIgnoringY(Location other) {
         return this.x() == other.x() && this.z() == other.z();
+    }
+
+    public String asChatCoordinates() {
+        return x + " " + y + " " + z;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/utils/mc/type/Location.java
+++ b/common/src/main/java/com/wynntils/utils/mc/type/Location.java
@@ -78,6 +78,14 @@ public class Location implements Comparable<Location> {
         return this.x() == other.x() && this.z() == other.z();
     }
 
+    public double distanceToSqr(Position position) {
+        double x_diff = position.x() - this.x;
+        double y_diff = position.y() - this.y;
+        double z_diff = position.z() - this.z;
+
+        return x_diff * x_diff + y_diff * y_diff + z_diff * z_diff;
+    }
+
     public String asChatCoordinates() {
         return x + " " + y + " " + z;
     }

--- a/common/src/main/java/com/wynntils/utils/render/Texture.java
+++ b/common/src/main/java/com/wynntils/utils/render/Texture.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.utils.render;
 
+import com.wynntils.utils.render.type.AbstractTexture;
 import net.minecraft.resources.ResourceLocation;
 
 // If a texture is currently in a specific category but you want to use
 // it elsewhere, please move it to a more appropriate location
-public enum Texture {
+public enum Texture implements AbstractTexture {
     // region Character Selection
     CHANGE_WORLD_BUTTON("character_selection/change_world_button.png", 26, 52),
     CHARACTER_BUTTON("character_selection/character_button.png", 104, 64),

--- a/common/src/main/java/com/wynntils/utils/render/type/AbstractTexture.java
+++ b/common/src/main/java/com/wynntils/utils/render/type/AbstractTexture.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.render.type;
+
+import net.minecraft.resources.ResourceLocation;
+
+public interface AbstractTexture {
+    ResourceLocation resource();
+
+    int width();
+
+    int height();
+}


### PR DESCRIPTION
Unfortunately this goes a bit against the design philosophy that a provider would just provide a stream of features, and not really care about what it exports in that stream.

Due to performance reasons, we need to cache this, and that means we need to track any changes.