### PR TITLE
fix: Fix wrong minimum hover/render alphas

### DIFF
--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
@@ -11,6 +11,7 @@ import com.wynntils.services.mapdata.attributes.type.MapDecoration;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.attributes.type.ResolvedMapAttributes;
 import com.wynntils.services.mapdata.type.MapFeature;
+import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.buffered.BufferedFontRenderer;
@@ -24,7 +25,8 @@ public class MapFeatureRenderer {
     private static final int SPACING = 2;
     private static final float TEXT_SCALE = 1f;
 
-    // Small enough alphas are turned into 255, so trying to render them results in visual glitches
+    // Small/Large enough alphas are turned into 0/255, so trying to render them results in visual glitches
+    // Generally <0.1f -> 0f, >0.9f -> 1f
     private static final float MINIMUM_RENDER_ALPHA = 0.1f;
 
     public static void renderMapFeature(
@@ -72,6 +74,18 @@ public class MapFeatureRenderer {
                     0,
                     iconWidth,
                     iconHeight);
+            BufferedFontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            bufferSource,
+                            StyledText.fromString(String.valueOf(iconAlpha)),
+                            0,
+                            yOffset,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.CENTER,
+                            VerticalAlignment.MIDDLE,
+                            attributes.labelShadow(),
+                            TEXT_SCALE);
             yOffset += (iconHeight + labelHeight) / 2 + SPACING;
         }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
@@ -11,7 +11,6 @@ import com.wynntils.services.mapdata.attributes.type.MapDecoration;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.attributes.type.ResolvedMapAttributes;
 import com.wynntils.services.mapdata.type.MapFeature;
-import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.buffered.BufferedFontRenderer;
@@ -74,18 +73,6 @@ public class MapFeatureRenderer {
                     0,
                     iconWidth,
                     iconHeight);
-            BufferedFontRenderer.getInstance()
-                    .renderText(
-                            poseStack,
-                            bufferSource,
-                            StyledText.fromString(String.valueOf(iconAlpha)),
-                            0,
-                            yOffset,
-                            CommonColors.WHITE,
-                            HorizontalAlignment.CENTER,
-                            VerticalAlignment.MIDDLE,
-                            attributes.labelShadow(),
-                            TEXT_SCALE);
             yOffset += (iconHeight + labelHeight) / 2 + SPACING;
         }
 


### PR DESCRIPTION
Fixes #2548

It seems like OpenGL ignores the first and last 10% render alpha, so `0.1f` is considered as `0f` alpha, and `0.9f` is considered as `1f`.
Taking all these into account, I've found two different, weird behavior:
- Due to `hoverAlphaFactor`, fully visible features were still rendered with `0.9f` alpha. Due to the weird OpenGL alphas, this was considered as `1f`.
- `0.1f` alphas were considered as rendered, but did not render, causing features to become rendered on hover, although there were invisible (#2548)

It seems like `hoverAlphaFactor` was introduced in `LabelPoi`, but I can't find any reason for their existence. It seems magicus ported this design detail, to preserve the original behavior, which is wrong, or confusing, at the very least.

# Debug Screenshots
## Old behavior
![image](https://github.com/Wynntils/Artemis/assets/49001742/f39abeb5-6e96-420f-9514-2e98ad9ac41d)
Observe that features with `0.075f` alpha is fully invisible. It can also be observed that features with "max" visibility are rendered with `0.9f` alpha (but are shown with max alpha).

## New Behavior
![image](https://github.com/Wynntils/Artemis/assets/49001742/c14a1170-3e1b-40e6-bf20-c6c7c8d05bd3)
![image](https://github.com/Wynntils/Artemis/assets/49001742/17f77720-7621-42cf-85e0-f539e334f555)
![image](https://github.com/Wynntils/Artemis/assets/49001742/08bceaed-443b-4d11-9bf5-84c7cc8956bf)
Observe that all rendered alphas are actually represented in the rendering of the icons. Also observe that fully visible features are rendered with the correct, `1f` alphas.