### PR TITLE
fix: Rotate minimap based on camera rotation instead of player rotation [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -154,7 +154,10 @@ public class MinimapOverlay extends Overlay {
         if (followPlayerRotation.get()) {
             poseStack.pushPose();
             RenderUtils.rotatePose(
-                    poseStack, centerX, centerZ, 180 - McUtils.mc().gameRenderer.getMainCamera().getYRot());
+                    poseStack,
+                    centerX,
+                    centerZ,
+                    180 - McUtils.mc().gameRenderer.getMainCamera().getYRot());
         }
 
         // avoid rotational overpass - This is a rather loose oversizing, if possible later
@@ -241,7 +244,8 @@ public class MinimapOverlay extends Overlay {
         float cosRotationRadians;
 
         if (followPlayerRotation.get()) {
-            double rotationRadians = Math.toRadians(McUtils.mc().gameRenderer.getMainCamera().getYRot());
+            double rotationRadians =
+                    Math.toRadians(McUtils.mc().gameRenderer.getMainCamera().getYRot());
             sinRotationRadians = (float) StrictMath.sin(rotationRadians);
             cosRotationRadians = (float) -StrictMath.cos(rotationRadians);
         } else {
@@ -426,7 +430,8 @@ public class MinimapOverlay extends Overlay {
         float northDY;
 
         if (followPlayerRotation.get()) {
-            float yawRadians = (float) Math.toRadians(McUtils.mc().gameRenderer.getMainCamera().getYRot());
+            float yawRadians = (float)
+                    Math.toRadians(McUtils.mc().gameRenderer.getMainCamera().getYRot());
             northDX = (float) StrictMath.sin(yawRadians);
             northDY = (float) StrictMath.cos(yawRadians);
 

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -154,7 +154,7 @@ public class MinimapOverlay extends Overlay {
         if (followPlayerRotation.get()) {
             poseStack.pushPose();
             RenderUtils.rotatePose(
-                    poseStack, centerX, centerZ, 180 - McUtils.player().getYRot());
+                    poseStack, centerX, centerZ, 180 - McUtils.mc().gameRenderer.getMainCamera().getYRot());
         }
 
         // avoid rotational overpass - This is a rather loose oversizing, if possible later
@@ -241,7 +241,7 @@ public class MinimapOverlay extends Overlay {
         float cosRotationRadians;
 
         if (followPlayerRotation.get()) {
-            double rotationRadians = Math.toRadians(McUtils.player().getYRot());
+            double rotationRadians = Math.toRadians(McUtils.mc().gameRenderer.getMainCamera().getYRot());
             sinRotationRadians = (float) StrictMath.sin(rotationRadians);
             cosRotationRadians = (float) -StrictMath.cos(rotationRadians);
         } else {
@@ -426,7 +426,7 @@ public class MinimapOverlay extends Overlay {
         float northDY;
 
         if (followPlayerRotation.get()) {
-            float yawRadians = (float) Math.toRadians(McUtils.player().getYRot());
+            float yawRadians = (float) Math.toRadians(McUtils.mc().gameRenderer.getMainCamera().getYRot());
             northDX = (float) StrictMath.sin(yawRadians);
             northDY = (float) StrictMath.cos(yawRadians);
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -917,7 +917,7 @@
   "feature.wynntils.minimap.overlay.minimap.borderType.name": "Minimap Border Type",
   "feature.wynntils.minimap.overlay.minimap.description": "Minimap that displays region surrounding player",
   "feature.wynntils.minimap.overlay.minimap.followPlayerRotation.description": "Should the minimap be locked facing north or rotate based on the direction you're facing?",
-  "feature.wynntils.minimap.overlay.minimap.followPlayerRotation.name": "Follow Player Rotation",
+  "feature.wynntils.minimap.overlay.minimap.followPlayerRotation.name": "Follow Camera Rotation",
   "feature.wynntils.minimap.overlay.minimap.hideWhenUnmapped.description": "What should be hidden in unmapped areas, minimap & coordinates or just minimap?",
   "feature.wynntils.minimap.overlay.minimap.hideWhenUnmapped.name": "Hide in Unmapped Areas",
   "feature.wynntils.minimap.overlay.minimap.maskType.description": "Should the minimap be a rectangle or a circle? (Circle is unsupported as of now)?",


### PR DESCRIPTION
Added the option to rotate the minimap based on camera rotation.
This is useful for when using other mods that lets you rotate the camera without rotating the player eg. BetterThirdPerson.