### PR TITLE
fix: Fix bomb tracking issues [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/items/gui/TerritoryItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/TerritoryItem.java
@@ -4,10 +4,14 @@
  */
 package com.wynntils.models.items.items.gui;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.wynntils.models.territories.type.GuildResource;
 import com.wynntils.models.territories.type.GuildResourceValues;
 import com.wynntils.models.territories.type.TerritoryUpgrade;
 import com.wynntils.utils.type.CappedValue;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
@@ -126,5 +130,12 @@ public class TerritoryItem extends GuiItem {
                 + treasuryBonus + ", alerts="
                 + alerts + ", upgrades="
                 + upgrades + '}';
+    }
+
+    public static class TerritorySerializer implements JsonSerializer<TerritoryItem> {
+        @Override
+        public JsonElement serialize(TerritoryItem territoryItem, Type type, JsonSerializationContext context) {
+            return null;
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/gui/TerritoryItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/TerritoryItem.java
@@ -4,14 +4,10 @@
  */
 package com.wynntils.models.items.items.gui;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import com.wynntils.models.territories.type.GuildResource;
 import com.wynntils.models.territories.type.GuildResourceValues;
 import com.wynntils.models.territories.type.TerritoryUpgrade;
 import com.wynntils.utils.type.CappedValue;
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
@@ -130,12 +126,5 @@ public class TerritoryItem extends GuiItem {
                 + treasuryBonus + ", alerts="
                 + alerts + ", upgrades="
                 + upgrades + '}';
-    }
-
-    public static class TerritorySerializer implements JsonSerializer<TerritoryItem> {
-        @Override
-        public JsonElement serialize(TerritoryItem territoryItem, Type type, JsonSerializationContext context) {
-            return null;
-        }
     }
 }

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -86,7 +86,7 @@ public final class BombModel extends Model {
         }
     }
 
-    private void addBombFromChatClue(String user, String bomb, String server) {
+    private void addBombFromChat(String user, String bomb, String server) {
         // Better to do a bit of processing and clean up the set than leaking memory
         removeOldTimers();
 
@@ -132,12 +132,10 @@ public final class BombModel extends Model {
             BombKey key = new BombKey(bombInfo.server(), bombInfo.bomb());
 
             // Ensure no duplicate bombs are added
-            if (bombs.containsKey(key)) {
-                if (replaceIfExists) {
-                    bombs.remove(key);
-                } else if (bombs.get(key).isActive()) {
-                    return;
-                }
+            removeOldTimers();
+            
+            if (bombs.containsKey(key) && !replaceIfExists) {
+                return;
             }
 
             bombs.put(key, bombInfo);

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -57,13 +57,13 @@ public final class BombModel extends Model {
 
         Matcher bellMatcher = message.getMatcher(BOMB_BELL_PATTERN, PartStyle.StyleType.NONE);
         if (bellMatcher.matches()) {
-            addBombFromChatClue(bellMatcher.group("user"), bellMatcher.group("bomb"), bellMatcher.group("server"));
+            addBombFromChat(bellMatcher.group("user"), bellMatcher.group("bomb"), bellMatcher.group("server"));
             return;
         }
 
         Matcher localMatcher = message.getMatcher(BOMB_THROWN_PATTERN);
         if (localMatcher.matches()) {
-            addBombFromChatClue(
+            addBombFromChat(
                     localMatcher.group("user"), localMatcher.group("bomb"), Models.WorldState.getCurrentWorldName());
             return;
         }
@@ -140,8 +140,6 @@ public final class BombModel extends Model {
             BombKey key = new BombKey(bombInfo.server(), bombInfo.bomb());
 
             // Ensure no duplicate bombs are added
-            removeOldTimers();
-
             if (bombs.containsKey(key) && !replaceIfExists) {
                 return;
             }

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -6,7 +6,9 @@ package com.wynntils.models.worlds;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.text.PartStyle;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.bossbar.TrackedBar;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.models.worlds.bossbars.InfoBar;
@@ -35,6 +37,10 @@ public final class BombModel extends Model {
     private static final Pattern BOMB_EXPIRED_PATTERN = Pattern.compile(
             "§b(?<user>.+)'s? §3bomb has expired. You can buy (?<bomb>.+) bombs at our website, §bwynncraft.com/store");
 
+    // Test in BombModel_BOMB_THROWN_PATTERN
+    private static final Pattern BOMB_THROWN_PATTERN = Pattern.compile(
+            "^§b(?<user>.+) has thrown a §b(?<bomb>.+)§3! The entire server gets §b.+ §3for §b\\d{1,2} minutes§3!$");
+
     private static final Map<BombType, BombInfo> CURRENT_SERVER_BOMBS = new EnumMap<>(BombType.class);
 
     private static final ActiveBombContainer BOMBS = new ActiveBombContainer();
@@ -47,27 +53,25 @@ public final class BombModel extends Model {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onChat(ChatMessageReceivedEvent event) {
-        Matcher matcher = event.getOriginalStyledText().getMatcher(BOMB_BELL_PATTERN, PartStyle.StyleType.NONE);
-        if (matcher.matches()) {
-            String user = matcher.group("user");
-            String bomb = matcher.group("bomb");
-            String server = matcher.group("server");
+        StyledText message = event.getOriginalStyledText();
 
-            // Better to do a bit of processing and clean up the set than leaking memory
-            removeOldTimers();
-
-            BombType bombType = BombType.fromString(bomb);
-            if (bombType == null) return;
-
-            BOMBS.add(new BombInfo(user, bombType, server, System.currentTimeMillis(), bombType.getActiveMinutes()));
-
+        Matcher bellMatcher = message.getMatcher(BOMB_BELL_PATTERN, PartStyle.StyleType.NONE);
+        if (bellMatcher.matches()) {
+            addBombFromChatClue(bellMatcher.group("user"), bellMatcher.group("bomb"), bellMatcher.group("server"));
             return;
         }
 
-        matcher = event.getOriginalStyledText().getMatcher(BOMB_EXPIRED_PATTERN);
-        if (matcher.matches()) {
-            String user = matcher.group("user");
-            String bomb = matcher.group("bomb");
+        Matcher localMatcher = message.getMatcher(BOMB_THROWN_PATTERN);
+        if (localMatcher.matches()) {
+            addBombFromChatClue(
+                    localMatcher.group("user"), localMatcher.group("bomb"), Models.WorldState.getCurrentWorldName());
+            return;
+        }
+
+        Matcher expiredMatcher = message.getMatcher(BOMB_EXPIRED_PATTERN);
+        if (expiredMatcher.matches()) {
+            String user = expiredMatcher.group("user");
+            String bomb = expiredMatcher.group("bomb");
 
             // Better to do a bit of processing and clean up the set than leaking memory
             removeOldTimers();
@@ -82,15 +86,25 @@ public final class BombModel extends Model {
         }
     }
 
+    private void addBombFromChatClue(String user, String bomb, String server) {
+        // Better to do a bit of processing and clean up the set than leaking memory
+        removeOldTimers();
+
+        BombType bombType = BombType.fromString(bomb);
+        if (bombType == null) return;
+
+        BOMBS.add(new BombInfo(user, bombType, server, System.currentTimeMillis(), bombType.getActiveMinutes()), true);
+    }
+
     @SubscribeEvent
     public void onWorldStateChange(WorldStateEvent event) {
         CURRENT_SERVER_BOMBS.clear();
     }
 
-    public void addBombInfo(BombType bombType, BombInfo bombInfo) {
-        BombInfo old = CURRENT_SERVER_BOMBS.put(bombType, bombInfo);
+    public void addBombInfo(BombInfo bombInfo, boolean replaceIfExists) {
+        CURRENT_SERVER_BOMBS.put(bombInfo.bomb(), bombInfo);
 
-        BOMBS.add(bombInfo);
+        BOMBS.add(bombInfo, replaceIfExists);
     }
 
     public boolean isBombActive(BombType bombType) {
@@ -114,11 +128,17 @@ public final class BombModel extends Model {
     private static final class ActiveBombContainer {
         private final Map<BombKey, BombInfo> bombs = new ConcurrentHashMap<>();
 
-        public void add(BombInfo bombInfo) {
+        public void add(BombInfo bombInfo, boolean replaceIfExists) {
             BombKey key = new BombKey(bombInfo.server(), bombInfo.bomb());
 
             // Ensure no duplicate bombs are added
-            if (bombs.containsKey(key) && bombs.get(key).isActive()) return;
+            if (bombs.containsKey(key)) {
+                if (replaceIfExists) {
+                    bombs.remove(key);
+                } else if (bombs.get(key).isActive()) {
+                    return;
+                }
+            }
 
             bombs.put(key, bombInfo);
         }

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -93,7 +93,7 @@ public final class BombModel extends Model {
         BombType bombType = BombType.fromString(bomb);
         if (bombType == null) return;
 
-        BOMBS.add(new BombInfo(user, bombType, server, System.currentTimeMillis(), bombType.getActiveMinutes()), true);
+        BOMBS.forceAdd(new BombInfo(user, bombType, server, System.currentTimeMillis(), bombType.getActiveMinutes()));
     }
 
     @SubscribeEvent
@@ -101,10 +101,10 @@ public final class BombModel extends Model {
         CURRENT_SERVER_BOMBS.clear();
     }
 
-    public void addBombInfo(BombInfo bombInfo, boolean replaceIfExists) {
+    public void addBombInfoFromInfoBar(BombInfo bombInfo) {
         CURRENT_SERVER_BOMBS.put(bombInfo.bomb(), bombInfo);
 
-        BOMBS.add(bombInfo, replaceIfExists);
+        BOMBS.add(bombInfo);
     }
 
     public boolean isBombActive(BombType bombType) {
@@ -128,7 +128,15 @@ public final class BombModel extends Model {
     private static final class ActiveBombContainer {
         private final Map<BombKey, BombInfo> bombs = new ConcurrentHashMap<>();
 
-        public void add(BombInfo bombInfo, boolean replaceIfExists) {
+        public void add(BombInfo bombInfo) {
+            add(bombInfo, false);
+        }
+
+        public void forceAdd(BombInfo bombInfo) {
+            add(bombInfo, true);
+        }
+
+        private void add(BombInfo bombInfo, boolean replaceIfExists) {
             BombKey key = new BombKey(bombInfo.server(), bombInfo.bomb());
 
             // Ensure no duplicate bombs are added

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -133,7 +133,7 @@ public final class BombModel extends Model {
 
             // Ensure no duplicate bombs are added
             removeOldTimers();
-            
+
             if (bombs.containsKey(key) && !replaceIfExists) {
                 return;
             }

--- a/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
+++ b/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
@@ -41,14 +41,12 @@ public class InfoBar extends TrackedBar {
             if (bombType == null) return;
 
             float length = Integer.parseInt(matcher.group("length")) + BOMB_TIMER_OFFSET;
-            Models.Bomb.addBombInfoFromInfoBar(
-                    new BombInfo(
-                            matcher.group("user"),
-                            bombType,
-                            Models.WorldState.getCurrentWorldName(),
-                            System.currentTimeMillis(),
-                            length)
-                    );
+            Models.Bomb.addBombInfoFromInfoBar(new BombInfo(
+                    matcher.group("user"),
+                    bombType,
+                    Models.WorldState.getCurrentWorldName(),
+                    System.currentTimeMillis(),
+                    length));
         } else if (matcher.pattern().equals(GUILD_INFO_PATTERN)) {
             Models.Guild.setGuildLevel(Integer.parseInt(matcher.group("level")));
             Models.Guild.setGuildLevelProgress(new CappedValue(Integer.parseInt(matcher.group("xp")), 100));

--- a/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
+++ b/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
@@ -41,14 +41,14 @@ public class InfoBar extends TrackedBar {
             if (bombType == null) return;
 
             float length = Integer.parseInt(matcher.group("length")) + BOMB_TIMER_OFFSET;
-            Models.Bomb.addBombInfo(
+            Models.Bomb.addBombInfoFromInfoBar(
                     new BombInfo(
                             matcher.group("user"),
                             bombType,
                             Models.WorldState.getCurrentWorldName(),
                             System.currentTimeMillis(),
-                            length),
-                    false);
+                            length)
+                    );
         } else if (matcher.pattern().equals(GUILD_INFO_PATTERN)) {
             Models.Guild.setGuildLevel(Integer.parseInt(matcher.group("level")));
             Models.Guild.setGuildLevelProgress(new CappedValue(Integer.parseInt(matcher.group("xp")), 100));

--- a/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
+++ b/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
@@ -42,13 +42,13 @@ public class InfoBar extends TrackedBar {
 
             float length = Integer.parseInt(matcher.group("length")) + BOMB_TIMER_OFFSET;
             Models.Bomb.addBombInfo(
-                    bombType,
                     new BombInfo(
                             matcher.group("user"),
                             bombType,
                             Models.WorldState.getCurrentWorldName(),
                             System.currentTimeMillis(),
-                            length));
+                            length),
+                    false);
         } else if (matcher.pattern().equals(GUILD_INFO_PATTERN)) {
             Models.Guild.setGuildLevel(Integer.parseInt(matcher.group("level")));
             Models.Guild.setGuildLevelProgress(new CappedValue(Integer.parseInt(matcher.group("xp")), 100));

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
@@ -48,7 +48,11 @@ public class WaypointsProvider extends BuiltInProvider {
         if (tier == 0) {
             String iconId = MapIconsProvider.getIconIdFromTexture(customPoi.getIcon());
             PROVIDED_FEATURES.add(new WaypointLocation(
-                    customPoi.getLocation().asLocation(), customPoi.getName(), iconId, customPoi.getColor(), customPoi.getVisibility()));
+                    customPoi.getLocation().asLocation(),
+                    customPoi.getName(),
+                    iconId,
+                    customPoi.getColor(),
+                    customPoi.getVisibility()));
         } else {
             PROVIDED_FEATURES.add(new FoundChestLocation(customPoi.getLocation().asLocation(), tier));
         }
@@ -64,7 +68,8 @@ public class WaypointsProvider extends BuiltInProvider {
         private final CustomPoi.Visibility visibility;
         private final int number;
 
-        private WaypointLocation(Location location, String name, String iconId, CustomColor color, CustomPoi.Visibility visibility) {
+        private WaypointLocation(
+                Location location, String name, String iconId, CustomColor color, CustomPoi.Visibility visibility) {
             this.location = location;
             this.name = name;
             this.iconId = iconId;

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -34,6 +34,7 @@ import com.wynntils.models.spells.actionbar.SpellSegment;
 import com.wynntils.models.statuseffects.StatusEffectModel;
 import com.wynntils.models.trademarket.TradeMarketModel;
 import com.wynntils.models.war.bossbar.WarTowerBar;
+import com.wynntils.models.worlds.BombModel;
 import com.wynntils.models.worlds.bossbars.InfoBar;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import java.lang.reflect.Field;
@@ -133,6 +134,15 @@ public class TestRegex {
         p.shouldMatch("§0[Pg. 1] §8v8j's§0 Misc. Bucket");
         p.shouldMatch("§0[Pg. 1] §8mag_icus'§0 Misc. Bucket");
         p.shouldMatch("§0[Pg. 1] §8Housing Island's§0 Block Bank");
+    }
+
+    @Test
+    public void BombModel_BOMB_THROWN_PATTERN() {
+        PatternTester p = new PatternTester(BombModel.class, "BOMB_THROWN_PATTERN");
+        p.shouldMatch(
+                "§bExampleUser1§3 has thrown a §bProfession XP Bomb§3! The entire server gets §bdouble profession xp §3for §b20 minutes§3!");
+        p.shouldMatch(
+                "§bExampleUser1§3 has thrown a §bProfession Speed Bomb§3! The entire server gets §bdouble Crafting/Gathering Speed, and Resource respawn time/Crafting Resource requirements are halved §3for §b10 minutes§3!");
     }
 
     @Test


### PR DESCRIPTION
This fixes two issues:
- When a bomb is thrown in the current world, it may take a few seconds to actually register due to the infobar being slow sometimes, so if you were to relay the bomb to e. g. guild chat, the bomb still hasnt registered yet and you'll be sending either nothing or the previous bomb.
- Due to delay in the bombell the timer might be a little longer than the actual bomb duration. This isn't the problem. The problem is if a new bomb is thrown directly afterwards, and the bell reaches the user before the local timer has run out, the bomb will simply get ignored.