### PR TITLE
feat: Add option to disable Discord rich presence in streamer mode

### DIFF
--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -96,9 +96,9 @@ public class DiscordRichPresenceFeature extends Feature {
 
     @SubscribeEvent
     public void onStreamToggle(StreamModeEvent e) {
-        if (e.isEnabled()) {
+        if (disableInStream.get() && e.isEnabled()) {
             onDisable();
-        } else {
+        } else if (!e.isEnabled()) {
             onEnable();
         }
     }

--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -17,6 +17,7 @@ import com.wynntils.mc.event.SetXpEvent;
 import com.wynntils.models.character.event.CharacterUpdateEvent;
 import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.territories.profile.TerritoryProfile;
+import com.wynntils.models.worlds.event.StreamModeEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.CappedValue;
@@ -33,6 +34,9 @@ public class DiscordRichPresenceFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> displayWorld = new Config<>(true);
+
+    @Persisted
+    public final Config<Boolean> disableInStream = new Config<>(true);
 
     private static final int TERRITORY_TICKS_DELAY = 10;
 
@@ -87,6 +91,15 @@ public class DiscordRichPresenceFeature extends Feature {
         } else {
             Services.Discord.setState("");
             stopTerritoryCheck();
+        }
+    }
+
+    @SubscribeEvent
+    public void onStreamToggle(StreamModeEvent e) {
+        if (e.isEnabled()) {
+            onDisable();
+        } else {
+            onEnable();
         }
     }
 

--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -110,7 +110,15 @@ public class DiscordRichPresenceFeature extends Feature {
 
     @Override
     protected void onConfigUpdate(Config<?> config) {
-        tryUpdateDisplayedInfo();
+        if (config == disableInStream && Models.WorldState.isInStream()) {
+            if (disableInStream.get()) {
+                disableRichPresence();
+            } else {
+                enableRichPresence();
+            }
+        } else {
+            tryUpdateDisplayedInfo();
+        }
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -97,16 +97,15 @@ public class DiscordRichPresenceFeature extends Feature {
     @SubscribeEvent
     public void onStreamToggle(StreamModeEvent e) {
         if (disableInStream.get() && e.isEnabled()) {
-            onDisable();
+            disableRichPresence();
         } else if (!e.isEnabled()) {
-            onEnable();
+            enableRichPresence();
         }
     }
 
     @SubscribeEvent
     public void onDisconnect(ConnectionEvent.DisconnectedEvent e) {
-        Services.Discord.unload();
-        stopTerritoryCheck();
+        disableRichPresence();
     }
 
     @Override
@@ -116,6 +115,15 @@ public class DiscordRichPresenceFeature extends Feature {
 
     @Override
     public void onEnable() {
+        enableRichPresence();
+    }
+
+    @Override
+    public void onDisable() {
+        disableRichPresence();
+    }
+
+    private void enableRichPresence() {
         // This isReady() check is required for Linux to not crash on config change.
         if (!Services.Discord.isReady()) {
             // Load the Discord SDK
@@ -129,8 +137,7 @@ public class DiscordRichPresenceFeature extends Feature {
         tryUpdateDisplayedInfo();
     }
 
-    @Override
-    public void onDisable() {
+    private void disableRichPresence() {
         Services.Discord.unload();
         stopTerritoryCheck();
     }

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -14,6 +14,7 @@ import com.wynntils.mc.event.PlayerInfoEvent.PlayerDisplayNameChangeEvent;
 import com.wynntils.mc.event.PlayerInfoEvent.PlayerLogOutEvent;
 import com.wynntils.mc.event.PlayerInfoFooterChangedEvent;
 import com.wynntils.mc.event.PlayerTeleportEvent;
+import com.wynntils.models.worlds.event.StreamModeEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.utils.mc.PosUtils;
@@ -77,6 +78,7 @@ public final class WorldStateModel extends Model {
 
         // Streamer mode is always disabled upon changing world state
         inStream = false;
+        WynntilsMod.postEvent(new StreamModeEvent(inStream));
 
         WorldState oldState = currentState;
         // Switch state before sending event
@@ -124,6 +126,7 @@ public final class WorldStateModel extends Model {
 
         if (matcher.matches()) {
             inStream = matcher.group(1).equals("was enabled");
+            WynntilsMod.postEvent(new StreamModeEvent(inStream));
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/worlds/event/StreamModeEvent.java
+++ b/common/src/main/java/com/wynntils/models/worlds/event/StreamModeEvent.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class StreamModeEvent extends Event {
+    private final boolean enabled;
+
+    public StreamModeEvent(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -458,6 +458,8 @@
   "feature.wynntils.dialogueOptionOverride.description": "Adds the ability to select dialogue options with slot buttons.",
   "feature.wynntils.dialogueOptionOverride.name": "Dialogue Button Override",
   "feature.wynntils.discordRichPresence.description": "Adds Discord Rich Presence support.",
+  "feature.wynntils.discordRichPresence.disableInStream.description": "Should the rich presence be disabled when in streamer mode?",
+  "feature.wynntils.discordRichPresence.disableInStream.name": "Disable in Streamer Mode",
   "feature.wynntils.discordRichPresence.displayCharacterInfo.description": "Should your character info be displayed in Discord?",
   "feature.wynntils.discordRichPresence.displayCharacterInfo.name": "Display Character Info",
   "feature.wynntils.discordRichPresence.displayLocation.description": "Should your location be displayed in Discord?",


### PR DESCRIPTION
One place I forgot we can still leak the world. I was going to just hide the world but I think hiding the whole presence is more useful as most people use streamer mode to hide that they are online vs just hiding their current world.