### PR TITLE
fix: Properly detect class joining

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -37,6 +37,7 @@ import com.wynntils.models.items.annotators.game.UnknownGearAnnotator;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
 import com.wynntils.models.items.annotators.gui.ActivityAnnotator;
 import com.wynntils.models.items.annotators.gui.ArchetypeAbilitiesAnnotator;
+import com.wynntils.models.items.annotators.gui.CharacterAnnotator;
 import com.wynntils.models.items.annotators.gui.CosmeticTierAnnotator;
 import com.wynntils.models.items.annotators.gui.DailyRewardMultiplierAnnotator;
 import com.wynntils.models.items.annotators.gui.IngredientPouchAnnotator;
@@ -86,6 +87,7 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new AbilityTreeAnnotator());
         Handlers.Item.registerAnnotator(new ActivityAnnotator());
         Handlers.Item.registerAnnotator(new ArchetypeAbilitiesAnnotator());
+        Handlers.Item.registerAnnotator(new CharacterAnnotator());
         Handlers.Item.registerAnnotator(new CosmeticTierAnnotator());
         Handlers.Item.registerAnnotator(new DailyRewardMultiplierAnnotator());
         Handlers.Item.registerAnnotator(new IngredientPouchAnnotator());

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/CharacterAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/CharacterAnnotator.java
@@ -20,7 +20,9 @@ public class CharacterAnnotator implements GuiItemAnnotator {
     private static final Pattern CLASS_MENU_NAME_PATTERN =
             Pattern.compile("(?:§l)?§6(?:§l)?\\[>\\] Select ((.+)|This Character)");
 
-    private static final Pattern CLASS_MENU_CLASS_PATTERN = Pattern.compile("§e- §7Class: §f(.+)");
+    // Test in CharacterAnnotator_CLASS_MENU_CLASS_PATTERN
+    private static final Pattern CLASS_MENU_CLASS_PATTERN =
+            Pattern.compile("§e- §7Class:(?: (?<gamemodes>§.[\uE027\uE083\uE026\uE029\uE028])+§r)? §f(?<class>.+)");
     private static final Pattern CLASS_MENU_LEVEL_PATTERN = Pattern.compile("§e- §7Level: §f(\\d+)");
 
     @Override
@@ -36,8 +38,8 @@ public class CharacterAnnotator implements GuiItemAnnotator {
         for (StyledText lore : LoreUtils.getLore(itemStack)) {
             Matcher classMatcher = lore.getMatcher(CLASS_MENU_CLASS_PATTERN);
             if (classMatcher.matches()) {
-                classType = ClassType.fromName(classMatcher.group(1));
-                reskinned = ClassType.isReskinned(classMatcher.group(1));
+                classType = ClassType.fromName(classMatcher.group("class"));
+                reskinned = ClassType.isReskinned(classMatcher.group("class"));
             }
 
             Matcher levelMatcher = lore.getMatcher(CLASS_MENU_LEVEL_PATTERN);

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/CharacterAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/CharacterAnnotator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.annotators.gui;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.item.GuiItemAnnotator;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.models.character.type.ClassType;
+import com.wynntils.models.items.items.gui.CharacterItem;
+import com.wynntils.utils.mc.LoreUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public class CharacterAnnotator implements GuiItemAnnotator {
+    // (?:§l)? is trying to account for the fact that seemingly Wynn is trying to bold the text,
+    // but Wynn adds a color after the bold, resetting the bold effect.
+    private static final Pattern CLASS_MENU_NAME_PATTERN =
+            Pattern.compile("(?:§l)?§6(?:§l)?\\[>\\] Select ((.+)|This Character)");
+
+    private static final Pattern CLASS_MENU_CLASS_PATTERN = Pattern.compile("§e- §7Class: §f(.+)");
+    private static final Pattern CLASS_MENU_LEVEL_PATTERN = Pattern.compile("§e- §7Level: §f(\\d+)");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
+        Matcher matcher = StyledText.fromComponent(itemStack.getHoverName()).getMatcher(CLASS_MENU_NAME_PATTERN);
+        if (!matcher.matches()) return null;
+
+        String className = matcher.group(1);
+        int level = 0;
+        ClassType classType = null;
+        boolean reskinned = false;
+
+        for (StyledText lore : LoreUtils.getLore(itemStack)) {
+            Matcher classMatcher = lore.getMatcher(CLASS_MENU_CLASS_PATTERN);
+            if (classMatcher.matches()) {
+                classType = ClassType.fromName(classMatcher.group(1));
+                reskinned = ClassType.isReskinned(classMatcher.group(1));
+            }
+
+            Matcher levelMatcher = lore.getMatcher(CLASS_MENU_LEVEL_PATTERN);
+            if (levelMatcher.matches()) {
+                level = Integer.parseInt(levelMatcher.group(1));
+            }
+        }
+
+        if (classType == null || classType == ClassType.NONE) return null;
+
+        return new CharacterItem(className, level, classType, reskinned);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/items/items/gui/CharacterItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/CharacterItem.java
@@ -34,4 +34,13 @@ public class CharacterItem extends GuiItem {
     public boolean isReskinned() {
         return reskinned;
     }
+
+    @Override
+    public String toString() {
+        return "CharacterItem{" + "className='"
+                + className + '\'' + ", level="
+                + level + ", classType="
+                + classType + ", reskinned="
+                + reskinned + '}';
+    }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/gui/CharacterItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/CharacterItem.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.items.gui;
+
+import com.wynntils.models.character.type.ClassType;
+
+public class CharacterItem extends GuiItem {
+    private final String className;
+    private final int level;
+    private final ClassType classType;
+    private final boolean reskinned;
+
+    public CharacterItem(String className, int level, ClassType classType, boolean reskinned) {
+        this.className = className;
+        this.level = level;
+        this.classType = classType;
+        this.reskinned = reskinned;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public ClassType getClassType() {
+        return classType;
+    }
+
+    public boolean isReskinned() {
+        return reskinned;
+    }
+}

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -24,6 +24,7 @@ import com.wynntils.models.items.annotators.game.IngredientAnnotator;
 import com.wynntils.models.items.annotators.game.RuneAnnotator;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
 import com.wynntils.models.items.annotators.gui.ArchetypeAbilitiesAnnotator;
+import com.wynntils.models.items.annotators.gui.CharacterAnnotator;
 import com.wynntils.models.items.annotators.gui.SkillPointAnnotator;
 import com.wynntils.models.items.annotators.gui.TerritoryUpgradeAnnotator;
 import com.wynntils.models.players.FriendsModel;
@@ -915,5 +916,14 @@ public class TestRegex {
         p.shouldMatch("§f⬡ §5Shiny Stratiformis");
         p.shouldMatch("§f⬡ §5Shiny Aftershock");
         p.shouldMatch("§f⬡ §5Shiny Crusade Sabatons");
+    }
+
+    @Test
+    public void CharacterAnnotator_CLASS_MENU_CLASS_PATTERN() {
+        PatternTester p = new PatternTester(CharacterAnnotator.class, "CLASS_MENU_CLASS_PATTERN");
+
+        p.shouldMatch("§e- §7Class: §6\uE029§5\uE028§r §fAssassin");
+        p.shouldMatch("§e- §7Class: §c\uE027§b\uE083§3\uE026§r §fKnight");
+        p.shouldMatch("§e- §7Class: §fWarrior");
     }
 }


### PR DESCRIPTION
Previously, we detected "any" clicks that was not air, so the edit buttons could "signal" a class update..

Fixes #2593