### PR TITLE
feat: Add the ability to have different attributes for each map feature type

### DIFF
--- a/common/src/main/java/com/wynntils/commands/LocateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LocateCommand.java
@@ -37,7 +37,8 @@ public class LocateCommand extends Command {
     public static final SuggestionProvider<CommandSourceStack> PLACES_SUGGESTION_PROVIDER =
             (context, builder) -> SharedSuggestionProvider.suggest(
                     Services.MapData.getFeaturesForCategory("wynntils:place")
-                            .map(f -> Services.MapData.resolveMapAttributes(f).label()),
+                            .map(f -> Services.MapData.resolvedMapFeatureAttributes(f)
+                                    .label()),
                     builder);
 
     @Override

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -255,7 +255,7 @@ public class MinimapOverlay extends Overlay {
         // Get all MapData features as Pois
         Stream<Pair<MapFeature, ResolvedMapAttributes>> mapFeatures = Services.MapData.getFeatures()
                 .filter(feature -> feature.isVisible(textureBoundingCircle))
-                .map(feature -> Pair.of(feature, Services.MapData.resolveMapAttributes(feature)))
+                .map(feature -> Pair.of(feature, Services.MapData.resolvedMapFeatureAttributes(feature)))
                 .sorted(Comparator.comparing(pair -> pair.b().priority()));
 
         // FIXME: Add back the pois that are still not converted to MapData

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -179,7 +179,7 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
 
         Stream<Pair<MapFeature, ResolvedMapAttributes>> mapFeatures = getRenderedMapFeatures()
                 .filter(feature -> feature.isVisible(mapBoundingBox))
-                .map(feature -> Pair.of(feature, Services.MapData.resolveMapAttributes(feature)))
+                .map(feature -> Pair.of(feature, Services.MapData.resolvedMapFeatureAttributes(feature)))
                 .sorted(Comparator.comparing(pair -> pair.b().priority()));
 
         Vector2f mapCenter = new Vector2f(mapCenterX, mapCenterZ);

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -18,7 +18,7 @@ import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.features.WaypointLocation;
 import com.wynntils.services.mapdata.providers.builtin.MapIconsProvider;
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
+import com.wynntils.services.mapdata.providers.json.JsonLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapAttributesBuilder;
 import com.wynntils.services.mapdata.providers.json.JsonMapVisibility;
 import com.wynntils.services.mapdata.type.MapFeature;
@@ -651,7 +651,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
         JsonMapVisibility iconVisibility =
                 new JsonMapVisibility(FixedMapVisibility.ICON_ALWAYS); // TODO: Add visibility input
 
-        JsonMapAttributes attributes = new JsonMapAttributesBuilder()
+        JsonLocationAttributes attributes = new JsonMapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(iconId)
                 .setPriority(priority)

--- a/common/src/main/java/com/wynntils/services/mapdata/MapAttributesResolver.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapAttributesResolver.java
@@ -6,46 +6,88 @@ package com.wynntils.services.mapdata;
 
 import com.wynntils.core.components.Services;
 import com.wynntils.services.mapdata.attributes.DefaultMapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
-import com.wynntils.services.mapdata.attributes.type.ResolvedMapAttributes;
+import com.wynntils.services.mapdata.attributes.type.ResolvedMapAreaAttributes;
+import com.wynntils.services.mapdata.attributes.type.ResolvedMapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.ResolvedMapPathAttributes;
 import com.wynntils.services.mapdata.attributes.type.ResolvedMapVisibility;
+import com.wynntils.services.mapdata.type.MapArea;
 import com.wynntils.services.mapdata.type.MapCategory;
 import com.wynntils.services.mapdata.type.MapFeature;
+import com.wynntils.services.mapdata.type.MapLocation;
+import com.wynntils.services.mapdata.type.MapPath;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * This will create a special type of MapAttributes that are a record with fixed values,
- * which are guarenteed to exist. It does this by extending the lookup for the
+ * This class will create a special type of MapAttributes that are a record with fixed values,
+ * which are guaranteed to exist. It does this by extending the lookup for the
  * attribute first to the category hierarchy for the given feature, and
  * finally by going to the default value for each attribute.
  */
-public final class MapAttributesResolver {
-    private final MapFeature feature;
+public final class MapAttributesResolver<F extends MapFeature, A extends MapAttributes> {
+    private final F feature;
+    private final A defaultAttributes;
+    private final Function<F, Optional<A>> featureAttributesGetter;
+    private final Function<MapCategory, Optional<A>> categoryAttributesGetter;
 
-    private MapAttributesResolver(MapFeature feature) {
+    public MapAttributesResolver(
+            F feature,
+            A defaultAttributes,
+            Function<F, Optional<A>> featureAttributesGetter,
+            Function<MapCategory, Optional<A>> categoryAttributesGetter) {
         this.feature = feature;
+        this.defaultAttributes = defaultAttributes;
+        this.featureAttributesGetter = featureAttributesGetter;
+        this.categoryAttributesGetter = categoryAttributesGetter;
     }
 
-    public static ResolvedMapAttributes resolve(MapFeature feature) {
-        MapAttributesResolver resolver = new MapAttributesResolver(feature);
+    public static ResolvedMapLocationAttributes resolve(MapLocation location) {
+        MapAttributesResolver<MapLocation, MapLocationAttributes> resolver = new MapAttributesResolver<>(
+                location,
+                DefaultMapAttributes.LOCATION,
+                MapLocation::getAttributes,
+                MapCategory::getLocationAttributes);
 
-        return new ResolvedMapAttributes(
-                resolver.getAttribute(MapAttributes::getLabel),
-                resolver.getAttribute(MapAttributes::getIconId),
-                resolver.getAttribute(MapAttributes::getPriority),
-                resolver.getAttribute(MapAttributes::getLevel),
-                resolver.getResolvedMapVisibility(MapAttributes::getLabelVisibility),
-                resolver.getAttribute(MapAttributes::getLabelColor),
-                resolver.getAttribute(MapAttributes::getLabelShadow),
-                resolver.getResolvedMapVisibility(MapAttributes::getIconVisibility),
-                resolver.getAttribute(MapAttributes::getIconColor),
-                resolver.getAttribute(MapAttributes::getIconDecoration));
+        return new ResolvedMapLocationAttributes(
+                resolver.getAttribute(MapLocationAttributes::getLabel),
+                resolver.getAttribute(MapLocationAttributes::getIconId),
+                resolver.getAttribute(MapLocationAttributes::getPriority),
+                resolver.getAttribute(MapLocationAttributes::getLevel),
+                resolver.getResolvedMapVisibility(MapLocationAttributes::getLabelVisibility),
+                resolver.getAttribute(MapLocationAttributes::getLabelColor),
+                resolver.getAttribute(MapLocationAttributes::getLabelShadow),
+                resolver.getResolvedMapVisibility(MapLocationAttributes::getIconVisibility),
+                resolver.getAttribute(MapLocationAttributes::getIconColor),
+                resolver.getAttribute(MapLocationAttributes::getIconDecoration));
     }
 
-    private <T> T getAttribute(Function<MapAttributes, Optional<T>> attributeGetter) {
+    public static ResolvedMapAreaAttributes resolve(MapArea area) {
+        MapAttributesResolver<MapArea, MapAreaAttributes> resolver = new MapAttributesResolver<>(
+                area, DefaultMapAttributes.AREA, MapArea::getAttributes, MapCategory::getAreaAttributes);
+
+        return new ResolvedMapAreaAttributes(
+                resolver.getAttribute(MapAreaAttributes::getLabel),
+                resolver.getAttribute(MapAreaAttributes::getPriority),
+                resolver.getAttribute(MapAreaAttributes::getLevel));
+    }
+
+    public static ResolvedMapPathAttributes resolve(MapPath path) {
+        MapAttributesResolver<MapPath, MapPathAttributes> resolver = new MapAttributesResolver<>(
+                path, DefaultMapAttributes.PATH, MapPath::getAttributes, MapCategory::getPathAttributes);
+
+        return new ResolvedMapPathAttributes(
+                resolver.getAttribute(MapPathAttributes::getLabel),
+                resolver.getAttribute(MapPathAttributes::getPriority),
+                resolver.getAttribute(MapPathAttributes::getLevel));
+    }
+
+    private <T> T getAttribute(Function<A, Optional<T>> attributeGetter) {
         // Check if the feature has overridden this attribute
         Optional<T> featureAttribute = getFromFeature(attributeGetter);
         if (featureAttribute.isPresent()) {
@@ -63,11 +105,10 @@ public final class MapAttributesResolver {
         }
 
         // Otherwise return the fallback default value
-        return attributeGetter.apply(DefaultMapAttributes.INSTANCE).get();
+        return attributeGetter.apply(defaultAttributes).get();
     }
 
-    private ResolvedMapVisibility getResolvedMapVisibility(
-            Function<MapAttributes, Optional<MapVisibility>> attributeGetter) {
+    private ResolvedMapVisibility getResolvedMapVisibility(Function<A, Optional<MapVisibility>> attributeGetter) {
         return new ResolvedMapVisibility(
                 getVisibilityValue(MapVisibility::getMin, attributeGetter),
                 getVisibilityValue(MapVisibility::getMax, attributeGetter),
@@ -76,7 +117,7 @@ public final class MapAttributesResolver {
 
     private float getVisibilityValue(
             Function<MapVisibility, Optional<Float>> valueGetter,
-            Function<MapAttributes, Optional<MapVisibility>> attributeGetter) {
+            Function<A, Optional<MapVisibility>> attributeGetter) {
         // Check if the feature has overridden this attribute
         Optional<MapVisibility> featureVisibility = getFromFeature(attributeGetter);
         if (featureVisibility.isPresent()) {
@@ -103,31 +144,28 @@ public final class MapAttributesResolver {
         }
 
         // Otherwise return the fallback default value
-        return valueGetter
-                .apply(attributeGetter.apply(DefaultMapAttributes.INSTANCE).get())
-                .get();
+        return valueGetter.apply(attributeGetter.apply(defaultAttributes).get()).get();
     }
 
     private String getCategoryId() {
         return feature.getCategoryId();
     }
 
-    private <T> Optional<T> getFromFeature(Function<MapAttributes, Optional<T>> attributeGetter) {
-        Optional<MapAttributes> attributes = feature.getAttributes();
+    private <T> Optional<T> getFromFeature(Function<A, Optional<T>> attributeGetter) {
+        Optional<A> attributes = featureAttributesGetter.apply(feature);
         if (attributes.isEmpty()) return Optional.empty();
 
         return attributeGetter.apply(attributes.get());
     }
 
-    private <T> Stream<T> getAttributesForCategoryId(
-            Function<MapAttributes, Optional<T>> attributeGetter, String categoryId) {
+    private <T> Stream<T> getAttributesForCategoryId(Function<A, Optional<T>> attributeGetter, String categoryId) {
         // Find all provided MapAttributes for this category level
-        Stream<MapAttributes> allAttributes = Services.MapData.getCategoryDefinitions(categoryId)
-                .map(MapCategory::getAttributes)
+        Stream<A> allAttributes = Services.MapData.getCategoryDefinitions(categoryId)
+                .map(categoryAttributesGetter)
                 .filter(Optional::isPresent)
                 .map(Optional::get);
 
-        // Mulitple providers might provide MapAttributes to the same category, but not
+        // Multiple providers might provide MapAttributes to the same category, but not
         // all of them might provide the attribute we're actually looking for, so
         // check all (in the arbitrary order that Services.MapData gave them to us).
         return allAttributes.map(attributeGetter).filter(Optional::isPresent).map(Optional::get);

--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
@@ -11,6 +11,7 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
 import com.wynntils.services.mapdata.attributes.type.ResolvedMapAttributes;
+import com.wynntils.services.mapdata.attributes.type.ResolvedMapLocationAttributes;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.services.mapdata.type.MapLocation;
 import com.wynntils.utils.MathUtils;
@@ -52,7 +53,7 @@ public final class MapFeatureRenderer {
                     poseStack,
                     bufferSource,
                     location,
-                    attributes,
+                    (ResolvedMapLocationAttributes) attributes,
                     mapCenter,
                     screenCenter,
                     rotationVector,
@@ -72,7 +73,7 @@ public final class MapFeatureRenderer {
             PoseStack poseStack,
             MultiBufferSource bufferSource,
             MapLocation location,
-            ResolvedMapAttributes attributes,
+            ResolvedMapLocationAttributes attributes,
             Vector2f mapCenter,
             Vector2f screenCenter,
             Vector2f rotationVector,
@@ -196,6 +197,8 @@ public final class MapFeatureRenderer {
             float zoomLevel,
             float featureRenderScale) {
         if (mapFeature instanceof MapLocation location) {
+            ResolvedMapLocationAttributes locationAttributes = (ResolvedMapLocationAttributes) attributes;
+
             Location featureLocation = location.getLocation();
             float dX = (featureLocation.x() - mapCenter.x()) * zoomRenderScale;
             float dZ = (featureLocation.z() - mapCenter.y()) * zoomRenderScale;
@@ -211,8 +214,8 @@ public final class MapFeatureRenderer {
 
             int yOffset = 0;
 
-            float iconAlpha = Services.MapData.calculateVisibility(attributes.iconVisibility(), zoomLevel);
-            Optional<MapIcon> icon = Services.MapData.getIcon(attributes.iconId());
+            float iconAlpha = Services.MapData.calculateVisibility(locationAttributes.iconVisibility(), zoomLevel);
+            Optional<MapIcon> icon = Services.MapData.getIcon(locationAttributes.iconId());
             boolean drawIcon = iconAlpha > MINIMUM_RENDER_ALPHA;
             if (icon.isPresent() && drawIcon) {
                 int iconWidth = (int) (icon.get().getWidth() * featureRenderScale);
@@ -231,7 +234,7 @@ public final class MapFeatureRenderer {
                 yOffset += (iconHeight + labelHeight) / 2 + SPACING;
             }
 
-            float labelAlpha = Services.MapData.calculateVisibility(attributes.labelVisibility(), zoomLevel);
+            float labelAlpha = Services.MapData.calculateVisibility(locationAttributes.labelVisibility(), zoomLevel);
             boolean drawLabel = labelAlpha > MINIMUM_RENDER_ALPHA;
             if (!attributes.label().isEmpty() && drawLabel) {
                 int labelWidth =

--- a/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
@@ -18,7 +18,7 @@ import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.services.mapdata.features.WaypointLocation;
 import com.wynntils.services.mapdata.providers.builtin.MapIconsProvider;
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
+import com.wynntils.services.mapdata.providers.json.JsonLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapAttributesBuilder;
 import com.wynntils.services.mapdata.providers.json.JsonMapVisibility;
 import com.wynntils.utils.mc.type.Location;
@@ -95,7 +95,7 @@ public class WaypointsService extends Service {
         String label = customPoi.getName();
         String subcategory = ""; // Subcategories did not use to exist
 
-        JsonMapAttributes attributes = new JsonMapAttributesBuilder()
+        JsonLocationAttributes attributes = new JsonMapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(MapIconsProvider.getIconIdFromTexture(customPoi.getIcon()))
                 .setIconColor(customPoi.getColor())

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapAttributes.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.services.mapdata.attributes;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.type.TextShadow;
 import java.util.Optional;
 
-public abstract class AbstractMapAttributes implements MapAttributes {
+public abstract class AbstractMapAttributes implements MapLocationAttributes {
     @Override
     public Optional<String> getLabel() {
         return Optional.empty();

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/DefaultMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/DefaultMapAttributes.java
@@ -4,9 +4,11 @@
  */
 package com.wynntils.services.mapdata.attributes;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
@@ -17,58 +19,90 @@ import java.util.Optional;
  * These are the fallback attributes used by FullFeatureAttribute if no other attributes
  * are defined. These are guaranteed to be non-empty.
  */
-public final class DefaultMapAttributes implements MapAttributes {
-    public static DefaultMapAttributes INSTANCE = new DefaultMapAttributes();
+public final class DefaultMapAttributes {
+    public static final MapLocationAttributes LOCATION = new MapLocationAttributes() {
+        @Override
+        public Optional<String> getLabel() {
+            return Optional.of("");
+        }
 
-    private DefaultMapAttributes() {}
+        @Override
+        public Optional<String> getIconId() {
+            return Optional.of(MapIcon.NO_ICON_ID);
+        }
 
-    @Override
-    public Optional<String> getLabel() {
-        return Optional.of("");
-    }
+        @Override
+        public Optional<Integer> getPriority() {
+            return Optional.of(500);
+        }
 
-    @Override
-    public Optional<String> getIconId() {
-        return Optional.of(MapIcon.NO_ICON_ID);
-    }
+        @Override
+        public Optional<Integer> getLevel() {
+            return Optional.of(0);
+        }
 
-    @Override
-    public Optional<Integer> getPriority() {
-        return Optional.of(500);
-    }
+        @Override
+        public Optional<MapVisibility> getLabelVisibility() {
+            return Optional.of(FixedMapVisibility.LABEL_ALWAYS);
+        }
 
-    @Override
-    public Optional<Integer> getLevel() {
-        return Optional.of(0);
-    }
+        @Override
+        public Optional<CustomColor> getLabelColor() {
+            return Optional.of(CommonColors.WHITE);
+        }
 
-    @Override
-    public Optional<MapVisibility> getLabelVisibility() {
-        return Optional.of(FixedMapVisibility.LABEL_ALWAYS);
-    }
+        @Override
+        public Optional<TextShadow> getLabelShadow() {
+            return Optional.of(TextShadow.OUTLINE);
+        }
 
-    @Override
-    public Optional<CustomColor> getLabelColor() {
-        return Optional.of(CommonColors.WHITE);
-    }
+        @Override
+        public Optional<MapVisibility> getIconVisibility() {
+            return Optional.of(FixedMapVisibility.ICON_ALWAYS);
+        }
 
-    @Override
-    public Optional<TextShadow> getLabelShadow() {
-        return Optional.of(TextShadow.OUTLINE);
-    }
+        @Override
+        public Optional<CustomColor> getIconColor() {
+            return Optional.of(CommonColors.WHITE);
+        }
 
-    @Override
-    public Optional<MapVisibility> getIconVisibility() {
-        return Optional.of(FixedMapVisibility.ICON_ALWAYS);
-    }
+        @Override
+        public Optional<MapDecoration> getIconDecoration() {
+            return Optional.of(MapDecoration.NONE);
+        }
+    };
 
-    @Override
-    public Optional<CustomColor> getIconColor() {
-        return Optional.of(CommonColors.WHITE);
-    }
+    public static final MapAreaAttributes AREA = new MapAreaAttributes() {
+        @Override
+        public Optional<String> getLabel() {
+            return Optional.of("");
+        }
 
-    @Override
-    public Optional<MapDecoration> getIconDecoration() {
-        return Optional.of(MapDecoration.NONE);
-    }
+        @Override
+        public Optional<Integer> getPriority() {
+            return Optional.of(500);
+        }
+
+        @Override
+        public Optional<Integer> getLevel() {
+            return Optional.of(0);
+        }
+    };
+
+    public static final MapPathAttributes PATH = new MapPathAttributes() {
+        @Override
+        public Optional<String> getLabel() {
+            return Optional.of("");
+        }
+
+        @Override
+        public Optional<Integer> getPriority() {
+            return Optional.of(500);
+        }
+
+        @Override
+        public Optional<Integer> getLevel() {
+            return Optional.of(0);
+        }
+    };
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public interface MapAreaAttributes extends MapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAttributes.java
@@ -1,11 +1,9 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;
 
-import com.wynntils.utils.colors.CustomColor;
-import com.wynntils.utils.render.type.TextShadow;
 import java.util.Optional;
 
 /**
@@ -19,9 +17,6 @@ public interface MapAttributes {
     // If this is the empty string (""), then no label will be displayed
     Optional<String> getLabel();
 
-    // If this is MapFeatureIcon.NO_ICON_ID ("none"), then no icon will be displayed
-    Optional<String> getIconId();
-
     // 1-1000, 1000 is the highest priority (drawn on top of everything else)
     Optional<Integer> getPriority();
 
@@ -29,16 +24,4 @@ public interface MapAttributes {
     // 0 means no information is available, or level is not applicable
     // 1 means suitable for all levels
     Optional<Integer> getLevel();
-
-    Optional<MapVisibility> getLabelVisibility();
-
-    Optional<CustomColor> getLabelColor();
-
-    Optional<TextShadow> getLabelShadow();
-
-    Optional<MapVisibility> getIconVisibility();
-
-    Optional<CustomColor> getIconColor();
-
-    Optional<MapDecoration> getIconDecoration();
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2023-2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+import java.util.Optional;
+
+public interface MapLocationAttributes extends MapAttributes {
+    // If this is MapFeatureIcon.NO_ICON_ID ("none"), then no icon will be displayed
+    Optional<String> getIconId();
+
+    Optional<MapVisibility> getLabelVisibility();
+
+    Optional<CustomColor> getLabelColor();
+
+    Optional<TextShadow> getLabelShadow();
+
+    Optional<MapVisibility> getIconVisibility();
+
+    Optional<CustomColor> getIconColor();
+
+    Optional<MapDecoration> getIconDecoration();
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public interface MapPathAttributes extends MapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapAreaAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public record ResolvedMapAreaAttributes(String label, int priority, int level) implements ResolvedMapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapAttributes.java
@@ -1,20 +1,17 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;
 
-import com.wynntils.utils.colors.CustomColor;
-import com.wynntils.utils.render.type.TextShadow;
+/**
+ * Resolved attributes for a map feature. This class is used to cache the resolved attributes
+ * for a map feature, so that they do not need to be recalculated every time they are requested.
+ */
+public interface ResolvedMapAttributes {
+    String label();
 
-public record ResolvedMapAttributes(
-        String label,
-        String iconId,
-        int priority,
-        int level,
-        ResolvedMapVisibility labelVisibility,
-        CustomColor labelColor,
-        TextShadow labelShadow,
-        ResolvedMapVisibility iconVisibility,
-        CustomColor iconColor,
-        MapDecoration iconDecoration) {}
+    int priority();
+
+    int level();
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapLocationAttributes.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © Wynntils 2023-2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public record ResolvedMapLocationAttributes(
+        String label,
+        String iconId,
+        int priority,
+        int level,
+        ResolvedMapVisibility labelVisibility,
+        CustomColor labelColor,
+        TextShadow labelShadow,
+        ResolvedMapVisibility iconVisibility,
+        CustomColor iconColor,
+        MapDecoration iconDecoration)
+        implements ResolvedMapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/ResolvedMapPathAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public record ResolvedMapPathAttributes(String label, int priority, int level) implements ResolvedMapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/features/CombatLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/CombatLocation.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
+import com.wynntils.services.mapdata.providers.json.JsonLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.Texture;
 import java.util.Arrays;
 
 public final class CombatLocation extends JsonMapLocation {
-    public CombatLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public CombatLocation(String featureId, String categoryId, JsonLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/PlaceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/PlaceLocation.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
+import com.wynntils.services.mapdata.providers.json.JsonLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.type.Location;
 
 public final class PlaceLocation extends JsonMapLocation {
-    private PlaceLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    private PlaceLocation(String featureId, String categoryId, JsonLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/ServiceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/ServiceLocation.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
+import com.wynntils.services.mapdata.providers.json.JsonLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.Texture;
 import java.util.Arrays;
 
 public final class ServiceLocation extends JsonMapLocation {
-    public ServiceLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public ServiceLocation(String featureId, String categoryId, JsonLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/WaypointLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/WaypointLocation.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
+import com.wynntils.services.mapdata.providers.json.JsonLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
 import com.wynntils.utils.mc.type.Location;
 import java.util.Locale;
 
 public final class WaypointLocation extends JsonMapLocation {
-    public WaypointLocation(Location location, String label, String subcategory, JsonMapAttributes attributes) {
+    public WaypointLocation(Location location, String label, String subcategory, JsonLocationAttributes attributes) {
         super(
                 "waypoint" + "-" + label.toLowerCase(Locale.ROOT).replaceAll("\\s", "-") + "-" + location.hashCode(),
                 "wynntils:personal:waypoint" + (subcategory.isEmpty() ? "" : ":" + subcategory),

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
@@ -8,8 +8,8 @@ import com.wynntils.models.containers.type.LootChestTier;
 import com.wynntils.services.hades.type.PlayerRelation;
 import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.services.mapdata.features.CombatLocation;
 import com.wynntils.services.mapdata.features.PlaceLocation;
@@ -74,7 +74,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<String> getIconId() {
@@ -96,7 +96,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<Integer> getPriority() {
@@ -143,7 +143,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<String> getIconId() {
@@ -209,7 +209,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<String> getLabel() {
@@ -271,7 +271,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<String> getLabel() {
@@ -335,7 +335,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<String> getIconId() {
@@ -382,7 +382,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<Integer> getPriority() {
@@ -420,7 +420,7 @@ public class CategoriesProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getLocationAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<CustomColor> getLabelColor() {

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
@@ -13,8 +13,8 @@ import com.wynntils.services.hades.HadesUser;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.services.hades.event.HadesUserEvent;
 import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.services.mapdata.type.MapLocation;
 import com.wynntils.utils.mc.SkinUtils;
@@ -98,7 +98,7 @@ public class PlayerProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
+        public Optional<MapLocationAttributes> getAttributes() {
             return Optional.of(new AbstractMapAttributes() {
                 @Override
                 public Optional<String> getLabel() {

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonAreaAttributes.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import java.util.Optional;
+
+public class JsonAreaAttributes implements MapAreaAttributes {
+    private final String label;
+    private final int priority;
+    private final int level;
+
+    public JsonAreaAttributes(String label, int priority, int level) {
+        this.label = label;
+        this.priority = priority;
+        this.level = level;
+    }
+
+    @Override
+    public Optional<String> getLabel() {
+        return Optional.of(label);
+    }
+
+    @Override
+    public Optional<Integer> getPriority() {
+        return Optional.of(priority);
+    }
+
+    @Override
+    public Optional<Integer> getLevel() {
+        return Optional.of(level);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonCategory.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonCategory.java
@@ -4,19 +4,30 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.services.mapdata.type.MapCategory;
 import java.util.Optional;
 
 public class JsonCategory implements MapCategory {
     private final String id;
     private final String name;
-    private final JsonMapAttributes attributes;
+    private final JsonLocationAttributes locationAttributes;
+    private final JsonAreaAttributes areaAttributes;
+    private final JsonPathAttributes pathAttributes;
 
-    public JsonCategory(String id, String name, JsonMapAttributes attributes) {
+    public JsonCategory(
+            String id,
+            String name,
+            JsonLocationAttributes locationAttributes,
+            JsonAreaAttributes areaAttributes,
+            JsonPathAttributes pathAttributes) {
         this.id = id;
         this.name = name;
-        this.attributes = attributes;
+        this.locationAttributes = locationAttributes;
+        this.areaAttributes = areaAttributes;
+        this.pathAttributes = pathAttributes;
     }
 
     @Override
@@ -30,7 +41,17 @@ public class JsonCategory implements MapCategory {
     }
 
     @Override
-    public Optional<MapAttributes> getAttributes() {
-        return Optional.ofNullable(attributes);
+    public Optional<MapLocationAttributes> getLocationAttributes() {
+        return Optional.ofNullable(locationAttributes);
+    }
+
+    @Override
+    public Optional<MapPathAttributes> getPathAttributes() {
+        return Optional.ofNullable(pathAttributes);
+    }
+
+    @Override
+    public Optional<MapAreaAttributes> getAreaAttributes() {
+        return Optional.ofNullable(areaAttributes);
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonLocationAttributes.java
@@ -4,14 +4,14 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.type.TextShadow;
 import java.util.Optional;
 
-public class JsonMapAttributes implements MapAttributes {
+public class JsonLocationAttributes implements MapLocationAttributes {
     private final String label;
     private final String icon;
     private final int priority;
@@ -22,7 +22,7 @@ public class JsonMapAttributes implements MapAttributes {
     private final CustomColor iconColor;
     private final JsonMapVisibility iconVisibility;
 
-    public JsonMapAttributes(
+    public JsonLocationAttributes(
             String label,
             String icon,
             int priority,

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
@@ -63,8 +63,8 @@ public class JsonMapAttributesBuilder {
         return this;
     }
 
-    public JsonMapAttributes build() {
-        return new JsonMapAttributes(
+    public JsonLocationAttributes build() {
+        return new JsonLocationAttributes(
                 label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapLocation.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.type.MapLocation;
 import com.wynntils.utils.mc.type.Location;
 import java.util.List;
@@ -13,10 +13,10 @@ import java.util.Optional;
 public class JsonMapLocation implements MapLocation {
     private final String featureId;
     private final String categoryId;
-    private final JsonMapAttributes attributes;
+    private final JsonLocationAttributes attributes;
     private final Location location;
 
-    public JsonMapLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public JsonMapLocation(String featureId, String categoryId, JsonLocationAttributes attributes, Location location) {
         this.featureId = featureId;
         this.categoryId = categoryId;
         this.attributes = attributes;
@@ -34,7 +34,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Optional<MapAttributes> getAttributes() {
+    public Optional<MapLocationAttributes> getAttributes() {
         return Optional.ofNullable(attributes);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonPathAttributes.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+import java.util.Optional;
+
+public class JsonPathAttributes implements MapPathAttributes {
+    private final String label;
+    private final int priority;
+    private final int level;
+
+    public JsonPathAttributes(String label, int priority, int level) {
+        this.label = label;
+        this.priority = priority;
+        this.level = level;
+    }
+
+    @Override
+    public Optional<String> getLabel() {
+        return Optional.of(label);
+    }
+
+    @Override
+    public Optional<Integer> getPriority() {
+        return Optional.of(priority);
+    }
+
+    @Override
+    public Optional<Integer> getLevel() {
+        return Optional.of(level);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
@@ -174,11 +174,19 @@ public final class JsonProvider implements MapDataProvider {
 
             String id = json.get("id").getAsString();
             String name = JsonUtils.getNullableJsonString(json, "name");
-            JsonElement attributesJson = json.get("attributes");
-            JsonMapAttributes attributes =
-                    attributesJson == null ? null : GSON.fromJson(attributesJson, JsonMapAttributes.class);
+            JsonElement locationAttributes = json.get("locationAttributes");
+            JsonLocationAttributes locationAttributesObj =
+                    locationAttributes == null ? null : GSON.fromJson(locationAttributes, JsonLocationAttributes.class);
 
-            return new JsonCategory(id, name, attributes);
+            JsonElement areaAttributes = json.get("areaAttributes");
+            JsonAreaAttributes areaAttributesObj =
+                    areaAttributes == null ? null : GSON.fromJson(areaAttributes, JsonAreaAttributes.class);
+
+            JsonElement pathAttributes = json.get("pathAttributes");
+            JsonPathAttributes pathAttributesObj =
+                    pathAttributes == null ? null : GSON.fromJson(pathAttributes, JsonPathAttributes.class);
+
+            return new JsonCategory(id, name, locationAttributesObj, areaAttributesObj, pathAttributesObj);
         }
     }
 
@@ -193,8 +201,8 @@ public final class JsonProvider implements MapDataProvider {
             JsonElement locationJson = json.get("location");
             Location location = GSON.fromJson(locationJson, Location.class);
             JsonElement attributesJson = json.get("attributes");
-            JsonMapAttributes attributes =
-                    attributesJson == null ? null : GSON.fromJson(attributesJson, JsonMapAttributes.class);
+            JsonLocationAttributes attributes =
+                    attributesJson == null ? null : GSON.fromJson(attributesJson, JsonLocationAttributes.class);
 
             return new JsonMapLocation(id, category, attributes, location);
         }

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapArea.java
@@ -4,15 +4,19 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
+import java.util.Optional;
 
 public interface MapArea extends MapFeature {
     // The area is described by a polygon. This list is the sequence of
     // vertices of that polygon, ordered in a counterclockwise orientation.
     // The last segment of the polygon connects from the last vertice to the first.
     List<Location> getPolygonArea();
+
+    Optional<MapAreaAttributes> getAttributes();
 
     @Override
     default boolean isVisible(BoundingShape boundingShape) {

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapCategory.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapCategory.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.services.mapdata.type;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import java.util.Optional;
 
 public interface MapCategory extends MapDataProvidedType {
@@ -12,5 +14,15 @@ public interface MapCategory extends MapDataProvidedType {
 
     Optional<String> getName();
 
-    Optional<MapAttributes> getAttributes();
+    default Optional<MapLocationAttributes> getLocationAttributes() {
+        return Optional.empty();
+    }
+
+    default Optional<MapAreaAttributes> getAreaAttributes() {
+        return Optional.empty();
+    }
+
+    default Optional<MapPathAttributes> getPathAttributes() {
+        return Optional.empty();
+    }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
@@ -4,18 +4,14 @@
  */
 package com.wynntils.services.mapdata.type;
 
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
-import java.util.Optional;
 
 public interface MapFeature extends MapDataProvidedType {
     // The id should be unique, and track the provenance of the feature
     String getFeatureId();
 
     String getCategoryId();
-
-    Optional<MapAttributes> getAttributes();
 
     boolean isVisible(BoundingShape boundingShape);
 

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapLocation.java
@@ -4,11 +4,15 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
+import java.util.Optional;
 
 public interface MapLocation extends MapFeature {
     Location getLocation();
+
+    Optional<MapLocationAttributes> getAttributes();
 
     @Override
     default boolean isVisible(BoundingShape boundingShape) {

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapPath.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapPath.java
@@ -4,13 +4,17 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
+import java.util.Optional;
 
 public interface MapPath extends MapFeature {
     // The path is described by a sequence of locations
     List<Location> getPath();
+
+    Optional<MapPathAttributes> getAttributes();
 
     @Override
     default boolean isVisible(BoundingShape boundingShape) {


### PR DESCRIPTION
Proposed fix for #2582 (fixes #2582)

I've explicitly wanted to avoid using generics in the implementation. Using generics in this case would "litter" the code everywhere, whereas, now, we only have a tiny amount of casting done in consumer classes, and most of the heavily lifting is done in MapAttributesResolver.

It's also on purpose that the new attribute types do not have any custom values, rather, they only have defaults defined. I think it's sane to implement these custom attributes the first time we use them (so, in the territory area PR for area, and the first map path PR).