### PR TITLE
port: Start using WynntilsCheckbox exclusively (1.21 backport) [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/screens/base/WynntilsGridLayoutScreen.java
+++ b/common/src/main/java/com/wynntils/screens/base/WynntilsGridLayoutScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.base;
@@ -11,7 +11,7 @@ import net.minecraft.network.chat.Component;
 public abstract class WynntilsGridLayoutScreen extends WynntilsScreen {
     private static final float GRID_DIVISIONS = 64f;
     // Certain elements require static 20 height or button textures will break
-    protected static final int BUTTON_HEIGHT = 20;
+    protected static final int BUTTON_SIZE = 20;
     protected float dividedHeight;
     protected float dividedWidth;
     /*

--- a/common/src/main/java/com/wynntils/screens/base/widgets/WynntilsCheckbox.java
+++ b/common/src/main/java/com/wynntils/screens/base/widgets/WynntilsCheckbox.java
@@ -16,71 +16,41 @@ import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 
-public class WynntilsCheckbox extends Checkbox {
+public class WynntilsCheckbox extends AbstractButton {
+    public static final ResourceLocation CHECKBOX_SELECTED_HIGHLIGHTED_SPRITE =
+            new ResourceLocation("minecraft:widget/checkbox_selected_highlighted");
+    public static final ResourceLocation CHECKBOX_SELECTED_SPRITE =
+            new ResourceLocation("minecraft:widget/checkbox_selected");
+    public static final ResourceLocation CHECKBOX_HIGHLIGHTED_SPRITE =
+            new ResourceLocation("minecraft:widget/checkbox_highlighted");
+    public static final ResourceLocation CHECKBOX_SPRITE = new ResourceLocation("minecraft:widget/checkbox");
+
+    public boolean selected;
     private final int maxTextWidth;
     private final CustomColor color;
-
-    private BiConsumer<WynntilsCheckbox, Integer> onClick;
-    private List<Component> tooltip;
-
-    public WynntilsCheckbox(
-            int x, int y, int width, int height, Component message, boolean selected, int maxTextWidth) {
-        super(x, y, width, height, message, selected);
-        this.maxTextWidth = maxTextWidth;
-        this.color = CommonColors.WHITE;
-    }
+    private final BiConsumer<WynntilsCheckbox, Boolean> onClick;
+    private final List<Component> tooltip;
 
     public WynntilsCheckbox(
             int x,
             int y,
-            int width,
-            int height,
+            int size,
             Component message,
             boolean selected,
             int maxTextWidth,
-            Consumer<Integer> onClick) {
-        super(x, y, width, height, message, selected);
-        this.maxTextWidth = maxTextWidth;
-        this.color = CommonColors.WHITE;
-        this.onClick = (checkbox, button) -> onClick.accept(button);
-    }
-
-    public WynntilsCheckbox(
-            int x,
-            int y,
-            int width,
-            int height,
-            Component message,
-            boolean selected,
-            int maxTextWidth,
-            Consumer<Integer> onClick,
+            CustomColor color,
+            BiConsumer<WynntilsCheckbox, Boolean> onClick,
             List<Component> tooltip) {
-        super(x, y, width, height, message, selected);
+        super(x, y, size, size, message);
+        this.selected = selected;
         this.maxTextWidth = maxTextWidth;
-        this.color = CommonColors.WHITE;
-        this.onClick = (checkbox, button) -> onClick.accept(button);
-        this.tooltip = tooltip;
-    }
-
-    public WynntilsCheckbox(
-            int x,
-            int y,
-            int width,
-            int height,
-            Component message,
-            boolean selected,
-            int maxTextWidth,
-            BiConsumer<WynntilsCheckbox, Integer> onClick,
-            List<Component> tooltip) {
-        super(x, y, width, height, message, selected);
-        this.maxTextWidth = maxTextWidth;
-        this.color = CommonColors.WHITE;
+        this.color = color;
         this.onClick = onClick;
         this.tooltip = tooltip;
     }
@@ -88,15 +58,39 @@ public class WynntilsCheckbox extends Checkbox {
     public WynntilsCheckbox(
             int x,
             int y,
-            int width,
-            int height,
+            int size,
             Component message,
             boolean selected,
             int maxTextWidth,
-            CustomColor color) {
-        super(x, y, width, height, message, selected);
-        this.maxTextWidth = maxTextWidth;
-        this.color = color;
+            BiConsumer<WynntilsCheckbox, Boolean> onClick,
+            List<Component> tooltip) {
+        this(x, y, size, message, selected, maxTextWidth, CommonColors.WHITE, onClick, tooltip);
+    }
+
+    public WynntilsCheckbox(int x, int y, int size, Component message, boolean selected, int maxTextWidth) {
+        this(x, y, size, message, selected, maxTextWidth, CommonColors.WHITE, (checkbox, bl) -> {}, List.of());
+    }
+
+    public WynntilsCheckbox(
+            int x,
+            int y,
+            int size,
+            Component message,
+            boolean selected,
+            int maxTextWidth,
+            BiConsumer<WynntilsCheckbox, Boolean> onClick) {
+        this(x, y, size, message, selected, maxTextWidth, CommonColors.WHITE, onClick, null);
+    }
+
+    public WynntilsCheckbox(
+            int x, int y, int size, Component message, boolean selected, int maxTextWidth, CustomColor color) {
+        this(x, y, size, message, selected, maxTextWidth, color, (checkbox, bl) -> {}, List.of());
+    }
+
+    @Override
+    public void onPress() {
+        this.selected = !this.selected;
+        this.onClick.accept(this, this.selected);
     }
 
     @Override
@@ -113,20 +107,18 @@ public class WynntilsCheckbox extends Checkbox {
 
         guiGraphics.blitSprite(resourceLocation, this.getX(), this.getY(), this.width, this.height);
         guiGraphics.setColor(1.0F, 1.0F, 1.0F, 1.0F);
-        if (this.showLabel) {
-            FontRenderer.getInstance()
-                    .renderScrollingText(
-                            guiGraphics.pose(),
-                            StyledText.fromComponent(this.getMessage()),
-                            this.getX() + this.width + 2,
-                            this.getY() + (this.height / 2f),
-                            maxTextWidth,
-                            color,
-                            HorizontalAlignment.LEFT,
-                            VerticalAlignment.MIDDLE,
-                            TextShadow.NORMAL,
-                            1f);
-        }
+        FontRenderer.getInstance()
+                .renderScrollingText(
+                        guiGraphics.pose(),
+                        StyledText.fromComponent(this.getMessage()),
+                        this.getX() + this.width + 2,
+                        this.getY() + (this.height / 2f),
+                        maxTextWidth,
+                        color,
+                        HorizontalAlignment.LEFT,
+                        VerticalAlignment.MIDDLE,
+                        TextShadow.NORMAL,
+                        1f);
 
         if (isHovered && tooltip != null) {
             McUtils.mc().screen.setTooltipForNextRenderPass(Lists.transform(tooltip, Component::getVisualOrderText));
@@ -134,17 +126,9 @@ public class WynntilsCheckbox extends Checkbox {
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (!isMouseOver(mouseX, mouseY)) return false;
+    protected void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {}
 
-        // Do the click before the onClick so that the checkbox is updated before the consumer is called.
-        boolean superClicked = super.mouseClicked(mouseX, mouseY, button);
-
-        // Only trigger the onClick if the super was actually clicked
-        if (onClick != null && superClicked) {
-            onClick.accept(this, button);
-        }
-
-        return superClicked;
+    public boolean isSelected() {
+        return selected;
     }
 }

--- a/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
@@ -29,7 +29,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
@@ -52,7 +51,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
     private final List<WynntilsCheckbox> recipientTypeBoxes = new ArrayList<>();
     private TextInputBoxWidget filterRegexInput;
     private TextWidget regexErrorMsg;
-    private Checkbox consumingCheckbox;
+    private WynntilsCheckbox consumingCheckbox;
 
     private Button saveButton;
     private Button saveAndCloseButton;
@@ -89,7 +88,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 35),
                 (int) ((dividedHeight * FIRST_ROW_Y)),
                 (int) (dividedWidth * 10),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 (s) -> updateSaveButtonActive(),
                 this,
                 nameInput);
@@ -108,7 +107,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 47),
                 (int) (dividedHeight * FIRST_ROW_Y),
                 (int) (dividedWidth * 10),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 null,
                 this,
                 autoCommandInput);
@@ -123,7 +122,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 59),
                 (int) (dividedHeight * FIRST_ROW_Y),
                 (int) (dividedWidth * 2),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 (s) -> updateSaveButtonActive(),
                 this,
                 orderInput);
@@ -136,7 +135,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
         // region Recipient Types
 
         // Display all recipient types in two rows of 4 checkboxes each
-        List<Checkbox> oldBoxes = new ArrayList<>(recipientTypeBoxes);
+        List<WynntilsCheckbox> oldBoxes = new ArrayList<>(recipientTypeBoxes);
         recipientTypeBoxes.clear();
 
         int x = (int) (dividedWidth * 35);
@@ -148,12 +147,12 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
             }
 
             RecipientType type = RecipientType.values()[i];
-            Checkbox oldCheckbox = oldBoxes.stream()
+            WynntilsCheckbox oldCheckbox = oldBoxes.stream()
                     .filter(checkbox -> checkbox.getMessage().getString().equals(type.getName()))
                     .findFirst()
                     .orElse(null);
 
-            boolean oldCheckboxSelected = oldCheckbox != null && oldCheckbox.selected();
+            boolean oldCheckboxSelected = oldCheckbox != null && oldCheckbox.isSelected();
             boolean editedFirstSetupSelected = firstSetup
                     && edited != null
                     && (edited.getFilteredTypes() == null
@@ -161,13 +160,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
             boolean ticked = oldCheckboxSelected || editedFirstSetupSelected;
 
             WynntilsCheckbox newBox = new WynntilsCheckbox(
-                    x,
-                    y,
-                    BUTTON_HEIGHT,
-                    BUTTON_HEIGHT,
-                    Component.literal(type.getName()),
-                    ticked,
-                    (int) (dividedWidth * 7) - 24);
+                    x, y, BUTTON_SIZE, Component.literal(type.getName()), ticked, (int) (dividedWidth * 7) - 24);
 
             this.addRenderableWidget(newBox);
             recipientTypeBoxes.add(newBox);
@@ -182,7 +175,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 35),
                 (int) (dividedHeight * THIRD_ROW_Y),
                 (int) (dividedWidth * 26),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 (s) -> updateSaveButtonActive(),
                 this,
                 filterRegexInput);
@@ -192,19 +185,18 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
         }
 
         regexErrorMsg = new TextWidget(
-                this.width / 2 - 160 + 100, this.height / 2 + 75 + 7, 200, BUTTON_HEIGHT, Component.empty());
+                this.width / 2 - 160 + 100, this.height / 2 + 75 + 7, 200, BUTTON_SIZE, Component.empty());
         this.addRenderableWidget(regexErrorMsg);
         // endregion
 
         // region Consuming
-        consumingCheckbox = new Checkbox(
+        consumingCheckbox = new WynntilsCheckbox(
                 (int) (dividedWidth * 35),
                 (int) (dividedHeight * FOURTH_ROW_Y),
-                BUTTON_HEIGHT,
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 Component.translatable("screens.wynntils.chatTabsGui.consuming"),
-                consumingCheckbox != null && consumingCheckbox.selected(),
-                true);
+                consumingCheckbox != null && consumingCheckbox.isSelected(),
+                (int) (dividedWidth * 7) - 24);
         this.addRenderableWidget(consumingCheckbox);
         if (firstSetup && edited != null) {
             consumingCheckbox.selected = edited.isConsuming();
@@ -220,7 +212,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                             reloadChatTabsWidgets();
                         })
                 .pos((int) (dividedWidth * 35), (int) (dividedHeight * FIFTH_ROW_Y))
-                .size((int) (dividedWidth * 8), BUTTON_HEIGHT)
+                .size((int) (dividedWidth * 8), BUTTON_SIZE)
                 .build();
         this.addRenderableWidget(saveButton);
 
@@ -233,14 +225,14 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                             this.onClose();
                         })
                 .pos((int) (dividedWidth * 44), (int) (dividedHeight * FIFTH_ROW_Y))
-                .size((int) (dividedWidth * 8), BUTTON_HEIGHT)
+                .size((int) (dividedWidth * 8), BUTTON_SIZE)
                 .build();
         this.addRenderableWidget(saveAndCloseButton);
 
         this.addRenderableWidget(new Button.Builder(
                         Component.translatable("screens.wynntils.chatTabsGui.cancel"), (button) -> this.onClose())
                 .pos((int) (dividedWidth * 53), (int) (dividedHeight * FIFTH_ROW_Y))
-                .size((int) (dividedWidth * 8), BUTTON_HEIGHT)
+                .size((int) (dividedWidth * 8), BUTTON_SIZE)
                 .build());
         // endregion
 
@@ -385,10 +377,10 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
 
         ChatTab chatTab = new ChatTab(
                 nameInput.getTextBoxInput(),
-                consumingCheckbox.selected(),
+                consumingCheckbox.isSelected(),
                 autoCommandInput.getTextBoxInput(),
                 recipientTypeBoxes.stream()
-                        .filter(Checkbox::selected)
+                        .filter(WynntilsCheckbox::isSelected)
                         .map(box -> RecipientType.fromName(box.getMessage().getString()))
                         .collect(Collectors.toSet()),
                 filterRegexInput.getTextBoxInput().isBlank() ? null : filterRegexInput.getTextBoxInput());
@@ -412,7 +404,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
 
         saveButton.active = !nameInput.getTextBoxInput().isEmpty()
                 && validatePattern()
-                && recipientTypeBoxes.stream().anyMatch(Checkbox::selected);
+                && recipientTypeBoxes.stream().anyMatch(WynntilsCheckbox::isSelected);
         saveAndCloseButton.active = saveButton.active;
     }
 
@@ -439,7 +431,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
         List<ChatTab> chatTabs = Services.ChatTab.getChatTabs();
 
         int initialVerticalOffset =
-                (int) (dividedHeight * 32) - (int) ((dividedHeight * (chatTabs.size() * 5 + 1) + BUTTON_HEIGHT) / 2);
+                (int) (dividedHeight * 32) - (int) ((dividedHeight * (chatTabs.size() * 5 + 1) + BUTTON_SIZE) / 2);
 
         for (int i = 0; i < chatTabs.size(); i++) {
             chatTabsWidgets.add(new ChatTabsWidget(
@@ -461,7 +453,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                 .pos(
                         (int) (dividedWidth * 13),
                         initialVerticalOffset + (int) (dividedHeight * (chatTabs.size() * 5 + 1)))
-                .size((int) (dividedWidth * 6), BUTTON_HEIGHT)
+                .size((int) (dividedWidth * 6), BUTTON_SIZE)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
@@ -196,7 +196,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                 BUTTON_SIZE,
                 Component.translatable("screens.wynntils.chatTabsGui.consuming"),
                 consumingCheckbox != null && consumingCheckbox.isSelected(),
-                (int) (dividedWidth * 7) - 24);
+                (int) (dividedWidth * 15));
         this.addRenderableWidget(consumingCheckbox);
         if (firstSetup && edited != null) {
             consumingCheckbox.selected = edited.isConsuming();

--- a/common/src/main/java/com/wynntils/screens/itemfilter/widgets/BooleanFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/itemfilter/widgets/BooleanFilterWidget.java
@@ -10,7 +10,6 @@ import com.wynntils.services.itemfilter.type.StatProviderAndFilterPair;
 import com.wynntils.utils.type.ConfirmedBoolean;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 
 public class BooleanFilterWidget extends GeneralFilterWidget {
     private final WynntilsCheckbox trueCheckbox;
@@ -25,12 +24,11 @@ public class BooleanFilterWidget extends GeneralFilterWidget {
                 getX() + 10,
                 getY() + 35,
                 20,
-                20,
                 Component.translatable("screens.wynntils.itemFilter.booleanTrue"),
                 this.state == ConfirmedBoolean.TRUE,
                 150,
-                (b) -> {
-                    if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                (checkbox, b) -> {
+                    if (b) {
                         toggleState(ConfirmedBoolean.TRUE);
                     }
                 });
@@ -39,12 +37,11 @@ public class BooleanFilterWidget extends GeneralFilterWidget {
                 getX() + 10,
                 getY() + 90,
                 20,
-                20,
                 Component.translatable("screens.wynntils.itemFilter.booleanFalse"),
                 this.state == ConfirmedBoolean.FALSE,
                 150,
-                (b) -> {
-                    if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                (checkbox, b) -> {
+                    if (b) {
                         toggleState(ConfirmedBoolean.FALSE);
                     }
                 });

--- a/common/src/main/java/com/wynntils/screens/itemfilter/widgets/SelectionFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/itemfilter/widgets/SelectionFilterWidget.java
@@ -45,8 +45,8 @@ public final class SelectionFilterWidget extends GeneralFilterWidget {
 
         used = filterPair.isPresent();
 
-        this.usedCheckbox = new WynntilsCheckbox(
-                x + width - 16, y + 2, 16, 16, Component.literal(""), used, 0, (b -> toggleUsed()));
+        this.usedCheckbox =
+                new WynntilsCheckbox(x + width - 16, y + 2, 16, Component.literal(""), used, 0, (c, b) -> toggleUsed());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/itemfilter/widgets/StringFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/itemfilter/widgets/StringFilterWidget.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 
 public class StringFilterWidget extends GeneralFilterWidget {
     private final Button removeButton;
@@ -60,15 +59,14 @@ public class StringFilterWidget extends GeneralFilterWidget {
                 getX() + inputWidth + 2,
                 getY(),
                 20,
-                20,
                 Component.translatable("screens.wynntils.itemFilter.strict"),
                 strict,
                 50,
-                (b -> {
-                    if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                (checkbox, bl) -> {
+                    if (bl) {
                         parent.updateQuery();
                     }
-                }),
+                },
                 List.of(Component.translatable("screens.wynntils.itemFilter.strictTooltip")));
 
         this.removeButton = new Button.Builder(Component.literal("🗑"), (button -> parent.removeWidget(this)))

--- a/common/src/main/java/com/wynntils/screens/itemfilter/widgets/numeric/InequalityStatValueFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/itemfilter/widgets/numeric/InequalityStatValueFilterWidget.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 
 public class InequalityStatValueFilterWidget extends InequalityNumericFilterWidget<StatValue> {
     private final WynntilsCheckbox percentageCheckbox;
@@ -89,14 +88,11 @@ public class InequalityStatValueFilterWidget extends InequalityNumericFilterWidg
                 getX() + getWidth() - 52,
                 getY(),
                 20,
-                20,
                 Component.literal("%"),
                 percentage,
                 10,
                 (checkbox, button) -> {
-                    if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-                        parent.updateQuery();
-                    }
+                    parent.updateQuery();
                 },
                 List.of(Component.translatable("screens.wynntils.itemFilter.percentageTooltip")));
     }

--- a/common/src/main/java/com/wynntils/screens/itemfilter/widgets/numeric/RangedStatValueFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/itemfilter/widgets/numeric/RangedStatValueFilterWidget.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 
 public class RangedStatValueFilterWidget extends RangedNumericFilterWidget<StatValue> {
     private final WynntilsCheckbox percentageCheckbox;
@@ -48,14 +47,11 @@ public class RangedStatValueFilterWidget extends RangedNumericFilterWidget<StatV
                 getX() + getWidth() - 52,
                 getY(),
                 20,
-                20,
                 Component.literal("%"),
                 percentage,
                 10,
                 (checkbox, button) -> {
-                    if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-                        parent.updateQuery();
-                    }
+                    parent.updateQuery();
                 },
                 List.of(Component.translatable("screens.wynntils.itemFilter.percentageTooltip")));
     }

--- a/common/src/main/java/com/wynntils/screens/itemfilter/widgets/numeric/SingleStatValueFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/itemfilter/widgets/numeric/SingleStatValueFilterWidget.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 
 public class SingleStatValueFilterWidget extends SingleNumericFilterWidget<StatValue> {
     private final WynntilsCheckbox percentageCheckbox;
@@ -46,14 +45,11 @@ public class SingleStatValueFilterWidget extends SingleNumericFilterWidget<StatV
                 getX() + getWidth() - 52,
                 getY(),
                 20,
-                20,
                 Component.literal("%"),
                 percentage,
                 10,
                 (checkbox, button) -> {
-                    if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-                        parent.updateQuery();
-                    }
+                    parent.updateQuery();
                 },
                 List.of(Component.translatable("screens.wynntils.itemFilter.percentageTooltip")));
     }

--- a/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
@@ -226,14 +226,12 @@ public final class ItemSharingScreen extends WynntilsScreen {
                     backgroundX + 15,
                     backgroundY + 25,
                     10,
-                    10,
                     Component.translatable("screens.wynntils.itemSharing.extended.name"),
                     Models.ItemEncoding.extendedIdentificationEncoding.get(),
                     Texture.ITEM_SHARING_BACKGROUND.width() - 30,
-                    (b) -> {
-                        if (b == 0) {
-                            Models.ItemEncoding.extendedIdentificationEncoding.store(
-                                    !Models.ItemEncoding.extendedIdentificationEncoding.get());
+                    (c, b) -> {
+                        if (b) {
+                            Models.ItemEncoding.extendedIdentificationEncoding.store(b);
                             refreshPreview();
                         }
                     },
@@ -247,13 +245,12 @@ public final class ItemSharingScreen extends WynntilsScreen {
                     backgroundX + 15,
                     backgroundY + 25,
                     10,
-                    10,
                     Component.translatable("screens.wynntils.itemSharing.itemName.name"),
                     Models.ItemEncoding.shareItemName.get(),
                     Texture.ITEM_SHARING_BACKGROUND.width() - 30,
-                    (b) -> {
-                        if (b == 0) {
-                            Models.ItemEncoding.shareItemName.store(!Models.ItemEncoding.shareItemName.get());
+                    (c, b) -> {
+                        if (b) {
+                            Models.ItemEncoding.shareItemName.store(b);
                             refreshPreview();
                         }
                     },

--- a/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/placement/OverlayManagementScreen.java
@@ -788,11 +788,10 @@ public final class OverlayManagementScreen extends WynntilsScreen {
                 this.width / 2 - BUTTON_WIDTH - 12 - 100,
                 yPos,
                 BUTTON_HEIGHT,
-                BUTTON_HEIGHT,
                 Component.translatable("screens.wynntils.overlayManagement.showPreview"),
                 showPreview,
                 80,
-                (b) -> showPreview = !showPreview,
+                (c, b) -> showPreview = !showPreview,
                 ComponentUtils.wrapTooltips(
                         List.of(Component.translatable("screens.wynntils.overlayManagement.showPreviewTooltip")),
                         150)));
@@ -836,11 +835,10 @@ public final class OverlayManagementScreen extends WynntilsScreen {
                     this.width / 2 + 12 + BUTTON_WIDTH + 10,
                     yPos,
                     BUTTON_HEIGHT,
-                    BUTTON_HEIGHT,
                     Component.translatable("screens.wynntils.overlayManagement.showOthers"),
                     renderAllOverlays,
                     120,
-                    (b) -> renderAllOverlays = !renderAllOverlays,
+                    (c, b) -> renderAllOverlays = b,
                     ComponentUtils.wrapTooltips(
                             List.of(Component.translatable("screens.wynntils.overlayManagement.showOthersTooltip")),
                             150)));

--- a/common/src/main/java/com/wynntils/screens/overlays/selection/OverlaySelectionScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/selection/OverlaySelectionScreen.java
@@ -134,11 +134,10 @@ public final class OverlaySelectionScreen extends WynntilsScreen {
                 (Texture.OVERLAY_SELECTION_GUI.width() / 2) - 70,
                 (int) (this.height - 70 - translationY),
                 20,
-                20,
                 Component.translatable("screens.wynntils.overlaySelection.showOverlays"),
                 showOverlays,
                 120,
-                (b) -> showOverlays = !showOverlays,
+                (c, b) -> showOverlays = b,
                 ComponentUtils.wrapTooltips(
                         List.of(Component.translatable("screens.wynntils.overlaySelection.showOverlaysTooltip")),
                         150)));

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.partymanagement;
@@ -68,7 +68,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 36),
                 (int) (dividedHeight * PARTY_LIST_DIV_HEIGHT) + 1,
                 (int) ((dividedWidth * 57) - (dividedWidth * 36)) - 1,
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 null,
                 this,
                 inviteInput);
@@ -78,7 +78,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                         Component.translatable("screens.wynntils.partyManagementGui.invite"),
                         (button) -> inviteFromField())
                 .pos((int) (dividedWidth * 57) + 1, (int) (dividedHeight * PARTY_LIST_DIV_HEIGHT) + 1)
-                .size((int) (dividedWidth * 3) - 1, BUTTON_HEIGHT)
+                .size((int) (dividedWidth * 3) - 1, BUTTON_SIZE)
                 .build();
         this.addRenderableWidget(inviteButton);
         // endregion
@@ -89,7 +89,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                                 .withStyle(ChatFormatting.GREEN),
                         (button) -> refreshAll())
                 .pos((int) (dividedWidth * 36) + 1, (int) (dividedHeight * MGMT_ROW_DIV_HEIGHT))
-                .size(mgmtButtonWidth, BUTTON_HEIGHT)
+                .size(mgmtButtonWidth, BUTTON_SIZE)
                 .build());
 
         kickOfflineButton = new Button.Builder(
@@ -97,7 +97,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                                 .withStyle(ChatFormatting.RED),
                         (button) -> Models.Party.partyKickOffline())
                 .pos((int) (dividedWidth * 44) + 1, (int) (dividedHeight * MGMT_ROW_DIV_HEIGHT))
-                .size(mgmtButtonWidth, BUTTON_HEIGHT)
+                .size(mgmtButtonWidth, BUTTON_SIZE)
                 .build();
         this.addRenderableWidget(kickOfflineButton);
         // endregion
@@ -291,7 +291,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 52) + 1,
                 (int) (dividedHeight * MGMT_ROW_DIV_HEIGHT),
                 mgmtButtonWidth,
-                BUTTON_HEIGHT);
+                BUTTON_SIZE);
     }
 
     /**
@@ -310,7 +310,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                     dividedWidth * 4,
                     dividedHeight * (9 + i * 3),
                     (int) (dividedWidth * 28) - (int) (dividedWidth * 2),
-                    BUTTON_HEIGHT,
+                    BUTTON_SIZE,
                     playerName,
                     Models.Party.getOfflineMembers().contains(playerName),
                     28 - 2));
@@ -337,7 +337,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                     dividedWidth * 36,
                     dividedHeight * (23 + i * 3),
                     (int) ((dividedWidth * 60) - (dividedWidth * 36)),
-                    BUTTON_HEIGHT,
+                    BUTTON_SIZE,
                     playerName,
                     60 - 36));
         }

--- a/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigurableButton.java
+++ b/common/src/main/java/com/wynntils/screens/settings/widgets/ConfigurableButton.java
@@ -65,7 +65,7 @@ public class ConfigurableButton extends WynntilsButton {
             enabled = selectedFeature.isEnabled();
         }
 
-        this.enabledCheckbox = new WynntilsCheckbox(x + width - 10, y, 10, 10, Component.literal(""), enabled, 0);
+        this.enabledCheckbox = new WynntilsCheckbox(x + width - 10, y, 10, Component.literal(""), enabled, 0);
 
         this.maskTopY = settingsScreen.getMaskTopY();
         this.maskBottomY = settingsScreen.getConfigurableMaskBottomY();

--- a/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
@@ -110,7 +110,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 35),
                 (int) (dividedHeight * 24),
                 (int) ((dividedWidth * 48) - (dividedWidth * 35)),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 (x) -> {
                     saveAssignedButton.active = !x.isBlank();
                     saveBuildButton.active = !x.isBlank();
@@ -125,7 +125,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 49),
                 (int) (dividedHeight * 24),
                 (int) ((dividedWidth * 53) - (dividedWidth * 49)),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 Component.translatable("screens.wynntils.skillPointLoadouts.save"),
                 this,
                 Models.SkillPoint::saveCurrentSkillPoints);
@@ -135,7 +135,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 54),
                 (int) (dividedHeight * 24),
                 (int) ((dividedWidth * 59) - (dividedWidth * 54)),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 Component.translatable("screens.wynntils.skillPointLoadouts.saveBuild"),
                 this,
                 Models.SkillPoint::saveCurrentBuild);
@@ -145,7 +145,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 35),
                 (int) (dividedHeight * 52),
                 (int) ((dividedWidth * 44) - (dividedWidth * 35)),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 Component.translatable("screens.wynntils.skillPointLoadouts.load"),
                 this);
         this.addRenderableWidget(loadButton);
@@ -154,7 +154,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 45),
                 (int) (dividedHeight * 52),
                 (int) ((dividedWidth * 51) - (dividedWidth * 45)),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 Component.translatable("screens.wynntils.skillPointLoadouts.delete")
                         .withStyle(ChatFormatting.RED),
                 this);
@@ -164,7 +164,7 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedWidth * 52),
                 (int) (dividedHeight * 52),
                 (int) ((dividedWidth * 59) - (dividedWidth * 52)),
-                BUTTON_HEIGHT,
+                BUTTON_SIZE,
                 Component.translatable("screens.wynntils.skillPointLoadouts.convert"),
                 this);
         this.addRenderableWidget(convertButton);


### PR DESCRIPTION
This change is easily done, and allows us to not depend on Minecraft's checkbox, which received breaking changes in 1.21 that makes it impractical to use for us.