### PR TITLE
fix: Disable AutoApplyResourcePackFeature on Forge (until 1.21/NeoForge) 

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/MinecraftMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/MinecraftMixin.java
@@ -61,21 +61,6 @@ public abstract class MinecraftMixin {
     }
 
     @Inject(
-            method = "<init>(Lnet/minecraft/client/main/GameConfig;)V",
-            at =
-                    @At(
-                            value = "INVOKE",
-                            target =
-                                    "Lnet/minecraft/client/Options;loadSelectedResourcePacks(Lnet/minecraft/server/packs/repository/PackRepository;)V",
-                            shift = At.Shift.AFTER))
-    private void onInitialResourcePackLoad(CallbackInfo ci) {
-        // Too early to post events here, but Service components are initialized (and their storages loaded)
-        // We add the resource pack to the selected list here
-        Services.ResourcePack.preloadResourcePack();
-        // Explicitly do not trigger a reload here, as it's too early, and the game will do it later
-    }
-
-    @Inject(
             method = "disconnect(Lnet/minecraft/client/gui/screens/Screen;)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/GameNarrator;clear()V", shift = At.Shift.AFTER))
     private void handleResourcePackPopPre(CallbackInfo ci) {

--- a/fabric/src/main/java/com/wynntils/fabric/mixins/MinecraftMixin.java
+++ b/fabric/src/main/java/com/wynntils/fabric/mixins/MinecraftMixin.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.fabric.mixins;
+
+import com.wynntils.core.components.Services;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+    @Inject(
+            method = "<init>(Lnet/minecraft/client/main/GameConfig;)V",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/Options;loadSelectedResourcePacks(Lnet/minecraft/server/packs/repository/PackRepository;)V",
+                            shift = At.Shift.AFTER))
+    private void onInitialResourcePackLoad(CallbackInfo ci) {
+        // Too early to post events here, but Service components are initialized (and their storages loaded)
+        // We add the resource pack to the selected list here
+        Services.ResourcePack.preloadResourcePack();
+        // Explicitly do not trigger a reload here, as it's too early, and the game will do it later
+    }
+}

--- a/fabric/src/main/java/com/wynntils/fabric/mixins/PackRepositoryMixin.java
+++ b/fabric/src/main/java/com/wynntils/fabric/mixins/PackRepositoryMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.fabric.mixins;
+
+import com.wynntils.services.resourcepack.WynntilsResourceProvider;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import net.minecraft.server.packs.repository.PackRepository;
+import net.minecraft.server.packs.repository.RepositorySource;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PackRepository.class)
+public abstract class PackRepositoryMixin {
+    @Mutable
+    @Shadow
+    @Final
+    private Set<RepositorySource> sources;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInit(CallbackInfo ci) {
+        // WynntilsResourceProvider is directly injected, as this called really early in the game initialization
+        // See WynntilsResourceProvider and ResourcePackService for more information
+        LinkedHashSet<RepositorySource> repositorySources = new LinkedHashSet<>(this.sources);
+        repositorySources.add(new WynntilsResourceProvider());
+        this.sources = repositorySources;
+    }
+}

--- a/fabric/src/main/resources/wynntils.mixins.fabric.json
+++ b/fabric/src/main/resources/wynntils.mixins.fabric.json
@@ -1,5 +1,7 @@
 {
   "client": [
+    "MinecraftMixin",
+    "PackRepositoryMixin",
     "RenderTargetMixin"
   ],
   "compatibilityLevel": "JAVA_17",


### PR DESCRIPTION
Forge's Mixin is still SpongePowered Mixin, which is much behind Fabric's fork of mixin. In 1.21, using NeoForge, we won't have this problem, as they use the same Mixin as Fabric.