### PR TITLE
refactor: Introduce overlay ticking [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/BarOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/BarOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.overlays;
@@ -11,7 +11,6 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.mc.event.TickEvent;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.Texture;
@@ -22,7 +21,6 @@ import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.type.ErrorOr;
 import com.wynntils.utils.type.Pair;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public abstract class BarOverlay extends DynamicOverlay {
     @Persisted(i18nKey = "overlay.wynntils.barOverlay.textShadow")
@@ -98,8 +96,8 @@ public abstract class BarOverlay extends DynamicOverlay {
         renderBar(poseStack, bufferSource, renderY + 10, barHeight, progress);
     }
 
-    @SubscribeEvent
-    public void onTick(TickEvent event) {
+    @Override
+    public void tick() {
         if (!Models.WorldState.onWorld() || !isRendered()) return;
 
         BarOverlayTemplatePair template = getTemplate();

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/Overlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.overlays;
@@ -73,6 +73,8 @@ public abstract class Overlay extends AbstractConfigurable implements Comparable
     public void renderPreview(PoseStack poseStack, MultiBufferSource bufferSource, float partialTicks, Window window) {
         this.render(poseStack, bufferSource, partialTicks, window);
     }
+
+    public void tick() {}
 
     @Override
     public final void updateConfigOption(Config<?> config) {

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -18,6 +18,7 @@ import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.OverlayGroupHolder;
 import com.wynntils.mc.event.DisplayResizeEvent;
 import com.wynntils.mc.event.RenderEvent;
+import com.wynntils.mc.event.TickEvent;
 import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.screens.overlays.placement.OverlayManagementScreen;
 import com.wynntils.screens.overlays.selection.OverlaySelectionScreen;
@@ -194,6 +195,14 @@ public final class OverlayManager extends Manager {
         holder.getOverlays()
                 .forEach(overlay -> registerOverlay(
                         overlay, holder.getParent(), holder.getElementType(), holder.getRenderState(), true));
+    }
+
+    // endregion
+
+    // region Ticking
+    @SubscribeEvent
+    public void onTick(TickEvent event) {
+        enabledOverlays.forEach(Overlay::tick);
     }
 
     // endregion

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
@@ -11,7 +11,6 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.mc.event.TickEvent;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.FontRenderer;
@@ -21,7 +20,6 @@ import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.ErrorOr;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 /**
  * An overlay, which main purpose is to display function templates.
@@ -106,10 +104,9 @@ public abstract class TextOverlay extends DynamicOverlay {
         }
     }
 
-    @SubscribeEvent
-    public void onTick(TickEvent event) {
+    @Override
+    public void tick() {
         if (!Models.WorldState.onWorld()) return;
-
         cachedLines = calculateTemplateValue(getTemplate());
     }
 

--- a/common/src/main/java/com/wynntils/overlays/SpellCastMessageOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/SpellCastMessageOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays;
@@ -12,7 +12,6 @@ import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.event.ItemRenamedEvent;
-import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.spells.event.SpellEvent;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.buffered.BufferedFontRenderer;
@@ -65,8 +64,8 @@ public class SpellCastMessageOverlay extends Overlay {
         spellMessageTimer = SPELL_MESSAGE_TICKS;
     }
 
-    @SubscribeEvent
-    public void onTick(TickEvent event) {
+    @Override
+    public void tick() {
         if (spellMessageTimer <= 0) return;
 
         spellMessageTimer--;

--- a/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
@@ -16,7 +16,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.bossbar.TrackedBar;
 import com.wynntils.handlers.bossbar.event.BossBarAddedEvent;
 import com.wynntils.handlers.bossbar.type.BossBarProgress;
-import com.wynntils.mc.event.TickEvent;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.Texture;
@@ -69,8 +68,8 @@ public abstract class BaseBarOverlay extends Overlay {
         }
     }
 
-    @SubscribeEvent
-    public void onTick(TickEvent event) {
+    @Override
+    public void tick() {
         if (!Models.WorldState.onWorld() || !isActive()) return;
 
         if (animationTime.get() == 0) {


### PR DESCRIPTION
(...instead of overlays registering tick event listeners)

This refactor helps with the 1.21/NeoForge ports. Overall, I think this refactor would even make sense, if we were not doing a port.