### PR TITLE
feat: Allow opening delete potions menu when item locked in blocking mode [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
@@ -18,6 +18,7 @@ import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.mc.event.DropHeldItemEvent;
 import com.wynntils.models.containers.type.FullscreenContainerProperty;
+import com.wynntils.models.items.items.game.MultiHealthPotionItem;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
@@ -49,6 +50,9 @@ public class ItemLockFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> allowClickOnEmeraldPouchInBlockingMode = new Config<>(true);
+
+    @Persisted
+    public final Config<Boolean> allowClickOnMultiHealthPotionsInBlockingMode = new Config<>(true);
 
     @SubscribeEvent
     public void onContainerRender(ContainerRenderEvent event) {
@@ -86,13 +90,18 @@ public class ItemLockFeature extends Feature {
             return;
         }
 
-        // We want to allow opening emerald pouch even if locked
-        // Right click is opening pouch, left click is picking it up.
-        // We want to allow opening pouch even if locked, but not picking it up.
-        if (allowClickOnEmeraldPouchInBlockingMode.get()
-                && event.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_RIGHT
-                && Models.Emerald.isEmeraldPouch(slotOptional.get().getItem())) {
-            return;
+        // We want to allow opening emerald pouches and deleting potions even if locked
+        // Right click is used to perform these actions, left click picks them up
+        // So only allow right click actions
+        if (event.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+            if (allowClickOnEmeraldPouchInBlockingMode.get()
+                    && Models.Emerald.isEmeraldPouch(slotOptional.get().getItem())) {
+                return;
+            } else if (allowClickOnMultiHealthPotionsInBlockingMode.get()
+                    && Models.Item.asWynnItem(slotOptional.get().getItem(), MultiHealthPotionItem.class)
+                            .isPresent()) {
+                return;
+            }
         }
 
         if (classSlotLockMap

--- a/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
@@ -97,7 +97,9 @@ public class ItemLockFeature extends Feature {
             if (allowClickOnEmeraldPouchInBlockingMode.get()
                     && Models.Emerald.isEmeraldPouch(slotOptional.get().getItem())) {
                 return;
-            } else if (allowClickOnMultiHealthPotionsInBlockingMode.get()
+            }
+
+            if (allowClickOnMultiHealthPotionsInBlockingMode.get()
                     && Models.Item.asWynnItem(slotOptional.get().getItem(), MultiHealthPotionItem.class)
                             .isPresent()) {
                 return;

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -719,6 +719,8 @@
   "feature.wynntils.itemHighlight.zeroStarIngredientHighlightEnabled.name": "0 Star Ingredient Highlight",
   "feature.wynntils.itemLock.allowClickOnEmeraldPouchInBlockingMode.description": "If Block All Actions on Locked Items is enabled, should opening an Emerald Pouch be allowed? You still won't be able to move your pouch.",
   "feature.wynntils.itemLock.allowClickOnEmeraldPouchInBlockingMode.name": "Allow Click on Emerald Pouch in Blocking Mode",
+  "feature.wynntils.itemLock.allowClickOnMultiHealthPotionsInBlockingMode.description": "If Block All Actions on Locked Items is enabled, should opening the Delete Potions menu be allowed? You still won't be able to move your potions.",
+  "feature.wynntils.itemLock.allowClickOnMultiHealthPotionsInBlockingMode.name": "Allow Click on Multi Health Potions in Blocking Mode",
   "feature.wynntils.itemLock.blockAllActionsOnLockedItems.description": "Should any click types be blocked on locked items?",
   "feature.wynntils.itemLock.blockAllActionsOnLockedItems.name": "Block All Actions on Locked Items",
   "feature.wynntils.itemLock.description": "Adds the ability to lock items in your inventory to prevent dropping or interacting with them.",


### PR DESCRIPTION
I believe there are no other items that have a right click in inventory action, besides ingredient pouch/compass/content book but those are "locked" by vanilla