### PR TITLE
fix: fix bigger config/storage files not getting saved properly

### DIFF
--- a/common/src/main/java/com/wynntils/core/json/JsonManager.java
+++ b/common/src/main/java/com/wynntils/core/json/JsonManager.java
@@ -76,6 +76,7 @@ public final class JsonManager extends Manager {
         try (OutputStreamWriter fileWriter =
                 new OutputStreamWriter(new FileOutputStream(jsonFile), StandardCharsets.UTF_8)) {
             GSON.toJson(jsonObject, fileWriter);
+            fileWriter.flush();
         } catch (IOException e) {
             WynntilsMod.error("Failed to save json file " + jsonFile, e);
         }


### PR DESCRIPTION
This is a long shot, there is no solid documentation on this from Java's part. Flushable/Closable are different interfaces, flushable does not extend closable. That means that a flushing before closing is an implementation specific detail, which may cause these issues.