### PR TITLE
chore: Bump workflows from alpha to beta [skip ci]

### DIFF
--- a/.github/workflows/autopromote.yml
+++ b/.github/workflows/autopromote.yml
@@ -7,9 +7,9 @@ on:
       - development
 
 jobs:
-  update-alpha:
+  update-beta:
     if: github.ref == 'refs/heads/development'
-    name: Merge development into alpha after a PR is merged
+    name: Merge development into beta after a PR is merged
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -20,7 +20,7 @@ jobs:
         with:
           github_token: ${{ secrets.PRIVATE_TOKEN }}
           source: 'development'
-          target: 'alpha'
+          target: 'beta'
 
   update-release:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,9 +1,9 @@
-name: Publish Alpha Release
+name: Publish Beta Release
 
 on:
   push:
     branches:
-      - alpha
+      - beta
 
 jobs:
   changelog:
@@ -44,7 +44,7 @@ jobs:
           skip-version-file: true
           skip-git-pull: true
           pre-release: true
-          pre-release-identifier: alpha
+          pre-release-identifier: beta
           release-count: 5
 
       - name: Create release


### PR DESCRIPTION
We really don't need to use alpha for anything, we can call pre-release versions as beta.