### PR TITLE
refactor: rewrite gammabright

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/GammabrightFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/GammabrightFeature.java
@@ -7,15 +7,11 @@ package com.wynntils.features.utilities;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
-import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.storage.Storage;
-import com.wynntils.models.worlds.event.WorldStateEvent;
-import com.wynntils.models.worlds.type.WorldState;
-import com.wynntils.utils.mc.McUtils;
+import com.wynntils.mc.event.LightmapEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.lwjgl.glfw.GLFW;
 
@@ -24,73 +20,19 @@ public class GammabrightFeature extends Feature {
     @Persisted
     public final Config<Boolean> gammabrightEnabled = new Config<>(false);
 
-    @Persisted
-    private final Storage<Double> lastGamma = new Storage<>(-1.0);
-
     @RegisterKeyBind
     private final KeyBind gammabrightKeyBind =
             new KeyBind("Gammabright", GLFW.GLFW_KEY_G, true, this::toggleGammaBright);
 
     @SubscribeEvent
-    public void onWorldStateChange(WorldStateEvent event) {
-        if (event.getNewState() != WorldState.WORLD) return;
-
-        applyGammabright();
-    }
-
-    @SubscribeEvent
-    public void onDisconnect(WynncraftConnectionEvent.Disconnected event) {
+    public void onLightmapUpdate(LightmapEvent lightmapEvent) {
         if (gammabrightEnabled.get()) {
-            resetGamma();
-        }
-    }
-
-    @Override
-    protected void onConfigUpdate(Config<?> config) {
-        if (config.getFieldName().equals("gammabrightEnabled")) {
-            applyGammabright();
-        }
-    }
-
-    @Override
-    public void onEnable() {
-        if (gammabrightEnabled.get() && McUtils.options().gamma().get() != 1000d) {
-            enableGammabright();
-        }
-    }
-
-    @Override
-    public void onDisable() {
-        resetGamma();
-    }
-
-    private void applyGammabright() {
-        if (!isEnabled()) return;
-        if (gammabrightEnabled.get() && McUtils.options().gamma().get() == 1000d) return;
-
-        if (gammabrightEnabled.get()) {
-            enableGammabright();
-        } else {
-            resetGamma();
+            lightmapEvent.setRgb(0xFFFFFFFF);
         }
     }
 
     private void toggleGammaBright() {
         gammabrightEnabled.store(!gammabrightEnabled.get());
-        applyGammabright();
-
         gammabrightEnabled.touched();
-    }
-
-    private void resetGamma() {
-        // If the gamma was never changed, don't reset it
-        if (lastGamma.get() == -1.0) return;
-
-        McUtils.options().gamma().value = lastGamma.get();
-    }
-
-    private void enableGammabright() {
-        lastGamma.store(McUtils.options().gamma().get());
-        McUtils.options().gamma().value = 1000d;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/LightmapEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/LightmapEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class LightmapEvent extends Event {
+    private int rgb;
+
+    public LightmapEvent(int rgb) {
+        this.rgb = rgb;
+    }
+
+    public int getRgb() {
+        return rgb;
+    }
+
+    public void setRgb(int rgb) {
+        this.rgb = rgb;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/LightTextureMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LightTextureMixin.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.mojang.blaze3d.platform.NativeImage;
+import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.LightmapEvent;
+import net.minecraft.client.renderer.LightTexture;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(LightTexture.class)
+public class LightTextureMixin {
+    @Redirect(
+            method = "updateLightTexture",
+            at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/NativeImage;setPixelRGBA(III)V"))
+    private void updateLightmapRGB(NativeImage image, int x, int y, int rgb) {
+        final LightmapEvent lightmapEvent = new LightmapEvent(rgb);
+        MixinHelper.post(lightmapEvent);
+        image.setPixelRGBA(x, y, lightmapEvent.getRgb());
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/LightTextureMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LightTextureMixin.java
@@ -4,22 +4,23 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.wynntils.core.events.MixinHelper;
 import com.wynntils.mc.event.LightmapEvent;
 import net.minecraft.client.renderer.LightTexture;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LightTexture.class)
 public class LightTextureMixin {
-    @Redirect(
+    @WrapOperation(
             method = "updateLightTexture",
             at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/NativeImage;setPixelRGBA(III)V"))
-    private void updateLightmapRGB(NativeImage image, int x, int y, int rgb) {
+    private void updateLightmapRGB(NativeImage image, int x, int y, int rgb, Operation<Void> original) {
         final LightmapEvent lightmapEvent = new LightmapEvent(rgb);
         MixinHelper.post(lightmapEvent);
-        image.setPixelRGBA(x, y, lightmapEvent.getRgb());
+        original.call(image, x, y, lightmapEvent.getRgb());
     }
 }

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -27,6 +27,7 @@
     "KeyMappingMixin",
     "KeyboardHandlerMixin",
     "LevelRendererMixin",
+    "LightTextureMixin",
     "LivingEntityRendererMixin",
     "LocalPlayerMixin",
     "MainMixin",


### PR DESCRIPTION
this commit rewrites the Gammabright feature.

### motivation
the current Gammabright feature writes directly to Minecraft's settings, which can potentially lead to state desync between Artemis and Minecraft, and subsequently writing out of bounds values to the Minecraft settings file. the code that manages this state is overly complex for what should be a very simple feature.

### the change
this rewrite instead simply writes our desired value (maximum brightness) directly to the lightmap. the lightmap is recalculated every render frame and never written to disk, so there is nothing to clean up. this stateless approach avoids interfering with Minecraft settings and significantly reduces the code complexity of the feature.