### PR TITLE
chore: Update mod incompatibilities [skip ci]

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -4,12 +4,11 @@
   ],
   "breaks": {
     "exordium": "*",
-    "memoryleakfix": "<1.1.2"
+    "ias": "*"
   },
   "conflicts": {
     "avomod": "*",
-    "chatpatches": "*",
-    "weirdchat": "*"
+    "chatpatches": "*"
   },
   "contact": {
     "homepage": "https://wynntils.com",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -3,8 +3,7 @@
     "Team Wynntils"
   ],
   "breaks": {
-    "exordium": "*",
-    "ias": "*"
+    "exordium": "*"
   },
   "conflicts": {
     "avomod": "*",

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -22,6 +22,11 @@ modId = "neoforge"
 mandatory = true
 versionRange = "${neoforge_version_range}"
 
+[[dependencies.wynntils]]
+modId = "ias"
+type = "incompatible"
+reason = "In-Game Account Switcher breaks Wynntils configs"
+
 [[mixins]]
 config = "wynntils.mixins.json"
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -22,11 +22,6 @@ modId = "neoforge"
 mandatory = true
 versionRange = "${neoforge_version_range}"
 
-[[dependencies.wynntils]]
-modId = "ias"
-type = "incompatible"
-reason = "In-Game Account Switcher breaks Wynntils configs"
-
 [[mixins]]
 config = "wynntils.mixins.json"
 


### PR DESCRIPTION
Weirdchat removed because the mod is dead (700 downloads, no update for a year). Also no version exists for 1.21.
Memory Leak Fix removed because 1.1.2 is only for Minecraft 1.16 or lower.