### PR TITLE
fix: Teleport scroll annotator beta port [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -427,6 +427,7 @@ public class ItemTextOverlayFeature extends Feature {
     private final class TeleportScrollOverlay implements TextOverlayInfo {
         private static final CustomColor CITY_COLOR = CustomColor.fromChatFormatting(ChatFormatting.AQUA);
         private static final CustomColor DUNGEON_COLOR = CustomColor.fromChatFormatting(ChatFormatting.GOLD);
+        private static final CustomColor OUT_OF_CHARGES_COLOR = CustomColor.fromChatFormatting(ChatFormatting.RED);
 
         private final TeleportScrollItem item;
 
@@ -441,7 +442,14 @@ public class ItemTextOverlayFeature extends Feature {
 
         @Override
         public TextOverlay getTextOverlay() {
-            CustomColor textColor = item.isDungeon() ? DUNGEON_COLOR : CITY_COLOR;
+            CustomColor textColor;
+            if (item.getRemainingCharges() <= 0) {
+                textColor = OUT_OF_CHARGES_COLOR;
+            } else if (item.isDungeon()) {
+                textColor = DUNGEON_COLOR;
+            } else {
+                textColor = CITY_COLOR;
+            }
 
             String text = item.getDestination();
             TextRenderSetting style =

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/TeleportScrollAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/TeleportScrollAnnotator.java
@@ -9,18 +9,13 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.GameItemAnnotator;
 import com.wynntils.handlers.item.ItemAnnotation;
 import com.wynntils.models.items.items.game.TeleportScrollItem;
-import com.wynntils.utils.mc.LoreUtils;
-import com.wynntils.utils.wynn.WynnUtils;
-import java.util.Arrays;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import net.minecraft.world.item.ItemStack;
 
 public final class TeleportScrollAnnotator implements GameItemAnnotator {
-    private static final Pattern TELEPORT_SCROLL_PATTERN = Pattern.compile("^§b(.*) Teleport Scroll$");
-    private static final Pattern TELEPORT_LOCATION_PATTERN = Pattern.compile("§3- §7Teleports to: §f(.*)");
+    private static final Pattern TELEPORT_SCROLL_PATTERN =
+            Pattern.compile("^§#8193ffff(.*) Teleportation Scroll §#f9e79eff\\[(\\d)/(\\d)]$");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
@@ -28,23 +23,13 @@ public final class TeleportScrollAnnotator implements GameItemAnnotator {
         if (!nameMatcher.matches()) return null;
 
         String scrollName = nameMatcher.group(1);
+        int remainingCharges = Integer.parseInt(nameMatcher.group(2));
 
-        if (scrollName.equals("Dungeon")) {
-            Matcher dungeonMatcher = LoreUtils.matchLoreLine(itemStack, 3, TELEPORT_LOCATION_PATTERN);
-            if (!dungeonMatcher.matches()) return null;
-
-            // remove "the" to properly represent forgery scrolls
-            String destination =
-                    WynnUtils.normalizeBadString(dungeonMatcher.group(1)).replace("the ", "");
-
-            destination = Arrays.stream(destination.split(" ", 2))
-                    .map(s -> s.substring(0, 1))
-                    .collect(Collectors.joining())
-                    .toUpperCase(Locale.ROOT);
-            return new TeleportScrollItem(destination, true);
-        } else {
-            String destination = Services.Destination.getAbbreviation(scrollName);
-            return new TeleportScrollItem(destination, false);
+        if (scrollName.equals("the Forgery")) {
+            return new TeleportScrollItem("For", true, remainingCharges);
         }
+
+        String destination = Services.Destination.getAbbreviation(scrollName);
+        return new TeleportScrollItem(destination, false, remainingCharges);
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/game/TeleportScrollItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/TeleportScrollItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;
@@ -9,10 +9,12 @@ import com.wynntils.models.items.properties.TargetedItemProperty;
 public class TeleportScrollItem extends GameItem implements TargetedItemProperty {
     private final String destination;
     private final boolean dungeon;
+    private final int remainingCharges;
 
-    public TeleportScrollItem(String destination, boolean dungeon) {
+    public TeleportScrollItem(String destination, boolean dungeon, int remainingCharges) {
         this.destination = destination;
         this.dungeon = dungeon;
+        this.remainingCharges = remainingCharges;
     }
 
     public String getDestination() {
@@ -23,6 +25,10 @@ public class TeleportScrollItem extends GameItem implements TargetedItemProperty
         return dungeon;
     }
 
+    public int getRemainingCharges() {
+        return remainingCharges;
+    }
+
     @Override
     public String getTarget() {
         return destination;
@@ -30,6 +36,9 @@ public class TeleportScrollItem extends GameItem implements TargetedItemProperty
 
     @Override
     public String toString() {
-        return "TeleportScrollItem{" + "destination='" + destination + '\'' + ", dungeon=" + dungeon + '}';
+        return "TeleportScrollItem{" + "destination='"
+                + destination + '\'' + ", dungeon="
+                + dungeon + ", remainingCharges="
+                + remainingCharges + '}';
     }
 }


### PR DESCRIPTION
Dungeon TP scrolls are no longer a thing (except forgery). Scrolls turn red now when out of charges.
![image](https://ryanzhou.dev/uploads/2024-07-09_01-19-19.png)