### PR TITLE
feat: Add ability tree reset and aspects containers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -8,6 +8,8 @@ import com.wynntils.core.components.Model;
 import com.wynntils.mc.event.ScreenClosedEvent;
 import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.models.containers.containers.AbilityTreeContainer;
+import com.wynntils.models.containers.containers.AbilityTreeResetContainer;
+import com.wynntils.models.containers.containers.AspectsContainer;
 import com.wynntils.models.containers.containers.CharacterInfoContainer;
 import com.wynntils.models.containers.containers.ContentBookContainer;
 import com.wynntils.models.containers.containers.CraftingStationContainer;
@@ -91,6 +93,8 @@ public final class ContainerModel extends Model {
     private void registerContainers() {
         // Order does not matter here so just keep it alphabetical
         registerContainer(new AbilityTreeContainer());
+        registerContainer(new AbilityTreeResetContainer());
+        registerContainer(new AspectsContainer());
         registerContainer(new AccountBankContainer());
         registerContainer(new BookshelfContainer());
         registerContainer(new ChallengeRewardContainer());

--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -61,7 +61,7 @@ public final class ContainerModel extends Model {
     public ContainerModel() {
         super(List.of());
 
-        registerWynncraftContainers();
+        registerContainers();
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -88,44 +88,44 @@ public final class ContainerModel extends Model {
         return currentContainer;
     }
 
-    private void registerWynncraftContainers() {
+    private void registerContainers() {
         // Order does not matter here so just keep it alphabetical
-        registerWynncraftContainer(new AbilityTreeContainer());
-        registerWynncraftContainer(new AccountBankContainer());
-        registerWynncraftContainer(new BookshelfContainer());
-        registerWynncraftContainer(new ChallengeRewardContainer());
-        registerWynncraftContainer(new CharacterBankContainer());
-        registerWynncraftContainer(new CharacterInfoContainer());
-        registerWynncraftContainer(new ContentBookContainer());
-        registerWynncraftContainer(new DailyRewardContainer());
-        registerWynncraftContainer(new FlyingChestContainer());
-        registerWynncraftContainer(new GuildBankContainer());
-        registerWynncraftContainer(new GuildManagementContainer());
-        registerWynncraftContainer(new GuildMemberListContainer());
-        registerWynncraftContainer(new GuildTerritoriesContainer());
-        registerWynncraftContainer(new HousingJukeboxContainer());
-        registerWynncraftContainer(new HousingListContainer());
-        registerWynncraftContainer(new IngredientPouchContainer());
-        registerWynncraftContainer(new IslandBlockBankContainer());
-        registerWynncraftContainer(new InventoryContainer());
-        registerWynncraftContainer(new JukeboxContainer());
-        registerWynncraftContainer(new LobbyContainer());
-        registerWynncraftContainer(new LootChestContainer());
-        registerWynncraftContainer(new MiscBucketContainer());
-        registerWynncraftContainer(new ObjectiveRewardContainer());
-        registerWynncraftContainer(new PersonalBlockBankContainer());
-        registerWynncraftContainer(new PetMenuContainer());
-        registerWynncraftContainer(new ScrapMenuContainer());
-        registerWynncraftContainer(new SeaskipperContainer());
-        registerWynncraftContainer(new TradeMarketFiltersContainer());
-        registerWynncraftContainer(new TradeMarketContainer());
+        registerContainer(new AbilityTreeContainer());
+        registerContainer(new AccountBankContainer());
+        registerContainer(new BookshelfContainer());
+        registerContainer(new ChallengeRewardContainer());
+        registerContainer(new CharacterBankContainer());
+        registerContainer(new CharacterInfoContainer());
+        registerContainer(new ContentBookContainer());
+        registerContainer(new DailyRewardContainer());
+        registerContainer(new FlyingChestContainer());
+        registerContainer(new GuildBankContainer());
+        registerContainer(new GuildManagementContainer());
+        registerContainer(new GuildMemberListContainer());
+        registerContainer(new GuildTerritoriesContainer());
+        registerContainer(new HousingJukeboxContainer());
+        registerContainer(new HousingListContainer());
+        registerContainer(new IngredientPouchContainer());
+        registerContainer(new IslandBlockBankContainer());
+        registerContainer(new InventoryContainer());
+        registerContainer(new JukeboxContainer());
+        registerContainer(new LobbyContainer());
+        registerContainer(new LootChestContainer());
+        registerContainer(new MiscBucketContainer());
+        registerContainer(new ObjectiveRewardContainer());
+        registerContainer(new PersonalBlockBankContainer());
+        registerContainer(new PetMenuContainer());
+        registerContainer(new ScrapMenuContainer());
+        registerContainer(new SeaskipperContainer());
+        registerContainer(new TradeMarketFiltersContainer());
+        registerContainer(new TradeMarketContainer());
 
         for (ProfessionType type : ProfessionType.craftingProfessionTypes()) {
-            registerWynncraftContainer(new CraftingStationContainer(Pattern.compile(type.getDisplayName()), type));
+            registerContainer(new CraftingStationContainer(Pattern.compile(type.getDisplayName()), type));
         }
     }
 
-    private void registerWynncraftContainer(Container container) {
+    private void registerContainer(Container container) {
         containerTypes.add(container);
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/containers/AbilityTreeResetContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/AbilityTreeResetContainer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.containers;
+
+import com.wynntils.models.containers.Container;
+import com.wynntils.models.containers.type.FullscreenContainerProperty;
+import java.util.regex.Pattern;
+
+public class AbilityTreeResetContainer extends Container implements FullscreenContainerProperty {
+    private static final Pattern TITLE_PATTERN = Pattern.compile("\uDAFF\uDFEA\uE001");
+
+    public AbilityTreeResetContainer() {
+        super(TITLE_PATTERN);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/containers/containers/AspectsContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/AspectsContainer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.containers;
+
+import com.wynntils.models.containers.Container;
+import com.wynntils.models.containers.type.FullscreenContainerProperty;
+import java.util.regex.Pattern;
+
+public class AspectsContainer extends Container implements FullscreenContainerProperty {
+    private static final Pattern TITLE_PATTERN = Pattern.compile("\uDAFF\uDFEA\uE002");
+
+    public AspectsContainer() {
+        super(TITLE_PATTERN);
+    }
+}


### PR DESCRIPTION
Just to stop item lock and potentially favourites rendering.

Aspects might be scrollable but I'm not certain, can't check the item name anyway if it is