### PR TITLE
fix: Fix BufferSource memory leaks

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -41,7 +41,8 @@ import net.neoforged.bus.api.SubscribeEvent;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
 public final class OverlayManager extends Manager {
-    private final MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(new ByteBufferBuilder(256));
+    private static final MultiBufferSource.BufferSource BUFFER_SOURCE =
+            MultiBufferSource.immediate(new ByteBufferBuilder(256));
 
     private final Map<Feature, List<Overlay>> overlayParentMap = new HashMap<>();
     private final Map<Overlay, OverlayInfoContainer> overlayInfoMap = new HashMap<>();
@@ -269,10 +270,10 @@ public final class OverlayManager extends Manager {
                     if (selectedOverlay != null && overlay != selectedOverlay && !renderNonSelected) continue;
 
                     overlay.renderPreview(
-                            event.getPoseStack(), bufferSource, event.getDeltaTracker(), event.getWindow());
+                            event.getPoseStack(), BUFFER_SOURCE, event.getDeltaTracker(), event.getWindow());
                 } else if (shouldRender) {
                     long startTime = System.currentTimeMillis();
-                    overlay.render(event.getPoseStack(), bufferSource, event.getDeltaTracker(), event.getWindow());
+                    overlay.render(event.getPoseStack(), BUFFER_SOURCE, event.getDeltaTracker(), event.getWindow());
                     logProfilingData(startTime, overlay);
                 }
             } catch (Throwable t) {
@@ -291,7 +292,7 @@ public final class OverlayManager extends Manager {
             }
         }
 
-        bufferSource.endBatch();
+        BUFFER_SOURCE.endBatch();
 
         // Hopefully we have none :)
         for (Overlay overlay : crashedOverlays) {

--- a/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
@@ -120,8 +120,9 @@ public class ItemScreenshotFeature extends Feature {
         // draw tooltip to framebuffer, create image
         McUtils.mc().getMainRenderTarget().unbindWrite();
 
-        GuiGraphics guiGraphics =
-                new GuiGraphics(McUtils.mc(), MultiBufferSource.immediate(new ByteBufferBuilder(256)));
+        ByteBufferBuilder byteBuffer = new ByteBufferBuilder(256);
+        MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(byteBuffer);
+        GuiGraphics guiGraphics = new GuiGraphics(McUtils.mc(), bufferSource);
         RenderTarget fb = new MainTarget(width * 2, height * 2);
         fb.setClearColor(1f, 1f, 1f, 0f);
         fb.createBuffers(width * 2, height * 2, false);
@@ -140,6 +141,10 @@ public class ItemScreenshotFeature extends Feature {
         McUtils.mc().getMainRenderTarget().bindWrite(true);
 
         BufferedImage bi = SystemUtils.createScreenshot(fb);
+
+        // Free the buffer source to prevent memory leaks
+        byteBuffer.close();
+        bufferSource = null;
 
         if (saveToDisk.get()) {
             // First try to save it to disk

--- a/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
@@ -28,6 +28,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.MAP)
 public class BeaconBeamFeature extends Feature {
+    private static final MultiBufferSource.BufferSource BUFFER_SOURCE =
+            MultiBufferSource.immediate(new ByteBufferBuilder(256));
+
     @Persisted
     public final Config<CustomColor> waypointBeamColor = new Config<>(CommonColors.RED);
 
@@ -65,7 +68,6 @@ public class BeaconBeamFeature extends Feature {
         if (markers.isEmpty()) return;
 
         PoseStack poseStack = event.getPoseStack();
-        MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(new ByteBufferBuilder(256));
 
         for (MarkerInfo marker : markers) {
             Position camera = event.getCamera().getPosition();
@@ -106,7 +108,7 @@ public class BeaconBeamFeature extends Feature {
 
             BeaconRenderer.renderBeaconBeam(
                     poseStack,
-                    bufferSource,
+                    BUFFER_SOURCE,
                     BeaconRenderer.BEAM_LOCATION,
                     event.getDeltaTracker().getGameTimeDeltaPartialTick(false),
                     1f,
@@ -120,6 +122,6 @@ public class BeaconBeamFeature extends Feature {
             poseStack.popPose();
         }
 
-        bufferSource.endLastBatch();
+        BUFFER_SOURCE.endLastBatch();
     }
 }

--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -44,6 +44,8 @@ import org.joml.Vector4f;
 
 @ConfigCategory(Category.MAP)
 public class WorldWaypointDistanceFeature extends Feature {
+    private static final MultiBufferSource.BufferSource BUFFER_SOURCE =
+            MultiBufferSource.immediate(new ByteBufferBuilder(256));
     private static final WaypointPoi DUMMY_WAYPOINT = new WaypointPoi(() -> null, "");
 
     @Persisted
@@ -208,12 +210,11 @@ public class WorldWaypointDistanceFeature extends Feature {
                 poseStack.mulPose(new Quaternionf().rotationXYZ(0, 0, (float) Math.toRadians(angle)));
                 poseStack.translate(-pointerDisplayPositionX, -pointerDisplayPositionY, 0);
 
-                MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(new ByteBufferBuilder(256));
                 DUMMY_WAYPOINT
                         .getPointerPoi()
                         .renderAt(
                                 poseStack,
-                                bufferSource,
+                                BUFFER_SOURCE,
                                 pointerDisplayPositionX,
                                 pointerDisplayPositionY,
                                 false,
@@ -221,7 +222,7 @@ public class WorldWaypointDistanceFeature extends Feature {
                                 1,
                                 50,
                                 true);
-                bufferSource.endBatch();
+                BUFFER_SOURCE.endBatch();
                 poseStack.popPose();
             }
         }

--- a/common/src/main/java/com/wynntils/screens/activities/WynntilsCaveScreen.java
+++ b/common/src/main/java/com/wynntils/screens/activities/WynntilsCaveScreen.java
@@ -52,6 +52,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 
 public final class WynntilsCaveScreen extends WynntilsListScreen<CaveInfo, CaveButton>
         implements SortableActivityScreen {
+    private static final MultiBufferSource.BufferSource BUFFER_SOURCE =
+            MultiBufferSource.immediate(new ByteBufferBuilder(256));
+
     private ActivitySortOrder activitySortOrder = ActivitySortOrder.LEVEL;
     private CaveInfo trackingRequested = null;
 
@@ -228,8 +231,6 @@ public final class WynntilsCaveScreen extends WynntilsListScreen<CaveInfo, CaveB
 
         List<MapTexture> maps = Services.Map.getMapsForBoundingBox(textureBoundingBox);
 
-        MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(new ByteBufferBuilder(256));
-
         for (MapTexture map : maps) {
             float textureX = map.getTextureXPosition(mapCenterX);
             float textureZ = map.getTextureZPosition(mapCenterZ);
@@ -237,7 +238,7 @@ public final class WynntilsCaveScreen extends WynntilsListScreen<CaveInfo, CaveB
             MapRenderer.renderMapQuad(
                     map,
                     poseStack,
-                    bufferSource,
+                    BUFFER_SOURCE,
                     centerX,
                     centerZ,
                     textureX,
@@ -247,7 +248,7 @@ public final class WynntilsCaveScreen extends WynntilsListScreen<CaveInfo, CaveB
                     1f / currentZoom);
         }
 
-        bufferSource.endBatch();
+        BUFFER_SOURCE.endBatch();
 
         RenderUtils.disableScissor();
     }

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -44,6 +44,9 @@ import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
 public abstract class AbstractMapScreen extends WynntilsScreen {
+    protected static final MultiBufferSource.BufferSource BUFFER_SOURCE =
+            MultiBufferSource.immediate(new ByteBufferBuilder(256));
+
     protected static final float SCREEN_SIDE_OFFSET = 10;
     private static final float BORDER_OFFSET = 6;
     private static final int MAP_CENTER_X = -400;
@@ -370,8 +373,6 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
 
         List<MapTexture> maps = Services.Map.getMapsForBoundingBox(textureBoundingBox);
 
-        MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(new ByteBufferBuilder(256));
-
         for (MapTexture map : maps) {
             float textureX = map.getTextureXPosition(mapCenterX);
             float textureZ = map.getTextureZPosition(mapCenterZ);
@@ -379,7 +380,7 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
             MapRenderer.renderMapQuad(
                     map,
                     poseStack,
-                    bufferSource,
+                    BUFFER_SOURCE,
                     centerX,
                     centerZ,
                     textureX,
@@ -389,7 +390,7 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                     1f / zoomRenderScale);
         }
 
-        bufferSource.endBatch();
+        BUFFER_SOURCE.endBatch();
 
         RenderUtils.disableScissor();
     }

--- a/common/src/main/java/com/wynntils/utils/render/FontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/FontRenderer.java
@@ -25,6 +25,8 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.util.Mth;
 
 public final class FontRenderer {
+    private static final MultiBufferSource.BufferSource BUFFER_SOURCE =
+            MultiBufferSource.immediate(new ByteBufferBuilder(256));
     private static final FontRenderer INSTANCE = new FontRenderer();
     private final Font font;
 
@@ -54,12 +56,10 @@ public final class FontRenderer {
             VerticalAlignment verticalAlignment,
             TextShadow shadow,
             float textScale) {
-        MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(new ByteBufferBuilder(256));
-
         BufferedFontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        bufferSource,
+                        BUFFER_SOURCE,
                         text,
                         x,
                         y,
@@ -69,7 +69,7 @@ public final class FontRenderer {
                         shadow,
                         textScale);
 
-        bufferSource.endBatch();
+        BUFFER_SOURCE.endBatch();
     }
 
     public void renderText(


### PR DESCRIPTION
This was actually quite stupid, this should have caused issues earlier. These buffer sources use MALLOC to allocate memory, so detecting it with regular Java Profilers was not possible before (as they generally profile heap allocations).