### PR TITLE
feat: Port LabelHandler to TextDisplay (without porting usages) [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/labels/event/EntityLabelChangedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/labels/event/EntityLabelChangedEvent.java
@@ -11,6 +11,8 @@ import net.minecraft.world.entity.Entity;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
+// Use TextDisplayChangedEvent.Component instead, Wynn does not use armor stands for most of its labels
+@Deprecated
 public class EntityLabelChangedEvent extends Event implements ICancellableEvent {
     private final Entity entity;
     private final StyledText oldName;

--- a/common/src/main/java/com/wynntils/handlers/labels/event/EntityLabelVisibilityEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/labels/event/EntityLabelVisibilityEvent.java
@@ -7,6 +7,8 @@ package com.wynntils.handlers.labels.event;
 import net.minecraft.world.entity.Entity;
 import net.neoforged.bus.api.Event;
 
+// Use TextDisplayChangedEvent instead, Wynn does not use armor stands for most of its labels
+@Deprecated
 public class EntityLabelVisibilityEvent extends Event {
     private final Entity entity;
     private final boolean value;

--- a/common/src/main/java/com/wynntils/handlers/labels/event/TextDisplayChangedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/labels/event/TextDisplayChangedEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.labels.event;
+
+import com.wynntils.core.text.StyledText;
+import net.minecraft.world.entity.Display;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+/**
+ * This event is called when data of a {@link net.minecraft.world.entity.Display.TextDisplay} is changed.
+ * <p>
+ * The various events are cancellable.
+ */
+public abstract class TextDisplayChangedEvent extends Event implements ICancellableEvent {
+    private final Display.TextDisplay textDisplay;
+
+    protected TextDisplayChangedEvent(Display.TextDisplay textDisplay) {
+        this.textDisplay = textDisplay;
+    }
+
+    public Display.TextDisplay getTextDisplay() {
+        return textDisplay;
+    }
+
+    public static class Text extends TextDisplayChangedEvent {
+        private StyledText text;
+
+        public Text(Display.TextDisplay textDisplay, StyledText text) {
+            super(textDisplay);
+            this.text = text;
+        }
+
+        public StyledText getText() {
+            return text;
+        }
+
+        public void setText(StyledText text) {
+            this.text = text;
+        }
+    }
+}

--- a/common/src/main/resources/wynntils.accessWidener
+++ b/common/src/main/resources/wynntils.accessWidener
@@ -32,6 +32,7 @@ accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScr
 accessible field net/minecraft/client/renderer/entity/ItemRenderer textureManager Lnet/minecraft/client/renderer/texture/TextureManager;
 accessible field net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation name Lnet/minecraft/network/chat/Component;
 accessible field net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateNameOperation name Lnet/minecraft/network/chat/Component;
+accessible field net/minecraft/world/entity/Display$TextDisplay DATA_TEXT_ID Lnet/minecraft/network/syncher/EntityDataAccessor;
 accessible field net/minecraft/world/entity/Entity DATA_CUSTOM_NAME Lnet/minecraft/network/syncher/EntityDataAccessor;
 accessible field net/minecraft/world/entity/Entity DATA_CUSTOM_NAME_VISIBLE Lnet/minecraft/network/syncher/EntityDataAccessor;
 accessible field net/minecraft/world/entity/item/ItemEntity DATA_ITEM Lnet/minecraft/network/syncher/EntityDataAccessor;
@@ -52,6 +53,7 @@ accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/St
 accessible method net/minecraft/client/renderer/blockentity/BeaconRenderer renderBeaconBeam (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/resources/ResourceLocation;FFJIIIFF)V
 accessible method net/minecraft/client/resources/server/DownloadedPackSource tryParseSha1Hash (Ljava/lang/String;)Lcom/google/common/hash/HashCode;
 accessible method net/minecraft/network/chat/Style <init> (Lnet/minecraft/network/chat/TextColor;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lnet/minecraft/network/chat/ClickEvent;Lnet/minecraft/network/chat/HoverEvent;Ljava/lang/String;Lnet/minecraft/resources/ResourceLocation;)V
+accessible method net/minecraft/world/entity/Display$TextDisplay getText ()Lnet/minecraft/network/chat/Component;
 accessible method net/minecraft/world/entity/Entity setSharedFlag (IZ)V
 extendable class net/minecraft/world/item/ItemStack
 extendable method net/minecraft/client/gui/components/AbstractSelectionList getEntryAtPosition (DD)Lnet/minecraft/client/gui/components/AbstractSelectionList$Entry;


### PR DESCRIPTION
This commit ports LabelHandler to TextDisplays, which are used instead of hidden armor stands in newer MC versions.