### PR TITLE
feat: Improve chat tab switching hotkeys [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -50,6 +50,9 @@ public class ChatTabsFeature extends Feature {
             new ChatTab("Private", false, "/r  ", Sets.newHashSet(RecipientType.PRIVATE), null),
             new ChatTab("Shout", false, null, Sets.newHashSet(RecipientType.SHOUT), null))));
 
+    @Persisted(i18nKey = "feature.wynntils.chatTabs.oldTabHotkey")
+    public final Config<Boolean> oldTabHotkey = new Config<>(false);
+
     // We do this here, and not in Services.ChatTab to not introduce a feature-model dependency.
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onChatReceived(ChatMessageReceivedEvent event) {
@@ -125,13 +128,38 @@ public class ChatTabsFeature extends Feature {
 
     @SubscribeEvent
     public void onChatScreenKeyTyped(ChatScreenKeyTypedEvent event) {
-        // We can't use keybinds here to not conflict with TAB key's other behaviours.
-        if (event.getKeyCode() != GLFW.GLFW_KEY_TAB) return;
         if (!(McUtils.mc().screen instanceof ChatScreen)) return;
-        if (!KeyboardUtils.isShiftDown()) return;
 
-        event.setCanceled(true);
-        Services.ChatTab.setFocusedTab(Services.ChatTab.getNextFocusedTab());
+        int keyCode = event.getKeyCode();
+        if (keyCode == GLFW.GLFW_KEY_TAB) {
+            boolean reverse = false;
+
+            if (KeyboardUtils.isShiftDown()) {
+                if (oldTabHotkey.get()) {
+                    Services.ChatTab.setFocusedTab(Services.ChatTab.getNextFocusedTab());
+                    event.setCanceled(true);
+                    return;
+                } else {
+                    reverse = true;
+                }
+            }
+
+            if (KeyboardUtils.isControlDown() && !oldTabHotkey.get()) {
+                int newTab = reverse ? Services.ChatTab.getLastFocusedTab() : Services.ChatTab.getNextFocusedTab();
+                Services.ChatTab.setFocusedTab(newTab);
+                event.setCanceled(true);
+                return;
+            }
+        }
+
+        if (keyCode >= GLFW.GLFW_KEY_1 && keyCode <= GLFW.GLFW_KEY_9) {
+            ChatTab newTab = Services.ChatTab.getTab(keyCode - GLFW.GLFW_KEY_1);
+            if (newTab != null) {
+                Services.ChatTab.setFocusedTab(newTab);
+            }
+            event.setCanceled(true);
+            return;
+        }
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)

--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -132,27 +132,27 @@ public class ChatTabsFeature extends Feature {
 
         int keyCode = event.getKeyCode();
         if (keyCode == GLFW.GLFW_KEY_TAB) {
-            boolean reverse = false;
-
-            if (KeyboardUtils.isShiftDown()) {
-                if (oldTabHotkey.get()) {
-                    Services.ChatTab.setFocusedTab(Services.ChatTab.getNextFocusedTab());
-                    event.setCanceled(true);
-                    return;
-                } else {
-                    reverse = true;
+            int newTab = -1;
+            if (oldTabHotkey.get()) {
+                if (KeyboardUtils.isShiftDown()) {
+                    newTab = Services.ChatTab.getNextFocusedTab();
+                }
+            } else {
+                if (KeyboardUtils.isControlDown()) {
+                    newTab = KeyboardUtils.isShiftDown()
+                            ? Services.ChatTab.getLastFocusedTab()
+                            : Services.ChatTab.getNextFocusedTab();
                 }
             }
 
-            if (KeyboardUtils.isControlDown() && !oldTabHotkey.get()) {
-                int newTab = reverse ? Services.ChatTab.getLastFocusedTab() : Services.ChatTab.getNextFocusedTab();
-                Services.ChatTab.setFocusedTab(newTab);
-                event.setCanceled(true);
-                return;
-            }
+            if (newTab == -1) return;
+
+            Services.ChatTab.setFocusedTab(newTab);
+            event.setCanceled(true);
+            return;
         }
 
-        if (keyCode >= GLFW.GLFW_KEY_1 && keyCode <= GLFW.GLFW_KEY_9) {
+        if (KeyboardUtils.isControlDown() && keyCode >= GLFW.GLFW_KEY_1 && keyCode <= GLFW.GLFW_KEY_9) {
             ChatTab newTab = Services.ChatTab.getTab(keyCode - GLFW.GLFW_KEY_1);
             if (newTab != null) {
                 Services.ChatTab.setFocusedTab(newTab);

--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -50,7 +50,7 @@ public class ChatTabsFeature extends Feature {
             new ChatTab("Private", false, "/r  ", Sets.newHashSet(RecipientType.PRIVATE), null),
             new ChatTab("Shout", false, null, Sets.newHashSet(RecipientType.SHOUT), null))));
 
-    @Persisted(i18nKey = "feature.wynntils.chatTabs.oldTabHotkey")
+    @Persisted
     public final Config<Boolean> oldTabHotkey = new Config<>(false);
 
     // We do this here, and not in Services.ChatTab to not introduce a feature-model dependency.
@@ -140,7 +140,7 @@ public class ChatTabsFeature extends Feature {
             } else {
                 if (KeyboardUtils.isControlDown()) {
                     newTab = KeyboardUtils.isShiftDown()
-                            ? Services.ChatTab.getLastFocusedTab()
+                            ? Services.ChatTab.getPreviousFocusedTab()
                             : Services.ChatTab.getNextFocusedTab();
                 }
             }

--- a/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
+++ b/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
@@ -81,10 +81,9 @@ public final class ChatTabService extends Service {
         return (getTabIndex(getFocusedTab()) + 1) % getTabCount();
     }
 
-    public int getLastFocusedTab() {
-        int tabCount = getTabCount();
-        int lastTab = getTabIndex(getFocusedTab()) - 1;
-        return lastTab == -1 ? tabCount - 1 : lastTab;
+    public int getPreviousFocusedTab() {
+        int tabIndex = getTabIndex(getFocusedTab());
+        return (tabIndex - 1 + getTabCount()) % getTabCount();
     }
 
     public void refocusFirstTab() {

--- a/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
+++ b/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
@@ -81,6 +81,12 @@ public final class ChatTabService extends Service {
         return (getTabIndex(getFocusedTab()) + 1) % getTabCount();
     }
 
+    public int getLastFocusedTab() {
+        int tabCount = getTabCount();
+        int lastTab = getTabIndex(getFocusedTab()) - 1;
+        return lastTab == -1 ? tabCount - 1 : lastTab;
+    }
+
     public void refocusFirstTab() {
         if (!isTabListEmpty()) {
             setFocusedTab(0);

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -239,6 +239,8 @@
   "feature.wynntils.chatRedirect.unusedPoints.notificationSkill": "You have %s unused skill points",
   "feature.wynntils.chatTabs.description": "Adds the ability to create separate chats for different message types.",
   "feature.wynntils.chatTabs.name": "Chat Tabs",
+  "feature.wynntils.chatTabs.oldTabHotkey.description": "Should the tab cycling hotkey be Shift+Tab instead of Ctrl+Tab/Ctrl+Shift+Tab?",
+  "feature.wynntils.chatTabs.oldTabHotkey.name": "Old Tab Cycling Hotkey",
   "feature.wynntils.chatTimestamp.description": "Adds timestamps to chat messages.",
   "feature.wynntils.chatTimestamp.formatPattern.description": "How should the timestamp look like in chat?",
   "feature.wynntils.chatTimestamp.formatPattern.name": "Timestamp Format",


### PR DESCRIPTION
Adds Ctrl+[1-9] hotkeys for switching chat tabs and changes the Shift+Tab hotkey to Ctrl+Tab instead, which is the same as most other software and also allows for Ctrl+Shift+Tab to cycle tabs backwards.

I've also added a setting to change the latter back since this seems to be a personal preference, though I've made it off by default because in my opinion it's a bit unintuitive. (I had no idea this was already implemented until I looked at the source code)