### PR TITLE
refactor: Move ChatMessageReceivedEvent and ClientsideMessageEvent to StyledText (only) [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -36,7 +36,7 @@ public class ChatCoordinatesFeature extends Feature {
         // No changes were made, there were no coordinates.
         if (styledText.equals(modified)) return;
 
-        e.setMessage(modified.getComponent());
+        e.setMessage(modified);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -50,7 +50,7 @@ public class ChatCoordinatesFeature extends Feature {
         // No changes were made, there were no coordinates.
         if (styledText.equals(modified)) return;
 
-        e.setMessage(modified.getComponent());
+        e.setMessage(modified);
     }
 
     private static StyledText getStyledTextWithCoordinatesInserted(StyledText styledText) {

--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -164,7 +164,7 @@ public class ChatItemFeature extends Feature {
 
         if (modified.equals(styledText)) return;
 
-        e.setMessage(modified.getComponent());
+        e.setMessage(modified);
     }
 
     private void shareItem(Slot hoveredSlot, boolean share) {

--- a/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -136,7 +136,7 @@ public class ChatMentionFeature extends Feature {
         if (styledText.equals(modified)) return;
 
         if (markMention.get()) {
-            e.setMessage(modified.getComponent());
+            e.setMessage(modified);
         }
 
         if (dingMention.get()) {

--- a/common/src/main/java/com/wynntils/features/chat/ChatTimestampFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTimestampFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.utils.mc.McUtils;
 import java.time.LocalDateTime;
@@ -46,7 +47,7 @@ public class ChatTimestampFeature extends Feature {
     public void onChat(ChatMessageReceivedEvent event) {
         if (formatter == null) return;
 
-        Component message = event.getMessage();
+        StyledText message = event.getStyledText();
 
         LocalDateTime date = LocalDateTime.now();
         MutableComponent timestamp = Component.empty()
@@ -54,8 +55,8 @@ public class ChatTimestampFeature extends Feature {
                 .append(Component.literal(date.format(formatter)).withStyle(ChatFormatting.GRAY))
                 .append(Component.literal("] ").withStyle(ChatFormatting.DARK_GRAY));
 
-        timestamp.append(message);
+        message = message.prepend(StyledText.fromComponent(timestamp));
 
-        event.setMessage(timestamp);
+        event.setMessage(message);
     }
 }

--- a/common/src/main/java/com/wynntils/features/chat/GuildRankReplacementFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/GuildRankReplacementFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -58,7 +58,7 @@ public class GuildRankReplacementFeature extends Feature {
 
         if (originalStyledText.equals(modified)) return; // no changes
 
-        e.setMessage(modified.getComponent());
+        e.setMessage(modified);
     }
 
     private StyledText modifyByRemovingRank(StyledText styledText) {

--- a/common/src/main/java/com/wynntils/features/chat/RevealNicknamesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/RevealNicknamesFeature.java
@@ -119,7 +119,7 @@ public class RevealNicknamesFeature extends Feature {
             return IterationDecision.CONTINUE;
         });
 
-        event.setMessage(styledText.getComponent());
+        event.setMessage(styledText);
     }
 
     public enum NicknameReplaceOption {

--- a/common/src/main/java/com/wynntils/features/redirects/AbilityRefreshRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/AbilityRefreshRedirectFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.redirects;
@@ -22,7 +22,7 @@ public class AbilityRefreshRedirectFeature extends Feature {
     public void onChat(ChatMessageReceivedEvent event) {
         if (event.getOriginalStyledText().matches(REFRESH_PATTERN, PartStyle.StyleType.NONE)) {
             event.setCanceled(true);
-            Managers.Notification.queueMessage(event.getOriginalMessage());
+            Managers.Notification.queueMessage(event.getOriginalStyledText());
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/redirects/BlacksmithRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/BlacksmithRedirectFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.redirects;
@@ -59,7 +59,8 @@ public class BlacksmithRedirectFeature extends Feature {
         // This is for selling items for emeralds.
         if (messageMatcher.group(1).equals("sold me")) {
             // Tally up the items that we sold.
-            for (Component sibling : event.getOriginalMessage().getSiblings()) {
+            for (Component sibling :
+                    event.getOriginalStyledText().getComponent().getSiblings()) {
                 // Retrieve the color code of the item, and then match it to the item tier.
                 Matcher itemMatcher =
                         StyledText.fromComponent(sibling).getMatcher(ITEM_PATTERN); // Second group contains the items.

--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -70,7 +70,7 @@ public class TranscribeMessagesFeature extends Feature {
 
         if (styledText.equals(modified)) return;
 
-        event.setMessage(modified.getComponent());
+        event.setMessage(modified);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.chat.event;
@@ -7,48 +7,32 @@ package com.wynntils.handlers.chat.event;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.type.MessageType;
 import com.wynntils.handlers.chat.type.RecipientType;
-import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
 public class ChatMessageReceivedEvent extends Event {
     // These are used to keep the original message so different features don't have to fight over it.
-    private final Component originalMessage;
     private final StyledText originalStyledText;
 
-    private Component message;
     private StyledText styledText;
 
     private final MessageType messageType;
     private final RecipientType recipientType;
 
-    public ChatMessageReceivedEvent(
-            Component message, StyledText styledText, MessageType messageType, RecipientType recipientType) {
-        this.originalMessage = message;
+    public ChatMessageReceivedEvent(StyledText styledText, MessageType messageType, RecipientType recipientType) {
         this.originalStyledText = styledText;
-
-        this.message = message;
-        this.styledText = styledText; // message, but as a styled string
+        this.styledText = styledText;
         this.messageType = messageType;
         this.recipientType = recipientType;
     }
 
-    public void setMessage(Component message) {
-        this.message = message;
-        this.styledText = StyledText.fromComponent(message);
-    }
-
-    public Component getOriginalMessage() {
-        return originalMessage;
+    public void setMessage(StyledText styledText) {
+        this.styledText = styledText;
     }
 
     public StyledText getOriginalStyledText() {
         return originalStyledText;
-    }
-
-    public Component getMessage() {
-        return message;
     }
 
     public StyledText getStyledText() {

--- a/common/src/main/java/com/wynntils/mc/event/ClientsideMessageEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ClientsideMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;
@@ -12,35 +12,21 @@ import net.minecraftforge.eventbus.api.Event;
 // Fired when a message is sent to the local chat.
 @Cancelable
 public class ClientsideMessageEvent extends Event {
-    private final Component originalComponent;
     private final StyledText originalStyledText;
 
-    private Component component;
     private StyledText styledText;
 
     public ClientsideMessageEvent(Component component) {
-        this.originalComponent = component;
         this.originalStyledText = StyledText.fromComponent(component);
-
-        this.component = originalComponent;
         this.styledText = originalStyledText;
     }
 
-    public void setMessage(Component component) {
-        this.component = component;
-        this.styledText = StyledText.fromComponent(component);
-    }
-
-    public Component getOriginalComponent() {
-        return originalComponent;
+    public void setMessage(StyledText styledText) {
+        this.styledText = styledText;
     }
 
     public StyledText getOriginalStyledText() {
         return originalStyledText;
-    }
-
-    public Component getComponent() {
-        return component;
     }
 
     public StyledText getStyledText() {

--- a/common/src/main/java/com/wynntils/models/npcdialogue/NpcDialogueModel.java
+++ b/common/src/main/java/com/wynntils/models/npcdialogue/NpcDialogueModel.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Pattern;
-import net.minecraft.network.chat.Component;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class NpcDialogueModel extends Model {
@@ -83,20 +82,17 @@ public class NpcDialogueModel extends Model {
         return List.copyOf(confirmationlessDialogues);
     }
 
-    public void handleDialogue(List<Component> chatMessage, boolean protectedDialogue, NpcDialogueType type) {
-        List<StyledText> msg =
-                chatMessage.stream().map(StyledText::fromComponent).toList();
-
+    public void handleDialogue(List<StyledText> chatMessage, boolean protectedDialogue, NpcDialogueType type) {
         // Print dialogue to the system log
-        WynntilsMod.info(
-                "[NPC] Type: " + (msg.isEmpty() ? "<empty> " : "") + (protectedDialogue ? "<protected> " : "") + type);
-        msg.forEach(s -> WynntilsMod.info("[NPC] " + (s.isEmpty() ? "<empty>" : s)));
+        WynntilsMod.info("[NPC] Type: " + (chatMessage.isEmpty() ? "<empty> " : "")
+                + (protectedDialogue ? "<protected> " : "") + type);
+        chatMessage.forEach(s -> WynntilsMod.info("[NPC] " + (s.isEmpty() ? "<empty>" : s)));
 
         // The same message can be repeating before we have finished removing the old
         // Just remove the old and add the new with an updated remove time
         // It can also happen that a confirmationless dialogue turn into a normal
         // dialogue after a while (the "Press SHIFT..." text do not appear immediately)
-        confirmationlessDialogues.removeIf(d -> d.currentDialogue().equals(msg));
+        confirmationlessDialogues.removeIf(d -> d.currentDialogue().equals(chatMessage));
 
         // If the message is "NONE", set an empty dialogue
         if (type == NpcDialogueType.NONE) {
@@ -109,14 +105,14 @@ public class NpcDialogueModel extends Model {
         // If the message is the same as the current one, and the mode is "normal", don't update it
         // (ChatHandler already filters duplicates, but there are rare cases where the same dialogue is refreshed after
         // a while)
-        if (type == NpcDialogueType.NORMAL && currentDialogue.currentDialogue().equals(msg)) return;
+        if (type == NpcDialogueType.NORMAL && currentDialogue.currentDialogue().equals(chatMessage)) return;
 
         NpcDialogue dialogue = new NpcDialogue(
-                msg,
+                chatMessage,
                 type,
                 protectedDialogue,
                 System.currentTimeMillis(),
-                System.currentTimeMillis() + calculateMessageReadTime(msg));
+                System.currentTimeMillis() + calculateMessageReadTime(chatMessage));
 
         if (type == NpcDialogueType.CONFIRMATIONLESS) {
             confirmationlessDialogues.add(dialogue);
@@ -124,10 +120,11 @@ public class NpcDialogueModel extends Model {
             currentDialogue = dialogue;
         }
 
-        if (!msg.isEmpty() && msg.get(0).getMatcher(NEW_QUEST_STARTED).find()) {
+        if (!chatMessage.isEmpty()
+                && chatMessage.get(0).getMatcher(NEW_QUEST_STARTED).find()) {
             // TODO: Show nice banner notification instead
             // but then we'd also need to confirm it with a sneak
-            Managers.Notification.queueMessage(msg.get(0));
+            Managers.Notification.queueMessage(chatMessage.get(0));
         }
 
         NpcDialogueProcessingEvent.Pre event = new NpcDialogueProcessingEvent.Pre(dialogue);
@@ -140,19 +137,16 @@ public class NpcDialogueModel extends Model {
                 return;
             }
 
-            // Capture the old dialogue from the method
-            final NpcDialogue oldDialogue = dialogue;
-
             // Should never happen, but just in case
             if (styledTexts.isEmpty()) {
                 WynntilsMod.warn("Dialogue processing returned an empty list.");
-                WynntilsMod.postEvent(new NpcDialogueProcessingEvent.Post(oldDialogue, oldDialogue.currentDialogue()));
+                WynntilsMod.postEvent(new NpcDialogueProcessingEvent.Post(dialogue, dialogue.currentDialogue()));
                 return;
             }
 
             // If the dialogue is the same as the old one, don't do anything
-            if (oldDialogue.currentDialogue().equals(styledTexts)) {
-                WynntilsMod.postEvent(new NpcDialogueProcessingEvent.Post(oldDialogue, styledTexts));
+            if (dialogue.currentDialogue().equals(styledTexts)) {
+                WynntilsMod.postEvent(new NpcDialogueProcessingEvent.Post(dialogue, styledTexts));
                 return;
             }
 
@@ -161,17 +155,17 @@ public class NpcDialogueModel extends Model {
             // Update the dialogue with the new one
             NpcDialogue newDialogue = new NpcDialogue(
                     styledTexts,
-                    oldDialogue.dialogueType(),
-                    oldDialogue.isProtected(),
-                    oldDialogue.addTime(),
-                    oldDialogue.removeTime());
+                    dialogue.dialogueType(),
+                    dialogue.isProtected(),
+                    dialogue.addTime(),
+                    dialogue.removeTime());
 
             // Update the current dialogue
-            if (oldDialogue == currentDialogue) {
+            if (dialogue == currentDialogue) {
                 currentDialogue = newDialogue;
             } else {
                 // Update the confirmationless dialogues, if the old dialogue is still in the list
-                if (confirmationlessDialogues.remove(oldDialogue)) {
+                if (confirmationlessDialogues.remove(dialogue)) {
                     confirmationlessDialogues.add(newDialogue);
                 }
             }

--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -146,8 +146,7 @@ public class RaidModel extends Model {
     public void onChatReceived(ChatMessageReceivedEvent event) {
         if (currentRaid == null) return;
 
-        Component component = event.getMessage();
-        StyledText styledText = StyledText.fromComponent(component);
+        StyledText styledText = event.getOriginalStyledText();
 
         if (styledText.equals(RAID_FAILED)) {
             // Raid failed, post event with timers

--- a/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
+++ b/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
@@ -138,7 +138,7 @@ public final class ChatTabService extends Service {
             if (!chatTab.isConsuming()) continue;
 
             if (matchMessageFromEvent(chatTab, event)) {
-                addMessageToTab(chatTab, event.getComponent());
+                addMessageToTab(chatTab, event.getStyledText().getComponent());
                 return;
             }
         }
@@ -148,7 +148,7 @@ public final class ChatTabService extends Service {
             if (chatTab.isConsuming()) continue;
 
             if (matchMessageFromEvent(chatTab, event)) {
-                addMessageToTab(chatTab, event.getComponent());
+                addMessageToTab(chatTab, event.getStyledText().getComponent());
             }
         }
     }
@@ -159,7 +159,7 @@ public final class ChatTabService extends Service {
             if (!chatTab.isConsuming()) continue;
 
             if (matchMessageFromEvent(chatTab, event)) {
-                addMessageToTab(chatTab, event.getMessage());
+                addMessageToTab(chatTab, event.getStyledText().getComponent());
                 return;
             }
         }
@@ -169,7 +169,7 @@ public final class ChatTabService extends Service {
             if (chatTab.isConsuming()) continue;
 
             if (matchMessageFromEvent(chatTab, event)) {
-                addMessageToTab(chatTab, event.getMessage());
+                addMessageToTab(chatTab, event.getStyledText().getComponent());
             }
         }
     }


### PR DESCRIPTION
This PR is in preparation for some beta-testing of better confirmation-less dialogue parsing. I am making this as a separate PR, since these are sane changes, but the dialogue parsing may have to be reverted, so the separation should make it easier to revert, if needed.

Previously, I did not do this move, as I wanted the event to provide a way to access the original component. However, the original component is not used anywhere, and the component itself is overridden with StyledText generated components in multiple places.