### PR TITLE
fix: Fix player nametags rendering incorrectly [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
@@ -765,7 +765,7 @@ public final class RenderUtils {
             matrixStack.pushPose();
             matrixStack.translate(0.0F, yOffset, 0.0F);
             matrixStack.mulPose(dispatcher.cameraOrientation());
-            matrixStack.scale(0.025F * nametagScale, -0.025F * nametagScale, 0.025F * nametagScale);
+            matrixStack.scale(0.025F * nametagScale, -0.025F * nametagScale, -0.025F * nametagScale);
             Matrix4f matrix4f = matrixStack.last().pose();
 
             font.drawInBatch(


### PR DESCRIPTION
Current 
![image](https://github.com/user-attachments/assets/2316cd5b-e75c-49f7-ad98-0751b82ea9c0)
Fixed
 ![image-1](https://github.com/user-attachments/assets/f8516f28-5a50-459c-9533-435803fc88c2)
