### PR TITLE
fix: Don't allow weapons as a valid item for mounting horses [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.mc.event.UseItemEvent;
-import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.items.game.HorseItem;
 import com.wynntils.utils.mc.McUtils;
 import java.util.List;
@@ -143,12 +142,6 @@ public class HorseMountFeature extends Feature {
             // horse item
             Optional<HorseItem> horseItemOpt = Models.Item.asWynnItem(itemStack, HorseItem.class);
             if (horseItemOpt.isPresent()) {
-                return i;
-            }
-
-            // weapons
-            Optional<GearItem> gearItemOpt = Models.Item.asWynnItem(itemStack, GearItem.class);
-            if (gearItemOpt.isPresent() && gearItemOpt.get().getGearType().isWeapon()) {
                 return i;
             }
         }


### PR DESCRIPTION
Mentioned to leave it in [here](https://github.com/Wynntils/Wynntils/pull/2641#discussion_r1669927265) but the feature is unusable if you have a weapon in first slot so better to remove it