### PR TITLE
feat: Allow 1.21.1 to be used with Wynntils

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -64,7 +64,7 @@ test {
 processResources {
     var replaceProperties = [
         mod_version                : rootProject.version,
-        minecraft_version          : minecraft_version,
+        minecraft_version          : fabric_minecraft_version_range,
         fabric_loader_version      : fabric_loader_version,
         mod_id                     : mod_id
     ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,10 @@ java_version=21
 
 # Minecraft and mappings versions
 minecraft_version=1.21
+# This is an array of versions that the mod supports.
+fabric_minecraft_version_range=>=1.21 <=1.21.1
+# This is a range of versions that the mod supports.
+neoforge_minecraft_version_range=[1.21,1.21.1]
 
 # Architectury
 # Check for latest at https://maven.architectury.dev/architectury-plugin/architectury-plugin.gradle.plugin
@@ -24,7 +28,7 @@ parchment_version=1.21:2024.07.28
 # Fabric
 # Check for latest at https://fabricmc.net/develop/
 fabric_loader_version=0.16.0
-fabric_version=0.100.7+1.21
+fabric_version=0.101.2+1.21
 
 # NeoForge
 # Check for latest at https://neoforged.net/

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 processResources {
     var replaceProperties = [
         mod_version                : rootProject.version,
-        minecraft_version          : minecraft_version,
+        minecraft_version          : neoforge_minecraft_version_range,
         neoforge_version_range     : neoforge_version_range,
         loader_version_range       : neoforge_loader_version_range,
         mod_id                     : mod_id

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -15,7 +15,7 @@ logoFile = "assets/wynntils/logo.png"
 [[dependencies.wynntils]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[${minecraft_version}]"
+versionRange = "${minecraft_version}"
 
 [[dependencies.wynntils]]
 modId = "neoforge"


### PR DESCRIPTION
The development environment stays on 1.21, but it's 100% free for us to allow 1.21.1 via version configuration files.