### PR TITLE
fix: Fix ReplayMod causing container features to not work [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/BankModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/BankModel.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.EventPriority;
@@ -73,10 +72,8 @@ public class BankModel extends Model {
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onScreenInit(ScreenInitEvent e) {
-        storageContainerType = null;
-
-        if (!(e.getScreen() instanceof AbstractContainerScreen<?>)) return;
         if (!(Models.Container.getCurrentContainer() instanceof PersonalStorageContainer container)) {
+            storageContainerType = null;
             return;
         }
 

--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -68,8 +68,6 @@ public final class ContainerModel extends Model {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onScreenInit(ScreenInitEvent e) {
-        currentContainer = null;
-
         if (!(e.getScreen() instanceof AbstractContainerScreen<?> screen)) return;
 
         for (Container container : containerTypes) {


### PR DESCRIPTION
ReplayMod seems to put another screen on top of containers, so currently ContainerModel sets current container to null whenever any screen opens and then checks for a container but that doesn't seem to be necessary as onScreenClose should handle that