### PR TITLE
fix: Reset current container if on a container screen [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -70,6 +70,8 @@ public final class ContainerModel extends Model {
     public void onScreenInit(ScreenInitEvent e) {
         if (!(e.getScreen() instanceof AbstractContainerScreen<?> screen)) return;
 
+        currentContainer = null;
+
         for (Container container : containerTypes) {
             if (container.isScreen(screen)) {
                 currentContainer = container;


### PR DESCRIPTION
Follow up to https://github.com/Wynntils/Wynntils/pull/2729, I remember why it always set current container to null, since accessing another menu from characterinfo like tomes or the cosmetics menu wouldn't close the screen to set it to null and then the skill points loadout button was still visible on those screens.

This won't reintroduce the ReplayMod issue as it is set to null after checking if the screen is an abstract container screen