### PR TITLE
fix: Correctly set game version requirement tags on Modrinth and CurseForge [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,8 @@ jobs:
           name: Wynntils (${{ matrix.modloader }}) ${{ needs.changelog.outputs.tag }}
           version: ${{ needs.changelog.outputs.tag }}
           version-type: release
-          game-versions: 1.21
+          game-versions: |
+            [1.21,1.21.1]
           changelog: ${{ needs.changelog.outputs.changelog }}
 
           loaders: ${{ matrix.modloader }}


### PR DESCRIPTION
My bad.. I guess this is why you don't develop when you are travelling. On the other hand, I had really wanted to get 1.21.1 compatibility out, to help our support team.