### PR TITLE
feat: Add RemoveWynncraftChatWrapFeature and fix ChatItemFeature not working in party/guild/private chat

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -27,6 +27,7 @@ import com.wynntils.features.chat.DialogueOptionOverrideFeature;
 import com.wynntils.features.chat.GuildRankReplacementFeature;
 import com.wynntils.features.chat.InputTranscriptionFeature;
 import com.wynntils.features.chat.MessageFilterFeature;
+import com.wynntils.features.chat.RemoveWynncraftChatWrapFeature;
 import com.wynntils.features.chat.RevealNicknamesFeature;
 import com.wynntils.features.combat.AbbreviateMobHealthFeature;
 import com.wynntils.features.combat.ContentTrackerFeature;
@@ -215,6 +216,7 @@ public final class FeatureManager extends Manager {
         registerFeature(new GuildRankReplacementFeature());
         registerFeature(new InputTranscriptionFeature());
         registerFeature(new MessageFilterFeature());
+        registerFeature(new RemoveWynncraftChatWrapFeature());
         registerFeature(new RevealNicknamesFeature());
         // endregion
 

--- a/common/src/main/java/com/wynntils/core/text/StyledText.java
+++ b/common/src/main/java/com/wynntils/core/text/StyledText.java
@@ -49,7 +49,7 @@ public final class StyledText implements Iterable<StyledTextPart> {
 
     /**
      * Note: All callers of this constructor should ensure that the event lists are collected from the parts.
-     *       Additionally, they should ensure that the events are distinct.
+     * Additionally, they should ensure that the events are distinct.
      */
     private StyledText(List<StyledTextPart> parts, List<ClickEvent> clickEvents, List<HoverEvent> hoverEvents) {
         this.parts = parts.stream()
@@ -236,6 +236,7 @@ public final class StyledText implements Iterable<StyledTextPart> {
 
     /**
      * Strips all of Wynncraft's unicode alignment characters from this {@link StyledText}.
+     *
      * @return the stripped {@link StyledText}
      */
     public StyledText stripAlignment() {
@@ -397,6 +398,7 @@ public final class StyledText implements Iterable<StyledTextPart> {
     /**
      * Splits this {@link StyledText} into multiple {@link StyledText}s at the given index.
      * <p> Note that {@link PartStyle.StyleType.NONE} is used when splitting.
+     *
      * @param regex the regex to split at
      * @return the split {@link StyledText}s
      */
@@ -534,8 +536,9 @@ public final class StyledText implements Iterable<StyledTextPart> {
 
     /**
      * Splits this {@link StyledText} into multiple {@link StyledText}s at the given indexes.
+     *
      * @param styleType the style type to use when calculating indexes
-     * @param indexes the indexes to split at, in ascending order
+     * @param indexes   the indexes to split at, in ascending order
      * @return the split {@link StyledText}s as an array
      * @throws IllegalArgumentException if the indexes are not in ascending order or an index splits a formatting code
      */
@@ -565,13 +568,24 @@ public final class StyledText implements Iterable<StyledTextPart> {
     /**
      * Replaces the first occurrence of the given regex with the given replacement.
      * <p> Note that {@link PartStyle.StyleType.NONE} is used when matching and replacing.
-     * @param regex the regex to replace
+     *
+     * @param regex       the regex to replace
      * @param replacement the replacement
      * @return the new {@link StyledText}
      */
     public StyledText replaceFirst(String regex, String replacement) {
-        final Pattern pattern = Pattern.compile(regex);
+        return replaceFirst(Pattern.compile(regex), replacement);
+    }
 
+    /**
+     * Replaces the first occurrence of the given regex with the given replacement.
+     * <p> Note that {@link PartStyle.StyleType.NONE} is used when matching and replacing.
+     *
+     * @param pattern     the pattern to replace
+     * @param replacement the replacement
+     * @return the new {@link StyledText}
+     */
+    public StyledText replaceFirst(Pattern pattern, String replacement) {
         List<StyledTextPart> newParts = new ArrayList<>();
 
         for (StyledTextPart part : parts) {
@@ -598,13 +612,24 @@ public final class StyledText implements Iterable<StyledTextPart> {
     /**
      * Replaces all occurrences of the given regex with the given replacement.
      * <p> Note that {@link PartStyle.StyleType.NONE} is used when matching and replacing.
-     * @param regex the regex to replace
+     *
+     * @param regex       the regex to replace
      * @param replacement the replacement
      * @return the new {@link StyledText}
      */
     public StyledText replaceAll(String regex, String replacement) {
-        final Pattern pattern = Pattern.compile(regex);
+        return replaceAll(Pattern.compile(regex), replacement);
+    }
 
+    /**
+     * Replaces all occurrences of the given regex with the given replacement.
+     * <p> Note that {@link PartStyle.StyleType.NONE} is used when matching and replacing.
+     *
+     * @param pattern     the pattern to replace
+     * @param replacement the replacement
+     * @return the new {@link StyledText}
+     */
+    public StyledText replaceAll(Pattern pattern, String replacement) {
         List<StyledTextPart> newParts = new ArrayList<>();
 
         for (StyledTextPart part : parts) {
@@ -627,6 +652,7 @@ public final class StyledText implements Iterable<StyledTextPart> {
 
     /**
      * Returns the parts of this {@link StyledText} as a {@link StyledText} array.
+     *
      * @return the array
      */
     public StyledText[] getPartsAsTextArray() {
@@ -714,6 +740,7 @@ public final class StyledText implements Iterable<StyledTextPart> {
 
     /**
      * Returns the first part of this {@link StyledText} that matches the given event.
+     *
      * @param clickEvent the event to find
      * @return the 1-based index, or -1
      */
@@ -735,6 +762,7 @@ public final class StyledText implements Iterable<StyledTextPart> {
 
     /**
      * Returns the first part of this {@link StyledText} that matches the given event.
+     *
      * @param hoverEvent the event to find
      * @return the 1-based index, or -1
      */

--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -34,6 +34,7 @@ import com.wynntils.screens.itemsharing.SavedItemsScreen;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.StyledTextUtils;
 import com.wynntils.utils.type.ErrorOr;
 import com.wynntils.utils.type.IterationDecision;
 import java.util.ArrayList;
@@ -131,14 +132,18 @@ public class ChatItemFeature extends Feature {
 
         StyledText styledText = e.getStyledText();
 
+        StyledText unwrapped = StyledTextUtils.unwrap(styledText);
+
         // Decode old chat item encoding
-        StyledText modified = styledText.iterate((part, changes) -> {
+        StyledText modified = unwrapped.iterate((part, changes) -> {
             decodeChatEncoding(changes, part);
             return IterationDecision.CONTINUE;
         });
 
-        if (modified.equals(styledText)) return;
+        if (modified.equals(unwrapped)) return;
 
+        // If the message had any chat items, we use our unwrapped version
+        // FIXME: This edited message could be re-wrapped if it is too long, to match the original message's style
         e.setMessage(modified);
     }
 

--- a/common/src/main/java/com/wynntils/features/chat/RemoveWynncraftChatWrapFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/RemoveWynncraftChatWrapFeature.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.chat;
+
+import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.properties.StartDisabled;
+import com.wynntils.core.persisted.config.Category;
+import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
+import com.wynntils.utils.mc.StyledTextUtils;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.SubscribeEvent;
+
+@StartDisabled
+@ConfigCategory(Category.CHAT)
+public class RemoveWynncraftChatWrapFeature extends Feature {
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onChatReceived(ChatMessageReceivedEvent event) {
+        event.setMessage(StyledTextUtils.unwrap(event.getStyledText()));
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.utils.mc;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
@@ -22,6 +23,9 @@ import net.minecraft.network.chat.Style;
 public final class StyledTextUtils {
     private static final Pattern COORDINATE_PATTERN =
             Pattern.compile(".*\\[(-?\\d+)(?:.\\d+)?, ?(-?\\d+)(?:.\\d+)?, ?(-?\\d+)(?:.\\d+)?\\].*");
+
+    private static final String NEWLINE_PREPARATION = "\n";
+    private static final Pattern NEWLINE_WRAP_PATTERN = Pattern.compile("\uDAFF\uDFFC\uE001\uDB00\uDC06");
 
     public static StyledTextPart createLocationPart(Location location) {
         String locationString = "[%d, %d, %d]".formatted(location.x, location.y, location.z);
@@ -58,6 +62,7 @@ public final class StyledTextUtils {
      * Multi-line messages use new lines not just to split the multi-line message, but also to format the message.
      * If a part is only a new line, we know it's a new message, but if the new line is in the middle of a part,
      * we know it's a new line in the same message, which we don't want to split.
+     *
      * @param styledText The styled text to split
      * @return A list of styled texts, each representing a line
      */
@@ -88,5 +93,104 @@ public final class StyledTextUtils {
      */
     public static StyledText joinAllLines(StyledText styledText) {
         return styledText.replaceAll("\n", "");
+    }
+
+    /**
+     * Removes the soft-wrap Wynn gives to all messages post 2.1.
+     *
+     * @param styledText The styled text to unwrap
+     * @return The unwrapped styled text
+     */
+    public static StyledText unwrap(StyledText styledText) {
+        List<StyledTextPart> newParts = new ArrayList<>();
+
+        StyledTextPart lastWrappedPart = null;
+        boolean expectEmptySpaceAfterWrap = false;
+        for (StyledTextPart part : styledText) {
+            String partString = part.getString(null, PartStyle.StyleType.NONE);
+
+            // After a wrap, Wynn injects an empty space, which we want to remove
+            if (expectEmptySpaceAfterWrap) {
+                // There is an edge-case where this space is the whole part, in which case we skip it
+                if (partString.equals(" ")) {
+                    expectEmptySpaceAfterWrap = false;
+                    continue;
+                }
+
+                // If the part starts with a space, we remove it
+                if (partString.startsWith(" ")) {
+                    partString = partString.substring(1);
+                    part = new StyledTextPart(partString, part.getPartStyle().getStyle(), null, null);
+                    expectEmptySpaceAfterWrap = false;
+                } else {
+                    // Log the edge-case
+                    WynntilsMod.warn("Unexpected edge-case in unwrap: " + part);
+                }
+
+                // Continue with execution, a part may have a wrap before and after it
+            }
+
+            // If the part ends with a newline, it may be a preparation for a wrap
+            if (partString.endsWith(NEWLINE_PREPARATION)) {
+                lastWrappedPart = part;
+                continue;
+            }
+
+            // Confirm whether the last part was wrapped
+            if (lastWrappedPart != null) {
+                if (NEWLINE_WRAP_PATTERN.matcher(partString).matches()) {
+                    // Skip the current part, add back the last part, without the newline
+                    String lastPartWithoutNewline = lastWrappedPart.getString(null, PartStyle.StyleType.NONE);
+                    lastPartWithoutNewline = lastPartWithoutNewline.substring(
+                            0, lastPartWithoutNewline.length() - NEWLINE_PREPARATION.length());
+
+                    // Check if the style of the current part matches with the one we added last time,
+                    // if so, we merge them
+                    if (!newParts.isEmpty()
+                            && newParts.getLast().getPartStyle().equals(lastWrappedPart.getPartStyle())) {
+                        StyledTextPart lastPart = newParts.removeLast();
+                        lastPartWithoutNewline =
+                                lastPart.getString(null, PartStyle.StyleType.NONE) + lastPartWithoutNewline;
+
+                        newParts.add(new StyledTextPart(
+                                lastPartWithoutNewline,
+                                lastWrappedPart.getPartStyle().getStyle(),
+                                null,
+                                null));
+                    } else {
+                        newParts.add(new StyledTextPart(
+                                lastPartWithoutNewline,
+                                lastWrappedPart.getPartStyle().getStyle(),
+                                null,
+                                null));
+                    }
+
+                    expectEmptySpaceAfterWrap = true;
+                } else {
+                    // The last part had a newline, but it was not a wrap, so we add it to the new parts
+                    newParts.add(lastWrappedPart);
+                    newParts.add(part);
+                }
+
+                lastWrappedPart = null;
+                continue;
+            }
+
+            // Check if the style of the current part matches with the one we added last time,
+            // if so, we merge them
+            if (!newParts.isEmpty() && newParts.getLast().getPartStyle().equals(part.getPartStyle())) {
+                StyledTextPart lastPart = newParts.removeLast();
+                partString = lastPart.getString(null, PartStyle.StyleType.NONE) + partString;
+
+                newParts.add(new StyledTextPart(partString, part.getPartStyle().getStyle(), null, null));
+
+                continue;
+            }
+
+            // If nothing special happened, we just add the part to the new parts
+            newParts.add(part);
+        }
+
+        return StyledText.fromParts(newParts);
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1106,6 +1106,8 @@
   "feature.wynntils.raidProgress.printTimes.name": "Print Raid Times",
   "feature.wynntils.rangeVisualizer.description": "Adds a visualizer for spell ranges.",
   "feature.wynntils.rangeVisualizer.name": "Major ID Range Visualizer",
+  "feature.wynntils.removeWynncraftChatWrap.description": "Removes the default Wynncraft chat wrap that's applied to most messages.",
+  "feature.wynntils.removeWynncraftChatWrap.name": "Remove Wynncraft Chat Wrap",
   "feature.wynntils.revealNicknames.description": "Reveals nicknames of players in chat.",
   "feature.wynntils.revealNicknames.name": "Reveal Nicknames",
   "feature.wynntils.revealNicknames.nicknameReplaceOption.description": "How should the nickname be replaced in chat?",


### PR DESCRIPTION
In theory, it wouldn't be so hard to re-wrap Wynn's messages, but currently, I'd rather get this out to fix the bug and work on the re-wrapping when things have calmed down.

# Before
![image](https://github.com/user-attachments/assets/42ebfb4f-7adc-4c67-ba06-15448869686e)

# After
![image](https://github.com/user-attachments/assets/56101082-d7b8-4e09-be85-fe120de3203d)

