### PR TITLE
fix: Move emeralds higher to avoid clipping [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -97,7 +97,7 @@ public class InventoryEmeraldCountFeature extends Feature {
                 && showInventoryEmeraldCount.get()
                 && bottomEmeralds != 0;
         if (topEmeralds != 0) {
-            int y = containerScreen.topPos;
+            int y = containerScreen.topPos - 9;
             switch (emeraldCountType.get()) {
                 case TEXT -> renderTextCount(event.getPoseStack(), textX, y, topEmeralds);
                 case TEXTURE -> {

--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -97,7 +97,7 @@ public class InventoryEmeraldCountFeature extends Feature {
                 && showInventoryEmeraldCount.get()
                 && bottomEmeralds != 0;
         if (topEmeralds != 0) {
-            int y = containerScreen.topPos - 9;
+            int y = isInventory ? containerScreen.topPos - 9 : containerScreen.topPos;
             switch (emeraldCountType.get()) {
                 case TEXT -> renderTextCount(event.getPoseStack(), textX, y, topEmeralds);
                 case TEXTURE -> {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/be27b173-365a-444c-ad05-aba6f4b64bdc)

After:
![image](https://github.com/user-attachments/assets/787994a0-4398-4785-89d5-7d3d859a304b)
