### PR TITLE
fix: Totem tracking doesn't bind timers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/abilities/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShamanTotemModel.java
@@ -172,7 +172,8 @@ public class ShamanTotemModel extends Model {
                 totem.setTime(parsedTime);
                 totem.setPosition(textDisplay.position());
 
-                WynntilsMod.postEvent(new TotemEvent.Updated(totem.getTotemNumber(), parsedTime, textDisplay.position()));
+                WynntilsMod.postEvent(
+                        new TotemEvent.Updated(totem.getTotemNumber(), parsedTime, textDisplay.position()));
                 break;
             }
         }

--- a/common/src/main/java/com/wynntils/models/abilities/type/ShamanTotem.java
+++ b/common/src/main/java/com/wynntils/models/abilities/type/ShamanTotem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.type;

--- a/common/src/main/java/com/wynntils/models/abilities/type/ShamanTotem.java
+++ b/common/src/main/java/com/wynntils/models/abilities/type/ShamanTotem.java
@@ -12,6 +12,10 @@ public class ShamanTotem {
     private int timerEntityId;
     private int time;
     private TotemState state;
+    /**
+     * Our internal representation of the totem/timer's position. Not guaranteed to match the position of either the
+     * totem or the timer.
+     * */
     private Position position;
 
     public ShamanTotem(


### PR DESCRIPTION
So I think the problem was that wynn spawns two TextDisplays now, one of them is empty and the other is the timer/hpr one. Since they're both unnamed at spawn and receive a name after one update, we can just check them during the rename. Doesn't fix the time rift problem yet, but one at a time right?