### PR TITLE
feat: Fully parse items without Wynn Item API (UnknownGear parsing)

### DIFF
--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -1,25 +1,29 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.character.type;
 
+import com.wynntils.models.gear.type.GearType;
+
 public enum ClassType {
-    MAGE("Mage", "Dark Wizard"),
-    ARCHER("Archer", "Hunter"),
-    WARRIOR("Warrior", "Knight"),
-    ASSASSIN("Assassin", "Ninja"),
-    SHAMAN("Shaman", "Skyseer"),
+    MAGE("Mage", "Dark Wizard", GearType.WAND),
+    ARCHER("Archer", "Hunter", GearType.BOW),
+    WARRIOR("Warrior", "Knight", GearType.SPEAR),
+    ASSASSIN("Assassin", "Ninja", GearType.DAGGER),
+    SHAMAN("Shaman", "Skyseer", GearType.RELIK),
 
     // This represents the class selection menu, or the generic spell
-    NONE("none", "none");
+    NONE("none", "none", null);
 
     private final String name;
     private final String reskinnedName;
+    private final GearType gearType;
 
-    ClassType(String name, String reskinnedName) {
+    ClassType(String name, String reskinnedName, GearType gearType) {
         this.name = name;
         this.reskinnedName = reskinnedName;
+        this.gearType = gearType;
     }
 
     public static ClassType fromName(String className) {
@@ -53,6 +57,10 @@ public enum ClassType {
 
     public String getFullName() {
         return name + "/" + reskinnedName;
+    }
+
+    public GearType getGearType() {
+        return gearType;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -7,6 +7,7 @@ package com.wynntils.models.gear;
 import com.google.gson.JsonObject;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
+import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.gear.type.GearTier;
@@ -25,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.minecraft.world.item.ItemStack;
 
@@ -44,6 +46,10 @@ import net.minecraft.world.item.ItemStack;
  * base = base + (base * percentage1) + (base * percentage2) + rawValue
  */
 public final class GearModel extends Model {
+    // Test in GearModel_GEAR_PATTERN
+    public static final Pattern GEAR_PATTERN = Pattern.compile(
+            "^(?:(?<unidrarity>§[5abcdef])(?<unidentified>Unidentified ))?(?:§f⬡ )?(?<idrarity>§[5abcdef])?(?:Shiny )?(?<name>.+)$");
+
     private final GearInfoRegistry gearInfoRegistry = new GearInfoRegistry();
 
     private final Map<GearBoxItem, List<GearInfo>> possibilitiesCache = new HashMap<>();
@@ -104,13 +110,7 @@ public final class GearModel extends Model {
         WynnItemParseResult result = WynnItemParser.parseInternalRolls(gearInfo, itemData);
 
         return GearInstance.create(
-                gearInfo,
-                result.identifications(),
-                result.powders(),
-                result.rerolls(),
-                result.shinyStat(),
-                false,
-                Optional.empty());
+                gearInfo, result.identifications(), result.powders(), 0, Optional.empty(), false, Optional.empty());
     }
 
     public CraftedGearItem parseCraftedGearItem(ItemStack itemStack) {
@@ -131,10 +131,9 @@ public final class GearModel extends Model {
         // If it is crafted, and has a skin, then we cannot determine weapon type from item stack
         // Maybe it is possible to find in the string type, e.g. "Crafted Wand"
         gearType = GearType.fromString(result.itemType());
-        if (gearType == null && craftedResults.requirements().classType().isPresent()) {
+        if (gearType == null && result.requirements().classType().isPresent()) {
             // If the item is signed, we can find the class type from the requirements
-            gearType = GearType.fromClassType(
-                    craftedResults.requirements().classType().get());
+            gearType = GearType.fromClassType(result.requirements().classType().get());
         }
 
         // If we still failed to find the gear type, try to find it from the item stack
@@ -151,11 +150,11 @@ public final class GearModel extends Model {
                 craftedResults.name(),
                 craftedResults.effectStrength(),
                 gearType,
-                craftedResults.attackSpeed(),
+                result.attackSpeed(),
                 result.health(),
-                craftedResults.damages(),
-                craftedResults.defences(),
-                craftedResults.requirements(),
+                result.damages(),
+                result.defences(),
+                result.requirements(),
                 possibleValuesMap.values().stream().toList(),
                 result.identifications(),
                 result.powders(),
@@ -168,17 +167,31 @@ public final class GearModel extends Model {
             String name, GearType gearType, GearTier gearTier, ItemStack itemStack) {
         WynnItemParseResult result = WynnItemParser.parseItemStack(itemStack, null);
 
-        // FIXME: Damages and requirements are not yet parsed
+        if (gearType == GearType.WEAPON) {
+            // If the gear type is weapon, we can try to find the weapon type from the requirements
+            gearType = result.requirements()
+                    .classType()
+                    .map(ClassType::getGearType)
+                    .orElse(gearType);
+        }
+
         return new UnknownGearItem(
                 name,
                 gearType,
                 gearTier,
                 result.level(),
-                List.of(),
-                List.of(),
+                result.attackSpeed(),
+                result.health(),
+                result.damages(),
+                result.defences(),
+                result.requirements(),
+                result.allRequirementsMet(),
                 result.identifications(),
                 result.powders(),
-                result.rerolls());
+                result.powderSlots(),
+                result.rerolls(),
+                result.setInstance().orElse(null),
+                result.shinyStat().orElse(null));
     }
 
     public GearInfo getGearInfoFromDisplayName(String gearName) {

--- a/common/src/main/java/com/wynntils/models/gear/type/GearType.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearType.java
@@ -4,9 +4,13 @@
  */
 package com.wynntils.models.gear.type;
 
+import com.wynntils.core.text.StyledText;
 import com.wynntils.models.character.type.ClassType;
+import com.wynntils.utils.mc.LoreUtils;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.Item;
@@ -68,6 +72,8 @@ public enum GearType {
     MASTERY_TOME(null, Items.IRON_HORSE_ARMOR, 76, 82, -1),
     CHARM(null, Items.CLAY_BALL, 0, 0, -1);
 
+    private static final Pattern SKINNED_GEAR_PATTERN = Pattern.compile("^§7\\[Active (.+) Skin: (.+)]$");
+
     private final ClassType classReq;
     private final Item defaultItem;
     private final List<Integer> models;
@@ -108,20 +114,31 @@ public enum GearType {
             // We only want to match for proper gear, not rewards
             if (gearType.isReward()) continue;
 
-            boolean itemMatches = gearType.defaultItem.equals(item) || gearType.otherItems.contains(item);
-            if (!itemMatches) continue;
-
             CustomModelData customModelData = itemStack.get(DataComponents.CUSTOM_MODEL_DATA);
 
             // Special case for armor gear
-            if (customModelData == null && gearType.models.isEmpty()) {
+            // Only check for the models in case the item is the default item, otherwise accept any item
+            if (customModelData == null && (gearType.defaultItem.equals(item) && gearType.models.isEmpty())
+                    || gearType.otherItems.contains(item)) {
                 return gearType;
             }
 
-            if (customModelData != null && gearType.models.contains(customModelData.value())) {
+            if (gearType.defaultItem.equals(item)
+                    && customModelData != null
+                    && gearType.models.contains(customModelData.value())) {
                 return gearType;
             }
         }
+
+        // Gears have a lot of different skinned items, checking for the string in lore is more reliable
+        List<StyledText> lore = LoreUtils.getLore(itemStack);
+        if (!lore.isEmpty()) {
+            Matcher matcher = lore.getLast().getMatcher(SKINNED_GEAR_PATTERN);
+            if (matcher.matches()) {
+                return GearType.fromString(matcher.group(1));
+            }
+        }
+
         return null;
     }
 

--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -64,6 +64,7 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new CharmAnnotator());
         Handlers.Item.registerAnnotator(new IngredientAnnotator());
         Handlers.Item.registerAnnotator(new MaterialAnnotator());
+        Handlers.Item.registerAnnotator(new UnknownGearAnnotator());
 
         // Then alphabetically
         Handlers.Item.registerAnnotator(new AmplifierAnnotator());
@@ -101,7 +102,6 @@ public class ItemModel extends Model {
 
         // ItemAnnotators
         // This must be done last
-        Handlers.Item.registerAnnotator(new UnknownGearAnnotator());
         Handlers.Item.registerAnnotator(new MiscAnnotator());
         Handlers.Item.registerAnnotator(new FallbackAnnotator());
     }

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/GearAnnotator.java
@@ -13,17 +13,12 @@ import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.items.items.game.GearItem;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public final class GearAnnotator implements GameItemAnnotator {
-    // Test in GearAnnotator_GEAR_PATTERN
-    private static final Pattern GEAR_PATTERN = Pattern.compile(
-            "^(?:(?<unidrarity>§[5abcdef])(?<unidentified>Unidentified ))?(?:§f⬡ )?(?<idrarity>§[5abcdef])?(?:Shiny )?(?<name>.+)$");
-
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
-        Matcher matcher = name.getMatcher(GEAR_PATTERN);
+        Matcher matcher = name.getMatcher(Models.Gear.GEAR_PATTERN);
         if (!matcher.matches()) return null;
 
         // Lookup Gear Profile

--- a/common/src/main/java/com/wynntils/models/items/items/game/UnknownGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/UnknownGearItem.java
@@ -1,50 +1,92 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;
 
+import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
+import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
+import com.wynntils.models.gear.type.SetInfo;
+import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.items.properties.GearTierItemProperty;
 import com.wynntils.models.items.properties.GearTypeItemProperty;
 import com.wynntils.models.items.properties.LeveledItemProperty;
+import com.wynntils.models.items.properties.PowderedItemProperty;
+import com.wynntils.models.items.properties.RequirementItemProperty;
+import com.wynntils.models.items.properties.RerollableItemProperty;
+import com.wynntils.models.items.properties.SetItemProperty;
+import com.wynntils.models.items.properties.ShinyItemProperty;
+import com.wynntils.models.stats.type.DamageType;
+import com.wynntils.models.stats.type.ShinyStat;
 import com.wynntils.models.stats.type.StatActualValue;
+import com.wynntils.utils.type.Pair;
+import com.wynntils.utils.type.RangedValue;
 import java.util.List;
+import java.util.Optional;
 
 public class UnknownGearItem extends GameItem
-        implements GearTierItemProperty, GearTypeItemProperty, LeveledItemProperty {
+        implements GearTierItemProperty,
+                GearTypeItemProperty,
+                LeveledItemProperty,
+                PowderedItemProperty,
+                RerollableItemProperty,
+                ShinyItemProperty,
+                SetItemProperty,
+                RequirementItemProperty {
     private final String name;
     private final GearType gearType;
     private final GearTier gearTier;
     private final int level;
-    // FIXME: Better types than strings...
-    private final List<String> damages;
-    private final List<String> requirements;
+    private final GearAttackSpeed attackSpeed;
+    private final int health;
+    private final List<Pair<DamageType, RangedValue>> damages;
+    private final List<Pair<Element, Integer>> defences;
+    private final GearRequirements requirements;
+    private final boolean allRequirementsMet;
     private final List<StatActualValue> identifications;
     private final List<Powder> powders;
+    private final int powderSlots;
     private final int rerolls;
+    private final SetInstance setInstance;
+    private final ShinyStat shinyStat;
 
     public UnknownGearItem(
             String name,
             GearType gearType,
             GearTier gearTier,
             int level,
-            List<String> damages,
-            List<String> requirements,
+            GearAttackSpeed attackSpeed,
+            int health,
+            List<Pair<DamageType, RangedValue>> damages,
+            List<Pair<Element, Integer>> defences,
+            GearRequirements requirements,
+            boolean allRequirementsMet,
             List<StatActualValue> identifications,
             List<Powder> powders,
-            int rerolls) {
+            int powderSlots,
+            int rerolls,
+            SetInstance setInstance,
+            ShinyStat shinyStat) {
         this.name = name;
         this.gearType = gearType;
         this.gearTier = gearTier;
         this.level = level;
+        this.attackSpeed = attackSpeed;
+        this.health = health;
         this.damages = damages;
+        this.defences = defences;
         this.requirements = requirements;
+        this.allRequirementsMet = allRequirementsMet;
         this.identifications = identifications;
         this.powders = powders;
+        this.powderSlots = powderSlots;
         this.rerolls = rerolls;
+        this.setInstance = setInstance;
+        this.shinyStat = shinyStat;
     }
 
     public String getName() {
@@ -66,11 +108,23 @@ public class UnknownGearItem extends GameItem
         return level;
     }
 
-    public List<String> getDamages() {
+    public GearAttackSpeed getAttackSpeed() {
+        return attackSpeed;
+    }
+
+    public int getHealth() {
+        return health;
+    }
+
+    public List<Pair<DamageType, RangedValue>> getDamages() {
         return damages;
     }
 
-    public List<String> getRequirements() {
+    public List<Pair<Element, Integer>> getDefences() {
+        return defences;
+    }
+
+    public GearRequirements getRequirements() {
         return requirements;
     }
 
@@ -78,12 +132,39 @@ public class UnknownGearItem extends GameItem
         return identifications;
     }
 
+    @Override
     public List<Powder> getPowders() {
         return powders;
     }
 
-    public int getRerolls() {
+    @Override
+    public int getPowderSlots() {
+        return powderSlots;
+    }
+
+    @Override
+    public boolean meetsActualRequirements() {
+        return allRequirementsMet;
+    }
+
+    @Override
+    public int getRerollCount() {
         return rerolls;
+    }
+
+    @Override
+    public Optional<SetInfo> getSetInfo() {
+        return Optional.ofNullable(setInstance).map(SetInstance::setInfo);
+    }
+
+    @Override
+    public Optional<SetInstance> getSetInstance() {
+        return Optional.ofNullable(setInstance);
+    }
+
+    @Override
+    public Optional<ShinyStat> getShinyStat() {
+        return Optional.ofNullable(shinyStat);
     }
 
     @Override
@@ -92,11 +173,18 @@ public class UnknownGearItem extends GameItem
                 + name + '\'' + ", gearType="
                 + gearType + ", gearTier="
                 + gearTier + ", level="
-                + level + ", damages="
-                + damages + ", requirements="
-                + requirements + ", identifications="
+                + level + ", attackSpeed="
+                + attackSpeed + ", health="
+                + health + ", damages="
+                + damages + ", defences="
+                + defences + ", requirements="
+                + requirements + ", allRequirementsMet="
+                + allRequirementsMet + ", identifications="
                 + identifications + ", powders="
-                + powders + ", rerolls="
-                + rerolls + '}';
+                + powders + ", powderSlots="
+                + powderSlots + ", rerolls="
+                + rerolls + ", setInstance="
+                + setInstance + ", shinyStat="
+                + shinyStat + '}';
     }
 }

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/CraftedItemParseResults.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/CraftedItemParseResults.java
@@ -4,21 +4,6 @@
  */
 package com.wynntils.models.wynnitem.parsing;
 
-import com.wynntils.models.elements.type.Element;
-import com.wynntils.models.gear.type.GearAttackSpeed;
-import com.wynntils.models.gear.type.GearRequirements;
-import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.utils.type.CappedValue;
-import com.wynntils.utils.type.Pair;
-import com.wynntils.utils.type.RangedValue;
-import java.util.List;
 
-public record CraftedItemParseResults(
-        String name,
-        int effectStrength,
-        CappedValue uses,
-        GearAttackSpeed attackSpeed,
-        List<Pair<DamageType, RangedValue>> damages,
-        List<Pair<Element, Integer>> defences,
-        GearRequirements requirements,
-        boolean allRequirementsMet) {}
+public record CraftedItemParseResults(String name, int effectStrength, CappedValue uses) {}

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
@@ -4,13 +4,19 @@
  */
 package com.wynntils.models.wynnitem.parsing;
 
+import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
+import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.SetInstance;
+import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.models.stats.type.ShinyStat;
 import com.wynntils.models.stats.type.StatActualValue;
 import com.wynntils.models.wynnitem.type.ItemEffect;
 import com.wynntils.models.wynnitem.type.NamedItemEffect;
+import com.wynntils.utils.type.Pair;
+import com.wynntils.utils.type.RangedValue;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,6 +27,10 @@ public record WynnItemParseResult(
         String itemType,
         int health,
         int level,
+        GearAttackSpeed attackSpeed,
+        List<Pair<DamageType, RangedValue>> damages,
+        List<Pair<Element, Integer>> defences,
+        GearRequirements requirements,
         List<StatActualValue> identifications,
         List<NamedItemEffect> namedEffects,
         List<ItemEffect> effects,
@@ -31,4 +41,27 @@ public record WynnItemParseResult(
         int durabilityMax,
         Optional<ShinyStat> shinyStat,
         boolean allRequirementsMet,
-        Optional<SetInstance> setInstance) {}
+        Optional<SetInstance> setInstance) {
+    public static WynnItemParseResult fromInternallRoll(List<StatActualValue> identifications, List<Powder> powders) {
+        return new WynnItemParseResult(
+                null,
+                null,
+                0,
+                0,
+                null,
+                List.of(),
+                List.of(),
+                null,
+                identifications,
+                List.of(),
+                List.of(),
+                powders,
+                0,
+                0,
+                0,
+                0,
+                Optional.empty(),
+                true,
+                Optional.empty());
+    }
+}

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -86,6 +86,9 @@ public final class WynnItemParser {
     private static final Pattern SKILL_REQ_PATTERN =
             Pattern.compile("^§(c✖|a✔)§7 (?<skill>[a-zA-Z]+) Min: (?<value>-?\\d+)$");
 
+    // Test in WynnItemParser_QUEST_REQ_PATTERN
+    private static final Pattern QUEST_REQ_PATTERN = Pattern.compile("^§(c✖|a✔)§7 Quest Req: (.+)$");
+
     // Test in WynnItemParser_MISC_REQ_PATTERN
     private static final Pattern MISC_REQ_PATTERN = Pattern.compile("^§(c✖|a✔)§7 (.+)$");
 
@@ -119,7 +122,13 @@ public final class WynnItemParser {
         List<Powder> powders = new ArrayList<>();
         int powderSlots = 0;
         int health = 0;
-        int level = 0;
+        GearAttackSpeed attackSpeed = null;
+        List<Pair<DamageType, RangedValue>> damages = new ArrayList<>();
+        List<Pair<Element, Integer>> defences = new ArrayList<>();
+        int levelReq = 0;
+        List<Pair<Skill, Integer>> skillReqs = new ArrayList<>();
+        ClassType classReq = null;
+        String questReq = null;
         int tierCount = 0;
         int durabilityMax = 0;
         GearTier tier = null;
@@ -217,17 +226,44 @@ public final class WynnItemParser {
                 continue;
             }
 
+            Matcher attackSpeedMatcher = coded.getMatcher(ITEM_ATTACK_SPEED_PATTERN);
+            if (attackSpeedMatcher.matches()) {
+                String speedName = attackSpeedMatcher.group(1);
+                attackSpeed = GearAttackSpeed.fromString(speedName.replaceAll(" ", "_"));
+            }
+
+            Matcher damageMatcher = coded.getMatcher(ITEM_DAMAGE_PATTERN);
+            if (damageMatcher.matches()) {
+                String symbol = damageMatcher.group("symbol");
+                RangedValue range = RangedValue.fromString(damageMatcher.group("range"));
+                damages.add(Pair.of(DamageType.fromSymbol(symbol), range));
+            }
+
+            Matcher defenceMatcher = coded.getMatcher(ITEM_DEFENCE_PATTERN);
+            if (defenceMatcher.matches()) {
+                String symbol = defenceMatcher.group("symbol");
+                int value = Integer.parseInt(defenceMatcher.group("value"));
+                defences.add(Pair.of(Element.fromSymbol(symbol), value));
+            }
+
             // Requirements
             // Combat level
             Matcher levelMatcher = normalizedCoded.getMatcher(MIN_LEVEL_PATTERN);
             if (levelMatcher.matches()) {
-                level = Integer.parseInt(levelMatcher.group("level"));
-                continue;
+                levelReq = Integer.parseInt(levelMatcher.group("level"));
+
+                String mark = levelMatcher.group(1);
+                if (mark.contains("✖")) {
+                    allRequirementsMet = false;
+                }
             }
 
             // Class
             Matcher classMatcher = normalizedCoded.getMatcher(CLASS_REQ_PATTERN);
             if (classMatcher.matches()) {
+                String className = classMatcher.group("name");
+                classReq = ClassType.fromName(className);
+
                 String mark = classMatcher.group(1);
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
@@ -237,7 +273,23 @@ public final class WynnItemParser {
             // Skills
             Matcher skillMatcher = normalizedCoded.getMatcher(SKILL_REQ_PATTERN);
             if (skillMatcher.matches()) {
+                String skillName = skillMatcher.group("skill");
+                Skill skill = Skill.fromString(skillName);
+                int value = Integer.parseInt(skillMatcher.group("value"));
+                skillReqs.add(Pair.of(skill, value));
+
                 String mark = skillMatcher.group(1);
+                if (mark.contains("✖")) {
+                    allRequirementsMet = false;
+                }
+            }
+
+            // Quests
+            Matcher questMatcher = normalizedCoded.getMatcher(QUEST_REQ_PATTERN);
+            if (questMatcher.matches()) {
+                questReq = questMatcher.group(2);
+
+                String mark = questMatcher.group(1);
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
                 }
@@ -366,7 +418,11 @@ public final class WynnItemParser {
                 tier,
                 itemType,
                 health,
-                level,
+                levelReq,
+                attackSpeed,
+                damages,
+                defences,
+                new GearRequirements(levelReq, Optional.ofNullable(classReq), skillReqs, Optional.ofNullable(questReq)),
                 identifications,
                 namedEffects,
                 effects,
@@ -425,22 +481,7 @@ public final class WynnItemParser {
                 : 0;
 
         // Shiny stats are not available from internal roll lore (on other players)
-        return new WynnItemParseResult(
-                gearInfo.tier(),
-                "",
-                0,
-                0,
-                identifications,
-                List.of(),
-                List.of(),
-                powders,
-                powders.size(),
-                rerolls,
-                0,
-                0,
-                Optional.empty(),
-                false,
-                Optional.empty());
+        return WynnItemParseResult.fromInternallRoll(identifications, powders);
     }
 
     public static CraftedItemParseResults parseCraftedItem(ItemStack itemStack) {
@@ -449,13 +490,6 @@ public final class WynnItemParser {
         String name = "";
         int effectStrength = -1;
         CappedValue uses = null;
-        GearAttackSpeed attackSpeed = null;
-        List<Pair<DamageType, RangedValue>> damages = new ArrayList<>();
-        List<Pair<Element, Integer>> defences = new ArrayList<>();
-        // requirements
-        int levelReq = 0;
-        List<Pair<Skill, Integer>> skillReqs = new ArrayList<>();
-        ClassType classReq = null;
 
         if (!lore.isEmpty()) {
             Matcher nameMatcher = StyledText.fromComponent(lore.getFirst()).getMatcher(CRAFTED_ITEM_NAME_PATTERN);
@@ -492,78 +526,7 @@ public final class WynnItemParser {
             }
         }
 
-        boolean allRequirementsMet = true;
-        for (Component loreLine : lore) {
-            StyledText coded = StyledText.fromComponent(loreLine);
-
-            Matcher attackSpeedMatcher = coded.getMatcher(ITEM_ATTACK_SPEED_PATTERN);
-            if (attackSpeedMatcher.matches()) {
-                String speedName = attackSpeedMatcher.group(1);
-                attackSpeed = GearAttackSpeed.fromString(speedName.replaceAll(" ", "_"));
-            }
-
-            Matcher damageMatcher = coded.getMatcher(ITEM_DAMAGE_PATTERN);
-            if (damageMatcher.matches()) {
-                String symbol = damageMatcher.group("symbol");
-                RangedValue range = RangedValue.fromString(damageMatcher.group("range"));
-                damages.add(Pair.of(DamageType.fromSymbol(symbol), range));
-            }
-
-            Matcher defenceMatcher = coded.getMatcher(ITEM_DEFENCE_PATTERN);
-            if (defenceMatcher.matches()) {
-                String symbol = defenceMatcher.group("symbol");
-                int value = Integer.parseInt(defenceMatcher.group("value"));
-                defences.add(Pair.of(Element.fromSymbol(symbol), value));
-            }
-
-            // Requirements
-            // Combat level
-            Matcher levelMatcher = coded.getMatcher(MIN_LEVEL_PATTERN);
-            if (levelMatcher.matches()) {
-                levelReq = Integer.parseInt(levelMatcher.group("level"));
-
-                String mark = levelMatcher.group(1);
-                if (mark.contains("✖")) {
-                    allRequirementsMet = false;
-                }
-            }
-
-            // Class
-            Matcher classMatcher = coded.getMatcher(CLASS_REQ_PATTERN);
-            if (classMatcher.matches()) {
-                String className = classMatcher.group("name");
-                classReq = ClassType.fromName(className);
-
-                String mark = classMatcher.group(1);
-                if (mark.contains("✖")) {
-                    allRequirementsMet = false;
-                }
-            }
-
-            // Skills
-            Matcher skillMatcher = coded.getMatcher(SKILL_REQ_PATTERN);
-            if (skillMatcher.matches()) {
-                String skillName = skillMatcher.group("skill");
-                Skill skill = Skill.fromString(skillName);
-                int value = Integer.parseInt(skillMatcher.group("value"));
-                skillReqs.add(Pair.of(skill, value));
-
-                String mark = skillMatcher.group(1);
-                if (mark.contains("✖")) {
-                    allRequirementsMet = false;
-                }
-            }
-        }
-
-        return new CraftedItemParseResults(
-                name,
-                effectStrength,
-                uses,
-                attackSpeed,
-                damages,
-                defences,
-                new GearRequirements(levelReq, Optional.ofNullable(classReq), skillReqs, Optional.empty()),
-                allRequirementsMet);
+        return new CraftedItemParseResults(name, effectStrength, uses);
     }
 
     private static StatActualValue getStatActualValue(GearInfo gearInfo, StatType statType, int internalRoll) {

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -230,6 +230,7 @@ public final class WynnItemParser {
             if (attackSpeedMatcher.matches()) {
                 String speedName = attackSpeedMatcher.group(1);
                 attackSpeed = GearAttackSpeed.fromString(speedName.replaceAll(" ", "_"));
+                continue;
             }
 
             Matcher damageMatcher = coded.getMatcher(ITEM_DAMAGE_PATTERN);
@@ -237,6 +238,7 @@ public final class WynnItemParser {
                 String symbol = damageMatcher.group("symbol");
                 RangedValue range = RangedValue.fromString(damageMatcher.group("range"));
                 damages.add(Pair.of(DamageType.fromSymbol(symbol), range));
+                continue;
             }
 
             Matcher defenceMatcher = coded.getMatcher(ITEM_DEFENCE_PATTERN);
@@ -244,6 +246,7 @@ public final class WynnItemParser {
                 String symbol = defenceMatcher.group("symbol");
                 int value = Integer.parseInt(defenceMatcher.group("value"));
                 defences.add(Pair.of(Element.fromSymbol(symbol), value));
+                continue;
             }
 
             // Requirements
@@ -256,6 +259,8 @@ public final class WynnItemParser {
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
                 }
+
+                continue;
             }
 
             // Class
@@ -268,6 +273,8 @@ public final class WynnItemParser {
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
                 }
+
+                continue;
             }
 
             // Skills
@@ -282,6 +289,8 @@ public final class WynnItemParser {
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
                 }
+
+                continue;
             }
 
             // Quests
@@ -293,6 +302,8 @@ public final class WynnItemParser {
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
                 }
+
+                continue;
             }
 
             // Misc requirements
@@ -302,6 +313,8 @@ public final class WynnItemParser {
                 if (mark.contains("✖")) {
                     allRequirementsMet = false;
                 }
+
+                continue;
             }
 
             Matcher setMatcher = normalizedCoded.getMatcher(SET_PATTERN);
@@ -309,6 +322,7 @@ public final class WynnItemParser {
                 String setName = setMatcher.group(1);
                 setInfo = Models.Set.getSetInfo(setName);
                 setWynnCount = Integer.parseInt(setMatcher.group(2));
+                continue;
             }
 
             Matcher setItemMatcher = normalizedCoded.getMatcher(SET_ITEM_PATTERN);
@@ -316,6 +330,7 @@ public final class WynnItemParser {
                 boolean active = setItemMatcher.group(1).equals("2");
                 String itemName = setItemMatcher.group(2);
                 activeItems.put(itemName, active);
+                continue;
             }
 
             Matcher setBonusMatcher = normalizedCoded.getMatcher(SET_BONUS_PATTERN);
@@ -323,6 +338,7 @@ public final class WynnItemParser {
                 // Any stat lines that follow from now on belongs to the Set Bonus
                 // These are collected at the top of this loop for efficiency
                 setBonusStats = true;
+                continue;
             }
 
             // Look for effects (only on consumables)

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -19,7 +19,7 @@ import com.wynntils.models.character.CharacterSelectionModel;
 import com.wynntils.models.containers.ContainerModel;
 import com.wynntils.models.damage.DamageModel;
 import com.wynntils.models.damage.label.DamageLabelParser;
-import com.wynntils.models.items.annotators.game.GearAnnotator;
+import com.wynntils.models.gear.GearModel;
 import com.wynntils.models.items.annotators.game.IngredientAnnotator;
 import com.wynntils.models.items.annotators.game.RuneAnnotator;
 import com.wynntils.models.items.annotators.gui.AbilityTreeAnnotator;
@@ -823,6 +823,13 @@ public class TestRegex {
     }
 
     @Test
+    public void WynnItemParser_QUEST_REQ_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "QUEST_REQ_PATTERN");
+        p.shouldMatch("§a✔§7 Quest Req: The Qira Hive");
+        p.shouldMatch("§c✖§7 Quest Req: Realm of Light V - The Realm of Light");
+    }
+
+    @Test
     public void WynnItemParser_MISC_REQ_PATTERN() {
         PatternTester p = new PatternTester(WynnItemParser.class, "MISC_REQ_PATTERN");
         p.shouldMatch("§a✔§7 Quest Req: The Qira Hive");
@@ -864,8 +871,8 @@ public class TestRegex {
     }
 
     @Test
-    public void GearAnnotator_GEAR_PATTERN() {
-        PatternTester p = new PatternTester(GearAnnotator.class, "GEAR_PATTERN");
+    public void GearModel_GEAR_PATTERN() {
+        PatternTester p = new PatternTester(GearModel.class, "GEAR_PATTERN");
 
         // Unidentified
         p.shouldMatch("§5Unidentified §f⬡ §5Shiny Crusade Sabatons");


### PR DESCRIPTION
This is useful for adding UnknownGear sharing in chat. It also fixes these items not being parsed as unknown gear and not being able to be used with spell cast keybinds.