### PR TITLE
fix: Fix weapon types not being counted as weapon

### DIFF
--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -4,26 +4,22 @@
  */
 package com.wynntils.models.character.type;
 
-import com.wynntils.models.gear.type.GearType;
-
 public enum ClassType {
-    MAGE("Mage", "Dark Wizard", GearType.WAND),
-    ARCHER("Archer", "Hunter", GearType.BOW),
-    WARRIOR("Warrior", "Knight", GearType.SPEAR),
-    ASSASSIN("Assassin", "Ninja", GearType.DAGGER),
-    SHAMAN("Shaman", "Skyseer", GearType.RELIK),
+    MAGE("Mage", "Dark Wizard"),
+    ARCHER("Archer", "Hunter"),
+    WARRIOR("Warrior", "Knight"),
+    ASSASSIN("Assassin", "Ninja"),
+    SHAMAN("Shaman", "Skyseer"),
 
     // This represents the class selection menu, or the generic spell
-    NONE("none", "none", null);
+    NONE("none", "none");
 
     private final String name;
     private final String reskinnedName;
-    private final GearType gearType;
 
-    ClassType(String name, String reskinnedName, GearType gearType) {
+    ClassType(String name, String reskinnedName) {
         this.name = name;
         this.reskinnedName = reskinnedName;
-        this.gearType = gearType;
     }
 
     public static ClassType fromName(String className) {
@@ -57,10 +53,6 @@ public enum ClassType {
 
     public String getFullName() {
         return name + "/" + reskinnedName;
-    }
-
-    public GearType getGearType() {
-        return gearType;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -7,7 +7,6 @@ package com.wynntils.models.gear;
 import com.google.gson.JsonObject;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
-import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.gear.type.GearTier;
@@ -171,7 +170,7 @@ public final class GearModel extends Model {
             // If the gear type is weapon, we can try to find the weapon type from the requirements
             gearType = result.requirements()
                     .classType()
-                    .map(ClassType::getGearType)
+                    .map(GearType::fromClassType)
                     .orElse(gearType);
         }
 


### PR DESCRIPTION
The underlying case, which is two enums (GearType and ClassType) cross-referencing each other, and failing to load, silently, is absolutely a Java speciality that should never happen...