### PR TITLE
fix: Fix reveal nicknames not working for nicknames ending with s [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/RevealNicknamesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/RevealNicknamesFeature.java
@@ -30,7 +30,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class RevealNicknamesFeature extends Feature {
     // Note: Post Wynncraft 2.1, the hover text is inconsistent, sometimes "'s" is white, sometimes it's gray
     private static final Pattern NICKNAME_PATTERN =
-            Pattern.compile("§f(?<nick>.+?)(§7)?'s(§7)? real username is §f(?<username>.+)");
+            Pattern.compile("§f(?<nick>.+?)(§7)?'s?(§7)? real username is §f(?<username>.+)");
     private static final String NICKNAME_HOVER_TEXT = "§f%s§7's nickname is §f%s";
 
     @Persisted


### PR DESCRIPTION
Current
![image](https://github.com/user-attachments/assets/c8f5e649-8a5f-41c4-8f4c-912ba976b9f7)
Fixed
![image](https://github.com/user-attachments/assets/cd39212b-cef0-40c6-bd17-720fc7d16c92)
