### PR TITLE
fix: Fix guild chat not ignoring username in chat mentions [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
@@ -26,7 +26,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.CHAT)
 public class ChatCoordinatesFeature extends Feature {
-    private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s");
+    private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s?");
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onChatReceived(ChatMessageReceivedEvent e) {

--- a/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
@@ -29,7 +29,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.CHAT)
 public class ChatMentionFeature extends Feature {
-    private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s");
+    private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s?");
     private static final Pattern NON_WORD_CHARACTERS =
             Pattern.compile("\\W"); // all non-alphanumeric-underscore characters
 

--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -51,7 +51,7 @@ public class TranscribeMessagesFeature extends Feature {
     @Persisted
     public final Config<ColorChatFormatting> wynnicColor = new Config<>(ColorChatFormatting.DARK_GREEN);
 
-    private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s");
+    private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s?");
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onChat(ChatMessageReceivedEvent event) {


### PR DESCRIPTION
Hopefully last change to this, I didn't test it on guild chat originally which doesn't have the whitespace after the `:` so it wasn't matching the pattern and would detect your username as a mention