### PR TITLE
fix: Fix flashback crashing when scoreboard is displayed [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardHandler.java
@@ -342,7 +342,7 @@ public final class ScoreboardHandler extends Handler {
                 SCOREBOARD_TITLE_COMPONENT,
                 ObjectiveCriteria.RenderType.INTEGER,
                 true,
-                new BlankFormat());
+                BlankFormat.INSTANCE);
 
         if (scoreboardSegments.stream().map(Pair::value).noneMatch(ScoreboardSegment::isVisible)) return;
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d276cc55-90fa-4a32-826b-48f2facff61f)

![image](https://github.com/user-attachments/assets/9cbd925c-11a1-41f6-9307-078080380fbb)
