### PR TITLE
chore: Don't stretch background texture on character selection and loading screen [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/screens/characterselector/CharacterSelectorScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/CharacterSelectorScreen.java
@@ -176,14 +176,17 @@ public final class CharacterSelectorScreen extends WynntilsScreen {
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         PoseStack poseStack = guiGraphics.pose();
 
+        float aspectRatio = (float) Texture.BACKGROUND_SPLASH.height() / Texture.BACKGROUND_SPLASH.width();
+        float textureHeight = this.width * aspectRatio;
+
         RenderUtils.drawScalingTexturedRect(
                 poseStack,
                 Texture.BACKGROUND_SPLASH.resource(),
                 0,
-                0,
+                (this.height - textureHeight) / 2f,
                 0,
                 this.width,
-                this.height,
+                textureHeight,
                 Texture.BACKGROUND_SPLASH.width(),
                 Texture.BACKGROUND_SPLASH.height());
     }

--- a/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
@@ -66,15 +66,18 @@ public final class LoadingScreen extends WynntilsScreen {
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         PoseStack poseStack = guiGraphics.pose();
 
+        float aspectRatio = (float) Texture.BACKGROUND_SPLASH.height() / Texture.BACKGROUND_SPLASH.width();
+        float textureHeight = this.width * aspectRatio;
+
         // Draw background
         RenderUtils.drawScalingTexturedRect(
                 poseStack,
                 Texture.BACKGROUND_SPLASH.resource(),
                 0,
-                0,
+                (this.height - textureHeight) / 2f,
                 0,
                 this.width,
-                this.height,
+                textureHeight,
                 Texture.BACKGROUND_SPLASH.width(),
                 Texture.BACKGROUND_SPLASH.height());
 


### PR DESCRIPTION
![2024-08-25_16 06 58](https://github.com/user-attachments/assets/8a9f89c4-b77b-4183-8fe3-942ba3ab6949)
![2024-08-25_16 07 04](https://github.com/user-attachments/assets/d5c3bd3f-16d5-427e-976c-b588e6bce3c4)
