### PR TITLE
feat: Introduce graphed, dependency based downloads

### DIFF
--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -216,6 +216,7 @@ public class WynntilsCommand extends Command {
 
         // Reload all downloaded data
         WynntilsMod.reloadAllComponentData();
+        Managers.Download.download();
 
         return 1;
     }

--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -204,6 +204,9 @@ public final class WynntilsMod {
         // Init storage for loaded components immediately
         Managers.Storage.initComponents();
 
+        // Ask every component about their data dependencies and register them
+        Managers.Download.initComponents(componentMap);
+
         addCrashCallbacks();
     }
 

--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -206,6 +206,7 @@ public final class WynntilsMod {
 
         // Ask every component about their data dependencies and register them
         Managers.Download.initComponents(componentMap);
+        Managers.Download.startDownloads();
 
         addCrashCallbacks();
     }

--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -206,7 +206,7 @@ public final class WynntilsMod {
 
         // Ask every component about their data dependencies and register them
         Managers.Download.initComponents(componentMap);
-        Managers.Download.startDownloads();
+        Managers.Download.download();
 
         addCrashCallbacks();
     }

--- a/common/src/main/java/com/wynntils/core/components/CoreComponent.java
+++ b/common/src/main/java/com/wynntils/core/components/CoreComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.components;
@@ -14,5 +14,9 @@ public abstract class CoreComponent implements Storageable {
         String name = this.getClass().getSimpleName().replace(getTypeName(), "");
         String nameCamelCase = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name);
         return getTypeName().toLowerCase(Locale.ROOT) + "." + nameCamelCase;
+    }
+
+    public void registerDownloads() {
+        // Override this method to register downloads for this component.
     }
 }

--- a/common/src/main/java/com/wynntils/core/components/CoreComponent.java
+++ b/common/src/main/java/com/wynntils/core/components/CoreComponent.java
@@ -5,6 +5,7 @@
 package com.wynntils.core.components;
 
 import com.google.common.base.CaseFormat;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.persisted.storage.Storageable;
 import java.util.Locale;
 
@@ -16,7 +17,7 @@ public abstract class CoreComponent implements Storageable {
         return getTypeName().toLowerCase(Locale.ROOT) + "." + nameCamelCase;
     }
 
-    public void registerDownloads() {
-        // Override this method to register downloads for this component.
+    public void registerDownloads(DownloadRegistry registry) {
+        // Override this method to register downloads for this component.\
     }
 }

--- a/common/src/main/java/com/wynntils/core/components/CoreComponent.java
+++ b/common/src/main/java/com/wynntils/core/components/CoreComponent.java
@@ -18,6 +18,6 @@ public abstract class CoreComponent implements Storageable {
     }
 
     public void registerDownloads(DownloadRegistry registry) {
-        // Override this method to register downloads for this component.\
+        // Override this method to register downloads for this component.
     }
 }

--- a/common/src/main/java/com/wynntils/core/components/Managers.java
+++ b/common/src/main/java/com/wynntils/core/components/Managers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.components;
@@ -14,6 +14,7 @@ import com.wynntils.core.keybinds.KeyBindManager;
 import com.wynntils.core.mod.ConnectionManager;
 import com.wynntils.core.mod.CrashReportManager;
 import com.wynntils.core.mod.TickSchedulerManager;
+import com.wynntils.core.net.DownloadManager;
 import com.wynntils.core.net.NetManager;
 import com.wynntils.core.net.UrlManager;
 import com.wynntils.core.notifications.NotificationManager;
@@ -26,6 +27,7 @@ public final class Managers {
     // Start with UrlManager to give it chance to update URLs in background
     public static final NetManager Net = new NetManager();
     public static final UrlManager Url = new UrlManager(Net);
+    public static final DownloadManager Download = new DownloadManager();
 
     public static final ClientCommandManager Command = new ClientCommandManager();
     public static final ConfigManager Config = new ConfigManager();

--- a/common/src/main/java/com/wynntils/core/components/Models.java
+++ b/common/src/main/java/com/wynntils/core/components/Models.java
@@ -87,6 +87,7 @@ public final class Models {
     public static final GuildModel Guild = new GuildModel();
     public static final GuildWarTowerModel GuildWarTower = new GuildWarTowerModel();
     public static final HorseModel Horse = new HorseModel();
+    public static final IngredientModel Ingredient = new IngredientModel();
     public static final InventoryModel Inventory = new InventoryModel();
     public static final ItemEncodingModel ItemEncoding = new ItemEncodingModel();
     public static final ItemModel Item = new ItemModel();
@@ -101,6 +102,7 @@ public final class Models {
     public static final ProfessionModel Profession = new ProfessionModel();
     public static final QuestModel Quest = new QuestModel();
     public static final RaidModel Raid = new RaidModel();
+    public static final RewardsModel Rewards = new RewardsModel();
     public static final SeaskipperModel Seaskipper = new SeaskipperModel();
     public static final ServerListModel ServerList = new ServerListModel();
     public static final SetModel Set = new SetModel();
@@ -124,6 +126,4 @@ public final class Models {
     public static final ActivityModel Activity = new ActivityModel(Marker);
     public static final GuildAttackTimerModel GuildAttackTimer = new GuildAttackTimerModel(Marker);
     public static final LootrunModel Lootrun = new LootrunModel(Marker);
-    public static final RewardsModel Rewards = new RewardsModel(WynnItem);
-    public static final IngredientModel Ingredient = new IngredientModel(WynnItem);
 }

--- a/common/src/main/java/com/wynntils/core/net/Dependency.java
+++ b/common/src/main/java/com/wynntils/core/net/Dependency.java
@@ -15,6 +15,11 @@ public abstract class Dependency {
         public List<Pair<CoreComponent, UrlId>> dependencies() {
             return List.of();
         }
+
+        @Override
+        public String toString() {
+            return "EmptyDependency{}";
+        }
     };
 
     public abstract List<Pair<CoreComponent, UrlId>> dependencies();
@@ -55,6 +60,11 @@ public abstract class Dependency {
         public List<Pair<CoreComponent, UrlId>> dependencies() {
             return List.of(Pair.of(component, urlId));
         }
+
+        @Override
+        public String toString() {
+            return "SimpleComponentDataDependency{" + "component=" + component + ", urlId=" + urlId + '}';
+        }
     }
 
     /**
@@ -73,6 +83,11 @@ public abstract class Dependency {
         public List<Pair<CoreComponent, UrlId>> dependencies() {
             return urlIds.stream().map(urlId -> Pair.of(component, urlId)).toList();
         }
+
+        @Override
+        public String toString() {
+            return "SingleComponentMultiDataDependency{" + "component=" + component + ", urlIds=" + urlIds + '}';
+        }
     }
 
     /**
@@ -90,6 +105,11 @@ public abstract class Dependency {
             return dependencies.stream()
                     .flatMap(dependency -> dependency.dependencies().stream())
                     .toList();
+        }
+
+        @Override
+        public String toString() {
+            return "ComplexDependency{" + "dependencies=" + dependencies + '}';
         }
     }
 }

--- a/common/src/main/java/com/wynntils/core/net/Dependency.java
+++ b/common/src/main/java/com/wynntils/core/net/Dependency.java
@@ -48,8 +48,6 @@ public abstract class Dependency {
 
         @Override
         public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
-            assert finishedDownloads.stream().allMatch(download -> download.status() == QueuedDownload.Status.FINISHED);
-
             return finishedDownloads.stream()
                     .filter(download -> download.callerComponent() == component)
                     .anyMatch(download -> download.urlId() == urlId);
@@ -70,8 +68,6 @@ public abstract class Dependency {
 
         @Override
         public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
-            assert finishedDownloads.stream().allMatch(download -> download.status() == QueuedDownload.Status.FINISHED);
-
             return finishedDownloads.stream()
                     .filter(download -> download.callerComponent() == component)
                     .map(QueuedDownload::urlId)
@@ -91,8 +87,6 @@ public abstract class Dependency {
 
         @Override
         public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
-            assert finishedDownloads.stream().allMatch(download -> download.status() == QueuedDownload.Status.FINISHED);
-
             return dependencies.stream().allMatch(dependency -> dependency.isSatisfied(finishedDownloads));
         }
     }

--- a/common/src/main/java/com/wynntils/core/net/Dependency.java
+++ b/common/src/main/java/com/wynntils/core/net/Dependency.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.net;
+
+import com.wynntils.core.components.CoreComponent;
+import java.util.List;
+import java.util.Set;
+
+public abstract class Dependency {
+    private static final Dependency EMPTY = new Dependency() {
+        @Override
+        public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
+            return true;
+        }
+    };
+
+    public abstract boolean isSatisfied(List<QueuedDownload> finishedDownloads);
+
+    public static Dependency empty() {
+        return EMPTY;
+    }
+
+    public static Dependency simple(CoreComponent component, UrlId urlId) {
+        return new SimpleComponentDataDependency(component, urlId);
+    }
+
+    public static Dependency multi(CoreComponent component, Set<UrlId> urlIds) {
+        return new SingleComponentMultiDataDependency(component, urlIds);
+    }
+
+    public static Dependency complex(Set<Dependency> dependencies) {
+        return new ComplexDependency(dependencies);
+    }
+
+    /**
+     * A simple dependency that checks if a specific component has downloaded a specific file.
+     */
+    private static final class SimpleComponentDataDependency extends Dependency {
+        private final CoreComponent component;
+        private final UrlId urlId;
+
+        private SimpleComponentDataDependency(CoreComponent component, UrlId urlId) {
+            this.component = component;
+            this.urlId = urlId;
+        }
+
+        @Override
+        public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
+            assert finishedDownloads.stream().allMatch(download -> download.status() == QueuedDownload.Status.FINISHED);
+
+            return finishedDownloads.stream()
+                    .filter(download -> download.callerComponent() == component)
+                    .anyMatch(download -> download.urlId() == urlId);
+        }
+    }
+
+    /**
+     * A dependency that checks if a specific component has downloaded a set of files.
+     */
+    private static final class SingleComponentMultiDataDependency extends Dependency {
+        private final CoreComponent component;
+        private final Set<UrlId> urlIds;
+
+        private SingleComponentMultiDataDependency(CoreComponent component, Set<UrlId> urlIds) {
+            this.component = component;
+            this.urlIds = urlIds;
+        }
+
+        @Override
+        public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
+            assert finishedDownloads.stream().allMatch(download -> download.status() == QueuedDownload.Status.FINISHED);
+
+            return finishedDownloads.stream()
+                    .filter(download -> download.callerComponent() == component)
+                    .map(QueuedDownload::urlId)
+                    .allMatch(urlIds::contains);
+        }
+    }
+
+    /**
+     * A dependency that checks whether a set of other dependencies are satisfied.
+     */
+    private static final class ComplexDependency extends Dependency {
+        private final Set<Dependency> dependencies;
+
+        private ComplexDependency(Set<Dependency> dependencies) {
+            this.dependencies = dependencies;
+        }
+
+        @Override
+        public boolean isSatisfied(List<QueuedDownload> finishedDownloads) {
+            assert finishedDownloads.stream().allMatch(download -> download.status() == QueuedDownload.Status.FINISHED);
+
+            return dependencies.stream().allMatch(dependency -> dependency.isSatisfied(finishedDownloads));
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/core/net/Download.java
+++ b/common/src/main/java/com/wynntils/core/net/Download.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2023.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.net;
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.FileUtils;
 
 public class Download extends NetResult {
-    protected final File localFile;
+    private final File localFile;
 
     // Saved since we might need to get timestamps from the HttpResponse
     private CompletableFuture<HttpResponse<Path>> httpResponse = null;

--- a/common/src/main/java/com/wynntils/core/net/Download.java
+++ b/common/src/main/java/com/wynntils/core/net/Download.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.net;
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.FileUtils;
 
 public class Download extends NetResult {
-    private final File localFile;
+    protected final File localFile;
 
     // Saved since we might need to get timestamps from the HttpResponse
     private CompletableFuture<HttpResponse<Path>> httpResponse = null;

--- a/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.net;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.CoreComponent;
+import com.wynntils.utils.type.Pair;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public final class DownloadDependencyGraph {
+    private final Map<Node, NodeState> nodeMap = new ConcurrentHashMap<>();
+
+    private DownloadDependencyGraph(List<Node> nodes) {
+        nodes.forEach(node ->
+                nodeMap.put(node, node.dependencies.isEmpty() ? NodeState.QUEUED : NodeState.WAITING_ON_DEPENDENCY));
+    }
+
+    public static DownloadDependencyGraph build(List<QueuedDownload> downloads) {
+        // Short circut on no downloads, to handle the edge-case one and for all in all sanity checks
+        if (downloads.isEmpty()) return new DownloadDependencyGraph(List.of());
+
+        // Firsly, run sanity checks on the queued downloads to determine if a valid graph can be built
+        // 1. Check for duplicate downloads
+        checkDuplicateDownloads(downloads);
+
+        // 2. Check for missign dependencies
+        checkMissingDependencies(downloads);
+
+        // Now, let's build a directed graph of the download dependencies
+        List<Node> nodes = downloads.stream().map(Node::new).toList();
+        nodes.forEach(node -> node.calculateDependencies(nodes));
+
+        // The latter part of the sanity checks can be ran after building the graph:
+        // 1. Check for circular dependencies
+        checkCircularDependencies(nodes);
+
+        return new DownloadDependencyGraph(nodes);
+    }
+
+    // region Processing
+
+    public QueuedDownload nextDownload() {
+        Node nextNode = nodeMap.entrySet().stream()
+                .filter(entry -> entry.getValue() == NodeState.QUEUED)
+                .map(Map.Entry::getKey)
+                .findAny()
+                .orElse(null);
+
+        if (nextNode == null) return null;
+
+        nodeMap.put(nextNode, NodeState.IN_PROGRESS);
+
+        return nextNode.download;
+    }
+
+    public void markDownloadCompleted(QueuedDownload download) {
+        Node node = nodeMap.keySet().stream()
+                .filter(n -> n.download == download)
+                .findAny()
+                .orElseThrow(() -> new IllegalStateException("Download not found in graph: " + download.urlId()));
+
+        nodeMap.put(node, NodeState.COMPLETED);
+
+        // Mark all dependents as ready to be downloaded, if all their dependencies are completed
+        node.dependents.forEach(dependent -> {
+            if (dependent.dependencies.stream()
+                    .allMatch(dependency -> nodeMap.get(dependency) == NodeState.COMPLETED)) {
+                nodeMap.put(dependent, NodeState.QUEUED);
+            }
+        });
+    }
+
+    public void markDownloadError(QueuedDownload download) {
+        Node node = nodeMap.keySet().stream()
+                .filter(n -> n.download == download)
+                .findAny()
+                .orElseThrow(() -> new IllegalStateException("Download not found in graph: " + download.urlId()));
+
+        nodeMap.put(node, NodeState.ERROR);
+
+        // Mark all dependents as error, as they cannot be downloaded
+        node.dependents.forEach(dependent -> nodeMap.put(dependent, NodeState.ERROR));
+    }
+
+    // endregion
+
+    // region State and Progress
+
+    public boolean isFinished() {
+        return nodeMap.values().stream().allMatch(state -> state == NodeState.COMPLETED || state == NodeState.ERROR);
+    }
+
+    public boolean hasError() {
+        return nodeMap.values().stream().anyMatch(state -> state == NodeState.ERROR);
+    }
+
+    public int totalDownloads() {
+        return nodeMap.size();
+    }
+
+    public int successfulDownloads() {
+        return (int) nodeMap.values().stream()
+                .filter(state -> state == NodeState.COMPLETED)
+                .count();
+    }
+
+    public int failedDownloads() {
+        return (int) nodeMap.values().stream()
+                .filter(state -> state == NodeState.ERROR)
+                .count();
+    }
+
+    public float errorRate() {
+        return (float) failedDownloads() / totalDownloads();
+    }
+
+    // endregion
+
+    // region Checks
+    private static void checkDuplicateDownloads(List<QueuedDownload> downloads) {
+        // Downloading the same resource in the same core component should always point to a schematic error
+        // in the component itself, so mark it as a critical issue and crash the mod
+        QueuedDownload duplicatedInSameComponent = downloads.stream()
+                .filter(download -> downloads.stream().anyMatch(other -> download != other && download.equals(other)))
+                .findAny()
+                .orElse(null);
+
+        if (duplicatedInSameComponent != null) {
+            throw new IllegalStateException(duplicatedInSameComponent.callerComponent()
+                    + " downloaded the same data twice: " + duplicatedInSameComponent.urlId());
+        }
+
+        // Downloading the same resouce in different core components is not a direct confirmation of a schematic issue,
+        // but is likely to be a mistake. Mark it as a warning and continue with the graph building
+        List<QueuedDownload> duplicatedDownloadsInSeparateComponenets = downloads.stream()
+                .filter(download ->
+                        downloads.stream().anyMatch(other -> download != other && download.urlId() == other.urlId()))
+                .toList();
+
+        if (!duplicatedDownloadsInSeparateComponenets.isEmpty()) {
+            WynntilsMod.warn("Multiple components downloaded the same data: "
+                    + duplicatedDownloadsInSeparateComponenets.getFirst().urlId() + ". Componenets: "
+                    + StringUtils.join(duplicatedDownloadsInSeparateComponenets.stream()
+                            .map(QueuedDownload::callerComponent)
+                            .toList()));
+        }
+    }
+
+    private static void checkMissingDependencies(List<QueuedDownload> downloads) {
+        Set<Pair<CoreComponent, UrlId>> allDependencies = downloads.stream()
+                .flatMap(download -> download.dependency().dependencies().stream())
+                .collect(Collectors.toUnmodifiableSet());
+
+        for (Pair<CoreComponent, UrlId> dependency : allDependencies) {
+            boolean missingDependency = downloads.stream()
+                    .noneMatch(download ->
+                            download.callerComponent() == dependency.a() && download.urlId() == dependency.b());
+
+            if (missingDependency) {
+                throw new IllegalStateException("Missing dependency: " + dependency.b() + " for " + dependency.a());
+            }
+        }
+    }
+
+    private static void checkCircularDependencies(List<Node> nodes) {
+        for (Node node : nodes) {
+            Deque<Node> stack = new LinkedList<>();
+            stack.addFirst(node);
+
+            while (!stack.isEmpty()) {
+                Node currentNode = stack.pop();
+                boolean circularDependency = currentNode.dependencies.stream()
+                        .anyMatch(dependencyNode -> dependencyNode.dependencies.contains(node));
+
+                if (circularDependency) {
+                    throw new IllegalStateException("Circular dependency detected on: " + node.download.urlId()
+                            + ". Starting from: " + node.download.callerComponent());
+                }
+
+                stack.addAll(currentNode.dependencies);
+            }
+        }
+    }
+
+    // endregion
+
+    // region Debug
+
+    void logGraph() {
+        WynntilsMod.info("[DownloadManager] Download Dependency Graph:");
+
+        // First, collect all UrlIds by their caller components
+        Map<CoreComponent, List<UrlId>> urlIdsByComponent = nodeMap.keySet().stream()
+                .sorted(Comparator.comparing(n -> n.download.callerComponent().getJsonName()))
+                .collect(Collectors.groupingBy(
+                        node -> node.download.callerComponent(),
+                        Collectors.mapping(node -> node.download.urlId(), Collectors.toList())));
+
+        // Then, log the graph, printing the caller component and its downloaded UrlIds, and their dependencies
+        urlIdsByComponent.forEach((component, urlIds) -> {
+            WynntilsMod.info("| -- " + StringUtils.capitalize(component.getJsonName()));
+            urlIds.forEach(urlId -> {
+                Node node = nodeMap.keySet().stream()
+                        .filter(n -> n.download.callerComponent() == component && n.download.urlId() == urlId)
+                        .findAny()
+                        .orElseThrow();
+
+                if (node.dependencies.isEmpty()) {
+                    WynntilsMod.info("|    - " + urlId);
+                } else {
+                    WynntilsMod.info("|    - " + urlId + " <- "
+                            + node.dependencies.stream()
+                                    .map(dependency -> dependency.download.urlId())
+                                    .toList());
+                }
+            });
+        });
+    }
+
+    // endregion
+
+    private enum NodeState {
+        WAITING_ON_DEPENDENCY,
+        QUEUED,
+        IN_PROGRESS,
+        COMPLETED,
+        ERROR,
+    }
+
+    private static final class Node {
+        private final QueuedDownload download;
+
+        private List<Node> dependencies = List.of();
+        private List<Node> dependents = List.of();
+
+        private Node(QueuedDownload download) {
+            this.download = download;
+        }
+
+        private void calculateDependencies(List<Node> nodes) {
+            List<Node> dependencies = new ArrayList<>();
+            List<Node> dependents = new ArrayList<>();
+
+            for (Node node : nodes) {
+                if (download.dependency().dependsOn(node.download.callerComponent(), node.download.urlId())) {
+                    dependencies.add(node);
+                } else if (node.download.dependency().dependsOn(download.callerComponent(), download.urlId())) {
+                    dependents.add(node);
+                }
+            }
+
+            this.dependencies = List.copyOf(dependencies);
+            this.dependents = List.copyOf(dependents);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Node node = (Node) o;
+            return Objects.equals(download, node.download);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(download);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
@@ -147,7 +147,7 @@ public final class DownloadDependencyGraph {
                     + " downloaded the same data twice: " + duplicatedInSameComponent.urlId());
         }
 
-        // Downloading the same resouce in different core components is not a direct confirmation of a schematic issue,
+        // Downloading the same resource in different core components is not a direct confirmation of a schematic issue,
         // but is likely to be a mistake. Mark it as a warning and continue with the graph building
         List<QueuedDownload> duplicatedDownloadsInSeparateComponenets = downloads.stream()
                 .filter(download ->

--- a/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
@@ -51,7 +51,7 @@ public final class DownloadDependencyGraph {
 
     // region Processing
 
-    public QueuedDownload nextDownload() {
+    public synchronized QueuedDownload nextDownload() {
         Node nextNode = nodeMap.entrySet().stream()
                 .filter(entry -> entry.getValue() == NodeState.QUEUED)
                 .map(Map.Entry::getKey)

--- a/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
@@ -94,6 +94,11 @@ public final class DownloadDependencyGraph {
         node.dependents.forEach(dependent -> nodeMap.put(dependent, NodeState.ERROR));
     }
 
+    public void resetState() {
+        nodeMap.replaceAll(
+                (node, state) -> node.dependencies.isEmpty() ? NodeState.QUEUED : NodeState.WAITING_ON_DEPENDENCY);
+    }
+
     // endregion
 
     // region State and Progress

--- a/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadDependencyGraph.java
@@ -35,7 +35,7 @@ public final class DownloadDependencyGraph {
         // 1. Check for duplicate downloads
         checkDuplicateDownloads(downloads);
 
-        // 2. Check for missign dependencies
+        // 2. Check for missing dependencies
         checkMissingDependencies(downloads);
 
         // Now, let's build a directed graph of the download dependencies

--- a/common/src/main/java/com/wynntils/core/net/DownloadManager.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadManager.java
@@ -155,7 +155,7 @@ public class DownloadManager extends Manager {
             return;
         }
 
-        throw new IllegalStateException(
+        WynntilsMod.error(
                 "Finished, but not yet replaced download not found in the current downloads: " + toBeReplaced);
     }
 

--- a/common/src/main/java/com/wynntils/core/net/DownloadManager.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadManager.java
@@ -58,7 +58,7 @@ public class DownloadManager extends Manager {
 
     private DownloadDependencyGraph graph = null;
 
-    private Pair<QueuedDownload, Download>[] currentDownloads = new Pair[MAX_PARALLEL_DOWNLOADS];
+    private Pair<QueuedDownload, Download>[] currentDownloads;
 
     public DownloadManager() {
         super(List.of());
@@ -82,7 +82,11 @@ public class DownloadManager extends Manager {
         }
     }
 
-    public void startDownloads() {
+    public void download() {
+        // Reset the state of the manager, as the downloads are being started
+        graph.resetState();
+        currentDownloads = new Pair[MAX_PARALLEL_DOWNLOADS];
+
         // Start the downloads by filling the parallel download slots
         // After that, the manager will regulate the downloads by itself
         for (int i = 0; i < MAX_PARALLEL_DOWNLOADS; i++) {

--- a/common/src/main/java/com/wynntils/core/net/DownloadManager.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.net;
+
+import com.wynntils.core.components.CoreComponent;
+import com.wynntils.core.components.Manager;
+import com.wynntils.core.components.Managers;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Manages downloading files from the internet. This manager acts as a middle layer between the caller components
+ * and {@link NetManager}. It's main purpose is to provide the components a well regulated and managed way
+ * of downloading dependency files.
+ * <p><b>This manager should not be used for spontainous downloads. Use one {@link NetManager}'s download methods
+ * if you want to download files during running, and not in a pre-planned fashion.</b></p>
+ * <p>This component provides multiple tools to ease the development of other components:</p>
+ * - The manager can handle dependency resoltion, allowing components to depend on other component's data files, without
+ * having to natively code the dependency resolution. As the manager is responsible for every components' downloads,
+ * it can also ensure that all dependencies are valid, meaning they are not circular or missing.
+ * <br>
+ * - The manager can directly handle re-download requests, allowing all data sources to be re-downloaded directly, if
+ * the user or system requires it.
+ * <br>
+ * - The manager can keep track of failed downloads, and easily retry them, knowing that no race conditions will occur
+ * on either successful or failed downloads. It can also provide the user with useful information about their cache state.
+ * <br>
+ * - The manager can handle parallel downloads, within regulated manners, ensuring a stable amount of downloads
+ * are happening at any given time. This allows more stable downloads for less stable internet connections. The manager
+ * can also provide a clear view of the download queue, and the download progress.
+ */
+public class DownloadManager extends Manager {
+    private static final int MAX_PARALLEL_DOWNLOADS = 4;
+
+    private final List<QueuedDownload> downloadQueue = new ArrayList<>();
+    private boolean queueLock = false;
+
+    public DownloadManager() {
+        super(List.of());
+    }
+
+    public QueuedDownload queueDownload(UrlId urlId, CoreComponent callerComponent) {
+        return queueDownload(urlId, callerComponent, Dependency.empty());
+    }
+
+    public QueuedDownload queueDownload(UrlId urlId, CoreComponent callerComponent, Dependency dependency) {
+        if (queueLock) {
+            throw new IllegalStateException("Cannot queue downloads after the first download request.");
+        }
+
+        QueuedDownload queuedDownload = new QueuedDownload(
+                Managers.Net.download(urlId), urlId, callerComponent, dependency, QueuedDownload.Status.QUEUED);
+        downloadQueue.add(queuedDownload);
+        return queuedDownload;
+    }
+
+    public CompletableFuture<Void> downloadAll() {
+        // Lock the queue after the first download request
+        queueLock = true;
+
+        return CompletableFuture.runAsync(() -> {});
+    }
+
+    private void createQueueTree() {
+        // Reverse tree for dependency graph, traverse by breadth-first search
+    }
+}

--- a/common/src/main/java/com/wynntils/core/net/DownloadManager.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadManager.java
@@ -139,12 +139,12 @@ public class DownloadManager extends Manager {
         throw new IllegalStateException("Queued download has no handler set: " + queuedDownload);
     }
 
-    private void replaceDownload(QueuedDownload toBeReplaced) {
+    private void queueNextDownload(QueuedDownload finishedDownload) {
         QueuedDownload nextDownload = graph.nextDownload();
 
         for (int i = 0; i < MAX_PARALLEL_DOWNLOADS; i++) {
             if (currentDownloads[i] == null) continue;
-            if (!currentDownloads[i].key().equals(toBeReplaced)) continue;
+            if (!currentDownloads[i].key().equals(finishedDownload)) continue;
 
             if (nextDownload == null) {
                 currentDownloads[i] = null;
@@ -156,7 +156,7 @@ public class DownloadManager extends Manager {
         }
 
         WynntilsMod.error(
-                "Finished, but not yet replaced download not found in the current downloads: " + toBeReplaced);
+                "Finished, but not yet replaced download not found in the current downloads: " + finishedDownload);
     }
 
     private <T> Consumer<T> wrapDownloadHandler(Consumer<T> handler, QueuedDownload download) {
@@ -176,7 +176,7 @@ public class DownloadManager extends Manager {
 
             // Mark the download as completed
             graph.markDownloadCompleted(download);
-            replaceDownload(download);
+            queueNextDownload(download);
             checkDownloadsFinished();
         };
     }
@@ -192,7 +192,7 @@ public class DownloadManager extends Manager {
 
             // Mark the download as failed
             graph.markDownloadError(download);
-            replaceDownload(download);
+            queueNextDownload(download);
             checkDownloadsFinished();
         };
     }

--- a/common/src/main/java/com/wynntils/core/net/DownloadManager.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadManager.java
@@ -4,13 +4,21 @@
  */
 package com.wynntils.core.net;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.CoreComponent;
 import com.wynntils.core.components.Manager;
 import com.wynntils.core.components.Managers;
+import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.type.Pair;
+import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Manages downloading files from the internet. This manager acts as a middle layer between the caller components
@@ -34,10 +42,23 @@ import java.util.concurrent.CompletableFuture;
  * can also provide a clear view of the download queue, and the download progress.
  */
 public class DownloadManager extends Manager {
-    private static final int MAX_PARALLEL_DOWNLOADS = 4;
+    // -Dwynntils.downloads.dump.graph=true
+    private static final String DOWNLOADS_DUMP_GRAPH = "wynntils.downloads.dump.graph";
+    // -Dwynntils.downloads.log.debug=true
+    private static final String DOWNLOADS_LOG_DEBUG = "wynntils.downloads.log.debug";
+    // -Dwynntils.downloads.max.parallel=8
+    private static final String DOWNLOADS_MAX_PARALLEL = "wynntils.downloads.max.parallel";
 
-    private final List<QueuedDownload> downloadQueue = new ArrayList<>();
-    private boolean queueLock = false;
+    private static final boolean DUMP_GRAPH = System.getProperty(DOWNLOADS_DUMP_GRAPH) != null;
+    private static final boolean DEBUG_LOGS = System.getProperty(DOWNLOADS_LOG_DEBUG) != null;
+    private static final int MAX_PARALLEL_DOWNLOADS = Integer.getInteger(DOWNLOADS_MAX_PARALLEL, 4);
+
+    private final List<QueuedDownload> registeredDownloads = new ArrayList<>();
+    private boolean registrationLock = false;
+
+    private DownloadDependencyGraph graph = null;
+
+    private Pair<QueuedDownload, Download>[] currentDownloads = new Pair[MAX_PARALLEL_DOWNLOADS];
 
     public DownloadManager() {
         super(List.of());
@@ -48,27 +69,148 @@ public class DownloadManager extends Manager {
             coreComponents.forEach(
                     coreComponent -> coreComponent.registerDownloads(new DownloadRegistry(this, coreComponent)));
         });
+
+        // Lock the queue, as the graph is being built,
+        // no modifications should be done during the lifetime of the game instance
+        registrationLock = true;
+
+        graph = DownloadDependencyGraph.build(registeredDownloads);
+
+        // Dump the graph if the system property is set
+        if (DUMP_GRAPH) {
+            graph.logGraph();
+        }
     }
 
-    public CompletableFuture<Void> downloadAll() {
-        // Lock the queue after the first download request
-        queueLock = true;
+    public void startDownloads() {
+        // Start the downloads by filling the parallel download slots
+        // After that, the manager will regulate the downloads by itself
+        for (int i = 0; i < MAX_PARALLEL_DOWNLOADS; i++) {
+            QueuedDownload queuedDownload = graph.nextDownload();
 
-        return CompletableFuture.runAsync(() -> {});
+            if (queuedDownload == null) {
+                // This may not be an issue, but it can be a sign of a bug, or a bad configuration
+                WynntilsMod.warn("Max parallel downloads was not reached, but there are no more downloads to start.");
+                return;
+            }
+
+            currentDownloads[i] = new Pair<>(queuedDownload, getDownload(queuedDownload));
+        }
     }
 
     QueuedDownload queueDownload(UrlId urlId, CoreComponent callerComponent, Dependency dependency) {
-        if (queueLock) {
-            throw new IllegalStateException("Cannot queue downloads after the first download request.");
+        if (registrationLock) {
+            throw new IllegalStateException("Cannot queue downloads after the download graph is already built.");
         }
 
-        QueuedDownload queuedDownload =
-                new QueuedDownload(Managers.Net.download(urlId), callerComponent, urlId, dependency);
-        downloadQueue.add(queuedDownload);
+        QueuedDownload queuedDownload = new QueuedDownload(callerComponent, urlId, dependency);
+        registeredDownloads.add(queuedDownload);
         return queuedDownload;
     }
 
-    private void createQueueTree() {
-        // Reverse tree for dependency graph, traverse by breadth-first search
+    private Download getDownload(QueuedDownload queuedDownload) {
+        Download download = Managers.Net.download(queuedDownload.urlId());
+
+        Consumer<Reader> readerHandler = queuedDownload.onCompletionReader();
+        if (readerHandler != null) {
+            download.handleReader(
+                    wrapDownloadHandler(readerHandler, queuedDownload), wrapDownloadFailure(queuedDownload));
+            return download;
+        }
+
+        Consumer<JsonObject> jsonObjectHandler = queuedDownload.onCompletionJsonObject();
+        if (jsonObjectHandler != null) {
+            download.handleJsonObject(
+                    wrapDownloadHandler(jsonObjectHandler, queuedDownload), wrapDownloadFailure(queuedDownload));
+            return download;
+        }
+
+        Consumer<JsonArray> jsonArrayHandler = queuedDownload.onCompletionJsonArray();
+        if (jsonArrayHandler != null) {
+            download.handleJsonArray(
+                    wrapDownloadHandler(jsonArrayHandler, queuedDownload), wrapDownloadFailure(queuedDownload));
+            return download;
+        }
+
+        throw new IllegalStateException("Queued download has no handler set: " + queuedDownload);
+    }
+
+    private void replaceDownload(QueuedDownload toBeReplaced) {
+        QueuedDownload nextDownload = graph.nextDownload();
+
+        for (int i = 0; i < MAX_PARALLEL_DOWNLOADS; i++) {
+            if (currentDownloads[i] == null) continue;
+            if (!currentDownloads[i].key().equals(toBeReplaced)) continue;
+
+            if (nextDownload == null) {
+                currentDownloads[i] = null;
+            } else {
+                currentDownloads[i] = new Pair<>(nextDownload, getDownload(nextDownload));
+            }
+
+            return;
+        }
+
+        throw new IllegalStateException(
+                "Finished, but not yet replaced download not found in the current downloads: " + toBeReplaced);
+    }
+
+    private <T> Consumer<T> wrapDownloadHandler(Consumer<T> handler, QueuedDownload download) {
+        return (T result) -> {
+            // Firstly, run the handler
+            handler.accept(result);
+
+            // The handling succeeded, mark the download as completed
+            // (if the handling failed, download itself handles the error)
+
+            // Log the progress if the system property is set
+            if (DEBUG_LOGS) {
+                WynntilsMod.info("Download finished: "
+                        + StringUtils.capitalizeFirst(download.callerComponent().getJsonName()) + " -> "
+                        + download.urlId());
+            }
+
+            // Mark the download as completed
+            graph.markDownloadCompleted(download);
+            replaceDownload(download);
+            checkDownloadsFinished();
+        };
+    }
+
+    private Consumer<Throwable> wrapDownloadFailure(QueuedDownload download) {
+        return (throwable) -> {
+            // Log the progress if the system property is set
+            if (DEBUG_LOGS) {
+                WynntilsMod.warn("Download failed: "
+                        + StringUtils.capitalizeFirst(download.callerComponent().getJsonName()) + " -> "
+                        + download.urlId());
+            }
+
+            // Mark the download as failed
+            graph.markDownloadError(download);
+            replaceDownload(download);
+            checkDownloadsFinished();
+        };
+    }
+
+    private void checkDownloadsFinished() {
+        if (!graph.isFinished()) return;
+        if (!Arrays.stream(currentDownloads).allMatch(Objects::isNull)) return;
+
+        // All downloads are finished, and there are no more downloads to start
+        // Display statistics from the graph
+        WynntilsMod.info("[DownloadManager] All downloads finished.");
+
+        if (graph.hasError()) {
+            WynntilsMod.warn("[DownloadManager] Some downloads failed. See the statistics for more information.");
+        }
+
+        if (graph.hasError() || DEBUG_LOGS) {
+            WynntilsMod.info("[DownloadManager] Download statistics:");
+            WynntilsMod.info("  - Total downloads: %d".formatted(graph.totalDownloads()));
+            WynntilsMod.info("  - Successful downloads: %d".formatted(graph.successfulDownloads()));
+            WynntilsMod.info("  - Failed downloads: %d".formatted(graph.failedDownloads()));
+            WynntilsMod.info("  - Error Rate: %.0f%%".formatted(graph.errorRate() * 100f));
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/core/net/DownloadRegistry.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadRegistry.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.net;
+
+import com.wynntils.core.components.CoreComponent;
+
+public class DownloadRegistry {
+    private final DownloadManager downloadManager;
+    private final CoreComponent callerComponent;
+
+    DownloadRegistry(DownloadManager downloadManager, CoreComponent callerComponent) {
+        this.downloadManager = downloadManager;
+        this.callerComponent = callerComponent;
+    }
+
+    public QueuedDownload registerDownload(UrlId urlId) {
+        return registerDownload(urlId, Dependency.empty());
+    }
+
+    public QueuedDownload registerDownload(UrlId urlId, Dependency dependency) {
+        return downloadManager.queueDownload(urlId, callerComponent, dependency);
+    }
+}

--- a/common/src/main/java/com/wynntils/core/net/NetManager.java
+++ b/common/src/main/java/com/wynntils/core/net/NetManager.java
@@ -53,19 +53,24 @@ public final class NetManager extends Manager {
         return callApi(urlId, Map.of());
     }
 
-    // Use DownloadManager instead. Only use this method if you are sure about what you are doing.
     public Download download(URI uri, String localFileName) {
         File localFile = new File(CACHE_DIR, localFileName);
         return download(uri, localFile, new NetResultProcessedEvent.ForLocalFile(localFileName));
     }
 
-    // Use DownloadManager instead. Only use this method if you are sure about what you are doing.
     public Download download(URI uri, String localFileName, String expectedHash) {
         File localFile = new File(CACHE_DIR, localFileName);
         return download(uri, localFile, expectedHash, new NetResultProcessedEvent.ForLocalFile(localFileName));
     }
 
-    // Use DownloadManager instead. Only use this method if you are sure about what you are doing.
+    /**
+     * Download a file from the given URL and save it to the cache directory.
+     * <p><b>This method should only be used when file needs to be downloaded dynamically.
+     * If you want to download a file in a {@link com.wynntils.core.components.CoreComponent} and use it,
+     * you may want to use {@link DownloadManager}'s download dependency system.</b></p>
+     * @param urlId The url id to download from
+     * @return The download object
+     */
     public Download download(UrlId urlId) {
         UrlManager.UrlInfo urlInfo = Managers.Url.getUrlInfo(urlId);
         URI uri = URI.create(urlInfo.url());

--- a/common/src/main/java/com/wynntils/core/net/NetManager.java
+++ b/common/src/main/java/com/wynntils/core/net/NetManager.java
@@ -53,16 +53,19 @@ public final class NetManager extends Manager {
         return callApi(urlId, Map.of());
     }
 
+    // Use DownloadManager instead. Only use this method if you are sure about what you are doing.
     public Download download(URI uri, String localFileName) {
         File localFile = new File(CACHE_DIR, localFileName);
         return download(uri, localFile, new NetResultProcessedEvent.ForLocalFile(localFileName));
     }
 
+    // Use DownloadManager instead. Only use this method if you are sure about what you are doing.
     public Download download(URI uri, String localFileName, String expectedHash) {
         File localFile = new File(CACHE_DIR, localFileName);
         return download(uri, localFile, expectedHash, new NetResultProcessedEvent.ForLocalFile(localFileName));
     }
 
+    // Use DownloadManager instead. Only use this method if you are sure about what you are doing.
     public Download download(UrlId urlId) {
         UrlManager.UrlInfo urlInfo = Managers.Url.getUrlInfo(urlId);
         URI uri = URI.create(urlInfo.url());

--- a/common/src/main/java/com/wynntils/core/net/NetResult.java
+++ b/common/src/main/java/com/wynntils/core/net/NetResult.java
@@ -25,8 +25,8 @@ public abstract class NetResult {
             (exception) -> WynntilsMod.error("Error while processing network request; ignored");
 
     protected final HttpRequest request;
-    private final String desc;
-    private final NetResultProcessedEvent processedEvent;
+    protected final String desc;
+    protected final NetResultProcessedEvent processedEvent;
 
     protected NetResult(String desc, HttpRequest request, NetResultProcessedEvent processedEvent) {
         this.request = request;

--- a/common/src/main/java/com/wynntils/core/net/NetResult.java
+++ b/common/src/main/java/com/wynntils/core/net/NetResult.java
@@ -25,8 +25,8 @@ public abstract class NetResult {
             (exception) -> WynntilsMod.error("Error while processing network request; ignored");
 
     protected final HttpRequest request;
-    protected final String desc;
-    protected final NetResultProcessedEvent processedEvent;
+    private final String desc;
+    private final NetResultProcessedEvent processedEvent;
 
     protected NetResult(String desc, HttpRequest request, NetResultProcessedEvent processedEvent) {
         this.request = request;

--- a/common/src/main/java/com/wynntils/core/net/QueuedDownload.java
+++ b/common/src/main/java/com/wynntils/core/net/QueuedDownload.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.net;
+
+import com.wynntils.core.components.CoreComponent;
+
+public record QueuedDownload(
+        Download download, UrlId urlId, CoreComponent callerComponent, Dependency dependency, Status status) {
+    public enum Status {
+        QUEUED,
+        DOWNLOADING,
+        FINISHED,
+        FAILED
+    }
+}

--- a/common/src/main/java/com/wynntils/core/net/QueuedDownload.java
+++ b/common/src/main/java/com/wynntils/core/net/QueuedDownload.java
@@ -4,18 +4,50 @@
  */
 package com.wynntils.core.net;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.CoreComponent;
+import java.io.Reader;
+import java.util.Objects;
+import java.util.function.Consumer;
 
-public class QueuedDownload extends Download {
+public class QueuedDownload {
+    private static final Consumer<Throwable> DEFAULT_ERROR_HANDLER =
+            (exception) -> WynntilsMod.error("Error while processing download request; ignored");
+
     private final CoreComponent callerComponent;
     private final UrlId urlId;
     private final Dependency dependency;
 
-    public QueuedDownload(Download download, CoreComponent callerComponent, UrlId urlId, Dependency dependency) {
-        super(download.desc, download.localFile, download.request, download.processedEvent);
+    // Callbacks for handling the download result,
+    // which are provided to download when it is processed
+    private Consumer<Reader> onCompletionReader;
+    private Consumer<JsonObject> onCompletionJsonObject;
+    private Consumer<JsonArray> onCompletionJsonArray;
+
+    QueuedDownload(CoreComponent callerComponent, UrlId urlId, Dependency dependency) {
         this.callerComponent = callerComponent;
         this.urlId = urlId;
         this.dependency = dependency;
+    }
+
+    public void handleReader(Consumer<Reader> readerConsume) {
+        this.onCompletionReader = readerConsume;
+        this.onCompletionJsonObject = null;
+        this.onCompletionJsonArray = null;
+    }
+
+    public void handleJsonObject(Consumer<JsonObject> jsonObjectConsume) {
+        this.onCompletionJsonObject = jsonObjectConsume;
+        this.onCompletionReader = null;
+        this.onCompletionJsonArray = null;
+    }
+
+    public void handleJsonArray(Consumer<JsonArray> jsonArrayConsume) {
+        this.onCompletionJsonArray = jsonArrayConsume;
+        this.onCompletionReader = null;
+        this.onCompletionJsonObject = null;
     }
 
     public CoreComponent callerComponent() {
@@ -28,5 +60,40 @@ public class QueuedDownload extends Download {
 
     public Dependency dependency() {
         return dependency;
+    }
+
+    public Consumer<Reader> onCompletionReader() {
+        return onCompletionReader;
+    }
+
+    public Consumer<JsonObject> onCompletionJsonObject() {
+        return onCompletionJsonObject;
+    }
+
+    public Consumer<JsonArray> onCompletionJsonArray() {
+        return onCompletionJsonArray;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueuedDownload that = (QueuedDownload) o;
+        return Objects.equals(callerComponent, that.callerComponent)
+                && urlId == that.urlId
+                && Objects.equals(dependency, that.dependency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(callerComponent, urlId, dependency);
+    }
+
+    @Override
+    public String toString() {
+        return "QueuedDownload{" + "callerComponent="
+                + callerComponent + ", urlId="
+                + urlId + ", dependency="
+                + dependency + '}';
     }
 }

--- a/common/src/main/java/com/wynntils/core/net/QueuedDownload.java
+++ b/common/src/main/java/com/wynntils/core/net/QueuedDownload.java
@@ -6,12 +6,27 @@ package com.wynntils.core.net;
 
 import com.wynntils.core.components.CoreComponent;
 
-public record QueuedDownload(
-        Download download, UrlId urlId, CoreComponent callerComponent, Dependency dependency, Status status) {
-    public enum Status {
-        QUEUED,
-        DOWNLOADING,
-        FINISHED,
-        FAILED
+public class QueuedDownload extends Download {
+    private final CoreComponent callerComponent;
+    private final UrlId urlId;
+    private final Dependency dependency;
+
+    public QueuedDownload(Download download, CoreComponent callerComponent, UrlId urlId, Dependency dependency) {
+        super(download.desc, download.localFile, download.request, download.processedEvent);
+        this.callerComponent = callerComponent;
+        this.urlId = urlId;
+        this.dependency = dependency;
+    }
+
+    public CoreComponent callerComponent() {
+        return callerComponent;
+    }
+
+    public UrlId urlId() {
+        return urlId;
+    }
+
+    public Dependency dependency() {
+        return dependency;
     }
 }

--- a/common/src/main/java/com/wynntils/models/abilitytree/AbilityTreeModel.java
+++ b/common/src/main/java/com/wynntils/models/abilitytree/AbilityTreeModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilitytree;
@@ -7,9 +7,8 @@ package com.wynntils.models.abilitytree;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.models.abilitytree.parser.AbilityTreeParser;
 import com.wynntils.models.abilitytree.type.AbilityTreeInfo;
@@ -32,14 +31,11 @@ public class AbilityTreeModel extends Model {
 
     public AbilityTreeModel() {
         super(List.of());
-
-        reloadData();
     }
 
     @Override
-    public void reloadData() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_ABILITIES);
-        dl.handleReader(reader -> {
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_ABILITIES).handleReader(reader -> {
             Type type = new TypeToken<HashMap<String, AbilityTreeInfo>>() {}.getType();
             Gson gson = new GsonBuilder().create();
 

--- a/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
@@ -39,8 +39,7 @@ public class GearInfoRegistry {
     private Map<String, GearInfo> gearInfoLookupApiName = Map.of();
 
     public void registerDownloads(DownloadRegistry registry) {
-        registry.registerDownload(
-                        UrlId.DATA_STATIC_GEAR_ADVANCED, Dependency.simple(Models.Set, UrlId.DATA_STATIC_ITEM_SETS))
+        registry.registerDownload(UrlId.DATA_STATIC_GEAR, Dependency.simple(Models.Set, UrlId.DATA_STATIC_ITEM_SETS))
                 .handleJsonObject(this::handleGearInfo);
     }
 

--- a/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
@@ -10,12 +10,10 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.Dependency;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
-import com.wynntils.core.net.event.NetResultProcessedEvent;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearMetaInfo;
 import com.wynntils.models.gear.type.GearRequirements;
@@ -34,34 +32,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import net.neoforged.bus.api.SubscribeEvent;
 
 public class GearInfoRegistry {
     private List<GearInfo> gearInfoRegistry = List.of();
     private Map<String, GearInfo> gearInfoLookup = Map.of();
     private Map<String, GearInfo> gearInfoLookupApiName = Map.of();
 
-    public GearInfoRegistry() {
-        WynntilsMod.registerEventListener(this);
-
-        loadData();
-    }
-
-    public void loadData() {
-        // We do not explicitly load the gear DB here,
-        // but when all of it's dependencies are loaded,
-        // the NetResultProcessedEvent will trigger the load.
-    }
-
-    @SubscribeEvent
-    public void onDataLoaded(NetResultProcessedEvent.ForUrlId event) {
-        UrlId urlId = event.getUrlId();
-        if (urlId == UrlId.DATA_STATIC_ITEM_SETS) {
-            if (!Models.Set.hasSetData()) return;
-
-            loadGearRegistry();
-            return;
-        }
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(
+                        UrlId.DATA_STATIC_GEAR_ADVANCED, Dependency.simple(Models.Set, UrlId.DATA_STATIC_ITEM_SETS))
+                .handleJsonObject(this::handleGearInfo);
     }
 
     public GearInfo getFromDisplayName(String gearName) {
@@ -81,43 +61,40 @@ public class GearInfoRegistry {
         return gearInfoRegistry.stream();
     }
 
-    private void loadGearRegistry() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_GEAR);
-        dl.handleJsonObject(json -> {
-            Gson gson = new GsonBuilder()
-                    .registerTypeHierarchyAdapter(GearInfo.class, new GearInfoDeserializer())
-                    .create();
+    private void handleGearInfo(JsonObject json) {
+        Gson gson = new GsonBuilder()
+                .registerTypeHierarchyAdapter(GearInfo.class, new GearInfoDeserializer())
+                .create();
 
-            List<GearInfo> registry = new ArrayList<>();
+        List<GearInfo> gearRegistry = new ArrayList<>();
 
-            for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
-                JsonObject itemObject = entry.getValue().getAsJsonObject();
+        for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
+            JsonObject itemObject = entry.getValue().getAsJsonObject();
 
-                // Inject the name into the object
-                itemObject.addProperty("name", entry.getKey());
+            // Inject the name into the object
+            itemObject.addProperty("name", entry.getKey());
 
-                // Deserialize the item
-                GearInfo gearInfo = gson.fromJson(itemObject, GearInfo.class);
+            // Deserialize the item
+            GearInfo gearInfo = gson.fromJson(itemObject, GearInfo.class);
 
-                // Add the item to the registry
-                registry.add(gearInfo);
+            // Add the item to the registry
+            gearRegistry.add(gearInfo);
+        }
+
+        // Create fast lookup maps
+        Map<String, GearInfo> lookupMap = new HashMap<>();
+        Map<String, GearInfo> altLookupMap = new HashMap<>();
+        for (GearInfo gearInfo : gearRegistry) {
+            lookupMap.put(gearInfo.name(), gearInfo);
+            if (gearInfo.metaInfo().apiName().isPresent()) {
+                altLookupMap.put(gearInfo.metaInfo().apiName().get(), gearInfo);
             }
+        }
 
-            // Create fast lookup maps
-            Map<String, GearInfo> lookupMap = new HashMap<>();
-            Map<String, GearInfo> altLookupMap = new HashMap<>();
-            for (GearInfo gearInfo : registry) {
-                lookupMap.put(gearInfo.name(), gearInfo);
-                if (gearInfo.metaInfo().apiName().isPresent()) {
-                    altLookupMap.put(gearInfo.metaInfo().apiName().get(), gearInfo);
-                }
-            }
-
-            // Make the result visisble to the world
-            gearInfoRegistry = registry;
-            gearInfoLookup = lookupMap;
-            gearInfoLookupApiName = altLookupMap;
-        });
+        // Make the result visisble to the world
+        gearInfoRegistry = gearRegistry;
+        gearInfoLookup = lookupMap;
+        gearInfoLookupApiName = altLookupMap;
     }
 
     private static final class GearInfoDeserializer extends AbstractItemInfoDeserializer<GearInfo> {

--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -7,6 +7,7 @@ package com.wynntils.models.gear;
 import com.google.gson.JsonObject;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.gear.type.GearTier;
@@ -57,6 +58,11 @@ public final class GearModel extends Model {
         super(List.of());
     }
 
+    @Override
+    public void registerDownloads(DownloadRegistry registry) {
+        gearInfoRegistry.registerDownloads(registry);
+    }
+
     public List<GearInfo> getPossibleGears(GearBoxItem gearBoxItem) {
         List<GearInfo> possibilities = possibilitiesCache.get(gearBoxItem);
         if (possibilities != null) return possibilities;
@@ -80,11 +86,6 @@ public final class GearModel extends Model {
         return !gear.metaInfo().preIdentified()
                 && gear.metaInfo().obtainInfo().stream()
                         .anyMatch(x -> ItemObtainType.BOXED_ITEMS.contains(x.sourceType()));
-    }
-
-    @Override
-    public void reloadData() {
-        gearInfoRegistry.loadData();
     }
 
     // For "real" gear items eg. from the inventory

--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
@@ -47,7 +47,7 @@ public class IngredientInfoRegistry {
 
     public void registerDownloads(DownloadRegistry registry) {
         registry.registerDownload(
-                        UrlId.DATA_STATIC_INGREDIENTS_ADVANCED,
+                        UrlId.DATA_STATIC_INGREDIENTS,
                         Dependency.multi(
                                 Models.WynnItem,
                                 Set.of(UrlId.DATA_STATIC_ITEM_OBTAIN, UrlId.DATA_STATIC_MATERIAL_CONVERSION)))

--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
@@ -12,9 +12,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.Dependency;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.ingredients.type.IngredientInfo;
@@ -33,19 +33,25 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class IngredientInfoRegistry {
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeHierarchyAdapter(IngredientInfo.class, new IngredientInfoDeserializer())
+            .create();
+
     private List<IngredientInfo> ingredientInfoRegistry = List.of();
     private Map<String, IngredientInfo> ingredientInfoLookup = Map.of();
     private Map<String, IngredientInfo> ingredientInfoLookupApiName = Map.of();
 
-    public IngredientInfoRegistry() {
-        loadData();
-    }
-
-    public void loadData() {
-        loadIngredients();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(
+                        UrlId.DATA_STATIC_INGREDIENTS_ADVANCED,
+                        Dependency.multi(
+                                Models.WynnItem,
+                                Set.of(UrlId.DATA_STATIC_ITEM_OBTAIN, UrlId.DATA_STATIC_MATERIAL_CONVERSION)))
+                .handleJsonObject(this::handleIngredients);
     }
 
     public IngredientInfo getFromDisplayName(String ingredientName) {
@@ -56,47 +62,36 @@ public class IngredientInfoRegistry {
         return ingredientInfoRegistry.stream();
     }
 
-    private void loadIngredients() {
-        if (!Models.WynnItem.hasObtainInfo()) return;
-        if (!Models.WynnItem.hasMaterialConversionInfo()) return;
+    private void handleIngredients(JsonObject json) {
+        // Create fast lookup maps
+        List<IngredientInfo> registry = new ArrayList<>();
 
-        // Download and parse the ingredient DB
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_INGREDIENTS);
-        dl.handleJsonObject(json -> {
-            Gson gson = new GsonBuilder()
-                    .registerTypeHierarchyAdapter(IngredientInfo.class, new IngredientInfoDeserializer())
-                    .create();
+        for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
+            JsonObject ingredientObject = entry.getValue().getAsJsonObject();
 
-            // Create fast lookup maps
-            List<IngredientInfo> registry = new ArrayList<>();
+            // Inject the name into the object
+            ingredientObject.addProperty("name", entry.getKey());
 
-            for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
-                JsonObject ingredientObject = entry.getValue().getAsJsonObject();
+            // Deserialize the item
+            IngredientInfo ingredientInfo = GSON.fromJson(ingredientObject, IngredientInfo.class);
 
-                // Inject the name into the object
-                ingredientObject.addProperty("name", entry.getKey());
+            // Add the item to the registry
+            registry.add(ingredientInfo);
+        }
 
-                // Deserialize the item
-                IngredientInfo ingredientInfo = gson.fromJson(ingredientObject, IngredientInfo.class);
-
-                // Add the item to the registry
-                registry.add(ingredientInfo);
+        Map<String, IngredientInfo> lookupMap = new HashMap<>();
+        Map<String, IngredientInfo> altLookupMap = new HashMap<>();
+        for (IngredientInfo ingredientInfo : registry) {
+            lookupMap.put(ingredientInfo.name(), ingredientInfo);
+            if (ingredientInfo.apiName().isPresent()) {
+                altLookupMap.put(ingredientInfo.apiName().get(), ingredientInfo);
             }
+        }
 
-            Map<String, IngredientInfo> lookupMap = new HashMap<>();
-            Map<String, IngredientInfo> altLookupMap = new HashMap<>();
-            for (IngredientInfo ingredientInfo : registry) {
-                lookupMap.put(ingredientInfo.name(), ingredientInfo);
-                if (ingredientInfo.apiName().isPresent()) {
-                    altLookupMap.put(ingredientInfo.apiName().get(), ingredientInfo);
-                }
-            }
-
-            // Make the result visisble to the world
-            ingredientInfoRegistry = registry;
-            ingredientInfoLookup = lookupMap;
-            ingredientInfoLookupApiName = altLookupMap;
-        });
+        // Make the result visisble to the world
+        ingredientInfoRegistry = registry;
+        ingredientInfoLookup = lookupMap;
+        ingredientInfoLookupApiName = altLookupMap;
     }
 
     private static final class IngredientInfoDeserializer extends AbstractItemInfoDeserializer<IngredientInfo> {

--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientModel.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientModel.java
@@ -6,8 +6,7 @@ package com.wynntils.models.ingredients;
 
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.net.UrlId;
-import com.wynntils.core.net.event.NetResultProcessedEvent;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.models.ingredients.type.IngredientInfo;
 import com.wynntils.models.wynnitem.WynnItemModel;
 import com.wynntils.models.wynnitem.type.ItemObtainInfo;
@@ -17,7 +16,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
-import net.neoforged.bus.api.SubscribeEvent;
 
 public class IngredientModel extends Model {
     private static final Map<ChatFormatting, Integer> TIER_COLOR_CODES = Map.of(
@@ -25,32 +23,16 @@ public class IngredientModel extends Model {
             ChatFormatting.YELLOW, 1,
             ChatFormatting.LIGHT_PURPLE, 2,
             ChatFormatting.AQUA, 3);
+
     private final IngredientInfoRegistry ingredientInfoRegistry = new IngredientInfoRegistry();
 
     public IngredientModel(WynnItemModel wynnItem) {
         super(List.of(wynnItem));
-
-        // We do not explicitly load the ingredient DB here,
-        // but when all of it's dependencies are loaded,
-        // the NetResultProcessedEvent will trigger the load.
     }
 
     @Override
-    public void reloadData() {
-        ingredientInfoRegistry.loadData();
-    }
-
-    @SubscribeEvent
-    public void onDataLoaded(NetResultProcessedEvent.ForUrlId event) {
-        UrlId urlId = event.getUrlId();
-        if (urlId == UrlId.DATA_STATIC_ITEM_OBTAIN || urlId == UrlId.DATA_STATIC_MATERIAL_CONVERSION) {
-            // We need both material conversio  and obtain info to be able to load the ingredient DB
-            if (!Models.WynnItem.hasObtainInfo()) return;
-            if (!Models.WynnItem.hasMaterialConversionInfo()) return;
-
-            ingredientInfoRegistry.loadData();
-            return;
-        }
+    public void registerDownloads(DownloadRegistry registry) {
+        ingredientInfoRegistry.registerDownloads(registry);
     }
 
     public int getTierFromColorCode(String tierColor) {

--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientModel.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientModel.java
@@ -8,7 +8,6 @@ import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.models.ingredients.type.IngredientInfo;
-import com.wynntils.models.wynnitem.WynnItemModel;
 import com.wynntils.models.wynnitem.type.ItemObtainInfo;
 import com.wynntils.models.wynnitem.type.ItemObtainType;
 import java.util.List;
@@ -26,8 +25,8 @@ public class IngredientModel extends Model {
 
     private final IngredientInfoRegistry ingredientInfoRegistry = new IngredientInfoRegistry();
 
-    public IngredientModel(WynnItemModel wynnItem) {
-        super(List.of(wynnItem));
+    public IngredientModel() {
+        super(List.of());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -10,7 +10,7 @@ import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
@@ -54,6 +54,7 @@ import com.wynntils.utils.mc.PosUtils;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.type.Pair;
+import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -190,16 +191,13 @@ public class LootrunModel extends Model {
     }
 
     @Override
-    public void reloadData() {
-        loadLootrunTaskLocations();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_LOOTRUN_TASKS_NAMED).handleReader(this::handleLootrunTaskLocations);
     }
 
-    private void loadLootrunTaskLocations() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_LOOTRUN_TASKS_NAMED);
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<Map<LootrunLocation, Set<TaskLocation>>>() {}.getType();
-            taskLocations = Managers.Json.GSON.fromJson(reader, type);
-        });
+    private void handleLootrunTaskLocations(Reader reader) {
+        Type type = new TypeToken<Map<LootrunLocation, Set<TaskLocation>>>() {}.getType();
+        taskLocations = Managers.Json.GSON.fromJson(reader, type);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -186,8 +186,6 @@ public class LootrunModel extends Model {
         Handlers.Scoreboard.addPart(LOOTRUN_SCOREBOARD_PART);
         Handlers.Particle.registerParticleVerifier(ParticleType.LOOTRUN_TASK, new LootrunTaskParticleVerifier());
         Models.Marker.registerMarkerProvider(LOOTRUN_BEACON_COMPASS_PROVIDER);
-
-        reloadData();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/rewards/RewardsModel.java
+++ b/common/src/main/java/com/wynntils/models/rewards/RewardsModel.java
@@ -16,7 +16,6 @@ import com.wynntils.models.rewards.type.CharmInfo;
 import com.wynntils.models.rewards.type.CharmInstance;
 import com.wynntils.models.rewards.type.TomeInfo;
 import com.wynntils.models.rewards.type.TomeInstance;
-import com.wynntils.models.wynnitem.WynnItemModel;
 import com.wynntils.models.wynnitem.parsing.WynnItemParseResult;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import java.util.List;
@@ -27,12 +26,8 @@ public class RewardsModel extends Model {
     private final TomeInfoRegistry tomeInfoRegistry = new TomeInfoRegistry();
     private final CharmInfoRegistry charmInfoRegistry = new CharmInfoRegistry();
 
-    public RewardsModel(WynnItemModel wynnItemModel) {
-        super(List.of(wynnItemModel));
-
-        // We do not explicitly load the ingredient DB here,
-        // but when all of it's dependencies are loaded,
-        // the NetResultProcessedEvent will trigger the load.
+    public RewardsModel() {
+        super(List.of());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/rewards/RewardsModel.java
+++ b/common/src/main/java/com/wynntils/models/rewards/RewardsModel.java
@@ -6,9 +6,7 @@ package com.wynntils.models.rewards;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
-import com.wynntils.core.components.Models;
-import com.wynntils.core.net.UrlId;
-import com.wynntils.core.net.event.NetResultProcessedEvent;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.ItemAnnotation;
 import com.wynntils.models.gear.type.GearTier;
@@ -24,7 +22,6 @@ import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import java.util.List;
 import java.util.stream.Stream;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.bus.api.SubscribeEvent;
 
 public class RewardsModel extends Model {
     private final TomeInfoRegistry tomeInfoRegistry = new TomeInfoRegistry();
@@ -39,23 +36,9 @@ public class RewardsModel extends Model {
     }
 
     @Override
-    public void reloadData() {
-        tomeInfoRegistry.reloadData();
-        charmInfoRegistry.reloadData();
-    }
-
-    @SubscribeEvent
-    public void onDataLoaded(NetResultProcessedEvent.ForUrlId event) {
-        UrlId urlId = event.getUrlId();
-        if (urlId == UrlId.DATA_STATIC_ITEM_OBTAIN || urlId == UrlId.DATA_STATIC_MATERIAL_CONVERSION) {
-            // We need both material conversion and obtain info to be able to load the ingredient DB
-            if (!Models.WynnItem.hasObtainInfo()) return;
-            if (!Models.WynnItem.hasMaterialConversionInfo()) return;
-
-            tomeInfoRegistry.reloadData();
-            charmInfoRegistry.reloadData();
-            return;
-        }
+    public void registerDownloads(DownloadRegistry registry) {
+        tomeInfoRegistry.registerDownloads(registry);
+        charmInfoRegistry.registerDownloads(registry);
     }
 
     public CharmInfo getCharmInfoFromDisplayName(String name) {

--- a/common/src/main/java/com/wynntils/models/seaskipper/SeaskipperModel.java
+++ b/common/src/main/java/com/wynntils/models/seaskipper/SeaskipperModel.java
@@ -6,10 +6,9 @@ package com.wynntils.models.seaskipper;
 
 import com.google.common.reflect.TypeToken;
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerSetContentEvent;
@@ -22,6 +21,7 @@ import com.wynntils.screens.maps.CustomSeaskipperScreen;
 import com.wynntils.services.map.pois.SeaskipperDestinationPoi;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.wynn.ContainerUtils;
+import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,8 +46,8 @@ public final class SeaskipperModel extends Model {
     }
 
     @Override
-    public void reloadData() {
-        loadSeaskipperPois();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_SEASKIPPER_DESTINATIONS).handleReader(this::handleSeaskipperPois);
     }
 
     @SubscribeEvent
@@ -147,16 +147,12 @@ public final class SeaskipperModel extends Model {
         return !allDestinations.isEmpty();
     }
 
-    private void loadSeaskipperPois() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_SEASKIPPER_DESTINATIONS);
+    private void handleSeaskipperPois(Reader reader) {
+        Type type = new TypeToken<ArrayList<SeaskipperDestinationProfile>>() {}.getType();
+        List<SeaskipperDestinationProfile> profiles = WynntilsMod.GSON.fromJson(reader, type);
 
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<ArrayList<SeaskipperDestinationProfile>>() {}.getType();
-            List<SeaskipperDestinationProfile> profiles = WynntilsMod.GSON.fromJson(reader, type);
-
-            allDestinations = profiles.stream()
-                    .map(profile -> new SeaskipperDestination(profile, null, -1))
-                    .toList();
-        });
+        allDestinations = profiles.stream()
+                .map(profile -> new SeaskipperDestination(profile, null, -1))
+                .toList();
     }
 }

--- a/common/src/main/java/com/wynntils/models/seaskipper/SeaskipperModel.java
+++ b/common/src/main/java/com/wynntils/models/seaskipper/SeaskipperModel.java
@@ -41,8 +41,6 @@ public final class SeaskipperModel extends Model {
 
     public SeaskipperModel() {
         super(List.of());
-
-        reloadData();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/stats/ShinyModel.java
+++ b/common/src/main/java/com/wynntils/models/stats/ShinyModel.java
@@ -9,13 +9,14 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.stats.type.ShinyStat;
 import com.wynntils.models.stats.type.ShinyStatType;
 import com.wynntils.utils.mc.McUtils;
+import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,23 +31,18 @@ public class ShinyModel extends Model {
 
     public ShinyModel() {
         super(List.of());
-        reloadData();
     }
 
     @Override
-    public void reloadData() {
-        loadShinyStatTypes();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_SHINY_STATS).handleReader(this::handleShinyStatTypes);
     }
 
-    private void loadShinyStatTypes() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_SHINY_STATS);
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<List<ShinyStatType>>() {}.getType();
-            List<ShinyStatType> statTypes = Managers.Json.GSON.fromJson(reader, type);
+    private void handleShinyStatTypes(Reader reader) {
+        Type type = new TypeToken<List<ShinyStatType>>() {}.getType();
+        List<ShinyStatType> statTypes = Managers.Json.GSON.fromJson(reader, type);
 
-            shinyStatTypes =
-                    statTypes.stream().collect(Collectors.toMap(ShinyStatType::displayName, statType -> statType));
-        });
+        shinyStatTypes = statTypes.stream().collect(Collectors.toMap(ShinyStatType::displayName, statType -> statType));
     }
 
     public ShinyStatType getShinyStatType(int id) {

--- a/common/src/main/java/com/wynntils/services/destination/DestinationService.java
+++ b/common/src/main/java/com/wynntils/services/destination/DestinationService.java
@@ -5,10 +5,10 @@
 package com.wynntils.services.destination;
 
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Service;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,13 +19,11 @@ public class DestinationService extends Service {
 
     public DestinationService() {
         super(List.of());
-
-        reloadData();
     }
 
     @Override
-    public void reloadData() {
-        loadDestinations();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_DESTINATIONS).handleReader(this::handleDestinations);
     }
 
     /**
@@ -62,18 +60,15 @@ public class DestinationService extends Service {
         return abbreviation;
     }
 
-    private void loadDestinations() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_DESTINATIONS);
-        dl.handleReader(reader -> {
-            Map<String, String> newDestinations = new HashMap<>();
+    private void handleDestinations(Reader reader) {
+        Map<String, String> newDestinations = new HashMap<>();
 
-            Destination result = WynntilsMod.GSON.fromJson(reader, Destination.class);
-            for (Destination.DestinationDetail destination : result.destinations) {
-                newDestinations.put(destination.location, destination.abbreviation);
-            }
+        Destination result = WynntilsMod.GSON.fromJson(reader, Destination.class);
+        for (Destination.DestinationDetail destination : result.destinations) {
+            newDestinations.put(destination.location, destination.abbreviation);
+        }
 
-            destinations = newDestinations;
-        });
+        destinations = newDestinations;
     }
 
     private static class Destination {

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -79,8 +79,8 @@ public class PoiService extends Service {
     @Override
     public void registerDownloads(DownloadRegistry registry) {
         registry.registerDownload(UrlId.DATA_STATIC_PLACES).handleReader(this::handlePlaces);
-        registry.registerDownload(UrlId.DATA_STATIC_SERVICES).handleReader(this::loadServices);
-        registry.registerDownload(UrlId.DATA_STATIC_COMBAT_LOCATIONS).handleReader(this::loadCombat);
+        registry.registerDownload(UrlId.DATA_STATIC_SERVICES).handleReader(this::handleServices);
+        registry.registerDownload(UrlId.DATA_STATIC_COMBAT_LOCATIONS).handleReader(this::handleCombat);
         registry.registerDownload(UrlId.DATA_STATIC_CAVE_INFO).handleReader(this::handleCaves);
     }
 
@@ -144,7 +144,7 @@ public class PoiService extends Service {
         }
     }
 
-    private void loadServices(Reader reader) {
+    private void handleServices(Reader reader) {
         Type type = new TypeToken<List<ServiceProfile>>() {}.getType();
 
         List<ServiceProfile> serviceList = GSON.fromJson(reader, type);
@@ -161,7 +161,7 @@ public class PoiService extends Service {
         }
     }
 
-    private void loadCombat(Reader reader) {
+    private void handleCombat(Reader reader) {
         Type type = new TypeToken<List<CombatProfileList>>() {}.getType();
 
         List<CombatProfileList> combatProfileLists = GSON.fromJson(reader, type);

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -12,9 +12,8 @@ import com.google.gson.JsonElement;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Service;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
-import com.wynntils.core.net.event.NetResultProcessedEvent;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.services.map.pois.CombatPoi;
@@ -30,6 +29,7 @@ import com.wynntils.services.mapdata.providers.builtin.ServiceListProvider;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.Texture;
+import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import net.neoforged.bus.api.SubscribeEvent;
 
 public class PoiService extends Service {
     public static final Gson GSON = new GsonBuilder()
@@ -75,85 +74,19 @@ public class PoiService extends Service {
 
     public PoiService() {
         super(List.of());
-
-        loadData();
     }
 
     @Override
-    public void reloadData() {
-        loadData();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_PLACES).handleReader(this::handlePlaces);
+        registry.registerDownload(UrlId.DATA_STATIC_SERVICES).handleReader(this::loadServices);
+        registry.registerDownload(UrlId.DATA_STATIC_COMBAT_LOCATIONS).handleReader(this::loadCombat);
+        registry.registerDownload(UrlId.DATA_STATIC_CAVE_INFO).handleReader(this::handleCaves);
     }
 
     @Override
     public void onStorageLoad() {
         loadCustomPoiProviders();
-    }
-
-    private void loadData() {
-        loadPlaces();
-        // Slightly hacky way to reduce risk of class loading race in development environment
-        // These are loaded serially after places instad
-        if (WynntilsMod.isDevelopmentEnvironment()) return;
-
-        loadCaves();
-        loadServices();
-        loadCombat();
-        loadCustomPoiProviders();
-    }
-
-    private void loadCaves() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_CAVE_INFO);
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<List<CaveProfile>>() {}.getType();
-
-            List<CaveProfile> profiles = GSON.fromJson(reader, type);
-
-            cavePois.addAll(profiles.stream()
-                    .map(profile -> {
-                        CombatListProvider.registerFeature(profile.location, CombatKind.CAVES, profile.name);
-                        return new CombatPoi(
-                                PoiLocation.fromLocation(profile.location), profile.name, CombatKind.CAVES);
-                    })
-                    .collect(Collectors.toUnmodifiableSet()));
-        });
-    }
-
-    public void loadCustomPoiProviders() {
-        for (CustomPoiProvider poiProvider : customPoiProviders.get()) {
-            Managers.Net.download(poiProvider.getUrl(), poiProvider.getName()).handleJsonArray(elements -> {
-                List<CustomPoi> pois = new ArrayList<>();
-
-                for (JsonElement jsonElement : elements) {
-                    CustomPoi poi = GSON.fromJson(jsonElement, CustomPoi.class);
-                    pois.add(poi);
-                }
-
-                providedCustomPois.put(poiProvider, ImmutableList.copyOf(pois));
-            });
-        }
-    }
-
-    @SubscribeEvent
-    public void onDataLoaded(NetResultProcessedEvent.ForUrlId event) {
-        if (!WynntilsMod.isDevelopmentEnvironment()) return;
-        // Serialize loading of POIs when on dev env
-
-        if (event.getUrlId() == UrlId.DATA_STATIC_PLACES) {
-            loadCaves();
-            return;
-        }
-        if (event.getUrlId() == UrlId.DATA_STATIC_CAVE_INFO) {
-            loadServices();
-            return;
-        }
-        if (event.getUrlId() == UrlId.DATA_STATIC_SERVICES) {
-            loadCombat();
-            return;
-        }
-        if (event.getUrlId() == UrlId.DATA_STATIC_COMBAT_LOCATIONS) {
-            loadCustomPoiProviders();
-            return;
-        }
     }
 
     public Stream<LabelPoi> getLabelPois() {
@@ -186,62 +119,6 @@ public class PoiService extends Service {
         loadCustomPoiProviders();
     }
 
-    public boolean isPoiProvided(CustomPoi customPoi) {
-        return getProvidedCustomPois().contains(customPoi);
-    }
-
-    private void loadPlaces() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_PLACES);
-        dl.handleReader(reader -> {
-            PlacesProfile places = GSON.fromJson(reader, PlacesProfile.class);
-            for (Label label : places.labels) {
-                labelPois.add(new LabelPoi(label));
-                PlaceListProvider.registerFeature(label);
-            }
-        });
-    }
-
-    private void loadServices() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_SERVICES);
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<List<ServiceProfile>>() {}.getType();
-
-            List<ServiceProfile> serviceList = GSON.fromJson(reader, type);
-            for (ServiceProfile service : serviceList) {
-                ServiceKind kind = ServiceKind.fromString(service.type);
-                if (kind != null) {
-                    for (PoiLocation location : service.locations) {
-                        servicePois.add(new ServicePoi(location, kind));
-                        ServiceListProvider.registerFeature(new Location(location), kind);
-                    }
-                } else {
-                    WynntilsMod.warn("Unknown service type in services.json: " + service.type);
-                }
-            }
-        });
-    }
-
-    private void loadCombat() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_COMBAT_LOCATIONS);
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<List<CombatProfileList>>() {}.getType();
-
-            List<CombatProfileList> combatProfileLists = GSON.fromJson(reader, type);
-            for (CombatProfileList combatList : combatProfileLists) {
-                CombatKind kind = CombatKind.fromString(combatList.type);
-                // We load caves separately... until the refactor
-                if (kind != null && kind != CombatKind.CAVES) {
-                    for (CombatProfile profile : combatList.locations) {
-                        combatPois.add(new CombatPoi(profile.coordinates, profile.name, kind));
-                        CombatListProvider.registerFeature(new Location(profile.coordinates), kind, profile.name);
-                    }
-                } else {
-                    WynntilsMod.warn("Unknown combat type in combat.json: " + combatList.type);
-                }
-            }
-        });
-    }
-
     public boolean removeCustomPoiProvider(String name) {
         Optional<CustomPoiProvider> provider = customPoiProviders.get().stream()
                 .filter(p -> p.getName().equals(name))
@@ -253,6 +130,81 @@ public class PoiService extends Service {
         providedCustomPois.remove(provider.get());
 
         return true;
+    }
+
+    public boolean isPoiProvided(CustomPoi customPoi) {
+        return getProvidedCustomPois().contains(customPoi);
+    }
+
+    private void handlePlaces(Reader reader) {
+        PlacesProfile places = GSON.fromJson(reader, PlacesProfile.class);
+        for (Label label : places.labels) {
+            labelPois.add(new LabelPoi(label));
+            PlaceListProvider.registerFeature(label);
+        }
+    }
+
+    private void loadServices(Reader reader) {
+        Type type = new TypeToken<List<ServiceProfile>>() {}.getType();
+
+        List<ServiceProfile> serviceList = GSON.fromJson(reader, type);
+        for (ServiceProfile service : serviceList) {
+            ServiceKind kind = ServiceKind.fromString(service.type);
+            if (kind != null) {
+                for (PoiLocation location : service.locations) {
+                    servicePois.add(new ServicePoi(location, kind));
+                    ServiceListProvider.registerFeature(new Location(location), kind);
+                }
+            } else {
+                WynntilsMod.warn("Unknown service type in services.json: " + service.type);
+            }
+        }
+    }
+
+    private void loadCombat(Reader reader) {
+        Type type = new TypeToken<List<CombatProfileList>>() {}.getType();
+
+        List<CombatProfileList> combatProfileLists = GSON.fromJson(reader, type);
+        for (CombatProfileList combatList : combatProfileLists) {
+            CombatKind kind = CombatKind.fromString(combatList.type);
+            // We load caves separately... until the refactor
+            if (kind != null && kind != CombatKind.CAVES) {
+                for (CombatProfile profile : combatList.locations) {
+                    combatPois.add(new CombatPoi(profile.coordinates, profile.name, kind));
+                    CombatListProvider.registerFeature(new Location(profile.coordinates), kind, profile.name);
+                }
+            } else {
+                WynntilsMod.warn("Unknown combat type in combat.json: " + combatList.type);
+            }
+        }
+    }
+
+    private void handleCaves(Reader reader) {
+        Type type = new TypeToken<List<CaveProfile>>() {}.getType();
+
+        List<CaveProfile> profiles = GSON.fromJson(reader, type);
+
+        cavePois.addAll(profiles.stream()
+                .map(profile -> {
+                    CombatListProvider.registerFeature(profile.location, CombatKind.CAVES, profile.name);
+                    return new CombatPoi(PoiLocation.fromLocation(profile.location), profile.name, CombatKind.CAVES);
+                })
+                .collect(Collectors.toUnmodifiableSet()));
+    }
+
+    public void loadCustomPoiProviders() {
+        for (CustomPoiProvider poiProvider : customPoiProviders.get()) {
+            Managers.Net.download(poiProvider.getUrl(), poiProvider.getName()).handleJsonArray(elements -> {
+                List<CustomPoi> pois = new ArrayList<>();
+
+                for (JsonElement jsonElement : elements) {
+                    CustomPoi poi = GSON.fromJson(jsonElement, CustomPoi.class);
+                    pois.add(poi);
+                }
+
+                providedCustomPois.put(poiProvider, ImmutableList.copyOf(pois));
+            });
+        }
     }
 
     private static class PlacesProfile {

--- a/common/src/main/java/com/wynntils/services/splashes/SplashService.java
+++ b/common/src/main/java/com/wynntils/services/splashes/SplashService.java
@@ -1,15 +1,15 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.splashes;
 
 import com.google.common.reflect.TypeToken;
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Service;
-import com.wynntils.core.net.Download;
+import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
+import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,30 +25,25 @@ public final class SplashService extends Service {
 
     public SplashService() {
         super(List.of());
-
-        updateCurrentSplash();
     }
 
     @Override
-    public void reloadData() {
-        updateCurrentSplash();
+    public void registerDownloads(DownloadRegistry registry) {
+        registry.registerDownload(UrlId.DATA_STATIC_SPLASHES).handleReader(this::handleCurrentSplash);
     }
 
     public String getCurrentSplash() {
         return currentSplash;
     }
 
-    private void updateCurrentSplash() {
-        Download dl = Managers.Net.download(UrlId.DATA_STATIC_SPLASHES);
-        dl.handleReader(reader -> {
-            Type type = new TypeToken<List<String>>() {}.getType();
-            allSplashes = WynntilsMod.GSON.fromJson(reader, type);
-            if (allSplashes.isEmpty()) {
-                // Use fallback in case of failure
-                currentSplash = DEFAULT_SPLASH;
-            } else {
-                currentSplash = allSplashes.get(RANDOM.nextInt(allSplashes.size()));
-            }
-        });
+    private void handleCurrentSplash(Reader reader) {
+        Type type = new TypeToken<List<String>>() {}.getType();
+        allSplashes = WynntilsMod.GSON.fromJson(reader, type);
+        if (allSplashes.isEmpty()) {
+            // Use fallback in case of failure
+            currentSplash = DEFAULT_SPLASH;
+        } else {
+            currentSplash = allSplashes.get(RANDOM.nextInt(allSplashes.size()));
+        }
     }
 }


### PR DESCRIPTION
`DownloadManager` has the documentation I'd put in the PR description.

TLDR; The goal is to eliminate download dependency race once and for all, all while taking benefit of having a manager behind all downloads, which include proper failure handling / retries, maximum parallel download settings, a clear and easily calculated download progress percentage and a list of download failures which can be shown to the user.