### PR TITLE
feat: Add CorruptedCacheAnnotator [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -13,6 +13,7 @@ import com.wynntils.handlers.item.ItemHandler;
 import com.wynntils.models.items.annotators.game.AmplifierAnnotator;
 import com.wynntils.models.items.annotators.game.AspectAnnotator;
 import com.wynntils.models.items.annotators.game.CharmAnnotator;
+import com.wynntils.models.items.annotators.game.CorruptedCacheAnnotator;
 import com.wynntils.models.items.annotators.game.CraftedConsumableAnnotator;
 import com.wynntils.models.items.annotators.game.CraftedGearAnnotator;
 import com.wynntils.models.items.annotators.game.DungeonKeyAnnotator;
@@ -69,6 +70,7 @@ public class ItemModel extends Model {
         // Then alphabetically
         Handlers.Item.registerAnnotator(new AmplifierAnnotator());
         Handlers.Item.registerAnnotator(new AspectAnnotator());
+        Handlers.Item.registerAnnotator(new CorruptedCacheAnnotator());
         Handlers.Item.registerAnnotator(new CraftedConsumableAnnotator());
         Handlers.Item.registerAnnotator(new CraftedGearAnnotator());
         Handlers.Item.registerAnnotator(new DungeonKeyAnnotator());

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/CorruptedCacheAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/CorruptedCacheAnnotator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.annotators.game;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.item.GameItemAnnotator;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.items.items.game.CorruptedCacheItem;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.item.ItemStack;
+
+public class CorruptedCacheAnnotator implements GameItemAnnotator {
+    private static final Pattern CACHE_PATTERN = Pattern.compile("^§(.)Corrupted Cache$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
+        Matcher matcher = name.getMatcher(CACHE_PATTERN);
+        if (!matcher.matches()) return null;
+
+        char colorChar = matcher.group(1).charAt(0);
+        GearTier gearTier = GearTier.fromChatFormatting(ChatFormatting.getByCode(colorChar));
+
+        if (gearTier == null) return null;
+
+        return new CorruptedCacheItem(gearTier);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/items/items/game/CorruptedCacheItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CorruptedCacheItem.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.items.game;
+
+import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.items.properties.GearTierItemProperty;
+
+public class CorruptedCacheItem extends GameItem implements GearTierItemProperty {
+    private final GearTier gearTier;
+
+    public CorruptedCacheItem(GearTier gearTier) {
+        this.gearTier = gearTier;
+    }
+
+    @Override
+    public GearTier getGearTier() {
+        return gearTier;
+    }
+
+    @Override
+    public String toString() {
+        return "CorruptedCacheItem{" + "gearTier=" + gearTier + '}';
+    }
+}


### PR DESCRIPTION
Not something that's very easy to get a hold of and test so I'm just basing it on this screenshot.

Won't count towards any dry streak but once the WorldEventModel is setup to detect event completion we should add one for this. For now this will just prevent users from closing the reward chest if the mythic blocker feature is enabled.

![Cache](https://github.com/user-attachments/assets/ba9c589c-5ce9-4f98-95c7-dca139198aa8)
