### PR TITLE
fix: Various party management screen fixes [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/players/PartyModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PartyModel.java
@@ -63,13 +63,14 @@ public final class PartyModel extends Model {
     private static final Pattern PARTY_LIST_SELF_FAILED =
             Pattern.compile(PARTY_PREFIX_REGEX + "You must be in a party to use this\\.");
 
+    // This message has no period unlike the others. Add a period here when Wynn adds one.
+    private static final Pattern PARTY_LEAVE_SELF =
+            Pattern.compile(PARTY_PREFIX_REGEX + "You have left your current party");
     private static final Pattern PARTY_LEAVE_OTHER =
             Pattern.compile(PARTY_PREFIX_REGEX + "(\\w{1,16}) has left the party\\.");
     private static final Pattern PARTY_LEAVE_SELF_ALREADYLEFT =
             Pattern.compile(PARTY_PREFIX_REGEX + "You must be in a party to leave\\.");
-
-    // This is a special case; Wynn sends the same message for when we leave a party or get kicked from a party
-    private static final Pattern PARTY_LEAVE_SELF_KICK =
+    private static final Pattern PARTY_LEAVE_KICK =
             Pattern.compile(PARTY_PREFIX_REGEX + "You have been removed from the party\\.");
 
     private static final Pattern PARTY_JOIN_OTHER =
@@ -165,7 +166,8 @@ public final class PartyModel extends Model {
         }
 
         if (styledText.matches(PARTY_DISBAND_ALL)
-                || styledText.matches(PARTY_LEAVE_SELF_KICK)
+                || styledText.matches(PARTY_LEAVE_SELF)
+                || styledText.matches(PARTY_LEAVE_KICK)
                 || styledText.matches(PARTY_LEAVE_SELF_ALREADYLEFT)
                 || styledText.matches(PARTY_DISBAND_SELF)) {
             WynntilsMod.info("Player left the party.");
@@ -292,7 +294,7 @@ public final class PartyModel extends Model {
 
         String[] partyList = StyledText.fromString(matcher.group(1))
                 .getStringWithoutFormatting()
-                .split("(, | and )");
+                .split("(?:,(?: and)? )");
         List<String> newPartyMembers = new ArrayList<>();
 
         boolean firstMember = true;

--- a/common/src/main/java/com/wynntils/models/players/PartyModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PartyModel.java
@@ -72,6 +72,9 @@ public final class PartyModel extends Model {
             Pattern.compile(PARTY_PREFIX_REGEX + "You must be in a party to leave\\.");
     private static final Pattern PARTY_LEAVE_KICK =
             Pattern.compile(PARTY_PREFIX_REGEX + "You have been removed from the party\\.");
+    // This message is currently not used in the model.
+    private static final Pattern PARTY_PLAYER_NOT_ON_SAME_WORLD =
+            Pattern.compile(PARTY_PREFIX_REGEX + "That player is not playing on your world \\(WC\\d+\\)!");
 
     private static final Pattern PARTY_JOIN_OTHER =
             Pattern.compile(PARTY_PREFIX_REGEX + "(\\w{1,16}) has joined your party, say hello!");
@@ -102,6 +105,8 @@ public final class PartyModel extends Model {
     // endregion
 
     private static final ScoreboardPart PARTY_SCOREBOARD_PART = new PartyScoreboardPart();
+
+    public static final int MAX_PARTY_MEMBER_COUNT = 10;
 
     private boolean expectingPartyMessage = false; // Whether the client is expecting a response from "/party list"
     private long lastPartyRequest = 0; // The last time the client requested party data

--- a/common/src/main/java/com/wynntils/models/players/PartyModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PartyModel.java
@@ -85,8 +85,9 @@ public final class PartyModel extends Model {
     private static final Pattern PARTY_PROMOTE_SELF = Pattern.compile(
             PARTY_PREFIX_REGEX + "You are now the leader of this party! Type /party for a list of commands\\.");
 
+    // This message has no period unlike the others. Add a period here when Wynn adds one.
     private static final Pattern PARTY_DISBAND_ALL =
-            Pattern.compile(PARTY_PREFIX_REGEX + "Your party has been disbanded\\.");
+            Pattern.compile(PARTY_PREFIX_REGEX + "Your party has been disbanded");
     private static final Pattern PARTY_DISBAND_SELF = Pattern.compile(
             PARTY_PREFIX_REGEX + "Your party has been disbanded since you were the only member remaining\\.");
 

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -14,6 +14,7 @@ import com.wynntils.screens.partymanagement.widgets.CreateLeaveButton;
 import com.wynntils.screens.partymanagement.widgets.PartyMemberWidget;
 import com.wynntils.screens.partymanagement.widgets.SuggestionPlayerWidget;
 import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.RenderUtils;
@@ -141,20 +142,24 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                 .isBlank(); // inParty check not required as button automatically makes new party if not in one
 
         // region Invite field header
+        String inviteFieldHeader = I18n.get("screens.wynntils.partyManagementGui.inviteFieldHeader1")
+                + ChatFormatting.GRAY
+                + I18n.get("screens.wynntils.partyManagementGui.inviteFieldHeader2");
+
         FontRenderer.getInstance()
-                .renderText(
+                .renderAlignedTextInBox(
                         poseStack,
-                        // Yes this is kind of abusive of the formatting system, and I should probably do
-                        // another .renderText call, but this makes aligning these two texts significantly easier
-                        // (especially with changing gui scales and resolutions)
-                        StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.inviteFieldHeader1")
-                                + ChatFormatting.GRAY
-                                + I18n.get("screens.wynntils.partyManagementGui.inviteFieldHeader2")),
+                        StyledText.fromString(inviteFieldHeader),
                         dividedWidth * 36,
+                        dividedWidth * 60,
+                        dividedHeight * PARTY_LIST_DIV_HEIGHT
+                                - FontRenderer.getInstance().calculateRenderHeight(
+                                        StyledText.fromString(inviteFieldHeader), dividedWidth * 24),
                         dividedHeight * PARTY_LIST_DIV_HEIGHT, // should be lined up with the party list header
+                        dividedWidth * 24,
                         CommonColors.WHITE,
                         HorizontalAlignment.LEFT,
-                        VerticalAlignment.BOTTOM,
+                        VerticalAlignment.TOP,
                         TextShadow.NORMAL);
         // endregion
 
@@ -166,7 +171,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                     dividedWidth * 4,
                     dividedHeight * PARTY_LIST_DIV_HEIGHT,
                     0,
-                    dividedWidth * 30 - dividedWidth * 4,
+                    dividedWidth * 30 - dividedWidth * 2,
                     1);
             FontRenderer.getInstance()
                     .renderText(
@@ -220,6 +225,21 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                             TextShadow.NORMAL);
 
             partyMembersWidgets.forEach(widget -> widget.render(guiGraphics, mouseX, mouseY, partialTick));
+        } else {
+            FontRenderer.getInstance()
+                    .renderAlignedTextInBox(
+                            poseStack,
+                            StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.notInParty")),
+                            dividedWidth * 4,
+                            dividedWidth * 30,
+                            dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                            dividedHeight * SUGGESTION_LIST_DIV_HEIGHT,
+                            dividedWidth * 30 - dividedWidth * 4,
+                            CustomColor.NONE,
+                            HorizontalAlignment.CENTER,
+                            VerticalAlignment.TOP,
+                            TextShadow.NORMAL,
+                            2);
         }
         // endregion
 

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -153,8 +153,9 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                         dividedWidth * 36,
                         dividedWidth * 60,
                         dividedHeight * PARTY_LIST_DIV_HEIGHT
-                                - FontRenderer.getInstance().calculateRenderHeight(
-                                        StyledText.fromString(inviteFieldHeader), dividedWidth * 24),
+                                - FontRenderer.getInstance()
+                                        .calculateRenderHeight(
+                                                StyledText.fromString(inviteFieldHeader), dividedWidth * 24),
                         dividedHeight * PARTY_LIST_DIV_HEIGHT, // should be lined up with the party list header
                         dividedWidth * 24,
                         CommonColors.WHITE,

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -159,66 +159,68 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
         // endregion
 
         // region Party list
-        RenderUtils.drawRect(
-                poseStack,
-                CommonColors.WHITE,
-                dividedWidth * 4,
-                dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                0,
-                dividedWidth * 30 - dividedWidth * 4,
-                1);
-        FontRenderer.getInstance()
-                .renderText(
-                        poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.head")),
-                        dividedWidth * 5,
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                        CommonColors.WHITE,
-                        HorizontalAlignment.CENTER,
-                        VerticalAlignment.BOTTOM,
-                        TextShadow.NORMAL);
-        FontRenderer.getInstance()
-                .renderText(
-                        poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.name")),
-                        dividedWidth * 7,
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                        CommonColors.WHITE,
-                        HorizontalAlignment.LEFT,
-                        VerticalAlignment.BOTTOM,
-                        TextShadow.NORMAL);
-        FontRenderer.getInstance()
-                .renderText(
-                        poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.promote")),
-                        dividedWidth * 22,
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                        CommonColors.WHITE,
-                        HorizontalAlignment.CENTER, // (!) center as the button spans 2 columns
-                        VerticalAlignment.BOTTOM,
-                        TextShadow.NORMAL);
-        FontRenderer.getInstance()
-                .renderText(
-                        poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.kick")),
-                        dividedWidth * 26,
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                        CommonColors.WHITE,
-                        HorizontalAlignment.CENTER, // (!) center as the button spans 2 columns
-                        VerticalAlignment.BOTTOM,
-                        TextShadow.NORMAL);
-        FontRenderer.getInstance()
-                .renderText(
-                        poseStack,
-                        StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.priority")),
-                        dividedWidth * 28,
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                        CommonColors.WHITE,
-                        HorizontalAlignment.LEFT,
-                        VerticalAlignment.BOTTOM,
-                        TextShadow.NORMAL);
+        if (inParty) {
+            RenderUtils.drawRect(
+                    poseStack,
+                    CommonColors.WHITE,
+                    dividedWidth * 4,
+                    dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                    0,
+                    dividedWidth * 30 - dividedWidth * 4,
+                    1);
+            FontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.head")),
+                            dividedWidth * 5,
+                            dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.CENTER,
+                            VerticalAlignment.BOTTOM,
+                            TextShadow.NORMAL);
+            FontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.name")),
+                            dividedWidth * 7,
+                            dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.LEFT,
+                            VerticalAlignment.BOTTOM,
+                            TextShadow.NORMAL);
+            FontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.promote")),
+                            dividedWidth * 22,
+                            dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.CENTER, // (!) center as the button spans 2 columns
+                            VerticalAlignment.BOTTOM,
+                            TextShadow.NORMAL);
+            FontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.kick")),
+                            dividedWidth * 26,
+                            dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.CENTER, // (!) center as the button spans 2 columns
+                            VerticalAlignment.BOTTOM,
+                            TextShadow.NORMAL);
+            FontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.priority")),
+                            dividedWidth * 28,
+                            dividedHeight * PARTY_LIST_DIV_HEIGHT,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.LEFT,
+                            VerticalAlignment.BOTTOM,
+                            TextShadow.NORMAL);
 
-        partyMembersWidgets.forEach(widget -> widget.render(guiGraphics, mouseX, mouseY, partialTick));
+            partyMembersWidgets.forEach(widget -> widget.render(guiGraphics, mouseX, mouseY, partialTick));
+        }
         // endregion
 
         // region Suggestions

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -232,10 +232,10 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                     .renderText(
                             poseStack,
                             StyledText.fromString(I18n.get("screens.wynntils.partyManagementGui.priority")),
-                            dividedWidth * 28,
+                            dividedWidth * 30,
                             dividedHeight * PARTY_LIST_DIV_HEIGHT,
                             CommonColors.WHITE,
-                            HorizontalAlignment.LEFT,
+                            HorizontalAlignment.CENTER,
                             VerticalAlignment.BOTTOM,
                             TextShadow.NORMAL);
 

--- a/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/PartyManagementScreen.java
@@ -38,17 +38,17 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
     private static final Pattern INVITE_REPLACER = Pattern.compile("[^\\w, ]+");
     private static final Pattern COMMA_REPLACER = Pattern.compile("[,; ]+");
 
-    private static final int PARTY_LIST_DIV_HEIGHT = 8;
+    private static final int START_HEIGHT = 8;
+    private static final int PARTY_LIST_DIV_HEIGHT = 14;
     private static final int SUGGESTION_LIST_DIV_HEIGHT = 22;
     private static final int MGMT_ROW_DIV_HEIGHT = 14;
     private int mgmtButtonWidth;
-
     private TextInputBoxWidget inviteInput;
     private Button inviteButton;
     private Button kickOfflineButton;
     private CreateLeaveButton createLeaveButton;
-    private List<AbstractWidget> suggestedPlayersWidgets = new ArrayList<>();
-    private List<AbstractWidget> partyMembersWidgets = new ArrayList<>();
+    private List<SuggestionPlayerWidget> suggestedPlayersWidgets = new ArrayList<>();
+    private List<PartyMemberWidget> partyMembersWidgets = new ArrayList<>();
 
     private PartyManagementScreen() {
         super(Component.literal("Party Management Screen"));
@@ -67,7 +67,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
         // region Invite input and button
         inviteInput = new TextInputBoxWidget(
                 (int) (dividedWidth * 36),
-                (int) (dividedHeight * PARTY_LIST_DIV_HEIGHT) + 1,
+                (int) (dividedHeight * START_HEIGHT) + 1,
                 (int) ((dividedWidth * 57) - (dividedWidth * 36)) - 1,
                 BUTTON_SIZE,
                 null,
@@ -78,7 +78,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
         inviteButton = new Button.Builder(
                         Component.translatable("screens.wynntils.partyManagementGui.invite"),
                         (button) -> inviteFromField())
-                .pos((int) (dividedWidth * 57) + 1, (int) (dividedHeight * PARTY_LIST_DIV_HEIGHT) + 1)
+                .pos((int) (dividedWidth * 57) + 1, (int) (dividedHeight * START_HEIGHT) + 1)
                 .size((int) (dividedWidth * 3) - 1, BUTTON_SIZE)
                 .build();
         this.addRenderableWidget(inviteButton);
@@ -152,11 +152,11 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                         StyledText.fromString(inviteFieldHeader),
                         dividedWidth * 36,
                         dividedWidth * 60,
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT
+                        dividedHeight * START_HEIGHT
                                 - FontRenderer.getInstance()
                                         .calculateRenderHeight(
                                                 StyledText.fromString(inviteFieldHeader), dividedWidth * 24),
-                        dividedHeight * PARTY_LIST_DIV_HEIGHT, // should be lined up with the party list header
+                        dividedHeight * START_HEIGHT, // should be lined up with the party member count header
                         dividedWidth * 24,
                         CommonColors.WHITE,
                         HorizontalAlignment.LEFT,
@@ -166,6 +166,20 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
 
         // region Party list
         if (inParty) {
+            FontRenderer.getInstance()
+                    .renderText(
+                            poseStack,
+                            StyledText.fromString(I18n.get(
+                                    "screens.wynntils.partyManagementGui.members",
+                                    Models.Party.getPartyMembers().size(),
+                                    Models.Party.MAX_PARTY_MEMBER_COUNT)),
+                            dividedWidth * 4,
+                            dividedHeight * START_HEIGHT,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.LEFT,
+                            VerticalAlignment.TOP,
+                            TextShadow.NORMAL,
+                            2);
             RenderUtils.drawRect(
                     poseStack,
                     CommonColors.WHITE,
@@ -234,11 +248,11 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                             dividedWidth * 4,
                             dividedWidth * 30,
                             dividedHeight * PARTY_LIST_DIV_HEIGHT,
-                            dividedHeight * SUGGESTION_LIST_DIV_HEIGHT,
+                            height - (dividedHeight * PARTY_LIST_DIV_HEIGHT),
                             dividedWidth * 30 - dividedWidth * 4,
                             CustomColor.NONE,
                             HorizontalAlignment.CENTER,
-                            VerticalAlignment.TOP,
+                            VerticalAlignment.MIDDLE,
                             TextShadow.NORMAL,
                             2);
         }
@@ -331,7 +345,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
 
             partyMembersWidgets.add(new PartyMemberWidget(
                     dividedWidth * 4,
-                    dividedHeight * (9 + i * 3),
+                    dividedHeight * (PARTY_LIST_DIV_HEIGHT + 2) + i * BUTTON_SIZE,
                     (int) (dividedWidth * 28) - (int) (dividedWidth * 2),
                     BUTTON_SIZE,
                     playerName,
@@ -354,6 +368,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
         suggestedPlayersWidgets = new ArrayList<>();
         for (int i = 0; i < suggestedPlayers.size(); i++) {
             String playerName = suggestedPlayers.get(i);
+            boolean isOffline = !Models.Friends.getOnlineFriends().containsKey(playerName);
             if (playerName == null) continue;
 
             suggestedPlayersWidgets.add(new SuggestionPlayerWidget(
@@ -362,6 +377,7 @@ public final class PartyManagementScreen extends WynntilsGridLayoutScreen {
                     (int) ((dividedWidth * 60) - (dividedWidth * 36)),
                     BUTTON_SIZE,
                     playerName,
+                    isOffline,
                     60 - 36));
         }
     }

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/AbstractPlayerListEntryWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/AbstractPlayerListEntryWidget.java
@@ -1,0 +1,70 @@
+package com.wynntils.screens.partymanagement.widgets;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.render.RenderUtils;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.client.resources.DefaultPlayerSkin;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+public abstract class AbstractPlayerListEntryWidget extends AbstractWidget {
+    protected final String playerName;
+    protected final boolean isOffline;
+    protected final float gridDivisions;
+
+    protected AbstractPlayerListEntryWidget(int x, int y, int width, int height,
+                                    String playerName, boolean isOffline, float gridDivisions) {
+        super(x, y, width, height, Component.literal(playerName));
+        this.playerName = playerName;
+        this.isOffline = false;
+        this.gridDivisions = gridDivisions;
+    }
+
+    @Override
+    protected void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        PoseStack poseStack = guiGraphics.pose();
+
+        PlayerInfo playerInfo =
+                McUtils.mc().getConnection().getPlayerInfo(playerName); // Disconnected players will just be Steves
+        ResourceLocation skin = (playerInfo == null)
+                ? DefaultPlayerSkin.getDefaultTexture()
+                : playerInfo.getSkin().texture();
+        // head rendering
+        RenderUtils.drawTexturedRect(
+                poseStack,
+                skin,
+                this.getX() + (this.width / gridDivisions) - 8,
+                this.getY() + (this.height / 2) - 8,
+                8,
+                16,
+                16,
+                8,
+                8,
+                8,
+                8,
+                64,
+                64);
+        // hat rendering
+        RenderUtils.drawTexturedRect(
+                poseStack,
+                skin,
+                this.getX() + (this.width / gridDivisions) - 8,
+                this.getY() + (this.height / 2) - 8,
+                8,
+                16,
+                16,
+                40,
+                8,
+                8,
+                8,
+                64,
+                64);
+    }
+
+    @Override
+    protected void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {}
+}

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/AbstractPlayerListEntryWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/AbstractPlayerListEntryWidget.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.screens.partymanagement.widgets;
 
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -16,8 +20,8 @@ public abstract class AbstractPlayerListEntryWidget extends AbstractWidget {
     protected final boolean isOffline;
     protected final float gridDivisions;
 
-    protected AbstractPlayerListEntryWidget(int x, int y, int width, int height,
-                                    String playerName, boolean isOffline, float gridDivisions) {
+    protected AbstractPlayerListEntryWidget(
+            int x, int y, int width, int height, String playerName, boolean isOffline, float gridDivisions) {
         super(x, y, width, height, Component.literal(playerName));
         this.playerName = playerName;
         this.isOffline = false;

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/PartyMemberWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/PartyMemberWidget.java
@@ -11,82 +11,53 @@ import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 
-public class PartyMemberWidget extends AbstractWidget {
-    private final String playerName;
-    private final boolean isOffline;
+public class PartyMemberWidget extends AbstractPlayerListEntryWidget {
     private final Button promoteButton;
     private final Button kickButton;
     private final Button disbandButton;
     private final Button moveUpButton;
     private final Button moveDownButton;
-    private final float gridDivisions;
 
-    public PartyMemberWidget(
-            float x, float y, int width, int height, String playerName, boolean isOffline, float gridDivisions) {
-        super((int) x, (int) y, width, height, Component.literal(playerName));
-        this.playerName = playerName;
-        this.isOffline = isOffline;
-        this.gridDivisions = gridDivisions;
+    public PartyMemberWidget(float x, float y, int width, int height,
+                             String playerName, boolean isOffline, float gridDivisions) {
+        super((int) x, (int) y, width, height, playerName, isOffline, gridDivisions);
+        int baseButtonWidth = (int) (this.width / gridDivisions);
+
         this.promoteButton = new Button.Builder(
                         Component.translatable("screens.wynntils.partyManagementGui.promote"),
                         (button) -> Models.Party.partyPromote(playerName))
                 .pos((int) (this.getX() + (this.width / this.gridDivisions * 16)) + 1, this.getY())
-                .size(
-                        (int) ((this.getX() + (this.width / this.gridDivisions * 20))
-                                        - (this.getX() + (this.width / this.gridDivisions * 16)))
-                                - 2,
-                        20)
+                .size(baseButtonWidth * 4, height)
                 .build();
         this.kickButton = new Button.Builder(
                         Component.translatable("screens.wynntils.partyManagementGui.kick"),
                         (button) -> Models.Party.partyKick(playerName))
                 .pos((int) (this.getX() + (this.width / this.gridDivisions * 20)) + 1, this.getY())
-                .size(
-                        (int) ((this.getX() + (this.width / this.gridDivisions * 24))
-                                        - (this.getX() + (this.width / this.gridDivisions * 20)))
-                                - 2,
-                        20)
+                .size(baseButtonWidth * 4, height)
                 .build();
         this.disbandButton = new Button.Builder(
                         Component.translatable("screens.wynntils.partyManagementGui.disband"),
                         (button) -> Models.Party.partyDisband())
                 .pos((int) (this.getX() + (this.width / this.gridDivisions * 20)) + 1, this.getY())
-                .size(
-                        (int) ((this.getX() + (this.width / this.gridDivisions * 24))
-                                        - (this.getX() + (this.width / this.gridDivisions * 20)))
-                                - 2,
-                        20)
+                .size(baseButtonWidth * 4, height)
                 .build();
         this.moveUpButton = new Button.Builder(
                         Component.literal("🠝"), (button) -> Models.Party.increasePlayerPriority(playerName))
                 .pos((int) (this.getX() + (this.width / this.gridDivisions * 24)) + 1, this.getY())
-                .size(
-                        (int) ((this.getX() + (this.width / this.gridDivisions * 25))
-                                        - (this.getX() + (this.width / this.gridDivisions * 24)))
-                                - 2,
-                        20)
+                .size(baseButtonWidth * 2, height)
                 .build();
         this.moveDownButton = new Button.Builder(
                         Component.literal("🠟"), (button) -> Models.Party.decreasePlayerPriority(playerName))
-                .pos((int) (this.getX() + (this.width / this.gridDivisions * 25)) + 1, this.getY())
-                .size(
-                        (int) ((this.getX() + (this.width / this.gridDivisions * 26))
-                                        - (this.getX() + (this.width / this.gridDivisions * 25)))
-                                - 2,
-                        20)
+                .pos((int) (this.getX() + (this.width / this.gridDivisions * 26)) + 1, this.getY())
+                .size(baseButtonWidth * 2, height)
                 .build();
         if (Models.Party.isPartyLeader(playerName)) {
             this.promoteButton.active = false;
@@ -98,43 +69,9 @@ public class PartyMemberWidget extends AbstractWidget {
 
     @Override
     public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        PoseStack poseStack = guiGraphics.pose();
+        super.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
 
-        PlayerInfo playerInfo =
-                McUtils.mc().getConnection().getPlayerInfo(playerName); // Disconnected players will just be steves
-        ResourceLocation skin = (playerInfo == null)
-                ? ResourceLocation.withDefaultNamespace("textures/entity/player/wide/steve.png")
-                : playerInfo.getSkin().texture();
-        // head rendering
-        RenderUtils.drawTexturedRect(
-                poseStack,
-                skin,
-                this.getX() + (this.width / gridDivisions) - 8,
-                this.getY() + (this.height / 2) - 8,
-                8,
-                16,
-                16,
-                8,
-                8,
-                8,
-                8,
-                64,
-                64);
-        // hat rendering
-        RenderUtils.drawTexturedRect(
-                poseStack,
-                skin,
-                this.getX() + (this.width / gridDivisions) - 8,
-                this.getY() + (this.height / 2) - 8,
-                1,
-                16,
-                16,
-                40,
-                8,
-                8,
-                8,
-                64,
-                64);
+        PoseStack poseStack = guiGraphics.pose();
 
         // name rendering
         CustomColor color = CommonColors.WHITE;
@@ -189,7 +126,4 @@ public class PartyMemberWidget extends AbstractWidget {
                 || kickButton.mouseClicked(mouseX, mouseY, button)
                 || disbandButton.mouseClicked(mouseX, mouseY, button);
     }
-
-    @Override
-    protected void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {}
 }

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/PartyMemberWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/PartyMemberWidget.java
@@ -26,8 +26,8 @@ public class PartyMemberWidget extends AbstractPlayerListEntryWidget {
     private final Button moveUpButton;
     private final Button moveDownButton;
 
-    public PartyMemberWidget(float x, float y, int width, int height,
-                             String playerName, boolean isOffline, float gridDivisions) {
+    public PartyMemberWidget(
+            float x, float y, int width, int height, String playerName, boolean isOffline, float gridDivisions) {
         super((int) x, (int) y, width, height, playerName, isOffline, gridDivisions);
         int baseButtonWidth = (int) (this.width / gridDivisions);
 

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/PartyMemberWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/PartyMemberWidget.java
@@ -103,7 +103,7 @@ public class PartyMemberWidget extends AbstractWidget {
         PlayerInfo playerInfo =
                 McUtils.mc().getConnection().getPlayerInfo(playerName); // Disconnected players will just be steves
         ResourceLocation skin = (playerInfo == null)
-                ? ResourceLocation.withDefaultNamespace("textures/entity/steve.png")
+                ? ResourceLocation.withDefaultNamespace("textures/entity/player/wide/steve.png")
                 : playerInfo.getSkin().texture();
         // head rendering
         RenderUtils.drawTexturedRect(

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/SuggestionPlayerWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/SuggestionPlayerWidget.java
@@ -8,29 +8,20 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.utils.colors.CommonColors;
-import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 
-public class SuggestionPlayerWidget extends AbstractWidget {
-    private final String playerName;
+public class SuggestionPlayerWidget extends AbstractPlayerListEntryWidget {
     private final Button inviteButton;
-    private final float gridDivisions;
 
-    public SuggestionPlayerWidget(float x, float y, int width, int height, String playerName, float gridDivisions) {
-        super((int) x, (int) y, width, height, Component.literal(playerName));
-        this.playerName = playerName;
-        this.gridDivisions = gridDivisions;
+    public SuggestionPlayerWidget(float x, float y, int width, int height,
+                                  String playerName, boolean isOffline, float gridDivisions) {
+        super((int) x, (int) y, width, height, playerName, isOffline, gridDivisions);
         this.inviteButton = new Button.Builder(
                         Component.translatable("screens.wynntils.partyManagementGui.invite"),
                         (button) -> Models.Party.partyInvite(playerName))
@@ -45,42 +36,9 @@ public class SuggestionPlayerWidget extends AbstractWidget {
 
     @Override
     public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        PoseStack poseStack = guiGraphics.pose();
+        super.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
 
-        PlayerInfo playerInfo =
-                McUtils.mc().getConnection().getPlayerInfo(playerName); // Disconnected players will just be steves
-        ResourceLocation skin = (playerInfo == null)
-                ? ResourceLocation.withDefaultNamespace("textures/entity/player/wide/steve.png")
-                : playerInfo.getSkin().texture();
-        // head rendering
-        RenderUtils.drawTexturedRect(
-                poseStack,
-                skin,
-                this.getX() + (this.width / gridDivisions) - 8,
-                this.getY() + (this.height / 2) - 8,
-                8,
-                16,
-                16,
-                8,
-                8,
-                8,
-                8,
-                64,
-                64);
-        RenderUtils.drawTexturedRect(
-                poseStack,
-                skin,
-                this.getX() + (this.width / gridDivisions) - 8,
-                this.getY() + (this.height / 2) - 8,
-                8,
-                16,
-                16,
-                40,
-                8,
-                8,
-                8,
-                64,
-                64);
+        PoseStack poseStack = guiGraphics.pose();
 
         // name rendering
         FontRenderer.getInstance()
@@ -102,7 +60,4 @@ public class SuggestionPlayerWidget extends AbstractWidget {
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         return inviteButton.mouseClicked(mouseX, mouseY, button);
     }
-
-    @Override
-    protected void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {}
 }

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/SuggestionPlayerWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/SuggestionPlayerWidget.java
@@ -19,8 +19,8 @@ import net.minecraft.network.chat.Component;
 public class SuggestionPlayerWidget extends AbstractPlayerListEntryWidget {
     private final Button inviteButton;
 
-    public SuggestionPlayerWidget(float x, float y, int width, int height,
-                                  String playerName, boolean isOffline, float gridDivisions) {
+    public SuggestionPlayerWidget(
+            float x, float y, int width, int height, String playerName, boolean isOffline, float gridDivisions) {
         super((int) x, (int) y, width, height, playerName, isOffline, gridDivisions);
         this.inviteButton = new Button.Builder(
                         Component.translatable("screens.wynntils.partyManagementGui.invite"),

--- a/common/src/main/java/com/wynntils/screens/partymanagement/widgets/SuggestionPlayerWidget.java
+++ b/common/src/main/java/com/wynntils/screens/partymanagement/widgets/SuggestionPlayerWidget.java
@@ -50,7 +50,7 @@ public class SuggestionPlayerWidget extends AbstractWidget {
         PlayerInfo playerInfo =
                 McUtils.mc().getConnection().getPlayerInfo(playerName); // Disconnected players will just be steves
         ResourceLocation skin = (playerInfo == null)
-                ? ResourceLocation.withDefaultNamespace("textures/entity/steve.png")
+                ? ResourceLocation.withDefaultNamespace("textures/entity/player/wide/steve.png")
                 : playerInfo.getSkin().texture();
         // head rendering
         RenderUtils.drawTexturedRect(

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2330,6 +2330,7 @@
   "screens.wynntils.partyManagementGui.leavePartyButton": "Leave Party",
   "screens.wynntils.partyManagementGui.legend": "Legend:",
   "screens.wynntils.partyManagementGui.name": "Name",
+  "screens.wynntils.partyManagementGui.notInParty": "You're not in a party.",
   "screens.wynntils.partyManagementGui.offline": "Offline",
   "screens.wynntils.partyManagementGui.priority": "Priority",
   "screens.wynntils.partyManagementGui.promote": "Promote",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2329,6 +2329,7 @@
   "screens.wynntils.partyManagementGui.leader": "Leader",
   "screens.wynntils.partyManagementGui.leavePartyButton": "Leave Party",
   "screens.wynntils.partyManagementGui.legend": "Legend:",
+  "screens.wynntils.partyManagementGui.members": "Members: %d/%d",
   "screens.wynntils.partyManagementGui.name": "Name",
   "screens.wynntils.partyManagementGui.notInParty": "You're not in a party.",
   "screens.wynntils.partyManagementGui.offline": "Offline",


### PR DESCRIPTION
- Fix texture not found in SuggestionPlayerWidget#renderWidget when trying to load the Steve skin for players with unknown skins
- Add pattern for new party leave message in Models.Party
- Fix "and" not being trimmed from the username of the last party member
- Hide party member column when the player is not in a party