### PR TITLE
fix: Fix ability tree annotators [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/AbilityTreeAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/AbilityTreeAnnotator.java
@@ -19,7 +19,7 @@ public final class AbilityTreeAnnotator implements GuiItemAnnotator {
     private static final Pattern COMPASS_ABILITY_POINTS_PATTERN = Pattern.compile("^§3✦ Unused Points: §f(\\d+)$");
 
     // Deals with the reset button in the ability tree screen
-    private static final StyledText TREE_ABILITY_POINTS_NAME = StyledText.fromString("§3§lAbility Points");
+    private static final StyledText TREE_ABILITY_POINTS_NAME = StyledText.fromString("§#82eff4ff§lAbility Points");
     // Test in AbilityTreeAnnotator_TREE_ABILITY_POINTS_PATTERN
     private static final Pattern TREE_ABILITY_POINTS_PATTERN =
             Pattern.compile("^§b✦ Available Points: §f(\\d+)§7/\\d+$");

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/ArchetypeAbilitiesAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/ArchetypeAbilitiesAnnotator.java
@@ -16,7 +16,7 @@ import net.minecraft.world.item.ItemStack;
 
 public final class ArchetypeAbilitiesAnnotator implements GuiItemAnnotator {
     // Test in ArchetypeAbilitiesAnnotator_ARCHETYPE_NAME
-    private static final Pattern ARCHETYPE_NAME = Pattern.compile("^§#([a-r0-9]{8})§l[A-Za-z ]+ Archetype$");
+    private static final Pattern ARCHETYPE_NAME = Pattern.compile("^§#([a-f0-9]{8})§l[A-Za-z ]+ Archetype$");
     // Test in ArchetypeAbilitiesAnnotator_ARCHETYPE_PATTERN
     private static final Pattern ARCHETYPE_PATTERN = Pattern.compile("^§a✔ §7Unlocked Abilities: §f(\\d+)§7/(\\d+)$");
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/ArchetypeAbilitiesAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/ArchetypeAbilitiesAnnotator.java
@@ -16,7 +16,7 @@ import net.minecraft.world.item.ItemStack;
 
 public final class ArchetypeAbilitiesAnnotator implements GuiItemAnnotator {
     // Test in ArchetypeAbilitiesAnnotator_ARCHETYPE_NAME
-    private static final Pattern ARCHETYPE_NAME = Pattern.compile("^§([a-r0-9])§l[A-Za-z ]+ Archetype$");
+    private static final Pattern ARCHETYPE_NAME = Pattern.compile("^§#([a-r0-9]{8})§l[A-Za-z ]+ Archetype$");
     // Test in ArchetypeAbilitiesAnnotator_ARCHETYPE_PATTERN
     private static final Pattern ARCHETYPE_PATTERN = Pattern.compile("^§a✔ §7Unlocked Abilities: §f(\\d+)§7/(\\d+)$");
 
@@ -31,7 +31,6 @@ public final class ArchetypeAbilitiesAnnotator implements GuiItemAnnotator {
 
         int count = Integer.parseInt(loreMatcher.group(1));
         int max = Integer.parseInt(loreMatcher.group(2));
-        char colorCode = nameMatcher.group(1).charAt(0);
-        return new ArchetypeAbilitiesItem(new CappedValue(count, max), colorCode);
+        return new ArchetypeAbilitiesItem(new CappedValue(count, max));
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/gui/ArchetypeAbilitiesItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/ArchetypeAbilitiesItem.java
@@ -1,20 +1,17 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;
 
 import com.wynntils.models.items.properties.CountedItemProperty;
 import com.wynntils.utils.type.CappedValue;
-import net.minecraft.ChatFormatting;
 
 public class ArchetypeAbilitiesItem extends GuiItem implements CountedItemProperty {
     private final CappedValue abilitiesCount;
-    private final ChatFormatting color;
 
-    public ArchetypeAbilitiesItem(CappedValue cappedValue, char colorCode) {
+    public ArchetypeAbilitiesItem(CappedValue cappedValue) {
         this.abilitiesCount = cappedValue;
-        this.color = ChatFormatting.getByCode(colorCode);
     }
 
     @Override
@@ -31,12 +28,8 @@ public class ArchetypeAbilitiesItem extends GuiItem implements CountedItemProper
         return abilitiesCount;
     }
 
-    public ChatFormatting getColor() {
-        return color;
-    }
-
     @Override
     public String toString() {
-        return "ArchetypeItem{" + "count=" + abilitiesCount + ", color=" + color.getName() + '}';
+        return "ArchetypeItem{" + "count=" + abilitiesCount + '}';
     }
 }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -109,10 +109,20 @@ public class TestRegex {
     @Test
     public void ArchetypeAbilitiesAnnotator_ARCHETYPE_NAME() {
         PatternTester p = new PatternTester(ArchetypeAbilitiesAnnotator.class, "ARCHETYPE_NAME");
-        p.shouldMatch("§e§lBoltslinger Archetype");
-        p.shouldMatch("§d§lSharpshooter Archetype");
-        p.shouldMatch("§2§lTrapper Archetype");
-        p.shouldMatch("§d§lLight Bender Archetype");
+        p.shouldMatch("§#eb3dfeff§lSharpshooter Archetype");
+        p.shouldMatch("§#dae069ff§lBoltslinger Archetype");
+        p.shouldMatch("§#87dd47ff§lTrapper Archetype");
+        p.shouldMatch("§#60c5cdff§lRiftwalker Archetype");
+        p.shouldMatch("§#eb3dfeff§lArcanist Archetype");
+        p.shouldMatch("§#f0c435ff§lSummoner Archetype");
+        p.shouldMatch("§#87dd47ff§lRitualist Archetype");
+        p.shouldMatch("§#ffa057ff§lAcolyte Archetype");
+        p.shouldMatch("§#ffa057ff§lFallen Archetype");
+        p.shouldMatch("§#dae069ff§lBattle Monk Archetype");
+        p.shouldMatch("§#60c5cdff§lPaladin Archetype");
+        p.shouldMatch("§#ffa057ff§lShadestepper Archetype");
+        p.shouldMatch("§#eb3dfeff§lTrickster Archetype");
+        p.shouldMatch("§#b8b0b0ff§lAcrobat Archetype");
     }
 
     @Test


### PR DESCRIPTION
Removed the color field from ArchetypeAbilitiesItem as it's no longer a ChatFormatting character and it wasn't used anywhere anyway

![image](https://github.com/user-attachments/assets/92eb724e-9cf8-4401-8284-cdfd38114a8f)
