### PR TITLE
fix: Fix getting stuck in interim state when changing world via housing join [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -31,7 +31,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public final class WorldStateModel extends Model {
     private static final UUID WORLD_NAME_UUID = UUID.fromString("16ff7452-714f-2752-b3cd-c3cb2068f6af");
     private static final Pattern WORLD_NAME = Pattern.compile("^§f {2}§lGlobal \\[(.*)\\]$");
-    private static final Pattern HOUSING_NAME = Pattern.compile("^§f  §l([^§\"\\\\]{1,18})$");
+    private static final Pattern HOUSING_NAME = Pattern.compile("^§f  §l([^§\"\\\\]{1,35})$");
     private static final Pattern HUB_NAME = Pattern.compile("^\n§6§l play.wynncraft.com \n$");
     private static final Pattern STREAMER_MESSAGE = Pattern.compile("§2Streamer mode (disabled|was enabled)\\.");
     private static final Position CHARACTER_SELECTION_POSITION = new Vec3(-1337.5, 16.2, -1120.5);
@@ -182,6 +182,9 @@ public final class WorldStateModel extends Model {
     private boolean setWorldIfMatched(Matcher m, boolean housing) {
         if (m.find()) {
             String worldName = housing ? currentWorldName : m.group(1);
+            if (worldName.isEmpty() && housing) {
+                WynntilsMod.warn("Changed world via housing join, current world name is unknown");
+            }
             setState(WorldState.WORLD, worldName, !hasJoinedAnyWorld);
             hasJoinedAnyWorld = true;
             onHousing = housing;

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -36,6 +36,7 @@ public final class WorldStateModel extends Model {
     private static final Pattern STREAMER_MESSAGE = Pattern.compile("§2Streamer mode (disabled|was enabled)\\.");
     private static final Position CHARACTER_SELECTION_POSITION = new Vec3(-1337.5, 16.2, -1120.5);
     private static final String WYNNCRAFT_BETA_NAME = "beta";
+    private static final String UNKNOWN_WORLD = "WC??";
     private static final StyledText CHARACTER_SELECTION_TITLE = StyledText.fromString("§8§lSelect a Character");
 
     private StyledText currentTabListFooter = StyledText.EMPTY;
@@ -183,6 +184,7 @@ public final class WorldStateModel extends Model {
         if (m.find()) {
             String worldName = housing ? currentWorldName : m.group(1);
             if (worldName.isEmpty() && housing) {
+                worldName = UNKNOWN_WORLD;
                 WynntilsMod.warn("Changed world via housing join, current world name is unknown");
             }
             setState(WorldState.WORLD, worldName, !hasJoinedAnyWorld);

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -37,6 +37,7 @@ import com.wynntils.models.territories.GuildAttackTimerModel;
 import com.wynntils.models.trademarket.TradeMarketModel;
 import com.wynntils.models.war.bossbar.WarTowerBar;
 import com.wynntils.models.worlds.BombModel;
+import com.wynntils.models.worlds.WorldStateModel;
 import com.wynntils.models.worlds.bossbars.InfoBar;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import java.lang.reflect.Field;
@@ -929,5 +930,12 @@ public class TestRegex {
         PatternTester p = new PatternTester(PartyModel.class, "PARTY_LIST_ALL");
         p.shouldMatch(
                 "§e󏿼󏿿󏿾 Party members: §bbolyai, §fMrRickroll, Talkair, Angel_Pup, wluma, LaMDaKiS, Tanoranko, GebutterteWurst, kristof345, §eand §fSpeedtart");
+    }
+
+    @Test
+    public void WorldStateModel_HOUSING_NAME() {
+        PatternTester p = new PatternTester(WorldStateModel.class, "HOUSING_NAME");
+        p.shouldMatch("§f  §lChiefs Of Corkus' HQ");
+        p.shouldMatch("§f  §lShadow's Home");
     }
 }


### PR DESCRIPTION
Fixes the main issue of https://github.com/Wynntils/Wynntils/issues/2388 however world name is still unknown but I don't think anything can be done about that unless we run /find or check world via API for players currently on the housing, but they could be in /stream so that info is hidden so there's no consistent method