### PR TITLE
fix: Fix outline text shadow not rendering around vanilla hud elements [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
@@ -118,7 +118,7 @@ public final class BufferedFontRenderer {
                         false,
                         poseStack.last().pose(),
                         bufferSource,
-                        Font.DisplayMode.NORMAL,
+                        Font.DisplayMode.SEE_THROUGH,
                         0,
                         0xF000F0);
                 font.drawInBatch(
@@ -129,7 +129,7 @@ public final class BufferedFontRenderer {
                         false,
                         poseStack.last().pose(),
                         bufferSource,
-                        Font.DisplayMode.NORMAL,
+                        Font.DisplayMode.SEE_THROUGH,
                         0,
                         0xF000F0);
                 font.drawInBatch(
@@ -140,7 +140,7 @@ public final class BufferedFontRenderer {
                         false,
                         poseStack.last().pose(),
                         bufferSource,
-                        Font.DisplayMode.NORMAL,
+                        Font.DisplayMode.SEE_THROUGH,
                         0,
                         0xF000F0);
                 font.drawInBatch(
@@ -151,7 +151,7 @@ public final class BufferedFontRenderer {
                         false,
                         poseStack.last().pose(),
                         bufferSource,
-                        Font.DisplayMode.NORMAL,
+                        Font.DisplayMode.SEE_THROUGH,
                         0,
                         0xF000F0);
 
@@ -163,7 +163,7 @@ public final class BufferedFontRenderer {
                         false,
                         poseStack.last().pose(),
                         bufferSource,
-                        Font.DisplayMode.NORMAL,
+                        Font.DisplayMode.SEE_THROUGH,
                         0,
                         0xF000F0);
             }


### PR DESCRIPTION
The display mode was changed to normal to fix an issue with ImmediatelyFast causing the text to render as completely black, however I have tried running this fix with just ImmediatelyFast and with other mods too and have been unable to reproduce that issue so it appears to have been fixed on their side.

Normal:
![2024-09-06_16 14 58](https://github.com/user-attachments/assets/4af95c9d-a497-4a89-85ca-d7934153cf3d)

See through:
![2024-09-06_16 14 33](https://github.com/user-attachments/assets/d0af0f63-5f4f-47bd-acb8-ca2c0260ec07)

See the top around boss bar and the right by scoreboard