### PR TITLE
chore!: bump neoforge req

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,8 +32,8 @@ fabric_version=0.101.2+1.21
 
 # NeoForge
 # Check for latest at https://neoforged.net/
-neoforge_version=21.0.143
-neoforge_version_range=[21.0.143,)
+neoforge_version=21.1.43
+neoforge_version_range=[21.1.43,)
 neoforge_loader_version_range=[4,)
 
 # Note: Must use same version of eventbus as is used in the above forge version!


### PR DESCRIPTION
bumps the req from `21.0.143` up to `21.1.43`