### PR TITLE
fix: Fix certain ingredients using API name not being annotated [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
@@ -52,6 +52,10 @@ public class IngredientInfoRegistry {
         return ingredientInfoLookup.get(ingredientName);
     }
 
+    public IngredientInfo getFromApiName(String ingredientName) {
+        return ingredientInfoLookupApiName.get(ingredientName);
+    }
+
     public Stream<IngredientInfo> getIngredientInfoStream() {
         return ingredientInfoRegistry.stream();
     }

--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientModel.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientModel.java
@@ -61,6 +61,10 @@ public class IngredientModel extends Model {
         return ingredientInfoRegistry.getFromDisplayName(ingredientName);
     }
 
+    public IngredientInfo getIngredientInfoFromApiName(String ingredientName) {
+        return ingredientInfoRegistry.getFromApiName(ingredientName);
+    }
+
     public List<ItemObtainInfo> getObtainInfo(IngredientInfo ingredientInfo) {
         List<ItemObtainInfo> obtainInfo = Models.WynnItem.getObtainInfo(ingredientInfo.name());
         if (obtainInfo == null) {

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/IngredientAnnotator.java
@@ -30,7 +30,10 @@ public final class IngredientAnnotator implements GameItemAnnotator {
 
         int tier = Models.Ingredient.getTierFromColorCode(tierColor);
         IngredientInfo ingredientInfo = Models.Ingredient.getIngredientInfoFromName(ingredientName);
-        if (ingredientInfo == null) return null;
+        if (ingredientInfo == null) {
+            ingredientInfo = Models.Ingredient.getIngredientInfoFromApiName(ingredientName);
+            if (ingredientInfo == null) return null;
+        }
 
         if (ingredientInfo.tier() != tier) {
             WynntilsMod.warn("Incorrect tier in ingredient database: " + ingredientName + " is currently " + tier

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/IngredientPouchAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/IngredientPouchAnnotator.java
@@ -44,7 +44,10 @@ public final class IngredientPouchAnnotator implements GuiItemAnnotator {
             IngredientInfo ingredientInfo = Models.Ingredient.getIngredientInfoFromName(ingredientName);
 
             // Skip unknown ingredients; the pouch list will be wrong but better than nothing
-            if (ingredientInfo == null) continue;
+            if (ingredientInfo == null) {
+                ingredientInfo = Models.Ingredient.getIngredientInfoFromApiName(ingredientName);
+                if (ingredientInfo == null) continue;
+            }
 
             if (ingredientInfo.tier() != tier) {
                 WynntilsMod.warn("Incorrect tier (pouch) in ingredient database: " + ingredientName + " is currently "

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/IngredientPouchAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/IngredientPouchAnnotator.java
@@ -43,9 +43,9 @@ public final class IngredientPouchAnnotator implements GuiItemAnnotator {
             int tier = Models.Ingredient.getTierFromColorCode(tierColor);
             IngredientInfo ingredientInfo = Models.Ingredient.getIngredientInfoFromName(ingredientName);
 
-            // Skip unknown ingredients; the pouch list will be wrong but better than nothing
             if (ingredientInfo == null) {
                 ingredientInfo = Models.Ingredient.getIngredientInfoFromApiName(ingredientName);
+                // Skip unknown ingredients; the pouch list will be wrong but better than nothing
                 if (ingredientInfo == null) continue;
             }
 


### PR DESCRIPTION
Fixes #2836

![image](https://github.com/user-attachments/assets/28a1c917-828f-4996-b403-c9e89ac4a793)


The specific ingredient mentioned in the issue uses `’` in the name in-game whereas all others with an apostrophe use `'`