### PR TITLE
fix: Fix info bar territory pattern [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
+++ b/common/src/main/java/com/wynntils/models/worlds/bossbars/InfoBar.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 public class InfoBar extends TrackedBar {
     // Test in InfoBar_TERRITORY_INFO_PATTERN
     private static final Pattern TERRITORY_INFO_PATTERN =
-            Pattern.compile("§[abc](?<territory>[a-zA-Z\\s]+)§[234] \\[(?<tag>[A-Za-z]{3,4})\\]");
+            Pattern.compile("§[abc](?<territory>[a-zA-Z\\s]+)§[234] (?<tag>\uE060\uDAFF\uDFFF.*\uDB00\uDC02)");
 
     // Test in InfoBar_GUILD_INFO_PATTERN
     private static final Pattern GUILD_INFO_PATTERN =

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -478,9 +478,12 @@ public class TestRegex {
     @Test
     public void InfoBar_TERRITORY_INFO_PATTERN() {
         PatternTester p = new PatternTester(InfoBar.class, "TERRITORY_INFO_PATTERN");
-        p.shouldMatch("§aLutho§2 [PROF]");
-        p.shouldMatch("§bCorkus City§3 [HOC]");
-        p.shouldMatch("§cDetlas§4 [AVO]");
+        p.shouldMatch(
+                "§aNexus of Light§2 \uE060\uDAFF\uDFFF\uE03C\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE03B\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE062\uDAFF\uDFE6§f\uE00C\uE004\uE00B\uE013\uDB00\uDC02"); // MELT tag
+        p.shouldMatch(
+                "§bFleris Cranny§3 \uE060\uDAFF\uDFFF\uE037\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE032\uDAFF\uDFFF\uE062\uDAFF\uDFEC§f\uE007\uE00E\uE002\uDB00\uDC02"); // HOC tag
+        p.shouldMatch(
+                "§cCinfras§4 \uE060\uDAFF\uDFFF\uE038\uDAFF\uDFFF\uE032\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE062\uDAFF\uDFEE§f\uE008\uE002\uE00E\uDB00\uDC02"); // ICO tag
     }
 
     @Test


### PR DESCRIPTION
Will stop `Failed to match already matched boss bar` from being spammed in logs, fortunately we don't use the tag for anything so no need to parse that