### PR TITLE
fix: Increase delay between territory updates when not in a guild

### DIFF
--- a/common/src/main/java/com/wynntils/models/players/GuildModel.java
+++ b/common/src/main/java/com/wynntils/models/players/GuildModel.java
@@ -12,6 +12,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.net.ApiResponse;
 import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
@@ -23,6 +24,7 @@ import com.wynntils.handlers.container.type.ContainerContent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.models.character.CharacterModel;
 import com.wynntils.models.containers.ContainerModel;
+import com.wynntils.models.players.event.GuildEvent;
 import com.wynntils.models.players.label.GuildSeasonLeaderboardHeaderLabelParser;
 import com.wynntils.models.players.label.GuildSeasonLeaderboardLabelParser;
 import com.wynntils.models.players.profile.GuildProfile;
@@ -158,6 +160,7 @@ public class GuildModel extends Model {
         StyledText message = e.getOriginalStyledText();
 
         if (message.matches(MSG_LEFT_GUILD)) {
+            WynntilsMod.postEvent(new GuildEvent.Left(guildName));
             guildName = "";
             guildRank = null;
             guildLevel = -1;
@@ -173,6 +176,7 @@ public class GuildModel extends Model {
             guildName = joinedGuildMatcher.group(1);
             guildRank = GuildRank.RECRUIT;
             WynntilsMod.info("User joined guild " + guildName + " as a " + guildRank);
+            WynntilsMod.postEvent(new GuildEvent.Joined(guildName));
             return;
         }
 
@@ -274,6 +278,7 @@ public class GuildModel extends Model {
             Matcher guildNameMatcher = line.getMatcher(GUILD_NAME_MATCHER);
             if (guildNameMatcher.matches()) {
                 guildName = guildNameMatcher.group("name");
+                Models.Territory.scheduleTerritoryUpdate(true);
                 continue;
             }
 

--- a/common/src/main/java/com/wynntils/models/players/GuildModel.java
+++ b/common/src/main/java/com/wynntils/models/players/GuildModel.java
@@ -12,7 +12,6 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
-import com.wynntils.core.components.Models;
 import com.wynntils.core.net.ApiResponse;
 import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
@@ -278,7 +277,6 @@ public class GuildModel extends Model {
             Matcher guildNameMatcher = line.getMatcher(GUILD_NAME_MATCHER);
             if (guildNameMatcher.matches()) {
                 guildName = guildNameMatcher.group("name");
-                Models.Territory.scheduleTerritoryUpdate(true);
                 continue;
             }
 

--- a/common/src/main/java/com/wynntils/models/players/GuildModel.java
+++ b/common/src/main/java/com/wynntils/models/players/GuildModel.java
@@ -403,6 +403,10 @@ public class GuildModel extends Model {
         return guildRank;
     }
 
+    public boolean isInGuild() {
+        return !guildName.isEmpty();
+    }
+
     public int getGuildLevel() {
         return guildLevel;
     }

--- a/common/src/main/java/com/wynntils/models/players/event/GuildEvent.java
+++ b/common/src/main/java/com/wynntils/models/players/event/GuildEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.players.event;
+
+import net.neoforged.bus.api.Event;
+
+public class GuildEvent extends Event {
+    /**
+     * Fired upon the user joining a guild
+     * @field guildName the name of the guild joined
+     */
+    public static class Joined extends GuildEvent {
+        private final String guildName;
+
+        public Joined(String guildName) {
+            this.guildName = guildName;
+        }
+
+        public String getGuildName() {
+            return guildName;
+        }
+    }
+
+    /**
+     * Fired upon the user leaving their guild
+     * @field guildName the name of the guiild left
+     */
+    public static class Left extends GuildEvent {
+        private final String guildName;
+
+        public Left(String guildName) {
+            this.guildName = guildName;
+        }
+
+        public String getGuildName() {
+            return guildName;
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -242,7 +242,7 @@ public final class TerritoryModel extends Model {
         }));
     }
 
-    public void scheduleTerritoryUpdate(boolean inGuild) {
+    private void scheduleTerritoryUpdate(boolean inGuild) {
         if (scheduledFuture != null && !scheduledFuture.isCancelled()) {
             scheduledFuture.cancel(false);
         }
@@ -275,9 +275,12 @@ public final class TerritoryModel extends Model {
                     allTerritoryPois = territoryProfileMap.values().stream()
                             .map(TerritoryPoi::new)
                             .collect(Collectors.toSet());
-                },
-                onError -> WynntilsMod.warn("Failed to update territory data."));
 
-        scheduleTerritoryUpdate(Models.Guild.isInGuild());
+                    scheduleTerritoryUpdate(Models.Guild.isInGuild());
+                },
+                onError -> {
+                    WynntilsMod.warn("Failed to update territory data.");
+                    scheduleTerritoryUpdate(Models.Guild.isInGuild());
+                });
     }
 }

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -72,7 +72,7 @@ public final class TerritoryModel extends Model {
 
         Handlers.WrappedScreen.registerWrappedScreen(new TerritoryManagementHolder());
 
-        scheduleTerritoryUpdate(true);
+        scheduleTerritoryUpdate();
     }
 
     public TerritoryProfile getTerritoryProfile(String name) {
@@ -242,7 +242,7 @@ public final class TerritoryModel extends Model {
         }));
     }
 
-    private void scheduleTerritoryUpdate(boolean inGuild) {
+    private void scheduleTerritoryUpdate() {
         if (scheduledFuture != null && !scheduledFuture.isCancelled()) {
             scheduledFuture.cancel(false);
         }
@@ -250,7 +250,7 @@ public final class TerritoryModel extends Model {
         scheduledFuture = timerExecutor.scheduleWithFixedDelay(
                 this::updateTerritoryProfileMap,
                 0,
-                inGuild ? IN_GUILD_TERRITORY_UPDATE_MS : NO_GUILD_TERRITORY_UPDATE_MS,
+                Models.Guild.isInGuild() ? IN_GUILD_TERRITORY_UPDATE_MS : NO_GUILD_TERRITORY_UPDATE_MS,
                 TimeUnit.MILLISECONDS);
     }
 
@@ -276,11 +276,11 @@ public final class TerritoryModel extends Model {
                             .map(TerritoryPoi::new)
                             .collect(Collectors.toSet());
 
-                    scheduleTerritoryUpdate(Models.Guild.isInGuild());
+                    scheduleTerritoryUpdate();
                 },
                 onError -> {
                     WynntilsMod.warn("Failed to update territory data.");
-                    scheduleTerritoryUpdate(Models.Guild.isInGuild());
+                    scheduleTerritoryUpdate();
                 });
     }
 }

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -178,12 +178,12 @@ public final class TerritoryModel extends Model {
 
     @SubscribeEvent
     public void onGuildJoined(GuildEvent.Joined e) {
-        scheduleTerritoryUpdate(true);
+        scheduleTerritoryUpdate();
     }
 
     @SubscribeEvent
     public void onGuildLeft(GuildEvent.Left e) {
-        scheduleTerritoryUpdate(false);
+        scheduleTerritoryUpdate();
     }
 
     public Map<TerritoryItem, TerritoryConnectionType> getTerritoryConnections(List<TerritoryItem> territoryItems) {

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -12,6 +12,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.net.Download;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.core.text.StyledText;
@@ -71,7 +72,7 @@ public final class TerritoryModel extends Model {
 
         Handlers.WrappedScreen.registerWrappedScreen(new TerritoryManagementHolder());
 
-        scheduleTerritoryUpdate(false);
+        scheduleTerritoryUpdate(true);
     }
 
     public TerritoryProfile getTerritoryProfile(String name) {
@@ -276,5 +277,7 @@ public final class TerritoryModel extends Model {
                             .collect(Collectors.toSet());
                 },
                 onError -> WynntilsMod.warn("Failed to update territory data."));
+
+        scheduleTerritoryUpdate(Models.Guild.isInGuild());
     }
 }


### PR DESCRIPTION
Not a requested change by Wynncraft devs, just a "does it need to call it this often" which for a large amount of players, even those in a guild, it doesn't. When we eventually have model configs there could even be a setting for the delay 