### PR TITLE
fix: custom loading screen fixes [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
@@ -5,7 +5,6 @@
 package com.wynntils.features.ui;
 
 import com.wynntils.core.consumers.features.Feature;
-import com.wynntils.core.events.MixinHelper;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.LoadingProgressEvent;
@@ -40,12 +39,6 @@ public class CustomLoadingScreenFeature extends Feature {
             // Ensures baseConnectScreen is cleared after the initial handshake occurs
             // Only our LoadingScreen and ConnectScreen should be able to work with baseConnectScreen
             baseConnectScreen = null;
-        }
-
-        // Enable the custom loading screen for world transfers
-        if (MixinHelper.onWynncraft() && event.getScreen() instanceof ReceivingLevelScreen && loadingScreen == null) {
-            loadingScreen = LoadingScreen.create();
-            McUtils.mc().setScreen(loadingScreen);
         }
 
         if (loadingScreen == null) return;
@@ -125,7 +118,10 @@ public class CustomLoadingScreenFeature extends Feature {
                 McUtils.mc().setScreen(loadingScreen);
             }
             case INTERIM -> {
-                if (loadingScreen == null) return;
+                if (loadingScreen == null) {
+                    loadingScreen = LoadingScreen.create();
+                    McUtils.mc().setScreen(loadingScreen);
+                }
 
                 loadingScreen.setMessage(I18n.get("feature.wynntils.customLoadingScreen.joiningWorld"));
             }

--- a/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
@@ -5,6 +5,7 @@
 package com.wynntils.features.ui;
 
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.events.MixinHelper;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.LoadingProgressEvent;
@@ -41,6 +42,12 @@ public class CustomLoadingScreenFeature extends Feature {
             baseConnectScreen = null;
         }
 
+        // Enable the custom loading screen for world transfers
+        if (MixinHelper.onWynncraft() && event.getScreen() instanceof ReceivingLevelScreen && loadingScreen == null) {
+            loadingScreen = LoadingScreen.create();
+            McUtils.mc().setScreen(loadingScreen);
+        }
+
         if (loadingScreen == null) return;
 
         if (event.getScreen() instanceof ProgressScreen) {
@@ -75,14 +82,14 @@ public class CustomLoadingScreenFeature extends Feature {
     public void onTitleSetText(TitleSetTextEvent e) {
         if (loadingScreen == null) return;
 
-        loadingScreen.setTitle(e.getComponent().getString());
+        loadingScreen.setHeading(e.getComponent().getString());
     }
 
     @SubscribeEvent
     public void onSubtitleSetText(SubtitleSetTextEvent e) {
         if (loadingScreen == null) return;
 
-        loadingScreen.setSubtitle(e.getComponent().getString());
+        loadingScreen.setSubheading(e.getComponent().getString());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
@@ -82,14 +82,14 @@ public class CustomLoadingScreenFeature extends Feature {
     public void onTitleSetText(TitleSetTextEvent e) {
         if (loadingScreen == null) return;
 
-        loadingScreen.setHeading(e.getComponent().getString());
+        loadingScreen.setTitle(e.getComponent().getString());
     }
 
     @SubscribeEvent
     public void onSubtitleSetText(SubtitleSetTextEvent e) {
         if (loadingScreen == null) return;
 
-        loadingScreen.setSubheading(e.getComponent().getString());
+        loadingScreen.setSubtitle(e.getComponent().getString());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
@@ -24,8 +24,9 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 
 public final class LoadingScreen extends WynntilsScreen {
-    private static final String LOGO_STRING = "\uDAFF\uDFFC\uE005\uDAFF\uDFFF\uE006\uDAFF\uDFFE";
+    private static final String LOGO_STRING = "\uE005\uDAFF\uDFFF\uE006";
     private static final String TEXT_LOGO_STRING = "Wynncraft";
+    private static final ResourceLocation LOGO_FONT_LOCATION = ResourceLocation.withDefaultNamespace("screen");
     private static final CustomColor MOSS_GREEN = CustomColor.fromInt(0x527529).withAlpha(255);
     private static final int SPINNER_SPEED = 1200;
 
@@ -95,14 +96,13 @@ public final class LoadingScreen extends WynntilsScreen {
         // Draw logo
         int centerX = Texture.SCROLL_BACKGROUND.width() / 2 + 15;
         Component logoComponent = Services.ResourcePack.isPreloadedPackSelected()
-                ? Component.literal(LOGO_STRING)
-                        .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("screen")))
+                ? Component.literal(LOGO_STRING).withStyle(Style.EMPTY.withFont(LOGO_FONT_LOCATION))
                 : Component.literal(TEXT_LOGO_STRING);
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
                         StyledText.fromComponent(logoComponent),
-                        centerX,
+                        centerX - font.width(logoComponent) / 2 + 7,
                         60,
                         CommonColors.WHITE,
                         HorizontalAlignment.CENTER,

--- a/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
@@ -30,8 +30,8 @@ public final class LoadingScreen extends WynntilsScreen {
     private static final int SPINNER_SPEED = 1200;
 
     private String message = "";
-    private String heading = "";
-    private String subheading = "";
+    private String title = "";
+    private String subtitle = "";
 
     private LoadingScreen() {
         super(Component.translatable("screens.wynntils.characterSelection.name"));
@@ -55,12 +55,12 @@ public final class LoadingScreen extends WynntilsScreen {
         this.message = message;
     }
 
-    public void setHeading(String heading) {
-        this.heading = heading;
+    public void setTitle(String title) {
+        this.title = title;
     }
 
-    public void setSubheading(String subheading) {
-        this.subheading = subheading;
+    public void setSubtitle(String subtitle) {
+        this.subtitle = subtitle;
     }
 
     @Override
@@ -125,7 +125,7 @@ public final class LoadingScreen extends WynntilsScreen {
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(heading),
+                        StyledText.fromString(title),
                         centerX,
                         120,
                         MOSS_GREEN,
@@ -135,7 +135,7 @@ public final class LoadingScreen extends WynntilsScreen {
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(subheading),
+                        StyledText.fromString(subtitle),
                         centerX,
                         130,
                         MOSS_GREEN,

--- a/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
@@ -94,10 +94,10 @@ public final class LoadingScreen extends WynntilsScreen {
 
         // Draw logo
         int centerX = Texture.SCROLL_BACKGROUND.width() / 2 + 15;
-        Component logoComponent = Services.ResourcePack.isPreloadedPackSelected() ?
-                Component.literal(LOGO_STRING).withStyle(Style.EMPTY.withFont(
-                        ResourceLocation.withDefaultNamespace("screen"))) :
-                Component.literal(TEXT_LOGO_STRING);
+        Component logoComponent = Services.ResourcePack.isPreloadedPackSelected()
+                ? Component.literal(LOGO_STRING)
+                        .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("screen")))
+                : Component.literal(TEXT_LOGO_STRING);
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,

--- a/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/characterselector/LoadingScreen.java
@@ -20,17 +20,18 @@ import com.wynntils.utils.render.type.VerticalAlignment;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 
 public final class LoadingScreen extends WynntilsScreen {
-    private static final String LOGO_STRING = "\u2060\u2064\u2061";
+    private static final String LOGO_STRING = "\uDAFF\uDFFC\uE005\uDAFF\uDFFF\uE006\uDAFF\uDFFE";
     private static final String TEXT_LOGO_STRING = "Wynncraft";
     private static final CustomColor MOSS_GREEN = CustomColor.fromInt(0x527529).withAlpha(255);
     private static final int SPINNER_SPEED = 1200;
 
     private String message = "";
-    private String title = "";
-    private String subtitle = "";
+    private String heading = "";
+    private String subheading = "";
 
     private LoadingScreen() {
         super(Component.translatable("screens.wynntils.characterSelection.name"));
@@ -54,12 +55,12 @@ public final class LoadingScreen extends WynntilsScreen {
         this.message = message;
     }
 
-    public void setTitle(String title) {
-        this.title = title;
+    public void setHeading(String heading) {
+        this.heading = heading;
     }
 
-    public void setSubtitle(String subtitle) {
-        this.subtitle = subtitle;
+    public void setSubheading(String subheading) {
+        this.subheading = subheading;
     }
 
     @Override
@@ -93,11 +94,14 @@ public final class LoadingScreen extends WynntilsScreen {
 
         // Draw logo
         int centerX = Texture.SCROLL_BACKGROUND.width() / 2 + 15;
-        String logoString = Services.ResourcePack.isPreloadedPackSelected() ? LOGO_STRING : TEXT_LOGO_STRING;
+        Component logoComponent = Services.ResourcePack.isPreloadedPackSelected() ?
+                Component.literal(LOGO_STRING).withStyle(Style.EMPTY.withFont(
+                        ResourceLocation.withDefaultNamespace("screen"))) :
+                Component.literal(TEXT_LOGO_STRING);
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(logoString),
+                        StyledText.fromComponent(logoComponent),
                         centerX,
                         60,
                         CommonColors.WHITE,
@@ -121,7 +125,7 @@ public final class LoadingScreen extends WynntilsScreen {
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(title),
+                        StyledText.fromString(heading),
                         centerX,
                         120,
                         MOSS_GREEN,
@@ -131,7 +135,7 @@ public final class LoadingScreen extends WynntilsScreen {
         FontRenderer.getInstance()
                 .renderText(
                         poseStack,
-                        StyledText.fromString(subtitle),
+                        StyledText.fromString(subheading),
                         centerX,
                         130,
                         MOSS_GREEN,

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
@@ -65,8 +65,8 @@ public final class BufferedFontRenderer {
 
         renderX = switch (horizontalAlignment) {
             case LEFT -> x;
-            case CENTER -> x - (font.width(text.getString()) / 2f * textScale);
-            case RIGHT -> x - font.width(text.getString()) * textScale;
+            case CENTER -> x - (font.width(text.getComponent()) / 2f * textScale);
+            case RIGHT -> x - font.width(text.getComponent()) * textScale;
         };
 
         renderY = switch (verticalAlignment) {

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
@@ -65,8 +65,8 @@ public final class BufferedFontRenderer {
 
         renderX = switch (horizontalAlignment) {
             case LEFT -> x;
-            case CENTER -> x - (font.width(text.getComponent()) / 2f * textScale);
-            case RIGHT -> x - font.width(text.getComponent()) * textScale;
+            case CENTER -> x - (font.width(text.getString()) / 2f * textScale);
+            case RIGHT -> x - font.width(text.getString()) * textScale;
         };
 
         renderY = switch (verticalAlignment) {


### PR DESCRIPTION
- Enable custom loading screen for world switching
- Fix incorrect width calculations when a non-default font is used in BufferedFontRenderer
- Fix Wynncraft logo on custom loading screen
- Rename "title" and "subtitle" fields in LoadingScreen to un-hide superclass field