### PR TITLE
feat: Add SystemPropertiesManager to handle custom manager JVM properties

### DIFF
--- a/common/src/main/java/com/wynntils/core/components/Manager.java
+++ b/common/src/main/java/com/wynntils/core/components/Manager.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.core.components;
 
+import com.wynntils.core.properties.Property;
 import java.util.List;
 
 /**
@@ -25,5 +26,13 @@ public abstract class Manager extends CoreComponent {
     @Override
     public String getTypeName() {
         return "Manager";
+    }
+
+    public final <T> Property<T> createProperty(Class<T> clazz, String propertyPath) {
+        return createProperty(clazz, propertyPath, null);
+    }
+
+    public final <T> Property<T> createProperty(Class<T> clazz, String propertyPath, T defaultValue) {
+        return new Property<>(this, clazz, propertyPath, defaultValue);
     }
 }

--- a/common/src/main/java/com/wynntils/core/components/Managers.java
+++ b/common/src/main/java/com/wynntils/core/components/Managers.java
@@ -22,9 +22,13 @@ import com.wynntils.core.persisted.PersistedManager;
 import com.wynntils.core.persisted.config.ConfigManager;
 import com.wynntils.core.persisted.storage.StorageManager;
 import com.wynntils.core.persisted.upfixers.UpfixerManager;
+import com.wynntils.core.properties.SystemPropertiesManager;
 
 public final class Managers {
-    // Start with UrlManager to give it chance to update URLs in background
+    // Start with SystemPropertiesManager so it can bootstrap before other Managers access properties
+    public static final SystemPropertiesManager SystemProperties = new SystemPropertiesManager();
+
+    // Then, load UrlManager to give it chance to update URLs in background
     public static final NetManager Net = new NetManager();
     public static final UrlManager Url = new UrlManager(Net);
     public static final DownloadManager Download = new DownloadManager();

--- a/common/src/main/java/com/wynntils/core/net/DownloadManager.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadManager.java
@@ -114,7 +114,7 @@ public class DownloadManager extends Manager {
                 getDownload(queuedDownload);
             }
 
-            if (DEBUG_LOGS) {
+            if (debugLogs.get()) {
                 WynntilsMod.info("[DownloadManager] Started downloads:");
                 currentDownloads.forEach(queuedDownload -> {
                     WynntilsMod.info("  - %s -> %s"

--- a/common/src/main/java/com/wynntils/core/properties/Property.java
+++ b/common/src/main/java/com/wynntils/core/properties/Property.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.properties;
+
+import com.wynntils.core.components.Manager;
+import com.wynntils.core.components.Managers;
+
+public class Property<T> {
+    private final Manager ownerManager;
+    private final Class<T> clazz;
+    private final String propertyPath;
+    private final T defaultValue;
+
+    private boolean loaded;
+    private T jvmArgValue;
+
+    public Property(Manager ownerManager, Class<T> clazz, String propertyPath, T defaultValue) {
+        this.ownerManager = ownerManager;
+        this.clazz = clazz;
+        this.propertyPath = propertyPath;
+        this.defaultValue = defaultValue;
+
+        // The JVM argument value is lazily loaded
+        this.loaded = false;
+        this.jvmArgValue = null;
+    }
+
+    public T get() {
+        if (!loaded) {
+            loadJvmArgValue();
+        }
+
+        return jvmArgValue != null ? jvmArgValue : defaultValue;
+    }
+
+    public Class<T> getClassType() {
+        return clazz;
+    }
+
+    String getFullJvmArgumentPath() {
+        // The JVM argument path is "wynntils.<ownerManagerName>.<propertyPath>"
+        return "wynntils." + ownerManager.getTranslationKeyName() + "." + propertyPath;
+    }
+
+    private void loadJvmArgValue() {
+        jvmArgValue = Managers.SystemProperties.loadJvmArg(this);
+        loaded = true;
+    }
+}

--- a/common/src/main/java/com/wynntils/core/properties/SystemPropertiesManager.java
+++ b/common/src/main/java/com/wynntils/core/properties/SystemPropertiesManager.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.properties;
+
+import com.google.common.collect.ImmutableMap;
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Manager;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class SystemPropertiesManager extends Manager {
+    private static final Map<Class<?>, Function<String, Object>> MAPPERS = ImmutableMap.of(
+            Integer.class, Integer::parseInt,
+            Boolean.class, Boolean::parseBoolean,
+            URI.class, URI::create);
+
+    public SystemPropertiesManager() {
+        super(List.of());
+    }
+
+    public <T> T loadJvmArg(Property<T> property) {
+        String propertyValue = System.getProperty(property.getFullJvmArgumentPath());
+
+        if (propertyValue == null) {
+            return null;
+        }
+
+        Function<String, Object> mapper = MAPPERS.get(property.getClassType());
+        if (mapper == null) {
+            WynntilsMod.error(
+                    "Couldn't convert a String JVM property into " + property.getClassType() + ". Using null.");
+            return null;
+        }
+
+        T value = null;
+        try {
+            value = (T) mapper.apply(propertyValue);
+        } catch (Throwable t) {
+            WynntilsMod.error(
+                    "Couldn't convert a String JVM property into " + property.getClassType() + ". Using null. Value: "
+                            + propertyValue,
+                    t);
+        }
+
+        return value;
+    }
+}

--- a/common/src/main/java/com/wynntils/core/properties/SystemPropertiesManager.java
+++ b/common/src/main/java/com/wynntils/core/properties/SystemPropertiesManager.java
@@ -42,7 +42,7 @@ public class SystemPropertiesManager extends Manager {
             }
         }
 
-        // Then fall back to using the mappers†
+        // Then fall back to using the mappers
         Function<String, Object> mapper = MAPPERS.get(property.getClassType());
         if (mapper == null) {
             WynntilsMod.error(

--- a/common/src/main/java/com/wynntils/core/properties/SystemPropertiesManager.java
+++ b/common/src/main/java/com/wynntils/core/properties/SystemPropertiesManager.java
@@ -7,6 +7,7 @@ package com.wynntils.core.properties;
 import com.google.common.collect.ImmutableMap;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Manager;
+import com.wynntils.utils.EnumUtils;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,19 @@ public class SystemPropertiesManager extends Manager {
             return null;
         }
 
+        // Try to convert as an enum first
+        if (property.getClassType().isEnum()) {
+            try {
+                T enumValue = (T) EnumUtils.searchEnum((Class<? extends Enum>) property.getClassType(), propertyValue);
+                return enumValue;
+            } catch (IllegalArgumentException e) {
+                WynntilsMod.warn("Could not parse enum from JVM property " + property.getFullJvmArgumentPath()
+                        + ". Using null. Value: " + propertyValue);
+                return null;
+            }
+        }
+
+        // Then fall back to using the mappers†
         Function<String, Object> mapper = MAPPERS.get(property.getClassType());
         if (mapper == null) {
             WynntilsMod.error(

--- a/common/src/main/java/com/wynntils/utils/EnumUtils.java
+++ b/common/src/main/java/com/wynntils/utils/EnumUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils;
@@ -27,6 +27,15 @@ public final class EnumUtils {
         } else {
             return List.of();
         }
+    }
+
+    public static <T extends Enum<?>> T searchEnum(Class<T> enumeration, String search) {
+        for (T each : enumeration.getEnumConstants()) {
+            if (each.name().compareToIgnoreCase(search) == 0) {
+                return each;
+            }
+        }
+        return null;
     }
 
     public static String toJsonFormat(Enum<?> enumValue) {


### PR DESCRIPTION
This should give us a nice, generalized way of using JVM arguments as properties. Currently, I have these properties limited to managers, however I think that makes a lot of sense from a design standpoint, as the user shouldn't be able to modify other CoreComponents' settings in this way.