### PR TITLE
refactor: Don't require onConfigUpdate to be overridden in overlays [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/BarOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/BarOverlay.java
@@ -187,9 +187,6 @@ public abstract class BarOverlay extends DynamicOverlay {
         };
     }
 
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
-
     protected abstract boolean isRendered();
 
     protected abstract Texture getTexture();

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/Overlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/Overlay.java
@@ -95,7 +95,9 @@ public abstract class Overlay extends AbstractConfigurable implements Comparable
         callOnConfigUpdate(config);
     }
 
-    protected abstract void onConfigUpdate(Config<?> config);
+    protected void onConfigUpdate(Config<?> config) {
+        // Override this method to handle config updates
+    }
 
     protected void callOnConfigUpdate(Config<?> config) {
         try {

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
@@ -128,9 +128,6 @@ public abstract class TextOverlay extends DynamicOverlay {
 
     protected abstract String getPreviewTemplate();
 
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
-
     public final boolean isRendered() {
         // If the enabled template is empty,
         // the overlay is rendered when the player is in the world.

--- a/common/src/main/java/com/wynntils/overlays/HeldItemCooldownOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/HeldItemCooldownOverlay.java
@@ -9,7 +9,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.OverlayPosition;
 import com.wynntils.core.consumers.overlays.OverlaySize;
-import com.wynntils.core.persisted.config.Config;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
@@ -70,7 +69,4 @@ public class HeldItemCooldownOverlay extends Overlay {
         BufferedRenderUtils.drawRect(poseStack, bufferSource, color, x1 + offset, y, 0, barWidth, height);
         BufferedRenderUtils.drawRect(poseStack, bufferSource, color, x2 - barWidth - offset, y, 0, barWidth, height);
     }
-
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
 }

--- a/common/src/main/java/com/wynntils/overlays/PartyMembersOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/PartyMembersOverlay.java
@@ -251,8 +251,5 @@ public class PartyMembersOverlay extends ContainerOverlay<PartyMembersOverlay.Pa
 
             poseStack.popPose();
         }
-
-        @Override
-        protected void onConfigUpdate(Config<?> config) {}
     }
 }

--- a/common/src/main/java/com/wynntils/overlays/SpellCastMessageOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/SpellCastMessageOverlay.java
@@ -9,7 +9,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.OverlayPosition;
 import com.wynntils.core.consumers.overlays.OverlaySize;
-import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.event.ItemRenamedEvent;
 import com.wynntils.models.spells.event.SpellEvent;
@@ -101,7 +100,4 @@ public class SpellCastMessageOverlay extends Overlay {
                         this.getRenderVerticalAlignment(),
                         TextShadow.NORMAL);
     }
-
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
 }

--- a/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
@@ -117,9 +117,6 @@ public abstract class BaseBarOverlay extends Overlay {
         };
     }
 
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
-
     protected void renderBar(
             PoseStack poseStack, MultiBufferSource bufferSource, float renderY, float renderHeight, float progress) {
         Texture universalBarTexture = Texture.UNIVERSAL_BAR;

--- a/common/src/main/java/com/wynntils/overlays/objectives/DailyObjectiveOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/objectives/DailyObjectiveOverlay.java
@@ -133,7 +133,4 @@ public class DailyObjectiveOverlay extends ObjectiveOverlayBase {
             offsetY += renderedHeightWithoutTextHeight + textHeight;
         }
     }
-
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
 }

--- a/common/src/main/java/com/wynntils/overlays/objectives/GuildObjectiveOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/objectives/GuildObjectiveOverlay.java
@@ -120,7 +120,4 @@ public class GuildObjectiveOverlay extends ObjectiveOverlayBase {
                     guildObjective.getProgress());
         }
     }
-
-    @Override
-    protected void onConfigUpdate(Config<?> config) {}
 }


### PR DESCRIPTION
This was already the case with features. It's fascinating this took so long.