### PR TITLE
fix: Do not send nor display crafted item names from item encodings

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
@@ -60,13 +60,9 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
         level = requirementsData.requirements().level();
 
         // Optional blocks
-        NameData nameData = itemDataMap.get(NameData.class);
-        if (nameData != null) {
-            name = nameData.name();
-        } else {
-            name = "Crafted "
-                    + StringUtils.capitalizeFirst(consumableType.name().toLowerCase(Locale.ROOT));
-        }
+        // Unfortunately, we cannot use the NameData from crafted items, since it can be
+        // set to unsuitable values by the users.
+        name = "Crafted " + StringUtils.capitalizeFirst(consumableType.name().toLowerCase(Locale.ROOT));
 
         EffectsData effectsData = itemDataMap.get(EffectsData.class);
         if (effectsData != null) {

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
@@ -94,7 +94,11 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
                 new GearRequirements(item.getLevel(), Optional.empty(), List.of(), Optional.empty())));
 
         if (encodingSettings.shareItemName()) {
-            dataList.add(new NameData(item.getName()));
+            // Unfortunately, we cannot use the name of crafted items, since it can be
+            // set to unsuitable values by the users.
+            String name = "Crafted " + StringUtils.capitalizeFirst(item.getConsumableType().name().toLowerCase(Locale.ROOT));
+
+            dataList.add(new NameData(name));
         }
 
         dataList.add(new EffectsData(item.getNamedEffects()));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
@@ -96,7 +96,9 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
         if (encodingSettings.shareItemName()) {
             // Unfortunately, we cannot use the name of crafted items, since it can be
             // set to unsuitable values by the users.
-            String name = "Crafted " + StringUtils.capitalizeFirst(item.getConsumableType().name().toLowerCase(Locale.ROOT));
+            String name = "Crafted "
+                    + StringUtils.capitalizeFirst(
+                            item.getConsumableType().name().toLowerCase(Locale.ROOT));
 
             dataList.add(new NameData(name));
         }

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -73,13 +73,10 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
         requirements = requirementsData.requirements();
 
         // Optional blocks
-        NameData nameData = itemDataMap.get(NameData.class);
-        if (nameData != null) {
-            name = nameData.name();
-        } else {
-            name = "Crafted "
-                    + StringUtils.capitalizeFirst(gearTypeData.gearType().name().toLowerCase(Locale.ROOT));
-        }
+        // Unfortunately, we cannot use the NameData from crafted items, since it can be
+        // set to unsuitable values by the users.
+        name = "Crafted "
+                + StringUtils.capitalizeFirst(gearTypeData.gearType().name().toLowerCase(Locale.ROOT));
 
         DamageData damageData = itemDataMap.get(DamageData.class);
         if (damageData != null) {

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -138,7 +138,12 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
 
         // Optional blocks
         if (encodingSettings.shareItemName()) {
-            dataList.add(new NameData(item.getName()));
+            // Unfortunately, we cannot use the name of crafted items, since it can be
+            // set to unsuitable values by the users.
+            String name = "Crafted "
+                    + StringUtils.capitalizeFirst(item.getGearType().name().toLowerCase(Locale.ROOT));
+
+            dataList.add(new NameData(name));
         }
 
         dataList.add(new DamageData(item.getAttackSpeed(), item.getDamages()));


### PR DESCRIPTION
This can be misused by users sending invalid characters or using unsuitable language that will not be blocked by Wynncraft chat filters.