### PR TITLE
feat: Add back sanitized custom name sharing to chat encoding, as an opt-in config [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -78,6 +78,9 @@ public class ChatItemFeature extends Feature {
     @Persisted
     public final Config<Boolean> showPerfectOrDefective = new Config<>(true);
 
+    @Persisted
+    public final Config<Boolean> showCraftedItemCustomNames = new Config<>(false);
+
     private final Map<String, String> chatItems = new HashMap<>();
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/items/encoding/data/NameData.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/data/NameData.java
@@ -6,9 +6,23 @@ package com.wynntils.models.items.encoding.data;
 
 import com.wynntils.models.items.encoding.type.ItemData;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import java.util.regex.Pattern;
 
 public record NameData(String name) implements ItemData {
+    private static final int MAX_NAME_LENGTH = 48;
+    private static final Pattern NAME_SANITIZER_PATTERN = Pattern.compile("[^a-zA-Z0-9 ]");
+
+    public static NameData from(String itemName) {
+        // Sanitize the name
+        itemName = itemName.substring(0, Math.min(itemName.length(), MAX_NAME_LENGTH));
+        itemName = NAME_SANITIZER_PATTERN.matcher(itemName).replaceAll("");
+        itemName = itemName.trim().replaceAll("\\s{2,}", " ");
+
+        return new NameData(itemName);
+    }
+
     public static NameData from(IdentifiableItemProperty property) {
-        return new NameData(property.getName());
+        String itemName = property.getName();
+        return from(itemName);
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/NameDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/NameDataTransformer.java
@@ -52,7 +52,7 @@ public class NameDataTransformer extends DataTransformer<NameData> {
             return ErrorOr.error("Name data is not null terminated");
         }
 
-        return ErrorOr.of(new NameData(UnsignedByteUtils.decodeString(bytes)));
+        return ErrorOr.of(NameData.from(UnsignedByteUtils.decodeString(bytes)));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.models.items.encoding.impl.item;
 
+import com.wynntils.core.components.Managers;
+import com.wynntils.features.chat.ChatItemFeature;
 import com.wynntils.models.gear.type.ConsumableType;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.items.encoding.data.CustomConsumableTypeData;
@@ -60,9 +62,16 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
         level = requirementsData.requirements().level();
 
         // Optional blocks
-        // Unfortunately, we cannot use the NameData from crafted items, since it can be
-        // set to unsuitable values by the users.
-        name = "Crafted " + StringUtils.capitalizeFirst(consumableType.name().toLowerCase(Locale.ROOT));
+        NameData nameData = itemDataMap.get(NameData.class);
+        if (nameData != null
+                && Managers.Feature.getFeatureInstance(ChatItemFeature.class)
+                        .showCraftedItemCustomNames
+                        .get()) {
+            name = nameData.name();
+        } else {
+            name = "Crafted "
+                    + StringUtils.capitalizeFirst(consumableType.name().toLowerCase(Locale.ROOT));
+        }
 
         EffectsData effectsData = itemDataMap.get(EffectsData.class);
         if (effectsData != null) {
@@ -94,13 +103,7 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
                 new GearRequirements(item.getLevel(), Optional.empty(), List.of(), Optional.empty())));
 
         if (encodingSettings.shareItemName()) {
-            // Unfortunately, we cannot use the name of crafted items, since it can be
-            // set to unsuitable values by the users.
-            String name = "Crafted "
-                    + StringUtils.capitalizeFirst(
-                            item.getConsumableType().name().toLowerCase(Locale.ROOT));
-
-            dataList.add(new NameData(name));
+            dataList.add(NameData.from(item.getName()));
         }
 
         dataList.add(new EffectsData(item.getNamedEffects()));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -4,6 +4,8 @@
  */
 package com.wynntils.models.items.encoding.impl.item;
 
+import com.wynntils.core.components.Managers;
+import com.wynntils.features.chat.ChatItemFeature;
 import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
@@ -73,10 +75,16 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
         requirements = requirementsData.requirements();
 
         // Optional blocks
-        // Unfortunately, we cannot use the NameData from crafted items, since it can be
-        // set to unsuitable values by the users.
-        name = "Crafted "
-                + StringUtils.capitalizeFirst(gearTypeData.gearType().name().toLowerCase(Locale.ROOT));
+        NameData nameData = itemDataMap.get(NameData.class);
+        if (nameData != null
+                && Managers.Feature.getFeatureInstance(ChatItemFeature.class)
+                        .showCraftedItemCustomNames
+                        .get()) {
+            name = nameData.name();
+        } else {
+            name = "Crafted "
+                    + StringUtils.capitalizeFirst(gearTypeData.gearType().name().toLowerCase(Locale.ROOT));
+        }
 
         DamageData damageData = itemDataMap.get(DamageData.class);
         if (damageData != null) {
@@ -138,12 +146,7 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
 
         // Optional blocks
         if (encodingSettings.shareItemName()) {
-            // Unfortunately, we cannot use the name of crafted items, since it can be
-            // set to unsuitable values by the users.
-            String name = "Crafted "
-                    + StringUtils.capitalizeFirst(item.getGearType().name().toLowerCase(Locale.ROOT));
-
-            dataList.add(new NameData(name));
+            dataList.add(NameData.from(item.getName()));
         }
 
         dataList.add(new DamageData(item.getAttackSpeed(), item.getDamages()));

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -156,6 +156,8 @@
   "feature.wynntils.chatItem.chatItemUnidentifiedError": "Cannot make chat link of unidentified gear!",
   "feature.wynntils.chatItem.description": "Adds the ability to share items in chat.",
   "feature.wynntils.chatItem.name": "Chat Item",
+  "feature.wynntils.chatItem.showCraftedItemCustomNames.description": "Should crafted items display their custom names in chat instead of the generic item name?",
+  "feature.wynntils.chatItem.showCraftedItemCustomNames.name": "Show Crafted Item Custom Names",
   "feature.wynntils.chatItem.showPerfectOrDefective.description": "Should the item be marked as perfect or defective in the chat message?",
   "feature.wynntils.chatItem.showPerfectOrDefective.name": "Show Perfect or Defective",
   "feature.wynntils.chatItem.showSharingScreen.description": "Should a screen with share options be shown instead of a clickable chat message?",


### PR DESCRIPTION
There are two main concerns for allowing custom name sharing:
- Anyone could encode strings that inject something into chat
- Wynncraft or us can't filter any profanity in custom names

With the names being sanitized on the client, even if bad actors can encode anything, the decoded output will be always valid from now on.

Custom names are now opt-in. This basically means the user accepts the "terms" of this config, and they accept that anything they see won't be filtered by Wynn or by us. As I brought this up on Discord, I essentially see this equivalent to how you can just send an URL of a pastebin to someone, and if they decide to open it, and they might see something rude there, or they may just see what they expected to see. I essentially agree with @Essentuan in #2877 that we shouldn't dumb down the feature just because of those few bad actors.

If anyone has something to add to this PR, please do. I'd be happy to leave this PR open for discussion for 1-2 days, so everyone can bring up their concerns.