### PR TITLE
fix: Don't throw error when clicking outside container GUI [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/inventory/InventoryHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/InventoryHandler.java
@@ -93,15 +93,20 @@ public class InventoryHandler extends Handler {
                 }
             }
             case THROW -> {
-                ItemStack slotStack = menu.getSlot(slotNum).getItem();
-                if (heldStack.isEmpty() && !slotStack.isEmpty()) {
-                    if (isImprovedSyncEnabled()) {
-                        forceSyncLater(menu);
-                        expect(new PendingInteraction.ThrowFromSlot(menu, slotNum, slotStack.copy()));
-                    } else {
-                        ItemStack thrown = event.getMouseButton() == 0 ? slotStack.copyWithCount(1) : slotStack.copy();
-                        WynntilsMod.postEvent(new InventoryInteractionEvent(
-                                menu, new InventoryInteraction.ThrowFromSlot(slotNum, thrown), Confidence.UNCERTAIN));
+                if (slotNum > 0) { // Slot -999 -> clicked outside the GUI
+                    ItemStack slotStack = menu.getSlot(slotNum).getItem();
+                    if (heldStack.isEmpty() && !slotStack.isEmpty()) {
+                        if (isImprovedSyncEnabled()) {
+                            forceSyncLater(menu);
+                            expect(new PendingInteraction.ThrowFromSlot(menu, slotNum, slotStack.copy()));
+                        } else {
+                            ItemStack thrown =
+                                    event.getMouseButton() == 0 ? slotStack.copyWithCount(1) : slotStack.copy();
+                            WynntilsMod.postEvent(new InventoryInteractionEvent(
+                                    menu,
+                                    new InventoryInteraction.ThrowFromSlot(slotNum, thrown),
+                                    Confidence.UNCERTAIN));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Relevant log

`[Render thread/ERROR] (wynntils) Exception in event listener not belonging to a feature
 java.lang.IndexOutOfBoundsException: Index -999 out of bounds for length 46
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:385) ~[?:?]
	at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at net.minecraft.core.NonNullList.get(NonNullList.java:47) ~[minecraft-merged-894a333e29-1.21.1-loom.mappings.1_21_1.layered+hash.652182843-v2.jar:?]
	at net.minecraft.world.inventory.AbstractContainerMenu.getSlot(AbstractContainerMenu.java:287) ~[minecraft-merged-894a333e29-1.21.1-loom.mappings.1_21_1.layered+hash.652182843-v2.jar:?]
	at com.wynntils.handlers.inventory.InventoryHandler.onSlotClick(InventoryHandler.java:96)`