### PR TITLE
fix: deal with inventory sync edge cases (fixes #2888, addresses #2891)

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ImprovedInventorySyncFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ImprovedInventorySyncFeature.java
@@ -5,6 +5,7 @@
 package com.wynntils.features.inventory;
 
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.properties.StartDisabled;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
@@ -20,6 +21,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
+@StartDisabled
 @ConfigCategory(Category.INVENTORY)
 public class ImprovedInventorySyncFeature extends Feature {
     @Persisted

--- a/common/src/main/java/com/wynntils/features/inventory/ImprovedInventorySyncFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ImprovedInventorySyncFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.handlers.inventory.event.DesyncableContainerClickEvent;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.utils.mc.McUtils;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -26,6 +27,14 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class ImprovedInventorySyncFeature extends Feature {
     @Persisted
     public Config<Boolean> forceSync = new Config<>(false);
+
+    @SubscribeEvent
+    public void onDesyncableContainerClick(DesyncableContainerClickEvent event) {
+        event.setShouldResync(true);
+        if (event.getResyncStrategy() == null) {
+            // TODO resolve resync strategy
+        }
+    }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onContainerClick(ContainerClickEvent event) {

--- a/common/src/main/java/com/wynntils/features/inventory/ImprovedInventorySyncFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ImprovedInventorySyncFeature.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.features.inventory;
 
+import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.properties.StartDisabled;
 import com.wynntils.core.persisted.Persisted;
@@ -11,11 +12,51 @@ import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.handlers.inventory.event.DesyncableContainerClickEvent;
+import com.wynntils.handlers.inventory.resync.ClickPlaceholderSlotResyncStrategy;
+import com.wynntils.handlers.inventory.resync.EmptySwapContentBookResyncStrategy;
+import com.wynntils.handlers.inventory.resync.IngredientPouchSwapContentBookResyncStrategy;
+import com.wynntils.handlers.inventory.resync.InventoryResyncStrategy;
+import com.wynntils.handlers.inventory.resync.SwapNonEmptySlotResyncStrategy;
 import com.wynntils.mc.event.ContainerClickEvent;
+import com.wynntils.models.containers.Container;
+import com.wynntils.models.containers.containers.AbilityTreeContainer;
+import com.wynntils.models.containers.containers.AbilityTreeResetContainer;
+import com.wynntils.models.containers.containers.AspectsContainer;
+import com.wynntils.models.containers.containers.CharacterInfoContainer;
+import com.wynntils.models.containers.containers.ContentBookContainer;
+import com.wynntils.models.containers.containers.CraftingStationContainer;
+import com.wynntils.models.containers.containers.GuildBankContainer;
+import com.wynntils.models.containers.containers.GuildManagementContainer;
+import com.wynntils.models.containers.containers.GuildMemberListContainer;
+import com.wynntils.models.containers.containers.GuildTerritoriesContainer;
+import com.wynntils.models.containers.containers.HousingJukeboxContainer;
+import com.wynntils.models.containers.containers.HousingListContainer;
+import com.wynntils.models.containers.containers.IngredientPouchContainer;
+import com.wynntils.models.containers.containers.InventoryContainer;
+import com.wynntils.models.containers.containers.JukeboxContainer;
+import com.wynntils.models.containers.containers.LobbyContainer;
+import com.wynntils.models.containers.containers.PetMenuContainer;
+import com.wynntils.models.containers.containers.SeaskipperContainer;
+import com.wynntils.models.containers.containers.TradeMarketContainer;
+import com.wynntils.models.containers.containers.TradeMarketFiltersContainer;
+import com.wynntils.models.containers.containers.TradeMarketSellContainer;
+import com.wynntils.models.containers.containers.personal.AccountBankContainer;
+import com.wynntils.models.containers.containers.personal.BookshelfContainer;
+import com.wynntils.models.containers.containers.personal.CharacterBankContainer;
+import com.wynntils.models.containers.containers.personal.IslandBlockBankContainer;
+import com.wynntils.models.containers.containers.personal.MiscBucketContainer;
+import com.wynntils.models.containers.containers.personal.PersonalBlockBankContainer;
+import com.wynntils.models.containers.containers.reward.ChallengeRewardContainer;
+import com.wynntils.models.containers.containers.reward.DailyRewardContainer;
+import com.wynntils.models.containers.containers.reward.EventContainer;
+import com.wynntils.models.containers.containers.reward.FlyingChestContainer;
+import com.wynntils.models.containers.containers.reward.LootChestContainer;
+import com.wynntils.models.containers.containers.reward.ObjectiveRewardContainer;
 import com.wynntils.utils.mc.McUtils;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.Arrays;
+import java.util.Map;
 import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
@@ -25,20 +66,79 @@ import net.neoforged.bus.api.SubscribeEvent;
 @StartDisabled
 @ConfigCategory(Category.INVENTORY)
 public class ImprovedInventorySyncFeature extends Feature {
+    // Generic strategy safe for anything
+    private static final InventoryResyncStrategy GENERIC_RESYNC_STRATEGY = InventoryResyncStrategy.chain(
+            ClickPlaceholderSlotResyncStrategy.INSTANCE, EmptySwapContentBookResyncStrategy.INSTANCE);
+    // For the player inventory
+    private static final InventoryResyncStrategy PLAYER_INV_RESYNC_STRATEGY = InventoryResyncStrategy.chain(
+            EmptySwapContentBookResyncStrategy.INSTANCE,
+            IngredientPouchSwapContentBookResyncStrategy.INSTANCE,
+            SwapNonEmptySlotResyncStrategy.INSTANCE);
+    // For reward containers like loot chests and daily rewards
+    private static final InventoryResyncStrategy REWARD_RESYNC_STRATEGY = InventoryResyncStrategy.chain(
+            EmptySwapContentBookResyncStrategy.INSTANCE, SwapNonEmptySlotResyncStrategy.INSTANCE);
+    // For "click-to-insert" UIs like blacksmiths and item identifiers
+    private static final InventoryResyncStrategy CLICK_TO_INSERT_RESYNC_STRATEGY = GENERIC_RESYNC_STRATEGY;
+    // For bank-like UIs like player banks and housing containers
+    private static final InventoryResyncStrategy BANK_RESYNC_STRATEGY = GENERIC_RESYNC_STRATEGY;
+    // For UIs where the player inventory is not visible or not interactible
+    private static final InventoryResyncStrategy UI_RESYNC_STRATEGY = GENERIC_RESYNC_STRATEGY;
+
+    private static final Map<Class<? extends Container>, InventoryResyncStrategy> RESYNC_STRATEGY_TABLE = Map.ofEntries(
+            Map.entry(AbilityTreeContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(AbilityTreeResetContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(AccountBankContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(AspectsContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(BookshelfContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(ChallengeRewardContainer.class, REWARD_RESYNC_STRATEGY),
+            Map.entry(CharacterBankContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(CharacterInfoContainer.class, GENERIC_RESYNC_STRATEGY),
+            Map.entry(ContentBookContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(CraftingStationContainer.class, CLICK_TO_INSERT_RESYNC_STRATEGY),
+            Map.entry(DailyRewardContainer.class, REWARD_RESYNC_STRATEGY),
+            Map.entry(EventContainer.class, REWARD_RESYNC_STRATEGY),
+            Map.entry(FlyingChestContainer.class, REWARD_RESYNC_STRATEGY),
+            Map.entry(GuildBankContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(GuildManagementContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(GuildMemberListContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(GuildTerritoriesContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(HousingJukeboxContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(HousingListContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(IngredientPouchContainer.class, PLAYER_INV_RESYNC_STRATEGY),
+            Map.entry(InventoryContainer.class, PLAYER_INV_RESYNC_STRATEGY),
+            Map.entry(IslandBlockBankContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(JukeboxContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(LobbyContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(LootChestContainer.class, REWARD_RESYNC_STRATEGY),
+            Map.entry(MiscBucketContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(ObjectiveRewardContainer.class, REWARD_RESYNC_STRATEGY),
+            Map.entry(PersonalBlockBankContainer.class, BANK_RESYNC_STRATEGY),
+            Map.entry(PetMenuContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(SeaskipperContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(TradeMarketContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(TradeMarketFiltersContainer.class, UI_RESYNC_STRATEGY),
+            Map.entry(TradeMarketSellContainer.class, UI_RESYNC_STRATEGY));
+
     @Persisted
     public Config<Boolean> forceSync = new Config<>(false);
 
     @SubscribeEvent
     public void onDesyncableContainerClick(DesyncableContainerClickEvent event) {
-        event.setShouldResync(true);
-        if (event.getResyncStrategy() == null) {
-            // TODO resolve resync strategy
+        if (event.getResyncStrategy() != null) {
+            event.setShouldResync(true);
+            return;
         }
+
+        InventoryResyncStrategy strategy = getResyncStrategy(event.getContainerMenu());
+        if (strategy == null) return;
+
+        event.setShouldResync(true);
+        event.setResyncStrategy(strategy);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onContainerClick(ContainerClickEvent event) {
-        if (!forceSync.get()) return;
+        if (!forceSync.get() || getResyncStrategy(event.getContainerMenu()) == null) return;
         event.setCanceled(true);
         AbstractContainerMenu menu = event.getContainerMenu();
 
@@ -73,5 +173,12 @@ public class ImprovedInventorySyncFeature extends Feature {
 
         // Restore previous inventory state in expectation of an update from the server (see InventoryHandler)
         menu.initializeContents(menu.getStateId(), Arrays.asList(oldItems), oldHeld);
+    }
+
+    private InventoryResyncStrategy getResyncStrategy(AbstractContainerMenu menu) {
+        Container container = Models.Container.getCurrentContainer();
+        if (container == null || container.getContainerId() != menu.containerId) return null;
+
+        return RESYNC_STRATEGY_TABLE.get(container.getClass());
     }
 }

--- a/common/src/main/java/com/wynntils/handlers/inventory/InventoryHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/InventoryHandler.java
@@ -93,15 +93,35 @@ public class InventoryHandler extends Handler {
                 }
             }
             case THROW -> {
-                ItemStack slotStack = menu.getSlot(slotNum).getItem();
-                if (heldStack.isEmpty() && !slotStack.isEmpty()) {
-                    if (isImprovedSyncEnabled()) {
-                        forceSyncLater(menu);
-                        expect(new PendingInteraction.ThrowFromSlot(menu, slotNum, slotStack.copy()));
-                    } else {
-                        ItemStack thrown = event.getMouseButton() == 0 ? slotStack.copyWithCount(1) : slotStack.copy();
-                        WynntilsMod.postEvent(new InventoryInteractionEvent(
-                                menu, new InventoryInteraction.ThrowFromSlot(slotNum, thrown), Confidence.UNCERTAIN));
+                if (slotNum < 0) { // Slot -999 -> tossed an item outside the GUI
+                    if (!heldStack.isEmpty()) { // This probably shouldn't happen, but we'll check anyways
+                        boolean throwAll = event.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_LEFT;
+                        if (throwAll || heldStack.getCount() == 1) {
+                            if (isImprovedSyncEnabled()) {
+                                forceSyncLater(menu);
+                            } else {
+                                ItemStack thrown = throwAll ? heldStack.copy() : heldStack.copyWithCount(1);
+                                WynntilsMod.postEvent(new InventoryInteractionEvent(
+                                        menu, new InventoryInteraction.ThrowFromHeld(thrown), Confidence.UNCERTAIN));
+                                return;
+                            }
+                        }
+                        expect(new PendingInteraction.ThrowFromHeld(menu, heldStack.copy()));
+                    }
+                } else {
+                    ItemStack slotStack = menu.getSlot(slotNum).getItem();
+                    if (heldStack.isEmpty() && !slotStack.isEmpty()) {
+                        if (isImprovedSyncEnabled()) {
+                            forceSyncLater(menu);
+                            expect(new PendingInteraction.ThrowFromSlot(menu, slotNum, slotStack.copy()));
+                        } else {
+                            ItemStack thrown =
+                                    event.getMouseButton() == 0 ? slotStack.copyWithCount(1) : slotStack.copy();
+                            WynntilsMod.postEvent(new InventoryInteractionEvent(
+                                    menu,
+                                    new InventoryInteraction.ThrowFromSlot(slotNum, thrown),
+                                    Confidence.UNCERTAIN));
+                        }
                     }
                 }
             }

--- a/common/src/main/java/com/wynntils/handlers/inventory/InventoryHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/InventoryHandler.java
@@ -17,6 +17,7 @@ import com.wynntils.models.items.items.gui.IngredientPouchItem;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.Confidence;
+import com.wynntils.utils.wynn.InventoryUtils;
 import com.wynntils.utils.wynn.ItemUtils;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -189,7 +190,7 @@ public class InventoryHandler extends Handler {
         }
 
         // Method 2: swap the content book into an empty slot
-        ItemStack contentBookStack = McUtils.player().getInventory().getItem(8);
+        ItemStack contentBookStack = McUtils.player().getInventory().getItem(InventoryUtils.CONTENT_BOOK_SLOT_NUM);
         if (!contentBookStack.isEmpty()) {
             for (int slotNum = 0; slotNum <= menu.slots.size(); slotNum++) {
                 Slot slot = menu.slots.get(slotNum);
@@ -199,7 +200,7 @@ public class InventoryHandler extends Handler {
                             menu.containerId,
                             menu.getStateId(),
                             slotNum,
-                            8,
+                            InventoryUtils.CONTENT_BOOK_SLOT_NUM,
                             ClickType.SWAP,
                             ItemStack.EMPTY,
                             Int2ObjectMaps.emptyMap()));
@@ -211,7 +212,8 @@ public class InventoryHandler extends Handler {
         // Method 3: swap the ingredient pouch into the content book
         // This is the method of last resort because in certain inventories with filtered interactions (e.g. housing
         // inventories or blacksmiths), swapping the pouch will prompt an annoying error message in the chat
-        int pouchSlot = menu instanceof InventoryMenu ? 13 : (menu.slots.size() - 32);
+        int pouchSlot =
+                menu instanceof InventoryMenu ? InventoryUtils.INGREDIENT_POUCH_SLOT_NUM : (menu.slots.size() - 32);
         // FIXME Reversed dependency of handler on model
         if (Models.Item.asWynnItem(menu.getSlot(pouchSlot).getItem(), IngredientPouchItem.class)
                 .isPresent()) {

--- a/common/src/main/java/com/wynntils/handlers/inventory/event/DesyncableContainerClickEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/event/DesyncableContainerClickEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.event;
+
+import com.wynntils.handlers.inventory.resync.InventoryResyncStrategy;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.neoforged.bus.api.Event;
+
+public class DesyncableContainerClickEvent extends Event {
+    private final AbstractContainerMenu containerMenu;
+    private final int slotNum;
+    private final ClickType clickType;
+    private final int mouseButton;
+
+    private InventoryResyncStrategy resyncStrategy;
+    private boolean shouldResync = false;
+
+    public DesyncableContainerClickEvent(
+            AbstractContainerMenu containerMenu,
+            int slotNum,
+            ClickType clickType,
+            int mouseButton,
+            InventoryResyncStrategy resyncStrategy) {
+        this.containerMenu = containerMenu;
+        this.slotNum = slotNum;
+        this.clickType = clickType;
+        this.mouseButton = mouseButton;
+        this.resyncStrategy = resyncStrategy;
+    }
+
+    public AbstractContainerMenu getContainerMenu() {
+        return containerMenu;
+    }
+
+    public int getSlotNum() {
+        return slotNum;
+    }
+
+    public ClickType getClickType() {
+        return clickType;
+    }
+
+    public int getMouseButton() {
+        return mouseButton;
+    }
+
+    public InventoryResyncStrategy getResyncStrategy() {
+        return resyncStrategy;
+    }
+
+    public void setResyncStrategy(InventoryResyncStrategy resyncStrategy) {
+        this.resyncStrategy = resyncStrategy;
+    }
+
+    public boolean getShouldResync() {
+        return shouldResync;
+    }
+
+    public void setShouldResync(boolean shouldResync) {
+        this.shouldResync = shouldResync;
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/inventory/resync/ClickPlaceholderSlotResyncStrategy.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/resync/ClickPlaceholderSlotResyncStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.resync;
+
+import com.wynntils.utils.wynn.ContainerUtils;
+import com.wynntils.utils.wynn.ItemUtils;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+
+/**
+ * Suitable for bank-like inventories that use placeholder slots to block quick-move operations. In theory, this should
+ * be safe to use in any inventory, since it'll fail-safe for any unsupported ones.
+ */
+public final class ClickPlaceholderSlotResyncStrategy implements InventoryResyncStrategy {
+    public static final ClickPlaceholderSlotResyncStrategy INSTANCE = new ClickPlaceholderSlotResyncStrategy();
+
+    private ClickPlaceholderSlotResyncStrategy() {}
+
+    @Override
+    public InventoryResynchronizer getResynchronizer(AbstractContainerMenu menu) {
+        if (menu.slots.size() <= 36) return null; // Sanity check
+
+        for (int slotNum = menu.slots.size() - 37; slotNum >= 0; slotNum--) {
+            if (ItemUtils.isNonSlotPlaceholder(menu.getSlot(slotNum).getItem())) {
+                return new Resynchronizer(menu, slotNum);
+            }
+        }
+        return null;
+    }
+
+    private static final class Resynchronizer extends InventoryResynchronizer {
+        private final int slotNum;
+
+        private Resynchronizer(AbstractContainerMenu menu, int slotNum) {
+            super(menu);
+            this.slotNum = slotNum;
+        }
+
+        @Override
+        public boolean isValid() {
+            return ItemUtils.isNonSlotPlaceholder(menu.getSlot(slotNum).getItem());
+        }
+
+        @Override
+        public void resync() {
+            ContainerUtils.sendSlotInteraction(menu, slotNum, ClickType.PICKUP, 0);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/inventory/resync/EmptySwapContentBookResyncStrategy.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/resync/EmptySwapContentBookResyncStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.resync;
+
+import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.wynn.ContainerUtils;
+import com.wynntils.utils.wynn.InventoryUtils;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Suitable for most inventories, but especially useful for "click-to-insert" UIs like blacksmiths and item identifiers,
+ * where other resync strategies may be too risky. In theory, this should be safe to use in any inventory so long as
+ * Wynncraft doesn't drastically change the way they handle inventory clicks.
+ */
+public final class EmptySwapContentBookResyncStrategy implements InventoryResyncStrategy {
+    public static final EmptySwapContentBookResyncStrategy INSTANCE = new EmptySwapContentBookResyncStrategy();
+
+    private EmptySwapContentBookResyncStrategy() {}
+
+    @Override
+    public InventoryResynchronizer getResynchronizer(AbstractContainerMenu menu) {
+        ItemStack bookStack = McUtils.player().getInventory().getItem(InventoryUtils.CONTENT_BOOK_SLOT_NUM);
+        if (bookStack.isEmpty()) return null;
+
+        for (int slotNum = 0; slotNum < menu.slots.size(); slotNum++) {
+            Slot slot = menu.getSlot(slotNum);
+            if (slot.getItem().isEmpty() && slot.mayPlace(bookStack)) {
+                return new Resynchronizer(menu, slotNum);
+            }
+        }
+        return null;
+    }
+
+    private static final class Resynchronizer extends InventoryResynchronizer {
+        private final int slotNum;
+
+        private Resynchronizer(AbstractContainerMenu menu, int slotNum) {
+            super(menu);
+            this.slotNum = slotNum;
+        }
+
+        @Override
+        public boolean isValid() {
+            ItemStack bookStack = McUtils.player().getInventory().getItem(InventoryUtils.CONTENT_BOOK_SLOT_NUM);
+            if (bookStack.isEmpty()) return false;
+            Slot slot = menu.getSlot(slotNum);
+            return slot.getItem().isEmpty() && slot.mayPlace(bookStack);
+        }
+
+        @Override
+        public void resync() {
+            ContainerUtils.sendSlotInteraction(menu, slotNum, ClickType.SWAP, InventoryUtils.CONTENT_BOOK_SLOT_NUM);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/inventory/resync/IngredientPouchSwapContentBookResyncStrategy.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/resync/IngredientPouchSwapContentBookResyncStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.resync;
+
+import com.wynntils.utils.wynn.ContainerUtils;
+import com.wynntils.utils.wynn.InventoryUtils;
+import com.wynntils.utils.wynn.ItemUtils;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.InventoryMenu;
+
+/**
+ * Suitable for the player inventory. Should not be used in filtered inventories because it prompts an annoying error
+ * message in the chat. MUST NOT be used for reward containers, as it runs the risk of opening the ingredient pouch!
+ */
+public final class IngredientPouchSwapContentBookResyncStrategy implements InventoryResyncStrategy {
+    public static final IngredientPouchSwapContentBookResyncStrategy INSTANCE =
+            new IngredientPouchSwapContentBookResyncStrategy();
+
+    private IngredientPouchSwapContentBookResyncStrategy() {}
+
+    @Override
+    public InventoryResynchronizer getResynchronizer(AbstractContainerMenu menu) {
+        int slotNum =
+                menu instanceof InventoryMenu ? InventoryUtils.INGREDIENT_POUCH_SLOT_NUM : (menu.slots.size() - 32);
+        return ItemUtils.isIngredientPouch(menu.getSlot(slotNum).getItem()) ? new Resynchronizer(menu, slotNum) : null;
+    }
+
+    private static final class Resynchronizer extends InventoryResynchronizer {
+        private final int slotNum;
+
+        private Resynchronizer(AbstractContainerMenu menu, int slotNum) {
+            super(menu);
+            this.slotNum = slotNum;
+        }
+
+        @Override
+        public boolean isValid() {
+            return ItemUtils.isIngredientPouch(menu.getSlot(slotNum).getItem());
+        }
+
+        @Override
+        public void resync() {
+            ContainerUtils.sendSlotInteraction(menu, slotNum, ClickType.SWAP, InventoryUtils.CONTENT_BOOK_SLOT_NUM);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/inventory/resync/InventoryResyncStrategy.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/resync/InventoryResyncStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.resync;
+
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+public interface InventoryResyncStrategy {
+    InventoryResynchronizer getResynchronizer(AbstractContainerMenu menu);
+
+    static InventoryResyncStrategy chain(InventoryResyncStrategy... strategies) {
+        return menu -> {
+            for (InventoryResyncStrategy strategy : strategies) {
+                InventoryResynchronizer resync = strategy.getResynchronizer(menu);
+                if (resync != null) {
+                    return resync;
+                }
+            }
+            return null;
+        };
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/inventory/resync/InventoryResynchronizer.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/resync/InventoryResynchronizer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.resync;
+
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+public abstract class InventoryResynchronizer {
+    protected final AbstractContainerMenu menu;
+
+    protected InventoryResynchronizer(AbstractContainerMenu menu) {
+        this.menu = menu;
+    }
+
+    public AbstractContainerMenu getMenu() {
+        return menu;
+    }
+
+    public abstract boolean isValid();
+
+    public abstract void resync();
+}

--- a/common/src/main/java/com/wynntils/handlers/inventory/resync/SwapNonEmptySlotResyncStrategy.java
+++ b/common/src/main/java/com/wynntils/handlers/inventory/resync/SwapNonEmptySlotResyncStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.inventory.resync;
+
+import com.wynntils.utils.wynn.ContainerUtils;
+import com.wynntils.utils.wynn.InventoryUtils;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.Slot;
+
+/**
+ * Suitable for inventories with no special interaction handling (e.g. no "click-to-insert" UIs, no filtering) such as
+ * the player inventory and reward containers. Relies on the fact that SWAP interactions are not supported on Wynncraft,
+ * but this may potentially be risky if that ever changes on Wynncraft's side. Should not be used for filtered
+ * inventories because it may prompt an annoying error message in the chat. MUST NOT be used for click-to-insert UIs, as
+ * it runs the risk of unintentionally inserting items!
+ */
+public final class SwapNonEmptySlotResyncStrategy implements InventoryResyncStrategy {
+    public static final SwapNonEmptySlotResyncStrategy INSTANCE = new SwapNonEmptySlotResyncStrategy();
+
+    private SwapNonEmptySlotResyncStrategy() {}
+
+    @Override
+    public InventoryResynchronizer getResynchronizer(AbstractContainerMenu menu) {
+        for (int slotNum = 0; slotNum < menu.slots.size(); slotNum++) {
+            Slot slot = menu.slots.get(slotNum);
+            if (!slot.getItem().isEmpty() && !isInteractable(slot)) {
+                return new Resynchronizer(menu, slotNum);
+            }
+        }
+        return null;
+    }
+
+    private static boolean isInteractable(Slot slot) {
+        if (!(slot.container instanceof Inventory)) return false;
+        int slotNum = slot.getContainerSlot();
+        return slotNum == InventoryUtils.COMPASS_SLOT_NUM || slotNum == InventoryUtils.CONTENT_BOOK_SLOT_NUM;
+    }
+
+    private static final class Resynchronizer extends InventoryResynchronizer {
+        private final int slotNum;
+
+        private Resynchronizer(AbstractContainerMenu menu, int slotNum) {
+            super(menu);
+            this.slotNum = slotNum;
+        }
+
+        @Override
+        public boolean isValid() {
+            return !menu.getSlot(slotNum).getItem().isEmpty();
+        }
+
+        @Override
+        public void resync() {
+            ContainerUtils.sendSlotInteraction(menu, slotNum, ClickType.SWAP, InventoryUtils.CONTENT_BOOK_SLOT_NUM);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/wynn/ContainerUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ContainerUtils.java
@@ -6,16 +6,16 @@ package com.wynntils.utils.wynn;
 
 import com.wynntils.utils.mc.McUtils;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import java.util.List;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import org.lwjgl.glfw.GLFW;
 
 public final class ContainerUtils {
@@ -44,58 +44,77 @@ public final class ContainerUtils {
         return true;
     }
 
+    public static void sendSlotInteraction(
+            int containerId,
+            int stateId,
+            int slotNumber,
+            ClickType clickType,
+            int mouseButton,
+            ItemStack heldStack,
+            Int2ObjectMap<ItemStack> changedSlots) {
+        McUtils.sendPacket(new ServerboundContainerClickPacket(
+                containerId, stateId, slotNumber, mouseButton, clickType, heldStack, changedSlots));
+    }
+
+    public static void sendSlotInteraction(
+            AbstractContainerMenu menu,
+            int slotNumber,
+            ClickType clickType,
+            int mouseButton,
+            ItemStack heldStack,
+            Int2ObjectMap<ItemStack> changedSlots) {
+        sendSlotInteraction(
+                menu.containerId, menu.getStateId(), slotNumber, clickType, mouseButton, heldStack, changedSlots);
+    }
+
+    public static void sendSlotInteraction(
+            AbstractContainerMenu menu, int slotNumber, ClickType clickType, int mouseButton) {
+        sendSlotInteraction(menu, slotNumber, clickType, mouseButton, ItemStack.EMPTY, Int2ObjectMaps.emptyMap());
+    }
+
     /**
      * Clicks on a slot in the specified container. containerId and the list of items should correspond to the
      * same container!
      */
     public static void clickOnSlot(int clickedSlot, int containerId, int mouseButton, List<ItemStack> items) {
-        Int2ObjectMap<ItemStack> changedSlots = new Int2ObjectOpenHashMap<>();
-        changedSlots.put(clickedSlot, new ItemStack(Items.AIR));
-
         // FIXME: To expand usage of this function, the following variables needs to
         // be properly handled
         int transactionId = 0;
 
-        McUtils.sendPacket(new ServerboundContainerClickPacket(
+        sendSlotInteraction(
                 containerId,
                 transactionId,
                 clickedSlot,
-                mouseButton,
                 ClickType.PICKUP,
+                mouseButton,
                 items.get(clickedSlot),
-                changedSlots));
+                Int2ObjectMaps.singleton(clickedSlot, ItemStack.EMPTY));
     }
 
     public static void shiftClickOnSlot(int clickedSlot, int containerId, int mouseButton, List<ItemStack> items) {
-        Int2ObjectMap<ItemStack> changedSlots = new Int2ObjectOpenHashMap<>();
-        changedSlots.put(clickedSlot, new ItemStack(Items.AIR));
-
         int transactionId = 0;
 
-        McUtils.sendPacket(new ServerboundContainerClickPacket(
+        sendSlotInteraction(
                 containerId,
                 transactionId,
                 clickedSlot,
-                mouseButton,
                 ClickType.QUICK_MOVE,
+                mouseButton,
                 items.get(clickedSlot),
-                changedSlots));
+                Int2ObjectMaps.singleton(clickedSlot, ItemStack.EMPTY));
     }
 
     public static void pressKeyOnSlot(int clickedSlot, int containerId, int buttonNum, List<ItemStack> items) {
-        Int2ObjectMap<ItemStack> changedSlots = new Int2ObjectOpenHashMap<>();
-        changedSlots.put(clickedSlot, new ItemStack(Items.AIR));
-
         int transactionId = 0;
 
-        McUtils.sendPacket(new ServerboundContainerClickPacket(
+        sendSlotInteraction(
                 containerId,
                 transactionId,
                 clickedSlot,
-                buttonNum,
                 ClickType.SWAP,
+                buttonNum,
                 items.get(clickedSlot),
-                changedSlots));
+                Int2ObjectMaps.singleton(clickedSlot, ItemStack.EMPTY));
     }
 
     public static void closeContainer(int containerId) {

--- a/common/src/main/java/com/wynntils/utils/wynn/InventoryUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/InventoryUtils.java
@@ -5,11 +5,9 @@
 package com.wynntils.utils.wynn;
 
 import com.wynntils.utils.mc.McUtils;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import java.util.ArrayList;
 import java.util.List;
-import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickType;
@@ -28,18 +26,13 @@ public final class InventoryUtils {
             List.of(RING_1_SLOT_NUM, RING_2_SLOT_NUM, BRACELET_SLOT_NUM, NECKLACE_SLOT_NUM);
 
     public static void sendInventorySlotMouseClick(int slotNumber, MouseClickType mouseButton) {
-        Int2ObjectMap<ItemStack> changedSlots = new Int2ObjectOpenHashMap<>();
-        ItemStack itemStack = McUtils.inventory().getItem(slotNumber);
-        changedSlots.put(slotNumber, itemStack);
-
-        McUtils.sendPacket(new ServerboundContainerClickPacket(
-                McUtils.inventoryMenu().containerId,
-                McUtils.inventoryMenu().getStateId(),
+        ContainerUtils.sendSlotInteraction(
+                McUtils.inventoryMenu(),
                 slotNumber,
-                mouseButton.ordinal(),
                 ClickType.PICKUP,
+                mouseButton.ordinal(),
                 ItemStack.EMPTY,
-                changedSlots));
+                Int2ObjectMaps.singleton(slotNumber, McUtils.inventory().getItem(slotNumber)));
     }
 
     public static List<ItemStack> getAccessories(Player player) {

--- a/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
@@ -47,7 +47,8 @@ public final class ItemUtils {
     }
 
     public static boolean isNonSlotPlaceholder(ItemStack itemStack) {
-        return !itemStack.isEmpty() && NON_SLOT_PLACEHOLDER_NAMES.contains(itemStack.getHoverName().getString());
+        return !itemStack.isEmpty()
+                && NON_SLOT_PLACEHOLDER_NAMES.contains(itemStack.getHoverName().getString());
     }
 
     public static StyledText getItemName(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
@@ -22,6 +22,7 @@ import net.minecraft.world.item.Items;
 public final class ItemUtils {
     public static final Pattern ITEM_RARITY_PATTERN =
             Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic)( Raid)? (Item|Reward).*");
+    public static final String NON_SLOT_PLACEHOLDER_NAME = "\uDB3F\uDFFF";
 
     public static boolean isWeapon(ItemStack itemStack) {
         Optional<GearTypeItemProperty> gearItemOpt =
@@ -36,6 +37,10 @@ public final class ItemUtils {
         return wynnItemOpt
                 .filter(wynnItem -> wynnItem instanceof GatheringToolItem)
                 .isPresent();
+    }
+
+    public static boolean isNonSlotPlaceholder(ItemStack itemStack) {
+        return itemStack.getHoverName().getString().equals(NON_SLOT_PLACEHOLDER_NAME);
     }
 
     public static StyledText getItemName(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
@@ -9,6 +9,7 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.items.game.GatheringToolItem;
+import com.wynntils.models.items.items.gui.IngredientPouchItem;
 import com.wynntils.models.items.properties.GearTypeItemProperty;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,11 @@ public final class ItemUtils {
         return wynnItemOpt
                 .filter(wynnItem -> wynnItem instanceof GatheringToolItem)
                 .isPresent();
+    }
+
+    public static boolean isIngredientPouch(ItemStack itemStack) {
+        Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
+        return wynnItemOpt.isPresent() && wynnItemOpt.get() instanceof IngredientPouchItem;
     }
 
     public static boolean isNonSlotPlaceholder(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ItemUtils.java
@@ -13,6 +13,7 @@ import com.wynntils.models.items.items.gui.IngredientPouchItem;
 import com.wynntils.models.items.properties.GearTypeItemProperty;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -23,7 +24,7 @@ import net.minecraft.world.item.Items;
 public final class ItemUtils {
     public static final Pattern ITEM_RARITY_PATTERN =
             Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic)( Raid)? (Item|Reward).*");
-    public static final String NON_SLOT_PLACEHOLDER_NAME = "\uDB3F\uDFFF";
+    public static final Set<String> NON_SLOT_PLACEHOLDER_NAMES = Set.of("\uDB3F\uDFFF"); // TODO complete
 
     public static boolean isWeapon(ItemStack itemStack) {
         Optional<GearTypeItemProperty> gearItemOpt =
@@ -46,7 +47,7 @@ public final class ItemUtils {
     }
 
     public static boolean isNonSlotPlaceholder(ItemStack itemStack) {
-        return itemStack.getHoverName().getString().equals(NON_SLOT_PLACEHOLDER_NAME);
+        return !itemStack.isEmpty() && NON_SLOT_PLACEHOLDER_NAMES.contains(itemStack.getHoverName().getString());
     }
 
     public static StyledText getItemName(ItemStack itemStack) {


### PR DESCRIPTION
This PR addresses #2888 by first trying to click a placeholder slot (the snow stacks in the bank navigation bar), which should prompt an inventory update without causing the "cannot place this item in this bank!" error. It also correctly handles the `THROW` case for out-of-inventory clicks as in #2891