### PR TITLE
fix: Fix beta warning feature sometimes failing to initialise

### DIFF
--- a/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
@@ -5,14 +5,15 @@
 package com.wynntils.features.wynntils;
 
 import com.wynntils.core.WynntilsMod;
-import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.mod.event.WynncraftConnectionEvent;
+import com.wynntils.core.net.UrlId;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.PlayerInfoEvent;
 import com.wynntils.utils.mc.McUtils;
+import java.util.function.Supplier;
 import net.minecraft.network.chat.Component;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -39,28 +40,26 @@ public class BetaWarningFeature extends Feature {
         if (warnType == WarnType.NONE) return;
 
         McUtils.sendMessageToClient(warnType.getWarning());
-
-        // Send a link to our Discord server for beta builds, we can't include the link in the message as Urls have
-        // not been loaded by the time the enum is initialised
-        if (warnType == WarnType.RELEASE) {
-            Handlers.Command.sendCommandImmediately("wynntils discord");
-        }
         warnType = WarnType.NONE;
     }
 
+    // As urls may not be initialised yet, we have to use a supplier so that it will be loaded when we need
+    // to access the Component which will only be after joining the server and urls should be loaded by then.
     private enum WarnType {
-        NONE(Component.empty()),
-        BETA(Component.translatable("feature.wynntils.betaWarning.usingBetaOnNormalServer")),
-        RELEASE(Component.translatable("feature.wynntils.betaWarning.usingReleaseOnBetaServer"));
+        NONE(Component::empty),
+        BETA(() -> Component.translatable("feature.wynntils.betaWarning.usingBetaOnNormalServer")),
+        RELEASE(() -> Component.translatable(
+                "feature.wynntils.betaWarning.usingReleaseOnBetaServer",
+                Managers.Url.getUrl(UrlId.LINK_WYNNTILS_DISCORD_INVITE)));
 
-        private final Component warning;
+        private final Supplier<Component> warningSupplier;
 
-        WarnType(Component warning) {
-            this.warning = warning;
+        WarnType(Supplier<Component> warningSupplier) {
+            this.warningSupplier = warningSupplier;
         }
 
         public Component getWarning() {
-            return warning;
+            return warningSupplier.get();
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
@@ -6,7 +6,6 @@ package com.wynntils.features.wynntils;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.persisted.config.Category;

--- a/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
@@ -5,10 +5,10 @@
 package com.wynntils.features.wynntils;
 
 import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.mod.event.WynncraftConnectionEvent;
-import com.wynntils.core.net.UrlId;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.PlayerInfoEvent;
@@ -39,15 +39,19 @@ public class BetaWarningFeature extends Feature {
         if (warnType == WarnType.NONE) return;
 
         McUtils.sendMessageToClient(warnType.getWarning());
+
+        // Send a link to our Discord server for beta builds, we can't include the link in the message as Urls have
+        // not been loaded by the time the enum is initialised
+        if (warnType == WarnType.RELEASE) {
+            Handlers.Command.sendCommandImmediately("wynntils discord");
+        }
         warnType = WarnType.NONE;
     }
 
     private enum WarnType {
         NONE(Component.empty()),
         BETA(Component.translatable("feature.wynntils.betaWarning.usingBetaOnNormalServer")),
-        RELEASE(Component.translatable(
-                "feature.wynntils.betaWarning.usingReleaseOnBetaServer",
-                Managers.Url.getUrl(UrlId.LINK_WYNNTILS_DISCORD_INVITE)));
+        RELEASE(Component.translatable("feature.wynntils.betaWarning.usingReleaseOnBetaServer"));
 
         private final Component warning;
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -116,7 +116,7 @@
   "feature.wynntils.betaWarning.description": "Adds a warning when you are playing on the beta server without the correct version.",
   "feature.wynntils.betaWarning.name": "Beta Warning",
   "feature.wynntils.betaWarning.usingBetaOnNormalServer": "You are using a beta version of Wynntils. This version may only be supported on the Wynncraft Beta, and may not work correctly on normal Wynncraft. If you have confirmed this version is working correctly, you can ignore this warning.",
-  "feature.wynntils.betaWarning.usingReleaseOnBetaServer": "You are using a release version of Wynntils. This version is not supported on the Wynncraft Beta and various features may be broken. Please connect to the normal Wynncraft server or use a beta version of Wynntils which you can find in our Discord at %s.",
+  "feature.wynntils.betaWarning.usingReleaseOnBetaServer": "You are using a release version of Wynntils. This version is not supported on the Wynncraft Beta and various features may be broken. Please connect to the normal Wynncraft server or use a beta version of Wynntils which you can find in our Discord.",
   "feature.wynntils.bombBellOverlay.description": "Adds an overlay to see active bombs.",
   "feature.wynntils.bombBellOverlay.name": "Bomb Bell",
   "feature.wynntils.bombBellOverlay.overlay.bombBell.fontScale.description": "How large should the bomb bell text be?",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -116,7 +116,7 @@
   "feature.wynntils.betaWarning.description": "Adds a warning when you are playing on the beta server without the correct version.",
   "feature.wynntils.betaWarning.name": "Beta Warning",
   "feature.wynntils.betaWarning.usingBetaOnNormalServer": "You are using a beta version of Wynntils. This version may only be supported on the Wynncraft Beta, and may not work correctly on normal Wynncraft. If you have confirmed this version is working correctly, you can ignore this warning.",
-  "feature.wynntils.betaWarning.usingReleaseOnBetaServer": "You are using a release version of Wynntils. This version is not supported on the Wynncraft Beta and various features may be broken. Please connect to the normal Wynncraft server or use a beta version of Wynntils which you can find in our Discord.",
+  "feature.wynntils.betaWarning.usingReleaseOnBetaServer": "You are using a release version of Wynntils. This version is not supported on the Wynncraft Beta and various features may be broken. Please connect to the normal Wynncraft server or use a beta version of Wynntils which you can find in our Discord at %s.",
   "feature.wynntils.bombBellOverlay.description": "Adds an overlay to see active bombs.",
   "feature.wynntils.bombBellOverlay.name": "Bomb Bell",
   "feature.wynntils.bombBellOverlay.overlay.bombBell.fontScale.description": "How large should the bomb bell text be?",


### PR DESCRIPTION
Everywhere else either accesses a Url in a registered download or in some kind of event so this should be the only place where one wasn't