### PR TITLE
chore: Make original unwrapped styledtext available in chat messages [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
@@ -15,7 +15,6 @@ import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.handlers.chat.type.MessageType;
 import com.wynntils.models.players.type.PlayerRank;
 import com.wynntils.utils.StringUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
@@ -136,7 +136,7 @@ public class ChatRedirectFeature extends Feature {
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onChatMessage(ChatMessageReceivedEvent e) {
-        StyledText message = StyledTextUtils.unwrap(e.getOriginalStyledText()).stripAlignment();
+        StyledText message = e.getOriginalUnwrappedStyledText().stripAlignment();
         MessageType messageType = e.getMessageType();
 
         for (Redirector redirector : redirectors) {

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageReceivedEvent.java
@@ -7,12 +7,14 @@ package com.wynntils.handlers.chat.event;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.type.MessageType;
 import com.wynntils.handlers.chat.type.RecipientType;
+import com.wynntils.utils.mc.StyledTextUtils;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
 public class ChatMessageReceivedEvent extends Event implements ICancellableEvent {
     // These are used to keep the original message so different features don't have to fight over it.
     private final StyledText originalStyledText;
+    private final StyledText originalUnwrappedStyledText;
 
     private StyledText styledText;
 
@@ -21,6 +23,7 @@ public class ChatMessageReceivedEvent extends Event implements ICancellableEvent
 
     public ChatMessageReceivedEvent(StyledText styledText, MessageType messageType, RecipientType recipientType) {
         this.originalStyledText = styledText;
+        this.originalUnwrappedStyledText = StyledTextUtils.unwrap(styledText);
         this.styledText = styledText;
         this.messageType = messageType;
         this.recipientType = recipientType;
@@ -32,6 +35,10 @@ public class ChatMessageReceivedEvent extends Event implements ICancellableEvent
 
     public StyledText getOriginalStyledText() {
         return originalStyledText;
+    }
+
+    public StyledText getOriginalUnwrappedStyledText() {
+        return originalUnwrappedStyledText;
     }
 
     public StyledText getStyledText() {

--- a/common/src/main/java/com/wynntils/models/territories/GuildAttackTimerModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/GuildAttackTimerModel.java
@@ -115,7 +115,7 @@ public final class GuildAttackTimerModel extends Model {
             return;
         }
 
-        matcher = StyledTextUtils.unwrap(event.getOriginalStyledText()).getMatcher(GUILD_DEFENSE_CHAT_PATTERN);
+        matcher = event.getOriginalUnwrappedStyledText().getMatcher(GUILD_DEFENSE_CHAT_PATTERN);
         if (matcher.matches()) {
             String territory = matcher.group(1);
             territoryDefenses.put(territory, GuildResourceValues.fromString(matcher.group(2)));


### PR DESCRIPTION
With chat wrapping being present in more chat messages, store the original unwrapped chat message in the chat event as well. At the moment this is only used by two methods, but there are a few regexes that are broken right now, which would rely on this as well.