### PR TITLE
fix: Fix trade market auto open chat and price conversion

### DIFF
--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketAutoOpenChatFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketAutoOpenChatFeature.java
@@ -8,29 +8,34 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.mc.event.ScreenClosedEvent;
 import com.wynntils.mc.event.ScreenOpenedEvent;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.regex.Pattern;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.TRADEMARKET)
 public class TradeMarketAutoOpenChatFeature extends Feature {
-    // Type the price in emeralds or type 'cancel' to cancel:
-    // Type the amount you wish to buy or type 'cancel' to cancel:
+    // Type the price in emeralds or formatted (e.g '10eb', '10stx 5eb') or type 'cancel' to cancel:
+    // Type the amount you wish to sell or type 'cancel' to cancel:
     // Type the item name or type 'cancel' to cancel:
-    private static final Pattern TYPE_TO_CHAT_PATTERN = Pattern.compile(
-            "^§5(\uE00A\uE002|\uE001) \n\uE001 Type the .* or type (\n\uE001 'cancel' to|'cancel' to \n\uE001) cancel:\n\uE001 ");
+    // Type the amount you wish to buy or type 'cancel' to cancel:
+    private static final Pattern TYPE_TO_CHAT_PATTERN =
+            Pattern.compile("^§5(\uE00A\uE002|\uE001) Type the .* or type 'cancel' to cancel:");
 
     private boolean openChatWhenContainerClosed = false;
 
     @SubscribeEvent
     public void onChatMessageReceive(ChatMessageReceivedEvent event) {
         if (!Models.WorldState.onWorld()) return;
+        StyledText styledText =
+                StyledTextUtils.unwrap(event.getOriginalStyledText()).stripAlignment();
 
-        if (event.getOriginalStyledText().stripAlignment().matches(TYPE_TO_CHAT_PATTERN)) {
+        if (styledText.matches(TYPE_TO_CHAT_PATTERN)) {
             openChatWhenContainerClosed = true;
         }
     }

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketAutoOpenChatFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketAutoOpenChatFeature.java
@@ -20,10 +20,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.TRADEMARKET)
 public class TradeMarketAutoOpenChatFeature extends Feature {
-    // Type the price in emeralds or formatted (e.g '10eb', '10stx 5eb') or type 'cancel' to cancel:
-    // Type the amount you wish to sell or type 'cancel' to cancel:
-    // Type the item name or type 'cancel' to cancel:
-    // Type the amount you wish to buy or type 'cancel' to cancel:
+    // Test in TradeMarketAutoOpenChatFeature_TYPE_TO_CHAT_PATTERN
     private static final Pattern TYPE_TO_CHAT_PATTERN =
             Pattern.compile("^§5(\uE00A\uE002|\uE001) Type the .* or type 'cancel' to cancel:");
 

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceConversionFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceConversionFeature.java
@@ -8,16 +8,18 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.mc.event.ChatSentEvent;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.regex.Pattern;
 import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.TRADEMARKET)
 public class TradeMarketPriceConversionFeature extends Feature {
     private static final Pattern PRICE_PATTERN = Pattern.compile(
-            "^§5(\uE00A\uE002|\uE001) \n\uE001 Type the price in emeralds or type \n\uE001 'cancel' to cancel:\n\uE001 ");
+            "^§5(\uE00A\uE002|\uE001) Type the price in emeralds or formatted \\(e\\.g '10eb', '10stx 5eb'\\) or type 'cancel' to cancel:$");
     private static final Pattern CANCELLED_PATTERN =
             Pattern.compile("^§4(\uE008\uE002|\uE001) You moved and your chat input was canceled.$");
 
@@ -25,10 +27,13 @@ public class TradeMarketPriceConversionFeature extends Feature {
 
     @SubscribeEvent
     public void onChatMessageReceive(ChatMessageReceivedEvent event) {
-        if (event.getOriginalStyledText().stripAlignment().matches(PRICE_PATTERN)) {
+        StyledText styledText =
+                StyledTextUtils.unwrap(event.getOriginalStyledText()).stripAlignment();
+
+        if (styledText.matches(PRICE_PATTERN)) {
             shouldConvert = true;
         }
-        if (event.getOriginalStyledText().stripAlignment().matches(CANCELLED_PATTERN)) {
+        if (styledText.matches(CANCELLED_PATTERN)) {
             shouldConvert = false;
         }
     }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -941,9 +941,10 @@ public class TestRegex {
         PatternTester p = new PatternTester(TradeMarketAutoOpenChatFeature.class, "TYPE_TO_CHAT_PATTERN");
 
         p.shouldMatch(
-                "§5\uE00A\uE002 \n\uE001 Type the amount you wish to buy or type \n\uE001 'cancel' to cancel:\n\uE001 ");
-        p.shouldMatch("§5\uE001 \n\uE001 Type the price in emeralds or type \n\uE001 'cancel' to cancel:\n\uE001 ");
-        p.shouldMatch("§5\uE00A\uE002 \n\uE001 Type the item name or type 'cancel' to \n\uE001 cancel:\n\uE001 ");
+                "§5\uE00A\uE002 Type the price in emeralds or formatted (e.g '10eb', '10stx 5eb') or type 'cancel' to cancel:");
+        p.shouldMatch("§5\uE001 Type the amount you wish to sell or type 'cancel' to cancel:");
+        p.shouldMatch("§5\uE001 Type the item name or type 'cancel' to cancel:");
+        p.shouldMatch("§5\uE00A\uE002 Type the amount you wish to buy or type 'cancel' to cancel:");
     }
 
     @Test


### PR DESCRIPTION
As of the new Wynn hotfix they have their own price conversion however ours is still better as theirs will parse "5.45le" as "45le" while we parse it as "5.45le" and we also have the "-t" tax remove. Unless they fix that we can keep our version and the "-t" could just be added separately