### PR TITLE
feat: Hide raid intermission by default and don't include in raid best time [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -222,7 +222,10 @@ public class RaidModel extends Model {
         WynntilsMod.postEvent(new RaidEndedEvent.Completed(
                 currentRaid, getAllRoomTimes(), currentRaidTime(), getAllRoomDamages(), getRaidDamage()));
 
-        checkForNewPersonalBest(currentRaid, currentRaidTime());
+        // Need to add boss time to get correct intermission time since
+        // currentRoom will still be boss room when getIntermissionTime() is called
+        checkForNewPersonalBest(
+                currentRaid, currentRaidTime() - (getIntermissionTime() + getRoomTime(RaidRoomType.BOSS_FIGHT)));
 
         currentRaid = null;
         currentRoom = null;

--- a/common/src/main/java/com/wynntils/overlays/RaidProgressOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/RaidProgressOverlay.java
@@ -18,16 +18,16 @@ public class RaidProgressOverlay extends TextOverlay {
     private String previewTemplate;
 
     @Persisted
-    private final Config<Boolean> showIntermission = new Config<>(true);
+    public final Config<Boolean> showIntermission = new Config<>(true);
 
     @Persisted
-    private final Config<Boolean> showMilliseconds = new Config<>(true);
+    public final Config<Boolean> showMilliseconds = new Config<>(true);
 
     @Persisted
-    private final Config<Boolean> totalIntermission = new Config<>(true);
+    public final Config<Boolean> totalIntermission = new Config<>(true);
 
     @Persisted
-    private final Config<Boolean> showDamage = new Config<>(true);
+    public final Config<Boolean> showDamage = new Config<>(true);
 
     public RaidProgressOverlay() {
         super(

--- a/common/src/main/java/com/wynntils/overlays/RaidProgressOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/RaidProgressOverlay.java
@@ -18,13 +18,13 @@ public class RaidProgressOverlay extends TextOverlay {
     private String previewTemplate;
 
     @Persisted
-    public final Config<Boolean> showIntermission = new Config<>(true);
+    public final Config<Boolean> showIntermission = new Config<>(false);
 
     @Persisted
     public final Config<Boolean> showMilliseconds = new Config<>(true);
 
     @Persisted
-    public final Config<Boolean> totalIntermission = new Config<>(true);
+    public final Config<Boolean> totalIntermission = new Config<>(false);
 
     @Persisted
     public final Config<Boolean> showDamage = new Config<>(true);

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1156,7 +1156,7 @@
   "feature.wynntils.raidProgress.overlay.raidProgress.showMilliseconds.name": "Show Milliseconds",
   "feature.wynntils.raidProgress.overlay.raidProgress.totalIntermission.description": "Should the total raid time include intermission times?",
   "feature.wynntils.raidProgress.overlay.raidProgress.totalIntermission.name": "Total Time include Intermission",
-  "feature.wynntils.raidProgress.personalBest": "New personal best for %s! Beaten in %d:%d:%d!",
+  "feature.wynntils.raidProgress.personalBest": "New personal best for %s! Beaten in %d:%d.%d!",
   "feature.wynntils.raidProgress.playSoundOnBest.description": "Should a sound be played when you get a new personal best time?",
   "feature.wynntils.raidProgress.playSoundOnBest.name": "Play sound on PB",
   "feature.wynntils.raidProgress.printTimes.description": "Should messages be sent showing raid times and personal bests after raid completion?",


### PR DESCRIPTION
The time given by Wynncraft at the end of raids doesn't include the intermission so we shouldn't include it in ours anymore