### PR TITLE
fix: fix lootrun beacon serialization crashing and location serialization depending on mappings

### DIFF
--- a/common/src/main/java/com/wynntils/models/beacons/BeaconModel.java
+++ b/common/src/main/java/com/wynntils/models/beacons/BeaconModel.java
@@ -18,6 +18,7 @@ import com.wynntils.models.beacons.type.BeaconMarker;
 import com.wynntils.models.beacons.type.BeaconMarkerKind;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.type.PreciseLocation;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +65,7 @@ public class BeaconModel extends Model {
 
             if (beaconKind == null) return;
 
-            Beacon beacon = new Beacon(entity.position(), beaconKind);
+            Beacon beacon = new Beacon(PreciseLocation.fromVec(entity.position()), beaconKind);
             beacons.put(event.getId(), beacon);
             WynntilsMod.postEvent(new BeaconEvent.Added(beacon, entity));
         } else if (entity instanceof Display.TextDisplay textDisplay) {
@@ -87,7 +88,7 @@ public class BeaconModel extends Model {
         Beacon movedBeacon = beacons.get(event.getEntity().getId());
         BeaconMarker movedBeaconMarker = beaconMarkers.get(event.getEntity().getId());
         if (movedBeacon != null) {
-            Beacon newBeacon = new Beacon(event.getNewPosition(), movedBeacon.beaconKind());
+            Beacon newBeacon = new Beacon(PreciseLocation.fromVec(event.getNewPosition()), movedBeacon.beaconKind());
             // Replace the old map entry
             beacons.put(event.getEntity().getId(), newBeacon);
             WynntilsMod.postEvent(new BeaconEvent.Moved(movedBeacon, newBeacon));

--- a/common/src/main/java/com/wynntils/models/beacons/type/Beacon.java
+++ b/common/src/main/java/com/wynntils/models/beacons/type/Beacon.java
@@ -4,19 +4,19 @@
  */
 package com.wynntils.models.beacons.type;
 
+import com.wynntils.utils.mc.type.PreciseLocation;
 import java.util.Objects;
-import net.minecraft.world.phys.Vec3;
 
 public final class Beacon<T extends BeaconKind> {
-    private final Vec3 position;
+    private final PreciseLocation position;
     private final T beaconKind;
 
-    public Beacon(Vec3 position, T beaconKind) {
+    public Beacon(PreciseLocation position, T beaconKind) {
         this.position = position;
         this.beaconKind = beaconKind;
     }
 
-    public Vec3 position() {
+    public PreciseLocation position() {
         return position;
     }
 

--- a/common/src/main/java/com/wynntils/models/beacons/type/Beacon.java
+++ b/common/src/main/java/com/wynntils/models/beacons/type/Beacon.java
@@ -4,6 +4,41 @@
  */
 package com.wynntils.models.beacons.type;
 
+import java.util.Objects;
 import net.minecraft.world.phys.Vec3;
 
-public record Beacon(Vec3 position, BeaconKind beaconKind) {}
+public final class Beacon<T extends BeaconKind> {
+    private final Vec3 position;
+    private final T beaconKind;
+
+    public Beacon(Vec3 position, T beaconKind) {
+        this.position = position;
+        this.beaconKind = beaconKind;
+    }
+
+    public Vec3 position() {
+        return position;
+    }
+
+    public T beaconKind() {
+        return beaconKind;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Beacon) obj;
+        return Objects.equals(this.position, that.position) && Objects.equals(this.beaconKind, that.beaconKind);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(position, beaconKind);
+    }
+
+    @Override
+    public String toString() {
+        return "Beacon[" + "position=" + position + ", " + "beaconKind=" + beaconKind + ']';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -173,7 +173,7 @@ public class LootrunModel extends Model {
     private final Storage<Map<String, LootrunBeaconKind>> lastTaskBeaconColorStorage = new Storage<>(new TreeMap<>());
 
     @Persisted
-    private final Storage<Map<String, Beacon>> closestBeaconStorage = new Storage<>(new TreeMap<>());
+    private final Storage<Map<String, Beacon<LootrunBeaconKind>>> closestBeaconStorage = new Storage<>(new TreeMap<>());
 
     @Persisted
     private final Storage<Map<String, Integer>> redBeaconTaskCountStorage = new Storage<>(new TreeMap<>());

--- a/common/src/main/java/com/wynntils/utils/mc/type/PreciseLocation.java
+++ b/common/src/main/java/com/wynntils/utils/mc/type/PreciseLocation.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.mc.type;
+
+import java.util.Comparator;
+import java.util.Objects;
+import net.minecraft.core.Position;
+import net.minecraft.world.phys.Vec3;
+
+public class PreciseLocation implements Position, Comparable<PreciseLocation> {
+    // Compare first x, then z, and finally y
+    private static final Comparator<PreciseLocation> LOCATION_COMPARATOR = Comparator.comparing(
+                    PreciseLocation::x, Double::compareTo)
+            .thenComparing(PreciseLocation::z, Double::compareTo)
+            .thenComparing(PreciseLocation::y, Double::compareTo);
+
+    private final double x;
+    private final double y;
+    private final double z;
+
+    public PreciseLocation(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public static PreciseLocation fromVec(Vec3 vec3) {
+        return new PreciseLocation(vec3.x, vec3.y, vec3.z);
+    }
+
+    @Override
+    public double x() {
+        return x;
+    }
+
+    @Override
+    public double y() {
+        return y;
+    }
+
+    @Override
+    public double z() {
+        return z;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PreciseLocation that = (PreciseLocation) o;
+        return Double.compare(x, that.x) == 0 && Double.compare(y, that.y) == 0 && Double.compare(z, that.z) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y, z);
+    }
+
+    public String toString() {
+        return "[" + this.x + ", " + this.y + ", " + this.z + "]";
+    }
+
+    @Override
+    public int compareTo(PreciseLocation preciseLocation) {
+        return LOCATION_COMPARATOR.compare(this, preciseLocation);
+    }
+}


### PR DESCRIPTION
Now that beacon is generic, GSON doesn't have issues with it. I've also went ahead and introduced `PreciseLocation` to use in favor of Minecraft's Vec3, which doesn't produce stable output when serialized with GSON, as it uses the current mapping  to get the field names, meaning it can be either "x" or "field_1234".