### PR TITLE
build: JVM runs out of memory after multiple hot swaps [skip ci]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ subprojects {
                 property("devauth.configDir", getRootProject().file(".devauth").absolutePath)
                 if (usingHotswapAgent) {
                     vmArgs "-XX:+AllowEnhancedClassRedefinition"
+                    // https://youtrack.jetbrains.com/issue/JBR-7351/JVM-CodeCache-will-not-be-cleaned-using-G1GC-if-Hotswap-Agent-is-enabled-since-JBR-6419-jbr21.351
+                    vmArgs "-XX:+ClassUnloading"
                     vmArgs "-XX:HotswapAgent=fatjar"
                 }
                 vmArgs "-ea" // run dev builds with asserts


### PR DESCRIPTION
I have been using the workaround mentioned in [JBR-7351](https://youtrack.jetbrains.com/issue/JBR-7351/JVM-CodeCache-will-not-be-cleaned-using-G1GC-if-Hotswap-Agent-is-enabled-since-JBR-6419-jbr21.351) for a few weeks, and it has remained stable. It may require additional testing to make sure it's also stable on other developers' machines.