### PR TITLE
fix: Fix seaskipper screen doubling destinations [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/seaskipper/SeaskipperModel.java
+++ b/common/src/main/java/com/wynntils/models/seaskipper/SeaskipperModel.java
@@ -53,12 +53,12 @@ public final class SeaskipperModel extends Model {
         if (!(Models.Container.getCurrentContainer() instanceof SeaskipperContainer seaskipperContainer)) return;
 
         containerId = seaskipperContainer.getContainerId();
-        availableDestinations = new ArrayList<>();
     }
 
     @SubscribeEvent
     public void onContainerSetContent(ContainerSetContentEvent.Post event) {
         if (event.getContainerId() != containerId) return;
+        availableDestinations = new ArrayList<>();
 
         for (int i = 0; i < event.getItems().size(); i++) {
             ItemStack item = event.getItems().get(i);


### PR DESCRIPTION
Sometimes the content of the container is set again which causes the list to have double the destinations so just clear the list in the set content event rather than the screen init