### PR TITLE
feat: New take on map attribute inheritance

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -18,8 +18,8 @@ import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.features.WaypointLocation;
 import com.wynntils.services.mapdata.providers.builtin.MapIconsProvider;
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapAttributesBuilder;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapVisibility;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.utils.colors.CommonColors;
@@ -651,7 +651,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
         JsonMapVisibility iconVisibility =
                 new JsonMapVisibility(FixedMapVisibility.ICON_ALWAYS); // TODO: Add visibility input
 
-        JsonMapAttributes attributes = new JsonMapAttributesBuilder()
+        JsonMapLocationAttributes attributes = new JsonMapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(iconId)
                 .setPriority(priority)
@@ -660,6 +660,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
                 .setLabelVisibility(labelVisibility)
                 .setIconColor(iconColor)
                 .setIconVisibility(iconVisibility)
+                .asLocationAttributes()
                 .build();
 
         WaypointLocation waypoint = new WaypointLocation(location, label, subcategory, attributes);

--- a/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
@@ -18,8 +18,8 @@ import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.services.mapdata.features.WaypointLocation;
 import com.wynntils.services.mapdata.providers.builtin.MapIconsProvider;
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapAttributesBuilder;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapVisibility;
 import com.wynntils.utils.mc.type.Location;
 import java.util.ArrayList;
@@ -95,7 +95,7 @@ public class WaypointsService extends Service {
         String label = customPoi.getName();
         String subcategory = ""; // Subcategories did not use to exist
 
-        JsonMapAttributes attributes = new JsonMapAttributesBuilder()
+        JsonMapLocationAttributes attributes = new JsonMapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(MapIconsProvider.getIconIdFromTexture(customPoi.getIcon()))
                 .setIconColor(customPoi.getColor())
@@ -105,6 +105,7 @@ public class WaypointsService extends Service {
                             case ALWAYS -> FixedMapVisibility.ICON_ALWAYS;
                             case HIDDEN -> FixedMapVisibility.ICON_NEVER;
                         }))
+                .asLocationAttributes()
                 .build();
 
         WaypointLocation waypointLocation = new WaypointLocation(location, label, subcategory, attributes);

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapAreaAttributes.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes;
+
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+
+public abstract class AbstractMapAreaAttributes extends AbstractMapAttributes implements MapAreaAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapLocationAttributes.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes;
+
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+
+public abstract class AbstractMapLocationAttributes extends AbstractMapAttributes implements MapLocationAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapPathAttributes.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes;
+
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+
+public abstract class AbstractMapPathAttributes extends AbstractMapAttributes implements MapPathAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public interface MapAreaAttributes extends MapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public interface MapLocationAttributes extends MapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+public interface MapPathAttributes extends MapAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/features/CombatLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/CombatLocation.java
@@ -4,14 +4,15 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.Texture;
 import java.util.Arrays;
 
 public final class CombatLocation extends JsonMapLocation {
-    public CombatLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public CombatLocation(
+            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/PlaceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/PlaceLocation.java
@@ -4,13 +4,14 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.type.Location;
 
 public final class PlaceLocation extends JsonMapLocation {
-    private PlaceLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    private PlaceLocation(
+            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/ServiceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/ServiceLocation.java
@@ -4,14 +4,15 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.Texture;
 import java.util.Arrays;
 
 public final class ServiceLocation extends JsonMapLocation {
-    public ServiceLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public ServiceLocation(
+            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/WaypointLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/WaypointLocation.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import java.util.Locale;
 
 public final class WaypointLocation extends JsonMapLocation {
-    public WaypointLocation(Location location, String label, String subcategory, JsonMapAttributes attributes) {
+    public WaypointLocation(Location location, String label, String subcategory, JsonMapLocationAttributes attributes) {
         super(
                 "waypoint" + "-" + label.toLowerCase(Locale.ROOT).replaceAll("\\s", "-") + "-" + location.hashCode(),
                 "wynntils:personal:waypoint" + (subcategory.isEmpty() ? "" : ":" + subcategory),

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
@@ -12,9 +12,9 @@ import com.wynntils.features.map.MinimapFeature;
 import com.wynntils.services.hades.HadesUser;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.services.hades.event.HadesUserEvent;
-import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.AbstractMapLocationAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.services.mapdata.type.MapLocation;
 import com.wynntils.utils.mc.SkinUtils;
@@ -98,8 +98,8 @@ public class PlayerProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
-            return Optional.of(new AbstractMapAttributes() {
+        public Optional<MapLocationAttributes> getAttributes() {
+            return Optional.of(new AbstractMapLocationAttributes() {
                 @Override
                 public Optional<String> getLabel() {
                     return Optional.of(hadesUser.getName());

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapArea.java
@@ -4,24 +4,24 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
-import com.wynntils.services.mapdata.type.MapLocation;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.type.MapArea;
 import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 
-public class JsonMapLocation implements MapLocation {
+public final class JsonMapArea implements MapArea {
     private final String featureId;
     private final String categoryId;
-    private final JsonMapLocationAttributes attributes;
-    private final Location location;
+    private final JsonMapAreaAttributes attributes;
+    private final List<Location> polygonArea;
 
-    public JsonMapLocation(
-            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
+    public JsonMapArea(
+            String featureId, String categoryId, JsonMapAreaAttributes attributes, List<Location> polygonArea) {
         this.featureId = featureId;
         this.categoryId = categoryId;
         this.attributes = attributes;
-        this.location = location;
+        this.polygonArea = polygonArea;
     }
 
     @Override
@@ -35,7 +35,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Optional<MapLocationAttributes> getAttributes() {
+    public Optional<MapAreaAttributes> getAttributes() {
         return Optional.ofNullable(attributes);
     }
 
@@ -45,7 +45,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Location getLocation() {
-        return location;
+    public List<Location> getPolygonArea() {
+        return polygonArea;
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAreaAttributes.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public final class JsonMapAreaAttributes extends JsonMapAttributes implements MapAreaAttributes {
+    public JsonMapAreaAttributes(
+            String label,
+            String icon,
+            int priority,
+            int level,
+            CustomColor labelColor,
+            TextShadow labelShadow,
+            JsonMapVisibility labelVisibility,
+            CustomColor iconColor,
+            JsonMapVisibility iconVisibility) {
+        super(label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
@@ -63,8 +63,36 @@ public class JsonMapAttributesBuilder {
         return this;
     }
 
-    public JsonMapAttributes build() {
-        return new JsonMapAttributes(
-                label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    public JsonMapLocationAttributesBuilder asLocationAttributes() {
+        return new JsonMapLocationAttributesBuilder();
+    }
+
+    public JsonMapPathAttributesBuilder asPathAttributes() {
+        return new JsonMapPathAttributesBuilder();
+    }
+
+    public JsonMapAreaAttributesBuilder asAreaAttributes() {
+        return new JsonMapAreaAttributesBuilder();
+    }
+
+    public final class JsonMapLocationAttributesBuilder extends JsonMapAttributesBuilder {
+        public JsonMapLocationAttributes build() {
+            return new JsonMapLocationAttributes(
+                    label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+        }
+    }
+
+    public final class JsonMapPathAttributesBuilder extends JsonMapAttributesBuilder {
+        public JsonMapPathAttributes build() {
+            return new JsonMapPathAttributes(
+                    label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+        }
+    }
+
+    public final class JsonMapAreaAttributesBuilder extends JsonMapAttributesBuilder {
+        public JsonMapAreaAttributes build() {
+            return new JsonMapAreaAttributes(
+                    label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapLocationAttributes.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public final class JsonMapLocationAttributes extends JsonMapAttributes implements MapLocationAttributes {
+    public JsonMapLocationAttributes(
+            String label,
+            String icon,
+            int priority,
+            int level,
+            CustomColor labelColor,
+            TextShadow labelShadow,
+            JsonMapVisibility labelVisibility,
+            CustomColor iconColor,
+            JsonMapVisibility iconVisibility) {
+        super(label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPath.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPath.java
@@ -4,24 +4,23 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
-import com.wynntils.services.mapdata.type.MapLocation;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+import com.wynntils.services.mapdata.type.MapPath;
 import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 
-public class JsonMapLocation implements MapLocation {
+public final class JsonMapPath implements MapPath {
     private final String featureId;
     private final String categoryId;
-    private final JsonMapLocationAttributes attributes;
-    private final Location location;
+    private final JsonMapPathAttributes attributes;
+    private final List<Location> path;
 
-    public JsonMapLocation(
-            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
+    public JsonMapPath(String featureId, String categoryId, JsonMapPathAttributes attributes, List<Location> path) {
         this.featureId = featureId;
         this.categoryId = categoryId;
         this.attributes = attributes;
-        this.location = location;
+        this.path = path;
     }
 
     @Override
@@ -35,7 +34,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Optional<MapLocationAttributes> getAttributes() {
+    public Optional<MapPathAttributes> getAttributes() {
         return Optional.ofNullable(attributes);
     }
 
@@ -45,7 +44,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Location getLocation() {
-        return location;
+    public List<Location> getPath() {
+        return path;
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPathAttributes.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public final class JsonMapPathAttributes extends JsonMapAttributes implements MapPathAttributes {
+    public JsonMapPathAttributes(
+            String label,
+            String icon,
+            int priority,
+            int level,
+            CustomColor labelColor,
+            TextShadow labelShadow,
+            JsonMapVisibility labelVisibility,
+            CustomColor iconColor,
+            JsonMapVisibility iconVisibility) {
+        super(label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapArea.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
 
-public interface MapArea extends MapFeature {
+public interface MapArea extends MapFeature<MapAreaAttributes> {
     // The area is described by a polygon. This list is the sequence of
     // vertices of that polygon, ordered in a counterclockwise orientation.
     // The last segment of the polygon connects from the last vertice to the first.

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
@@ -9,13 +9,13 @@ import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
 import java.util.Optional;
 
-public interface MapFeature extends MapDataProvidedType {
+public interface MapFeature<A extends MapAttributes> extends MapDataProvidedType {
     // The id should be unique, and track the provenance of the feature
     String getFeatureId();
 
     String getCategoryId();
 
-    Optional<MapAttributes> getAttributes();
+    Optional<A> getAttributes();
 
     boolean isVisible(BoundingShape boundingShape);
 

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapLocation.java
@@ -4,10 +4,11 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 
-public interface MapLocation extends MapFeature {
+public interface MapLocation extends MapFeature<MapLocationAttributes> {
     Location getLocation();
 
     @Override

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapPath.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapPath.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
 
-public interface MapPath extends MapFeature {
+public interface MapPath extends MapFeature<MapPathAttributes> {
     // The path is described by a sequence of locations
     List<Location> getPath();
 


### PR DESCRIPTION
I was not entirely happy with #2595, in particular how that lost the simple `attribute` json field.

This is another approach, basically what I wanted to do all along but for some reason did not fully figure out how to do earlier. 

The core idea here is that MapFeature's `getAttributes()` returns an `Optional<A>` where `<A extends MapLocation>`.

So we can then say e.g.:
```
public interface MapLocation extends MapFeature<MapLocationAttributes> 
```

to have the Java type system guarantee that all MapLocations have MapLocationAttributes.

The second part of getting consistency is making sure that json imported data is correct. I've added code to actually read in paths and areas now (previously we only had support for locations). This will verify that one and only one of the fields `location`, `path` or `area` is present, and then it will read the `attributes` tag as the corresponding MapAttributes subclass.

This will let the GSON framework parse the subclass-specific attributes correctly. 

However, you might ask, what if I add some attribute that is not valid for that type? Let's assume that MapAreaAttributes has an `areaColor`, and we set that on the attributes of a location? Then we will just ignore that. But that is just the way json works -- if there are unknown, extra tags, they are just ignored. So this is not anything special.

This will resolve #2582.