### PR TITLE
feat: Inverted attribute inheritance

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -18,8 +18,8 @@ import com.wynntils.services.map.pois.Poi;
 import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.features.WaypointLocation;
 import com.wynntils.services.mapdata.providers.builtin.MapIconsProvider;
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapAttributesBuilder;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapVisibility;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.utils.colors.CommonColors;
@@ -651,7 +651,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
         JsonMapVisibility iconVisibility =
                 new JsonMapVisibility(FixedMapVisibility.ICON_ALWAYS); // TODO: Add visibility input
 
-        JsonMapAttributes attributes = new JsonMapAttributesBuilder()
+        JsonMapLocationAttributes attributes = new JsonMapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(iconId)
                 .setPriority(priority)
@@ -660,6 +660,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
                 .setLabelVisibility(labelVisibility)
                 .setIconColor(iconColor)
                 .setIconVisibility(iconVisibility)
+                .asLocationAttributes()
                 .build();
 
         WaypointLocation waypoint = new WaypointLocation(location, label, subcategory, attributes);

--- a/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
@@ -18,8 +18,8 @@ import com.wynntils.services.mapdata.attributes.FixedMapVisibility;
 import com.wynntils.services.mapdata.attributes.type.MapVisibility;
 import com.wynntils.services.mapdata.features.WaypointLocation;
 import com.wynntils.services.mapdata.providers.builtin.MapIconsProvider;
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapAttributesBuilder;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapVisibility;
 import com.wynntils.utils.mc.type.Location;
 import java.util.ArrayList;
@@ -95,7 +95,7 @@ public class WaypointsService extends Service {
         String label = customPoi.getName();
         String subcategory = ""; // Subcategories did not use to exist
 
-        JsonMapAttributes attributes = new JsonMapAttributesBuilder()
+        JsonMapLocationAttributes attributes = new JsonMapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(MapIconsProvider.getIconIdFromTexture(customPoi.getIcon()))
                 .setIconColor(customPoi.getColor())
@@ -105,6 +105,7 @@ public class WaypointsService extends Service {
                             case ALWAYS -> FixedMapVisibility.ICON_ALWAYS;
                             case HIDDEN -> FixedMapVisibility.ICON_NEVER;
                         }))
+                .asLocationAttributes()
                 .build();
 
         WaypointLocation waypointLocation = new WaypointLocation(location, label, subcategory, attributes);

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapAreaAttributes.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes;
+
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+
+public abstract class AbstractMapAreaAttributes extends AbstractMapAttributes implements MapAreaAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapLocationAttributes.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes;
+
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+
+public abstract class AbstractMapLocationAttributes extends AbstractMapAttributes implements MapLocationAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/AbstractMapPathAttributes.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes;
+
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+
+public abstract class AbstractMapPathAttributes extends AbstractMapAttributes implements MapPathAttributes {}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+import java.util.List;
+
+public interface MapAreaAttributes extends MapAttributes {
+    static List<String> getUnsupportedAttributes() {
+        return List.of();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+import java.util.List;
+
+public interface MapLocationAttributes extends MapAttributes {
+    static List<String> getUnsupportedAttributes() {
+        return List.of();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.type;
+
+import com.wynntils.utils.colors.CustomColor;
+import java.util.List;
+import java.util.Optional;
+
+public interface MapPathAttributes extends MapAttributes {
+    static List<String> getUnsupportedAttributes() {
+        return List.of("iconId", "iconVisibility", "iconColor", "iconDecoration");
+    }
+
+    default Optional<String> getIconId() {
+        return Optional.empty();
+    }
+
+    default Optional<MapVisibility> getIconVisibility() {
+        return Optional.empty();
+    }
+
+    default Optional<CustomColor> getIconColor() {
+        return Optional.empty();
+    }
+
+    default Optional<MapDecoration> getIconDecoration() {
+        return Optional.empty();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/features/CombatLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/CombatLocation.java
@@ -4,14 +4,15 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.Texture;
 import java.util.Arrays;
 
 public final class CombatLocation extends JsonMapLocation {
-    public CombatLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public CombatLocation(
+            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/PlaceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/PlaceLocation.java
@@ -4,13 +4,14 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.type.Location;
 
 public final class PlaceLocation extends JsonMapLocation {
-    private PlaceLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    private PlaceLocation(
+            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/ServiceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/ServiceLocation.java
@@ -4,14 +4,15 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.Texture;
 import java.util.Arrays;
 
 public final class ServiceLocation extends JsonMapLocation {
-    public ServiceLocation(String featureId, String categoryId, JsonMapAttributes attributes, Location location) {
+    public ServiceLocation(
+            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
         super(featureId, categoryId, attributes, location);
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/features/WaypointLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/WaypointLocation.java
@@ -4,13 +4,13 @@
  */
 package com.wynntils.services.mapdata.features;
 
-import com.wynntils.services.mapdata.providers.json.JsonMapAttributes;
 import com.wynntils.services.mapdata.providers.json.JsonMapLocation;
+import com.wynntils.services.mapdata.providers.json.JsonMapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import java.util.Locale;
 
 public final class WaypointLocation extends JsonMapLocation {
-    public WaypointLocation(Location location, String label, String subcategory, JsonMapAttributes attributes) {
+    public WaypointLocation(Location location, String label, String subcategory, JsonMapLocationAttributes attributes) {
         super(
                 "waypoint" + "-" + label.toLowerCase(Locale.ROOT).replaceAll("\\s", "-") + "-" + location.hashCode(),
                 "wynntils:personal:waypoint" + (subcategory.isEmpty() ? "" : ":" + subcategory),

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
@@ -12,9 +12,9 @@ import com.wynntils.features.map.MinimapFeature;
 import com.wynntils.services.hades.HadesUser;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.services.hades.event.HadesUserEvent;
-import com.wynntils.services.mapdata.attributes.AbstractMapAttributes;
-import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.AbstractMapLocationAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.services.mapdata.type.MapFeature;
 import com.wynntils.services.mapdata.type.MapLocation;
 import com.wynntils.utils.mc.SkinUtils;
@@ -98,8 +98,8 @@ public class PlayerProvider extends BuiltInProvider {
         }
 
         @Override
-        public Optional<MapAttributes> getAttributes() {
-            return Optional.of(new AbstractMapAttributes() {
+        public Optional<MapLocationAttributes> getAttributes() {
+            return Optional.of(new AbstractMapLocationAttributes() {
                 @Override
                 public Optional<String> getLabel() {
                     return Optional.of(hadesUser.getName());

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapArea.java
@@ -4,24 +4,24 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
-import com.wynntils.services.mapdata.type.MapLocation;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.type.MapArea;
 import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 
-public class JsonMapLocation implements MapLocation {
+public final class JsonMapArea implements MapArea {
     private final String featureId;
     private final String categoryId;
-    private final JsonMapLocationAttributes attributes;
-    private final Location location;
+    private final JsonMapAreaAttributes attributes;
+    private final List<Location> polygonArea;
 
-    public JsonMapLocation(
-            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
+    public JsonMapArea(
+            String featureId, String categoryId, JsonMapAreaAttributes attributes, List<Location> polygonArea) {
         this.featureId = featureId;
         this.categoryId = categoryId;
         this.attributes = attributes;
-        this.location = location;
+        this.polygonArea = polygonArea;
     }
 
     @Override
@@ -35,7 +35,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Optional<MapLocationAttributes> getAttributes() {
+    public Optional<MapAreaAttributes> getAttributes() {
         return Optional.ofNullable(attributes);
     }
 
@@ -45,7 +45,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Location getLocation() {
-        return location;
+    public List<Location> getPolygonArea() {
+        return polygonArea;
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAreaAttributes.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public final class JsonMapAreaAttributes extends JsonMapAttributes implements MapAreaAttributes {
+    public JsonMapAreaAttributes(
+            String label,
+            String icon,
+            int priority,
+            int level,
+            CustomColor labelColor,
+            TextShadow labelShadow,
+            JsonMapVisibility labelVisibility,
+            CustomColor iconColor,
+            JsonMapVisibility iconVisibility) {
+        super(label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
@@ -4,8 +4,13 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.type.TextShadow;
+import java.lang.reflect.Field;
 
 public class JsonMapAttributesBuilder {
     private String label;
@@ -63,8 +68,56 @@ public class JsonMapAttributesBuilder {
         return this;
     }
 
-    public JsonMapAttributes build() {
-        return new JsonMapAttributes(
-                label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    public JsonMapLocationAttributesBuilder asLocationAttributes() {
+        return new JsonMapLocationAttributesBuilder();
+    }
+
+    public JsonMapPathAttributesBuilder asPathAttributes() {
+        return new JsonMapPathAttributesBuilder();
+    }
+
+    public JsonMapAreaAttributesBuilder asAreaAttributes() {
+        return new JsonMapAreaAttributesBuilder();
+    }
+
+    protected void checkInvalidAttribute(String fieldName) {
+        if (!WynntilsMod.isDevelopmentBuild()) return;
+
+        try {
+            // Use reflection to get our field given by the name
+            Field field = JsonMapAttributesBuilder.class.getDeclaredField(fieldName);
+            if (field.get(this) != null) {
+                throw new IllegalStateException("Unsupported attribute set: " + fieldName);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Silently ignore invalid field checks
+        }
+    }
+
+    public final class JsonMapLocationAttributesBuilder extends JsonMapAttributesBuilder {
+        public JsonMapLocationAttributes build() {
+            MapLocationAttributes.getUnsupportedAttributes().forEach(this::checkInvalidAttribute);
+
+            return new JsonMapLocationAttributes(
+                    label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+        }
+    }
+
+    public final class JsonMapPathAttributesBuilder extends JsonMapAttributesBuilder {
+        public JsonMapPathAttributes build() {
+            MapPathAttributes.getUnsupportedAttributes().forEach(this::checkInvalidAttribute);
+
+            return new JsonMapPathAttributes(
+                    label, priority, level, labelColor, labelShadow, labelVisibility);
+        }
+    }
+
+    public final class JsonMapAreaAttributesBuilder extends JsonMapAttributesBuilder {
+        public JsonMapAreaAttributes build() {
+            MapAreaAttributes.getUnsupportedAttributes().forEach(this::checkInvalidAttribute);
+
+            return new JsonMapAreaAttributes(
+                    label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapAttributesBuilder.java
@@ -107,8 +107,7 @@ public class JsonMapAttributesBuilder {
         public JsonMapPathAttributes build() {
             MapPathAttributes.getUnsupportedAttributes().forEach(this::checkInvalidAttribute);
 
-            return new JsonMapPathAttributes(
-                    label, priority, level, labelColor, labelShadow, labelVisibility);
+            return new JsonMapPathAttributes(label, priority, level, labelColor, labelShadow, labelVisibility);
         }
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapLocationAttributes.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public final class JsonMapLocationAttributes extends JsonMapAttributes implements MapLocationAttributes {
+    public JsonMapLocationAttributes(
+            String label,
+            String icon,
+            int priority,
+            int level,
+            CustomColor labelColor,
+            TextShadow labelShadow,
+            JsonMapVisibility labelVisibility,
+            CustomColor iconColor,
+            JsonMapVisibility iconVisibility) {
+        super(label, icon, priority, level, labelColor, labelShadow, labelVisibility, iconColor, iconVisibility);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPath.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPath.java
@@ -4,24 +4,23 @@
  */
 package com.wynntils.services.mapdata.providers.json;
 
-import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
-import com.wynntils.services.mapdata.type.MapLocation;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+import com.wynntils.services.mapdata.type.MapPath;
 import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 
-public class JsonMapLocation implements MapLocation {
+public final class JsonMapPath implements MapPath {
     private final String featureId;
     private final String categoryId;
-    private final JsonMapLocationAttributes attributes;
-    private final Location location;
+    private final JsonMapPathAttributes attributes;
+    private final List<Location> path;
 
-    public JsonMapLocation(
-            String featureId, String categoryId, JsonMapLocationAttributes attributes, Location location) {
+    public JsonMapPath(String featureId, String categoryId, JsonMapPathAttributes attributes, List<Location> path) {
         this.featureId = featureId;
         this.categoryId = categoryId;
         this.attributes = attributes;
-        this.location = location;
+        this.path = path;
     }
 
     @Override
@@ -35,7 +34,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Optional<MapLocationAttributes> getAttributes() {
+    public Optional<MapPathAttributes> getAttributes() {
         return Optional.ofNullable(attributes);
     }
 
@@ -45,7 +44,7 @@ public class JsonMapLocation implements MapLocation {
     }
 
     @Override
-    public Location getLocation() {
-        return location;
+    public List<Location> getPath() {
+        return path;
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonMapPathAttributes.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.json;
+
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+
+public final class JsonMapPathAttributes extends JsonMapAttributes implements MapPathAttributes {
+    public JsonMapPathAttributes(
+            String label,
+            int priority,
+            int level,
+            CustomColor labelColor,
+            TextShadow labelShadow,
+            JsonMapVisibility labelVisibility) {
+        super(label, null, priority, level, labelColor, labelShadow, labelVisibility, null, null);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
@@ -11,11 +11,15 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.MalformedJsonException;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.net.Download;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapIcon;
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.services.mapdata.providers.MapDataProvider;
 import com.wynntils.services.mapdata.type.MapCategory;
 import com.wynntils.services.mapdata.type.MapDataProvidedType;
@@ -191,12 +195,67 @@ public final class JsonProvider implements MapDataProvider {
             String id = JsonUtils.getNullableJsonString(json, "id");
             String category = JsonUtils.getNullableJsonString(json, "category");
             JsonElement locationJson = json.get("location");
-            Location location = GSON.fromJson(locationJson, Location.class);
-            JsonElement attributesJson = json.get("attributes");
-            JsonMapAttributes attributes =
-                    attributesJson == null ? null : GSON.fromJson(attributesJson, JsonMapAttributes.class);
+            JsonElement pathJson = json.get("path");
+            JsonElement areaJson = json.get("area");
 
-            return new JsonMapLocation(id, category, attributes, location);
+            if (locationJson != null) {
+                if (pathJson != null || areaJson != null) {
+                    throw new JsonParseException("Feature can only have one of location, path or area");
+                }
+
+                Location location = GSON.fromJson(locationJson, Location.class);
+                JsonElement attributesJson = json.get("attributes");
+                JsonMapLocationAttributes attributes =
+                        attributesJson == null ? null : GSON.fromJson(attributesJson, JsonMapLocationAttributes.class);
+
+                MapLocationAttributes.getUnsupportedAttributes().forEach(invalidAttribute -> {
+                    if (attributesJson.getAsJsonObject().has(invalidAttribute)) {
+                        WynntilsMod.warn("Unsupported attribute set for location: " + invalidAttribute);
+                    }
+                });
+
+                return new JsonMapLocation(id, category, attributes, location);
+            }
+
+            if (pathJson != null) {
+                if (areaJson != null) {
+                    throw new JsonParseException("Feature can only have one of location, path or area");
+                }
+
+                Type type = new TypeToken<List<Location>>() {}.getType();
+                List<Location> path = GSON.fromJson(pathJson, type);
+                JsonElement attributesJson = json.get("attributes");
+
+                JsonMapPathAttributes attributes =
+                        attributesJson == null ? null : GSON.fromJson(attributesJson, JsonMapPathAttributes.class);
+
+                MapPathAttributes.getUnsupportedAttributes().forEach(invalidAttribute -> {
+                    if (attributesJson.getAsJsonObject().has(invalidAttribute)) {
+                        WynntilsMod.warn("Unsupported attribute set for path: " + invalidAttribute);
+                    }
+                });
+
+                return new JsonMapPath(id, category, attributes, path);
+            }
+
+            if (areaJson != null) {
+                Type type = new TypeToken<List<Location>>() {}.getType();
+                List<Location> path = GSON.fromJson(pathJson, type);
+                List<Location> polygonArea = GSON.fromJson(pathJson, type);
+                JsonElement attributesJson = json.get("attributes");
+                JsonMapAreaAttributes attributes =
+                        attributesJson == null ? null : GSON.fromJson(attributesJson, JsonMapAreaAttributes.class);
+
+                MapAreaAttributes.getUnsupportedAttributes().forEach(invalidAttribute -> {
+                    if (attributesJson.getAsJsonObject().has(invalidAttribute)) {
+                        WynntilsMod.warn("Unsupported attribute set for area: " + invalidAttribute);
+                    }
+                });
+
+                return new JsonMapArea(id, category, attributes, polygonArea);
+            }
+
+            throw new JsonParseException("Feature neither has location, path nor area");
         }
     }
 

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapArea.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
 
-public interface MapArea extends MapFeature {
+public interface MapArea extends MapFeature<MapAreaAttributes> {
     // The area is described by a polygon. This list is the sequence of
     // vertices of that polygon, ordered in a counterclockwise orientation.
     // The last segment of the polygon connects from the last vertice to the first.

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapFeature.java
@@ -9,13 +9,13 @@ import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
 import java.util.Optional;
 
-public interface MapFeature extends MapDataProvidedType {
+public interface MapFeature<A extends MapAttributes> extends MapDataProvidedType {
     // The id should be unique, and track the provenance of the feature
     String getFeatureId();
 
     String getCategoryId();
 
-    Optional<MapAttributes> getAttributes();
+    Optional<A> getAttributes();
 
     boolean isVisible(BoundingShape boundingShape);
 

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapLocation.java
@@ -4,10 +4,11 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 
-public interface MapLocation extends MapFeature {
+public interface MapLocation extends MapFeature<MapLocationAttributes> {
     Location getLocation();
 
     @Override

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapPath.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapPath.java
@@ -4,11 +4,12 @@
  */
 package com.wynntils.services.mapdata.type;
 
+import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.BoundingShape;
 import java.util.List;
 
-public interface MapPath extends MapFeature {
+public interface MapPath extends MapFeature<MapPathAttributes> {
     // The path is described by a sequence of locations
     List<Location> getPath();
 


### PR DESCRIPTION
So, I turned this on its head instead.

Now I assume that a MapAttribute can hold any possible attribute, even if it is not applicable in a specific case. That is the only way we can design general enough categories -- a single category must be able to apply to all of the three mapfeature types, even if not every attribute applies to every type.

So instead I let the three subclasses of MapAttribute "block" the attributes that are not relevant for them. There is no way to fully protect against this, but I check three places:

1) In the code, I still use the MapAttribute hierarchy, where the specific Map<Type>Attribute classes defaults to noop implementations for unsupported attributes. (Currently I only disabled icon for paths; when we want to add e.g. Marker attributes to locations, we'll have to add them to the MapAttribute top class, and then disable them for area and path, etc).

2) When using the Builder, I verify that we do not set invalid attributes. This is checked only for development builds.

3) When reading json files, I verify that it does not set invalid attributes. (The error handling here probably needs some additional tweaking -- should this be propagated to the user, and if so, how?)

This PR supersedes #2595, completely replaces #2929, and intends to solve #2582.