### PR TITLE
feat: Add commands for adding/removing online/local providers, and reordering providers

### DIFF
--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
@@ -118,8 +118,8 @@ public final class JsonProvider implements MapDataProvider {
      * @param url The url to load
      * @param registerCallback The callback to call with the loaded provider
      */
-    public static void loadOnlineResource(String id, String url, BiConsumer<String, MapDataProvider> registerCallback) {
-        Download dl = Managers.Net.download(URI.create(url), id);
+    public static void loadOnlineResource(String id, URI url, BiConsumer<String, MapDataProvider> registerCallback) {
+        Download dl = Managers.Net.download(url, id);
         dl.handleReader(
                 reader -> {
                     try {


### PR DESCRIPTION
I'm not sure how much work we need to do here for the initial implementation. It might be that it is enough to just support local providers. Doing this properly will definitely need some work. 

Doing it properly, for me, means:

1) The ordering of providers is important. We need a GUI to be able to reorder providers. For instance, a specific URL could be intended to override build-in providers (to give another look&feel to the map), or it could be intended to just complement it, and should come after the built-in providers in the order. This order also needs to be persisted.

2) When adding a URL, I think it makes sense to either download the URL once, as a snapshot, and then just keep it local, or to "subscribe" to it, and regularly re-download it. For instance, that way you can subscribe to a mapdata provider that gives the location of daily treasure hunt targets, etc. It is not clear how often such refreshing should happen. Maybe we should only have a single type (instead of a "static download" vs "subscription"), and just have a manual "refresh" button for each URL? Or you can give a suggested refresh interval when adding the URL? Given that you accept the overhead, having like a refresh interval of 1 minute or so could be used to give an almost live up to date position of another player or whatsnot.

3) We should also be able to add local files that can be treated as additional providers. Either by some special "upload" command/GUI, or by just placing the json files in the proper directory. Just line online sources, they need an ordering, but they will not need updating.