### PR TITLE
fix: Always remove encoded crafted item names and don't use plain-text name data if an illegal character is detected for chat encoded items

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/encoding/ItemTransformerRegistry.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/ItemTransformerRegistry.java
@@ -93,12 +93,14 @@ public final class ItemTransformerRegistry {
         TypeData typeData = typeDataOpt.get();
         ItemTransformer<WynnItem> transformer = itemTransformers.get(typeData.itemType());
 
-        // Override the name block if we have a clear-chat name
+        // Don't use the name block for crafted gear and consumables
         // This is used for crafted gear and consumables, so that "bad" names can't be injected into the item
-        if (itemName != null
-                && (typeData.itemType() == ItemType.CRAFTED_GEAR
-                        || typeData.itemType() == ItemType.CRAFTED_CONSUMABLE)) {
+        if (typeData.itemType() == ItemType.CRAFTED_GEAR || typeData.itemType() == ItemType.CRAFTED_CONSUMABLE) {
             itemData.removeIf(data -> data instanceof NameData);
+        }
+
+        // Override the name block if we have a clear-chat name
+        if (itemName != null) {
             itemData.add(NameData.from(itemName));
         }
 

--- a/common/src/main/java/com/wynntils/models/items/encoding/ItemTransformerRegistry.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/ItemTransformerRegistry.java
@@ -101,7 +101,7 @@ public final class ItemTransformerRegistry {
 
         // Override the name block if we have a clear-chat name
         if (itemName != null) {
-            itemData.add(NameData.from(itemName));
+            itemData.add(NameData.sanitized(itemName));
         }
 
         try {

--- a/common/src/main/java/com/wynntils/models/items/encoding/data/NameData.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/data/NameData.java
@@ -6,22 +6,42 @@ package com.wynntils.models.items.encoding.data;
 
 import com.wynntils.models.items.encoding.type.ItemData;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
-public record NameData(String name) implements ItemData {
+public record NameData(Optional<String> name) implements ItemData {
+    public static final NameData EMPTY = new NameData(Optional.empty());
+
     private static final int MAX_NAME_LENGTH = 48;
     private static final Pattern SANITIZE_PATTERN = Pattern.compile("[^a-zA-Z0-9'\\s]");
 
-    public static NameData from(IdentifiableItemProperty property) {
-        return NameData.from(property.getName());
+    /**
+     * Creates a new {@link NameData} object with the given name.
+     * The name is obtained from the given {@link IdentifiableItemProperty}, and we assume it is safe.
+     *
+     * @param property the property to get the name from
+     * @return a new {@link NameData} object with the given name
+     */
+    public static NameData fromSafeName(IdentifiableItemProperty property) {
+        return new NameData(Optional.ofNullable(property.getName()));
     }
 
-    public static NameData from(String name) {
-        name = SANITIZE_PATTERN.matcher(name).replaceAll("");
+    /**
+     * Sanitizes the given name.
+     * If any characters are not alphanumeric, an apostrophe, or a space, the name is sanitized, and is not displayed.
+     * The name is trimmed, and any consecutive spaces are replaced with a single space.
+     * @param name the name to sanitize
+     * @return an {@link Optional} containing the sanitized name, or an empty {@link Optional} if the name is empty
+     */
+    public static NameData sanitized(String name) {
+        if (SANITIZE_PATTERN.matcher(name).find()) {
+            return EMPTY;
+        }
+
         name = name.trim();
         name = name.replaceAll("\\s+", " ");
         name = name.substring(0, Math.min(name.length(), MAX_NAME_LENGTH));
 
-        return new NameData(name);
+        return new NameData(Optional.of(name));
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/NameDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/NameDataTransformer.java
@@ -19,7 +19,7 @@ public class NameDataTransformer extends DataTransformer<NameData> {
     @Override
     public ErrorOr<UnsignedByte[]> encodeData(ItemTransformingVersion version, NameData data) {
         return switch (version) {
-            case VERSION_1 -> encodeName(data.name());
+            case VERSION_1 -> encodeName(data.name().orElse(""));
         };
     }
 
@@ -52,7 +52,7 @@ public class NameDataTransformer extends DataTransformer<NameData> {
             return ErrorOr.error("Name data is not null terminated");
         }
 
-        return ErrorOr.of(NameData.from(UnsignedByteUtils.decodeString(bytes)));
+        return ErrorOr.of(NameData.sanitized(UnsignedByteUtils.decodeString(bytes)));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CharmItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CharmItemTransformer.java
@@ -31,7 +31,8 @@ public class CharmItemTransformer extends ItemTransformer<CharmItem> {
             return ErrorOr.error("Charm item does not have name data!");
         }
 
-        CharmInfo charmInfo = Models.Rewards.getCharmInfoFromDisplayName(nameData.name());
+        CharmInfo charmInfo =
+                Models.Rewards.getCharmInfoFromDisplayName(nameData.name().orElse(""));
         if (charmInfo == null) {
             return ErrorOr.error("Unknown charm item: " + nameData.name());
         }
@@ -58,7 +59,7 @@ public class CharmItemTransformer extends ItemTransformer<CharmItem> {
     protected List<ItemData> encodeItem(CharmItem item, EncodingSettings encodingSettings) {
         List<ItemData> dataList = new ArrayList<>();
 
-        dataList.add(NameData.from(item));
+        dataList.add(NameData.fromSafeName(item));
         dataList.add(IdentificationData.from(item, encodingSettings.extendedIdentificationEncoding()));
         dataList.add(RerollData.from(item));
 

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
@@ -64,8 +64,8 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
         //           input sanitization issues.
         //           The name data present here is from plain-text string shared after the encoded item.
         NameData nameData = itemDataMap.get(NameData.class);
-        if (nameData != null) {
-            name = nameData.name();
+        if (nameData != null && nameData.name().isPresent()) {
+            name = nameData.name().get();
         } else {
             name = "Crafted "
                     + StringUtils.capitalizeFirst(consumableType.name().toLowerCase(Locale.ROOT));
@@ -101,7 +101,7 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
                 new GearRequirements(item.getLevel(), Optional.empty(), List.of(), Optional.empty())));
 
         if (encodingSettings.shareItemName()) {
-            dataList.add(NameData.from(item.getName()));
+            dataList.add(NameData.sanitized(item.getName()));
         }
 
         dataList.add(new EffectsData(item.getNamedEffects()));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -77,8 +77,8 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
         //           input sanitization issues.
         //           The name data present here is from plain-text string shared after the encoded item.
         NameData nameData = itemDataMap.get(NameData.class);
-        if (nameData != null) {
-            name = nameData.name();
+        if (nameData != null && nameData.name().isPresent()) {
+            name = nameData.name().get();
         } else {
             name = "Crafted "
                     + StringUtils.capitalizeFirst(gearTypeData.gearType().name().toLowerCase(Locale.ROOT));
@@ -144,7 +144,7 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
 
         // Optional blocks
         if (encodingSettings.shareItemName()) {
-            dataList.add(NameData.from(item.getName()));
+            dataList.add(NameData.sanitized(item.getName()));
         }
 
         dataList.add(new DamageData(item.getAttackSpeed(), item.getDamages()));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/GearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/GearItemTransformer.java
@@ -37,7 +37,8 @@ public class GearItemTransformer extends ItemTransformer<GearItem> {
             return ErrorOr.error("Gear item does not have name data!");
         }
 
-        GearInfo gearInfo = Models.Gear.getGearInfoFromDisplayName(nameData.name());
+        GearInfo gearInfo =
+                Models.Gear.getGearInfoFromDisplayName(nameData.name().orElse(""));
         if (gearInfo == null) {
             return ErrorOr.error("Unknown gear item: " + nameData.name());
         }
@@ -78,7 +79,7 @@ public class GearItemTransformer extends ItemTransformer<GearItem> {
     public List<ItemData> encodeItem(GearItem item, EncodingSettings encodingSettings) {
         List<ItemData> dataList = new ArrayList<>();
 
-        dataList.add(NameData.from(item));
+        dataList.add(NameData.fromSafeName(item));
         dataList.add(IdentificationData.from(item, encodingSettings.extendedIdentificationEncoding()));
         dataList.add(PowderData.from(item));
         dataList.add(RerollData.from(item));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/TomeItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/TomeItemTransformer.java
@@ -31,7 +31,8 @@ public class TomeItemTransformer extends ItemTransformer<TomeItem> {
             return ErrorOr.error("Tome item does not have name data!");
         }
 
-        TomeInfo tomeInfo = Models.Rewards.getTomeInfoFromDisplayName(nameData.name());
+        TomeInfo tomeInfo =
+                Models.Rewards.getTomeInfoFromDisplayName(nameData.name().orElse(""));
         if (tomeInfo == null) {
             return ErrorOr.error("Unknown tome item: " + nameData.name());
         }
@@ -58,7 +59,7 @@ public class TomeItemTransformer extends ItemTransformer<TomeItem> {
     protected List<ItemData> encodeItem(TomeItem item, EncodingSettings encodingSettings) {
         List<ItemData> dataList = new ArrayList<>();
 
-        dataList.add(NameData.from(item));
+        dataList.add(NameData.fromSafeName(item));
         dataList.add(IdentificationData.from(item, encodingSettings.extendedIdentificationEncoding()));
         dataList.add(RerollData.from(item));
 


### PR DESCRIPTION
The first commit fixes incorrect logic from my last PR. The second commit fixes a possible breach of the Wynn filter, for example "b-a-d w-o-r-d" would not be filtered by Wynn, and after our sanitization, we displayed "bad word" as the name. Now, if we detect any illegal characters, we discard the whole name.