### PR TITLE
fix: Fix item sharing not working in certain cases

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/encoding/ItemTransformerRegistry.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/ItemTransformerRegistry.java
@@ -97,11 +97,11 @@ public final class ItemTransformerRegistry {
         // This is used for crafted gear and consumables, so that "bad" names can't be injected into the item
         if (typeData.itemType() == ItemType.CRAFTED_GEAR || typeData.itemType() == ItemType.CRAFTED_CONSUMABLE) {
             itemData.removeIf(data -> data instanceof NameData);
-        }
 
-        // Override the name block if we have a clear-chat name
-        if (itemName != null) {
-            itemData.add(NameData.sanitized(itemName));
+            // Override the name block if we have a clear-chat name
+            if (itemName != null) {
+                itemData.add(NameData.sanitized(itemName));
+            }
         }
 
         try {


### PR DESCRIPTION
Only need to add the NameData if it was removed otherwise you get `Duplicate key class com.wynntils.models.items.encoding.data.NameData (attempted merging values NameData[name=Optional[Monster]] and NameData[name=Optional[Monster]])`