### PR TITLE
fix: Correct RegEx used to find overall progress [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -81,8 +81,7 @@ public final class ActivityModel extends Model {
     private static final Pattern REWARD_HEADER_PATTERN = Pattern.compile("^\uDB00\uDC0E§dRewards:$");
     private static final Pattern REWARD_PATTERN = Pattern.compile("^§d\uDB00\uDC04(?<newline>- )?§7\\+?(?<reward>.+)$");
     private static final Pattern TRACKING_PATTERN = Pattern.compile("^.*§(?:#.{8}|.)§lCLICK TO (UN)?TRACK$");
-    private static final Pattern OVERALL_PROGRESS_PATTERN =
-            Pattern.compile("^\uDB00\uDC1F*§7(\\d+) of (\\d+) completed$");
+    private static final Pattern OVERALL_PROGRESS_PATTERN = Pattern.compile("^\\S*§7(\\d+) of (\\d+) completed$");
 
     private static final ScoreboardPart TRACKER_SCOREBOARD_PART = new ActivityTrackerScoreboardPart();
     private static final ContentBookQueries CONTAINER_QUERIES = new ContentBookQueries();


### PR DESCRIPTION
The "Progress" tracker on the right side of the Wynntils Content Book was always showing "100% [0/0]":
![image](https://github.com/user-attachments/assets/6ed16b03-7920-42a9-9296-f3b48b3b6c57)

This is now fixed:
![image](https://github.com/user-attachments/assets/a3866f9c-293a-4e11-8d0a-6e3b854df212)

---

I'm not *entirely* happy with skipping all non-whitespace characters until we get to the progress info bit of the string, but I couldn't get the actual bytes being sent (which seem to be `F39080A2C2`) to be detected properly.