### PR TITLE
fix: Fix trade market conversion when quick search hide prompt option is enabled [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketQuickSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketQuickSearchFeature.java
@@ -134,7 +134,8 @@ public class TradeMarketQuickSearchFeature extends Feature {
         }
     }
 
-    @SubscribeEvent
+    // Lower priority so features such as TradeMarketPriceConversionFeature won't have the messaged be cancelled
+    @SubscribeEvent(priority = EventPriority.LOW)
     public void onChatMessageReceive(ChatMessageReceivedEvent event) {
         if (!Models.WorldState.onWorld()) return;
 


### PR DESCRIPTION
I thought this was done in the quick search pr but guess not