### PR TITLE
fix: Block marker options from paths and areas, refactor how "blocking" works

### DIFF
--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAreaAttributes.java
@@ -5,5 +5,35 @@
 package com.wynntils.services.mapdata.attributes.impl;
 
 import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapMarkerOptions;
+import com.wynntils.services.mapdata.attributes.type.MapVisibility;
+import com.wynntils.utils.colors.CustomColor;
+import java.util.Optional;
 
-public abstract class AbstractMapAreaAttributes extends AbstractMapAttributes implements MapAreaAttributes {}
+public abstract class AbstractMapAreaAttributes extends AbstractMapAttributes implements MapAreaAttributes {
+    @Override
+    public final Optional<String> getIconId() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<CustomColor> getIconColor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<MapVisibility> getIconVisibility() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<MapDecoration> getIconDecoration() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<MapMarkerOptions> getMarkerOptions() {
+        return Optional.empty();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapLocationAttributes.java
@@ -5,5 +5,22 @@
 package com.wynntils.services.mapdata.attributes.impl;
 
 import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
+import com.wynntils.utils.colors.CustomColor;
+import java.util.Optional;
 
-public abstract class AbstractMapLocationAttributes extends AbstractMapAttributes implements MapLocationAttributes {}
+public abstract class AbstractMapLocationAttributes extends AbstractMapAttributes implements MapLocationAttributes {
+    @Override
+    public final Optional<CustomColor> getFillColor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<CustomColor> getBorderColor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<Float> getBorderWidth() {
+        return Optional.empty();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapPathAttributes.java
@@ -4,6 +4,51 @@
  */
 package com.wynntils.services.mapdata.attributes.impl;
 
+import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapMarkerOptions;
 import com.wynntils.services.mapdata.attributes.type.MapPathAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapVisibility;
+import com.wynntils.utils.colors.CustomColor;
+import java.util.Optional;
 
-public abstract class AbstractMapPathAttributes extends AbstractMapAttributes implements MapPathAttributes {}
+public abstract class AbstractMapPathAttributes extends AbstractMapAttributes implements MapPathAttributes {
+    @Override
+    public final Optional<String> getIconId() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<MapVisibility> getIconVisibility() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<CustomColor> getIconColor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<MapDecoration> getIconDecoration() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<MapMarkerOptions> getMarkerOptions() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<CustomColor> getFillColor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<CustomColor> getBorderColor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<Float> getBorderWidth() {
+        return Optional.empty();
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
@@ -4,28 +4,10 @@
  */
 package com.wynntils.services.mapdata.attributes.type;
 
-import com.wynntils.utils.colors.CustomColor;
 import java.util.List;
-import java.util.Optional;
 
 public interface MapAreaAttributes extends MapAttributes {
     static List<String> getUnsupportedAttributes() {
-        return List.of("iconId", "iconVisibility", "iconColor", "iconDecoration");
-    }
-
-    default Optional<String> getIconId() {
-        return Optional.empty();
-    }
-
-    default Optional<MapVisibility> getIconVisibility() {
-        return Optional.empty();
-    }
-
-    default Optional<CustomColor> getIconColor() {
-        return Optional.empty();
-    }
-
-    default Optional<MapDecoration> getIconDecoration() {
-        return Optional.empty();
+        return List.of("iconId", "iconVisibility", "iconColor", "iconDecoration", "markerOptions");
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
@@ -4,24 +4,10 @@
  */
 package com.wynntils.services.mapdata.attributes.type;
 
-import com.wynntils.utils.colors.CustomColor;
 import java.util.List;
-import java.util.Optional;
 
 public interface MapLocationAttributes extends MapAttributes {
     static List<String> getUnsupportedAttributes() {
         return List.of("fillColor", "borderWidth", "borderColor");
-    }
-
-    default Optional<CustomColor> getFillColor() {
-        return Optional.empty();
-    }
-
-    default Optional<CustomColor> getBorderColor() {
-        return Optional.empty();
-    }
-
-    default Optional<Float> getBorderWidth() {
-        return Optional.empty();
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
@@ -4,41 +4,18 @@
  */
 package com.wynntils.services.mapdata.attributes.type;
 
-import com.wynntils.utils.colors.CustomColor;
 import java.util.List;
-import java.util.Optional;
 
 public interface MapPathAttributes extends MapAttributes {
     static List<String> getUnsupportedAttributes() {
         return List.of(
-                "iconId", "iconVisibility", "iconColor", "iconDecoration", "fillColor", "borderWidth", "borderColor");
-    }
-
-    default Optional<String> getIconId() {
-        return Optional.empty();
-    }
-
-    default Optional<MapVisibility> getIconVisibility() {
-        return Optional.empty();
-    }
-
-    default Optional<CustomColor> getIconColor() {
-        return Optional.empty();
-    }
-
-    default Optional<MapDecoration> getIconDecoration() {
-        return Optional.empty();
-    }
-
-    default Optional<CustomColor> getFillColor() {
-        return Optional.empty();
-    }
-
-    default Optional<CustomColor> getBorderColor() {
-        return Optional.empty();
-    }
-
-    default Optional<Float> getBorderWidth() {
-        return Optional.empty();
+                "iconId",
+                "iconVisibility",
+                "iconColor",
+                "iconDecoration",
+                "markerOptions",
+                "fillColor",
+                "borderWidth",
+                "borderColor");
     }
 }


### PR DESCRIPTION
This way, we can't actually override these methods in the abstract classes, so the compiler blocks "wrong" overrides, and our IDEs work better with the blocking.