### PR TITLE
fix: Update shaman masks & parsing [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/abilities/ShamanMaskModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShamanMaskModel.java
@@ -35,6 +35,8 @@ public final class ShamanMaskModel extends Model {
 
     @SubscribeEvent
     public void onTitle(TitleSetTextEvent event) {
+        if (currentMaskType == ShamanMaskType.AWAKENED) return;
+
         StyledText title = StyledText.fromComponent(event.getComponent());
 
         if (title.matches(AWAKENED_PATTERN)) {
@@ -55,6 +57,9 @@ public final class ShamanMaskModel extends Model {
 
         if (title.contains("Mask of the ") || title.contains("➤")) {
             parseMask(title);
+
+            if (currentMaskType == null) return;
+
             ShamanMaskTitlePacketEvent maskEvent = new ShamanMaskTitlePacketEvent();
             WynntilsMod.postEvent(maskEvent);
 

--- a/common/src/main/java/com/wynntils/models/abilities/type/ShamanMaskType.java
+++ b/common/src/main/java/com/wynntils/models/abilities/type/ShamanMaskType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.type;
@@ -11,9 +11,9 @@ import net.minecraft.ChatFormatting;
 
 public enum ShamanMaskType {
     NONE("None", ChatFormatting.GRAY, null),
-    LUNATIC("L", ChatFormatting.RED, StyledText.fromString("§cL")),
-    FANATIC("F", ChatFormatting.GOLD, StyledText.fromString("§6F")),
-    COWARD("C", ChatFormatting.AQUA, StyledText.fromString("§bC")),
+    LUNATIC("L", ChatFormatting.RED, StyledText.fromString("§c\uE024")),
+    FANATIC("F", ChatFormatting.GOLD, StyledText.fromString("§6\uE023")),
+    HERETIC("H", ChatFormatting.AQUA, StyledText.fromString("§b\uE022")),
     AWAKENED("A", ChatFormatting.DARK_PURPLE, StyledText.fromString("Awakened"));
 
     private final String alias;


### PR DESCRIPTION
Having 1 mask still uses the same "Mask of the ??" title so no changes there, just the symbols and a fix for awakened