### PR TITLE
fix: Fix incompatibility with Legendary Tooltips (and Iceberg/Prism)

### DIFF
--- a/common/src/main/java/com/wynntils/core/text/PartStyle.java
+++ b/common/src/main/java/com/wynntils/core/text/PartStyle.java
@@ -191,7 +191,8 @@ public final class PartStyle {
 
     public Style getStyle() {
         // Optimization: Use raw Style constructor, instead of the builder.
-        TextColor textColor = color == CustomColor.NONE ? null : TextColor.fromRgb(color.asInt());
+        // Mask the color int to be 0xRRGGBB instead of 0xAARRGGBB (as TextColor doesn't expect alpha).
+        TextColor textColor = color == CustomColor.NONE ? null : TextColor.fromRgb(color.asInt() & 0x00FFFFFF);
         return new Style(
                 textColor, bold, italic, underlined, strikethrough, obfuscated, clickEvent, hoverEvent, null, font);
     }


### PR DESCRIPTION
I am not quite sure how this issue is not triggered when not using Prism, it really feels like it should not have worked at all before.