### PR TITLE
fix: Fix extended season leaderboard when less than 1 day left in season [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/ExtendedSeasonLeaderboardFeature.java
+++ b/common/src/main/java/com/wynntils/features/ExtendedSeasonLeaderboardFeature.java
@@ -74,12 +74,8 @@ public class ExtendedSeasonLeaderboardFeature extends Feature {
 
             newLabel.append(Component.literal("\nSeason ends in ").withStyle(ChatFormatting.GRAY));
 
-            if (seasonEnd == 1) {
-                newLabel.append(Component.literal("1 day\n\n").withStyle(ChatFormatting.AQUA, ChatFormatting.BOLD));
-            } else {
-                newLabel.append(
-                        Component.literal(seasonEnd + " days\n\n").withStyle(ChatFormatting.AQUA, ChatFormatting.BOLD));
-            }
+            newLabel.append(Component.literal(seasonEnd + " " + guildSeasonLeaderboardLabelInfo.getTimeUnit() + " \n\n")
+                    .withStyle(ChatFormatting.AQUA, ChatFormatting.BOLD));
         } else {
             int endMonth = guildSeasonLeaderboardLabelInfo.getEndingDate().getFirst();
             int endDay = guildSeasonLeaderboardLabelInfo.getEndingDate().get(1);

--- a/common/src/main/java/com/wynntils/models/players/label/GuildSeasonLeaderboardLabelInfo.java
+++ b/common/src/main/java/com/wynntils/models/players/label/GuildSeasonLeaderboardLabelInfo.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.Entity;
 public class GuildSeasonLeaderboardLabelInfo extends LabelInfo {
     private final int season;
     private final boolean currentSeason;
+    private final String timeUnit;
     private final List<Integer> endingDate;
     private final List<GuildLeaderboardInfo> guildLeaderboardInfo;
     private final boolean firstPage;
@@ -26,6 +27,7 @@ public class GuildSeasonLeaderboardLabelInfo extends LabelInfo {
             Entity entity,
             int season,
             boolean currentSeason,
+            String timeUnit,
             List<Integer> endingDate,
             List<GuildLeaderboardInfo> guildLeaderboardInfo,
             boolean firstPage,
@@ -33,6 +35,7 @@ public class GuildSeasonLeaderboardLabelInfo extends LabelInfo {
         super(label, location, entity);
         this.season = season;
         this.currentSeason = currentSeason;
+        this.timeUnit = timeUnit;
         this.endingDate = endingDate;
         this.guildLeaderboardInfo = guildLeaderboardInfo;
         this.firstPage = firstPage;
@@ -45,6 +48,10 @@ public class GuildSeasonLeaderboardLabelInfo extends LabelInfo {
 
     public boolean isCurrentSeason() {
         return currentSeason;
+    }
+
+    public String getTimeUnit() {
+        return timeUnit;
     }
 
     public List<Integer> getEndingDate() {
@@ -68,7 +75,8 @@ public class GuildSeasonLeaderboardLabelInfo extends LabelInfo {
         return "GuildSeasonLeaderboardLabelInfo{" + "label="
                 + label + ", season="
                 + season + ", currentSeason="
-                + currentSeason + ", endingDate="
+                + currentSeason + ", timeUnit='"
+                + timeUnit + '\'' + ", endingDate="
                 + endingDate + ", guildLeaderboardInfo="
                 + guildLeaderboardInfo + ", firstPage="
                 + firstPage + ", lastPage="

--- a/common/src/main/java/com/wynntils/models/players/label/GuildSeasonLeaderboardLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/players/label/GuildSeasonLeaderboardLabelParser.java
@@ -18,7 +18,7 @@ import net.minecraft.world.entity.Entity;
 
 public class GuildSeasonLeaderboardLabelParser implements LabelParser {
     private static final Pattern GUILD_SEASON_LEADERBOARD_LABEL = Pattern.compile(
-            "§d§lSeason (?<season>\\d+) Leaderboard\n§7Season (?:ends in §b§l(?<remaining>\\d+) day(s)?|ended at §b§l(?<month>\\d{2})/(?<day>\\d{2})/(?<year>\\d{4}))\n\n(?<guilds>.*?)\n§(?<firstpage>7|a)§l«§e ⬟ §(?<lastpage>7|a)§l»\n§eClick for Options",
+            "§d§lSeason (?<season>\\d+) Leaderboard\n§7Season (?:ends in §b§l(?<remaining>\\d+) (?<timeunit>(day|hour)s?)|ended at §b§l(?<month>\\d{2})/(?<day>\\d{2})/(?<year>\\d{4}))\n\n(?<guilds>.*?)\n§(?<firstpage>7|a)§l«§e ⬟ §(?<lastpage>7|a)§l»\n§eClick for Options",
             Pattern.DOTALL);
     private static final Pattern GUILD_LEADERBOARD_POSITION =
             Pattern.compile("^§.(?:§l)?(?<place>\\d+)(?:§7)? - §b(?<guild>.+)§d \\((\\d{1,3}(?:,\\d{3})*) SR\\)$");
@@ -32,9 +32,11 @@ public class GuildSeasonLeaderboardLabelParser implements LabelParser {
             String[] guildPositions = matcher.group("guilds").split("\n");
             boolean currentSeason = matcher.group("remaining") != null;
             List<Integer> endingDate = new ArrayList<>();
+            String timeUnit = "";
 
             if (currentSeason) {
                 endingDate.add(Integer.parseInt(matcher.group("remaining")));
+                timeUnit = matcher.group("timeunit");
             } else {
                 endingDate.add(Integer.parseInt(matcher.group("month")));
                 endingDate.add(Integer.parseInt(matcher.group("day")));
@@ -66,6 +68,7 @@ public class GuildSeasonLeaderboardLabelParser implements LabelParser {
                     entity,
                     season,
                     currentSeason,
+                    timeUnit,
                     endingDate,
                     guildLeaderboardInfo,
                     firstPage,

--- a/common/src/main/java/com/wynntils/models/players/label/GuildSeasonLeaderboardLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/players/label/GuildSeasonLeaderboardLabelParser.java
@@ -18,7 +18,7 @@ import net.minecraft.world.entity.Entity;
 
 public class GuildSeasonLeaderboardLabelParser implements LabelParser {
     private static final Pattern GUILD_SEASON_LEADERBOARD_LABEL = Pattern.compile(
-            "§d§lSeason (?<season>\\d+) Leaderboard\n§7Season (?:ends in §b§l(?<remaining>\\d+) (?<timeunit>(day|hour)s?)|ended at §b§l(?<month>\\d{2})/(?<day>\\d{2})/(?<year>\\d{4}))\n\n(?<guilds>.*?)\n§(?<firstpage>7|a)§l«§e ⬟ §(?<lastpage>7|a)§l»\n§eClick for Options",
+            "§d§lSeason (?<season>\\d+) Leaderboard\n§7Season (?:ends in §b§l(?<remaining>\\d+) (?<timeunit>(day|hour|minute|second)s?)|ended at §b§l(?<month>\\d{2})/(?<day>\\d{2})/(?<year>\\d{4}))\n\n(?<guilds>.*?)\n§(?<firstpage>7|a)§l«§e ⬟ §(?<lastpage>7|a)§l»\n§eClick for Options",
             Pattern.DOTALL);
     private static final Pattern GUILD_LEADERBOARD_POSITION =
             Pattern.compile("^§.(?:§l)?(?<place>\\d+)(?:§7)? - §b(?<guild>.+)§d \\((\\d{1,3}(?:,\\d{3})*) SR\\)$");


### PR DESCRIPTION
![2024-10-27_13 31 12](https://github.com/user-attachments/assets/23535bbe-fc7d-4bd6-8b66-8e3785ef9238)

I'm not sure if the season end time is consistent, if so we could potentially change the time to be an actual countdown, but would look into that for next season