### PR TITLE
fix: Use encoding ids in all chat-encoding related classes, fix documentation revolving ids [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -5,21 +5,23 @@
 package com.wynntils.models.character.type;
 
 public enum ClassType {
-    MAGE("Mage", "Dark Wizard"),
-    ARCHER("Archer", "Hunter"),
-    WARRIOR("Warrior", "Knight"),
-    ASSASSIN("Assassin", "Ninja"),
-    SHAMAN("Shaman", "Skyseer"),
+    MAGE("Mage", "Dark Wizard", 1),
+    ARCHER("Archer", "Hunter", 2),
+    WARRIOR("Warrior", "Knight", 3),
+    ASSASSIN("Assassin", "Ninja", 4),
+    SHAMAN("Shaman", "Skyseer", 5),
 
     // This represents the class selection menu, or the generic spell
-    NONE("none", "none");
+    NONE("none", "none", 0);
 
     private final String name;
     private final String reskinnedName;
+    private final int encodingId;
 
-    ClassType(String name, String reskinnedName) {
+    ClassType(String name, String reskinnedName, int encodingId) {
         this.name = name;
         this.reskinnedName = reskinnedName;
+        this.encodingId = encodingId;
     }
 
     public static ClassType fromName(String className) {
@@ -53,6 +55,10 @@ public enum ClassType {
 
     public String getFullName() {
         return name + "/" + reskinnedName;
+    }
+
+    public int getEncodingId() {
+        return encodingId;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/elements/type/Element.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements.type;
@@ -8,25 +8,36 @@ import com.wynntils.utils.StringUtils;
 import net.minecraft.ChatFormatting;
 
 public enum Element {
-    EARTH("✤", ChatFormatting.DARK_GREEN),
-    THUNDER("✦", ChatFormatting.YELLOW),
-    WATER("❉", ChatFormatting.AQUA),
-    FIRE("✹", ChatFormatting.RED),
-    AIR("❋", ChatFormatting.WHITE);
+    EARTH("✤", ChatFormatting.DARK_GREEN, 0),
+    THUNDER("✦", ChatFormatting.YELLOW, 1),
+    WATER("❉", ChatFormatting.AQUA, 2),
+    FIRE("✹", ChatFormatting.RED, 3),
+    AIR("❋", ChatFormatting.WHITE, 4);
 
     private final String symbol;
     private final ChatFormatting colorCode;
     private final String displayName;
+    private final int encodingId;
 
-    Element(String symbol, ChatFormatting colorCode) {
+    Element(String symbol, ChatFormatting colorCode, int encodingId) {
         this.symbol = symbol;
         this.colorCode = colorCode;
+        this.encodingId = encodingId;
         this.displayName = StringUtils.capitalized(this.name());
     }
 
     public static Element fromSymbol(String symbol) {
         for (Element element : Element.values()) {
             if (element.symbol.equals(symbol)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    public static Element fromEncodingId(int encodingId) {
+        for (Element element : Element.values()) {
+            if (element.encodingId == encodingId) {
                 return element;
             }
         }
@@ -43,5 +54,9 @@ public enum Element {
 
     public ChatFormatting getColorCode() {
         return colorCode;
+    }
+
+    public int getEncodingId() {
+        return encodingId;
     }
 }

--- a/common/src/main/java/com/wynntils/models/elements/type/Skill.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Skill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements.type;
@@ -37,6 +37,15 @@ public enum Skill {
         String str = apiId.toLowerCase(Locale.ROOT);
         for (Skill skill : values()) {
             if (skill.getApiName().equals(str)) {
+                return skill;
+            }
+        }
+        return null;
+    }
+
+    public static Skill fromElement(Element element) {
+        for (Skill skill : values()) {
+            if (skill.getAssociatedElement() == element) {
                 return skill;
             }
         }

--- a/common/src/main/java/com/wynntils/models/gear/type/GearAttackSpeed.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearAttackSpeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;
@@ -8,20 +8,20 @@ import com.wynntils.core.WynntilsMod;
 import java.util.Locale;
 
 public enum GearAttackSpeed {
-    SUPER_FAST("Super Fast Attack Speed", 3),
-    VERY_FAST("Very Fast Attack Speed", 2),
-    FAST("Fast Attack Speed", 1),
-    NORMAL("Normal Attack Speed", 0),
-    SLOW("Slow Attack Speed", -1),
-    VERY_SLOW("Very Slow Attack Speed", -2),
-    SUPER_SLOW("Super Slow Attack Speed", -3);
+    SUPER_FAST("Super Fast Attack Speed", 0),
+    VERY_FAST("Very Fast Attack Speed", 1),
+    FAST("Fast Attack Speed", 2),
+    NORMAL("Normal Attack Speed", 3),
+    SLOW("Slow Attack Speed", 4),
+    VERY_SLOW("Very Slow Attack Speed", 5),
+    SUPER_SLOW("Super Slow Attack Speed", 6);
 
     private final String name;
-    private final int offset;
+    private final int encodingId;
 
-    GearAttackSpeed(String name, int offset) {
+    GearAttackSpeed(String name, int encodingId) {
         this.name = name;
-        this.offset = offset;
+        this.encodingId = encodingId;
     }
 
     public static GearAttackSpeed fromString(String str) {
@@ -34,11 +34,21 @@ public enum GearAttackSpeed {
         }
     }
 
+    public static GearAttackSpeed fromEncodingId(int id) {
+        for (GearAttackSpeed attackSpeed : values()) {
+            if (attackSpeed.encodingId == id) {
+                return attackSpeed;
+            }
+        }
+        WynntilsMod.warn("Invalid gear attack speed encoding id: " + id);
+        return null;
+    }
+
     public String getName() {
         return name;
     }
 
-    public int getOffset() {
-        return offset;
+    public int getEncodingId() {
+        return encodingId;
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/DefenseDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/DefenseDataTransformer.java
@@ -54,8 +54,8 @@ public class DefenseDataTransformer extends DataTransformer<DefenseData> {
 
         // A defense stat is encoded the following way:
         for (Pair<Element, Integer> defence : data.defences()) {
-            // The first byte is the id of the skill (`ETFWA`).
-            bytes.add(UnsignedByte.of((byte) defence.a().ordinal()));
+            // The first byte is the id of the skill (`ETWFA`).
+            bytes.add(UnsignedByte.of((byte) defence.a().getEncodingId()));
 
             // The next bytes are the defense bytes, which are assembled into an integer.
             unsignedBytes = UnsignedByteUtils.encodeVariableSizedInteger(defence.b());
@@ -75,8 +75,8 @@ public class DefenseDataTransformer extends DataTransformer<DefenseData> {
 
         for (int i = 0; i < defencesCount; i++) {
             // A defense stat is encoded the following way:
-            // The first byte is the id of the skill (`ETFWA`).
-            Element element = Element.values()[byteReader.read().value()];
+            // The first byte is the id of the skill (`ETWFA`).
+            Element element = Element.fromEncodingId(byteReader.read().value());
 
             // The next bytes are the defense bytes, which are assembled into an integer.
             int defence = (int) UnsignedByteUtils.decodeVariableSizedInteger(byteReader);

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.items.encoding.impl.block;
 
+import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.items.encoding.data.PowderData;
 import com.wynntils.models.items.encoding.type.DataTransformer;
@@ -58,7 +59,7 @@ public class PowderDataTransformer extends DataTransformer<PowderData> {
         // 5 `0` bits are used to represent that no powder is present at the slot.
         for (int i = 0; i < data.powders().size(); i++) {
             Pair<Powder, Integer> powder = data.powders().get(i);
-            int element = powder.key().ordinal();
+            int element = powder.key().getElement().getEncodingId();
             int tier = powder.value();
             int powderDataIndex = i * 5;
 
@@ -140,7 +141,7 @@ public class PowderDataTransformer extends DataTransformer<PowderData> {
             int tier = powderValue % 6;
 
             // Add the powder to the data
-            data.add(new Pair<>(Powder.values()[element - 1], tier));
+            data.add(new Pair<>(Powder.fromElement(Element.fromEncodingId(element - 1)), tier));
         }
 
         return ErrorOr.of(new PowderData(powderSlots, data));

--- a/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.type;
@@ -12,7 +12,7 @@ import net.minecraft.ChatFormatting;
 
 public enum DamageType {
     ALL("", "❤", ChatFormatting.DARK_RED),
-    NEUTRAL("Neutral", "✣", ChatFormatting.GOLD),
+    NEUTRAL("Neutral", "✣", ChatFormatting.GOLD, 5),
     FIRE(Element.FIRE),
     WATER(Element.WATER),
     AIR(Element.AIR),
@@ -26,6 +26,7 @@ public enum DamageType {
     private final String apiName;
     private final String symbol;
     private final ChatFormatting colorCode;
+    private final int encodingId;
 
     DamageType(String name) {
         this.element = null;
@@ -34,6 +35,7 @@ public enum DamageType {
         this.apiName = name;
         this.symbol = "";
         this.colorCode = null;
+        this.encodingId = -1;
     }
 
     DamageType(String name, String symbol, ChatFormatting colorCode) {
@@ -44,6 +46,18 @@ public enum DamageType {
 
         this.symbol = symbol;
         this.colorCode = colorCode;
+        this.encodingId = -1;
+    }
+
+    DamageType(String name, String symbol, ChatFormatting colorCode, int encodingId) {
+        this.element = null;
+        // displayName needs padding if non-empty
+        this.displayName = name.isEmpty() ? "" : name + " ";
+        this.apiName = name;
+
+        this.symbol = symbol;
+        this.colorCode = colorCode;
+        this.encodingId = encodingId;
     }
 
     DamageType(Element element) {
@@ -53,6 +67,9 @@ public enum DamageType {
         this.apiName = element.getDisplayName();
         this.symbol = element.getSymbol();
         this.colorCode = element.getColorCode();
+
+        // Encoding id is the element id
+        this.encodingId = element.getEncodingId();
     }
 
     public static List<DamageType> statValues() {
@@ -70,6 +87,15 @@ public enum DamageType {
     public static DamageType fromSymbol(String symbol) {
         for (DamageType type : values()) {
             if (type.symbol.equals(symbol)) return type;
+        }
+        return null;
+    }
+
+    public static DamageType fromEncodingId(int id) {
+        for (DamageType type : values()) {
+            if (type.encodingId == id) {
+                return type;
+            }
         }
         return null;
     }
@@ -92,5 +118,10 @@ public enum DamageType {
 
     public ChatFormatting getColorCode() {
         return colorCode;
+    }
+
+    public int getEncodingId() {
+        assert encodingId != -1 : "Encoding id not set for " + this;
+        return encodingId;
     }
 }


### PR DESCRIPTION
The code changes here are only "hardenings", they do not fix any issue, rather, they make the code more explicit and less prone to issues when enums are reordered. The one exception is RequirementsDataTransformer where `CLASS_TYPE_IDS` had a typo resulting in two classes having the same id.

https://github.com/Wynntils/Wynntils/issues/2246 was updated along with this PR.

I've tested encoding across the old and new versions, and I have not found any regressions.