### PR TITLE
fix powder data decoding

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
@@ -137,11 +137,23 @@ public class PowderDataTransformer extends DataTransformer<PowderData> {
             }
 
             // Decode the powder value
-            int element = powderValue / 6;
-            int tier = powderValue % 6;
+            // if the powder value is 0, it means no powder is present, thus no data is
+            // decoded for it
+            if (powderValue != 0) {
+                int element = powderValue / 6;
+                int tier = powderValue % 6;
 
-            // Add the powder to the data
-            data.add(new Pair<>(Powder.fromElement(Element.fromEncodingId(element - 1)), tier));
+                // if the powder value is divisible by 6, it means that we have a tier 6 powder
+                if (powderValue % 6 == 0) {
+                    // subtract 1 from the element to get the correct element
+                    element--;
+                    // set the correct tier
+                    tier = 6;
+                }
+
+                // Add the powder to the data
+                data.add(new Pair<>(Powder.fromElement(Element.fromEncodingId(element)), tier));
+            }
         }
 
         return ErrorOr.of(new PowderData(powderSlots, data));


### PR DESCRIPTION
This pr fixes the powder data decoding as the current system has a number of issues

1. powder types are only decoded correctly when processing tier 6 powders
2. tier 6 powders get decoded as tier 0 powders
3. empty powders cause errors during decode (at least as defined in #2246)

All of these issues have managed to slip by as it seems that wynntils at least currently always encodes items as having tier 6 powders. And doesnt encode any empty slots using the broken method.

The proposal also says that the powders are padded with 1 bits while also 2 sentences later claiming they are padded with 0's. I would fix this but obviously I cannot edit your comment. Would it be a good idea to maybe move the written standard to a .md file in this repo instead of just having it as a comment in the issues?