### PR TITLE
feat: Introduce MapDataOverrideProvider, prepare to replace MarkerModel

### DIFF
--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -14,7 +14,6 @@ import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.commands.Command;
 import com.wynntils.models.marker.type.MarkerInfo;
 import com.wynntils.models.territories.profile.TerritoryProfile;
-import com.wynntils.services.mapdata.MapIconTextureWrapper;
 import com.wynntils.services.mapdata.features.builtin.ServiceLocation;
 import com.wynntils.services.mapdata.features.type.MapLocation;
 import com.wynntils.utils.StringUtils;
@@ -189,10 +188,7 @@ public class CompassCommand extends Command {
         MapLocation closestService = closestServiceOptional.get();
 
         Models.Marker.USER_WAYPOINTS_PROVIDER.removeAllLocations();
-        Models.Marker.USER_WAYPOINTS_PROVIDER.addLocation(
-                closestService.getLocation(),
-                new MapIconTextureWrapper(Services.MapData.getIconOrFallback(closestService)),
-                Services.MapData.resolveMapAttributes(closestService).label());
+        Models.Marker.addUserMarkedFeature(closestService);
 
         MutableComponent response = Component.literal("Compass set to "
                         + Services.MapData.resolveMapAttributes(closestService).label() + " at ")

--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.commands;

--- a/common/src/main/java/com/wynntils/commands/LocateCommand.java
+++ b/common/src/main/java/com/wynntils/commands/LocateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.commands;

--- a/common/src/main/java/com/wynntils/core/components/Services.java
+++ b/common/src/main/java/com/wynntils/core/components/Services.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.components;

--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021-2024.
+ * Copyright © Wynntils 2021-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.features;

--- a/common/src/main/java/com/wynntils/core/net/UrlId.java
+++ b/common/src/main/java/com/wynntils/core/net/UrlId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.net;

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers;

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/BeaconBeamToWorldMarkersUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/BeaconBeamToWorldMarkersUpfixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers.config;

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/WorldMarkersDistanceConfigRenameUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/WorldMarkersDistanceConfigRenameUpfixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers.config;

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/WorldMarkersFeatureRenamesUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/WorldMarkersFeatureRenamesUpfixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers.config;

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/WorldMarkersRenameUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/WorldMarkersRenameUpfixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers.config;

--- a/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.map;

--- a/common/src/main/java/com/wynntils/features/map/WorldMarkersFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldMarkersFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.map;

--- a/common/src/main/java/com/wynntils/models/containers/LootChestModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/LootChestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.containers;

--- a/common/src/main/java/com/wynntils/models/marker/MarkerModel.java
+++ b/common/src/main/java/com/wynntils/models/marker/MarkerModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.marker;

--- a/common/src/main/java/com/wynntils/models/marker/MarkerModel.java
+++ b/common/src/main/java/com/wynntils/models/marker/MarkerModel.java
@@ -1,19 +1,34 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.marker;
 
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Services;
 import com.wynntils.models.marker.type.MarkerInfo;
 import com.wynntils.models.marker.type.MarkerProvider;
 import com.wynntils.services.map.pois.Poi;
+import com.wynntils.services.mapdata.attributes.impl.AbstractMapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.features.type.MapFeature;
+import com.wynntils.services.mapdata.providers.type.MapDataOverrideProvider;
+import com.wynntils.services.mapdata.type.MapDataProvidedType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public class MarkerModel extends Model {
     public static final UserWaypointMarkerProvider USER_WAYPOINTS_PROVIDER = new UserWaypointMarkerProvider();
+
+    private final Set<MapFeature> userMarkedMapFeatures = new CopyOnWriteArraySet<>();
+
+    private static final String MARKED_OVERRIDE_PROVIDER_ID = "override:user_marked_provider";
+    private final UserMarkerOverrideProvider userMarkedOverrideProvider = new UserMarkerOverrideProvider();
 
     private final List<MarkerProvider> markerProviders = new ArrayList<>();
 
@@ -21,6 +36,18 @@ public class MarkerModel extends Model {
         super(List.of());
 
         registerMarkerProvider(USER_WAYPOINTS_PROVIDER);
+    }
+
+    @Override
+    public void reloadData() {
+        // FIXME: This should only be done once, in the  constructor but referencing Services in Model contructors
+        //        is not alloved. This is easily fixed by making this model a service, as essentially, it is one.
+        Services.MapData.registerOverrideProvider(MARKED_OVERRIDE_PROVIDER_ID, userMarkedOverrideProvider);
+    }
+
+    public void addUserMarkedFeature(MapFeature mapFeature) {
+        userMarkedMapFeatures.add(mapFeature);
+        userMarkedOverrideProvider.notifyCallbacks(mapFeature);
     }
 
     public void registerMarkerProvider(MarkerProvider provider) {
@@ -33,5 +60,38 @@ public class MarkerModel extends Model {
 
     public Stream<Poi> getAllPois() {
         return markerProviders.stream().filter(MarkerProvider::isEnabled).flatMap(MarkerProvider::getPois);
+    }
+
+    private final class UserMarkerOverrideProvider implements MapDataOverrideProvider {
+        private final Set<Consumer<MapDataProvidedType>> callbacks = new CopyOnWriteArraySet<>();
+
+        @Override
+        public MapAttributes getOverrideAttributes() {
+            return new AbstractMapAttributes() {
+                @Override
+                public Optional<Boolean> getHasMarker() {
+                    return Optional.of(true);
+                }
+            };
+        }
+
+        @Override
+        public Stream<String> getOverridenFeatureIds() {
+            return userMarkedMapFeatures.stream().map(MapFeature::getFeatureId);
+        }
+
+        @Override
+        public Stream<String> getOverridenCategoryIds() {
+            return Stream.empty();
+        }
+
+        @Override
+        public void onChange(Consumer<MapDataProvidedType> callback) {
+            callbacks.add(callback);
+        }
+
+        public void notifyCallbacks(MapDataProvidedType type) {
+            callbacks.forEach(c -> c.accept(type));
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/models/marker/UserWaypointMarkerProvider.java
+++ b/common/src/main/java/com/wynntils/models/marker/UserWaypointMarkerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.marker;

--- a/common/src/main/java/com/wynntils/models/marker/type/MarkerInfo.java
+++ b/common/src/main/java/com/wynntils/models/marker/type/MarkerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.marker.type;

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories;

--- a/common/src/main/java/com/wynntils/models/territories/event/TerritoriesUpdatedEvent.java
+++ b/common/src/main/java/com/wynntils/models/territories/event/TerritoriesUpdatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories.event;

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays.minimap;

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;

--- a/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -651,6 +651,8 @@ public final class PoiCreationScreen extends AbstractMapScreen {
         MapVisibilityImpl iconVisibility =
                 new MapVisibilityImpl(DefaultMapAttributes.ICON_ALWAYS); // TODO: Add visibility input
 
+        // FIXME: It is vital to only save "non-default" values to the waypoint, otherwise the default values will be
+        //        written into the config file, which is not desired.
         MapLocationAttributesImpl attributes = new MapAttributesBuilder()
                 .setLabel(label)
                 .setIcon(iconId)

--- a/common/src/main/java/com/wynntils/screens/maps/PoiManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiManagementScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.map;

--- a/common/src/main/java/com/wynntils/services/map/pois/CustomPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/CustomPoi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.map.pois;

--- a/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/IconPoi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.map.pois;

--- a/common/src/main/java/com/wynntils/services/map/pois/MarkerPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/MarkerPoi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.map.pois;

--- a/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata;
@@ -8,6 +8,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Service;
 import com.wynntils.core.components.Services;
 import com.wynntils.services.mapdata.attributes.resolving.MapAttributesResolver;
+import com.wynntils.services.mapdata.attributes.resolving.OverrideMapAttributes;
 import com.wynntils.services.mapdata.attributes.resolving.ResolvedMapAttributes;
 import com.wynntils.services.mapdata.attributes.resolving.ResolvedMapVisibility;
 import com.wynntils.services.mapdata.attributes.resolving.ResolvedMarkerOptions;
@@ -128,13 +129,13 @@ public class MapDataService extends Service {
     }
 
     public Optional<MapAttributes> getOverrideAttributesForFeature(MapFeature feature) {
-        return overrideProviders.values().stream()
-                .filter(attr -> attr.getOverridenFeatureIds()
-                                .anyMatch(attrFeatureId -> attrFeatureId.equals(feature.getFeatureId()))
-                        || attr.getOverridenCategoryIds()
-                                .anyMatch(attrCategoryId -> attrCategoryId.equals(feature.getCategoryId())))
+        return OverrideMapAttributes.from(Stream.concat(
+                        overrideProviders.values().stream().filter(attr -> attr.getOverridenFeatureIds()
+                                .anyMatch(attrFeatureId -> attrFeatureId.equals(feature.getFeatureId()))),
+                        overrideProviders.values().stream().filter(attr -> attr.getOverridenCategoryIds()
+                                .anyMatch(attrCategoryId -> attrCategoryId.equals(feature.getCategoryId()))))
                 .map(MapDataOverrideProvider::getOverrideAttributes)
-                .findFirst();
+                .toList());
     }
 
     // endregion

--- a/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapDataService.java
@@ -80,7 +80,7 @@ public class MapDataService extends Service {
         return getFeatures().filter(f -> f.getCategoryId().startsWith(categoryId));
     }
 
-    // region Lookup features and resolve attributes
+    // region Lookup features and attribute resolution
 
     public ResolvedMapAttributes resolveMapAttributes(MapFeature feature) {
         return resolvedAttributesCache.computeIfAbsent(feature, k -> MapAttributesResolver.resolve(feature));

--- a/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata;

--- a/common/src/main/java/com/wynntils/services/mapdata/MapIconTextureWrapper.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/MapIconTextureWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata;

--- a/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/DefaultMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/DefaultMapAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/DefaultMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/DefaultMapAttributes.java
@@ -25,8 +25,9 @@ public final class DefaultMapAttributes implements MapAttributes {
     public static final MapVisibility ICON_NEVER = new MapVisibilityImpl(100f, 0f, 6f);
     public static final MapVisibility LABEL_ALWAYS = new MapVisibilityImpl(0f, 100f, 3f);
     public static final MapVisibility LABEL_NEVER = new MapVisibilityImpl(100f, 0f, 3f);
-    public static final MapMarkerOptions NONE =
-            new MapMarkerOptionsImpl(0f, 0f, 0f, CustomColor.NONE, false, false, false);
+
+    public static final MapMarkerOptions DEFAULT_MARKER_OPTIONS =
+            new MapMarkerOptionsImpl(0f, 15000f, 3f, CommonColors.RED, true, true, true);
 
     public static final DefaultMapAttributes INSTANCE = new DefaultMapAttributes();
 
@@ -83,8 +84,13 @@ public final class DefaultMapAttributes implements MapAttributes {
     }
 
     @Override
+    public Optional<Boolean> getHasMarker() {
+        return Optional.of(false);
+    }
+
+    @Override
     public Optional<MapMarkerOptions> getMarkerOptions() {
-        return Optional.of(NONE);
+        return Optional.of(DEFAULT_MARKER_OPTIONS);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/MapAttributesBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/MapAttributesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/MapAttributesBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/MapAttributesBuilder.java
@@ -27,10 +27,11 @@ public class MapAttributesBuilder {
     private String icon;
     private MapVisibilityImpl iconVisibility;
     private CustomColor iconColor;
+    private Boolean hasMarker;
     private MapMarkerOptionsImpl markerOptions;
     private CustomColor fillColor;
     private CustomColor borderColor;
-    private float borderWidth;
+    private Float borderWidth;
 
     public MapAttributesBuilder setPriority(int priority) {
         this.priority = priority;
@@ -77,6 +78,11 @@ public class MapAttributesBuilder {
         return this;
     }
 
+    public MapAttributesBuilder setHasMarker(Boolean hasMarker) {
+        this.hasMarker = hasMarker;
+        return this;
+    }
+
     public MapAttributesBuilder setMarkerOptions(MapMarkerOptionsImpl markerOptions) {
         this.markerOptions = markerOptions;
         return this;
@@ -90,7 +96,7 @@ public class MapAttributesBuilder {
         this.borderColor = borderColor;
     }
 
-    public void setBorderWidth(float borderWidth) {
+    public void setBorderWidth(Float borderWidth) {
         this.borderWidth = borderWidth;
     }
 
@@ -134,6 +140,7 @@ public class MapAttributesBuilder {
                     icon,
                     iconVisibility,
                     iconColor,
+                    hasMarker,
                     markerOptions);
         }
     }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/MapMarkerOptionsBuilder.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/MapMarkerOptionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAreaAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAreaAttributes.java
@@ -33,6 +33,11 @@ public abstract class AbstractMapAreaAttributes extends AbstractMapAttributes im
     }
 
     @Override
+    public Optional<Boolean> getHasMarker() {
+        return Optional.empty();
+    }
+
+    @Override
     public final Optional<MapMarkerOptions> getMarkerOptions() {
         return Optional.empty();
     }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapAttributes.java
@@ -64,6 +64,11 @@ public abstract class AbstractMapAttributes implements MapAttributes {
     }
 
     @Override
+    public Optional<Boolean> getHasMarker() {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<MapMarkerOptions> getMarkerOptions() {
         return Optional.empty();
     }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapLocationAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapPathAttributes.java
@@ -33,6 +33,11 @@ public abstract class AbstractMapPathAttributes extends AbstractMapAttributes im
     }
 
     @Override
+    public Optional<Boolean> getHasMarker() {
+        return Optional.empty();
+    }
+
+    @Override
     public final Optional<MapMarkerOptions> getMarkerOptions() {
         return Optional.empty();
     }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/AbstractMapPathAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
@@ -18,7 +18,7 @@ public final class MapAreaAttributesImpl extends MapAttributesImpl implements Ma
             TextShadow labelShadow,
             CustomColor fillColor,
             CustomColor borderColor,
-            float borderWidth) {
+            Float borderWidth) {
         super(
                 priority,
                 level,
@@ -29,6 +29,7 @@ public final class MapAreaAttributesImpl extends MapAttributesImpl implements Ma
                 null,
                 null,
                 null,
+                false,
                 null,
                 fillColor,
                 borderColor,

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
@@ -29,7 +29,7 @@ public final class MapAreaAttributesImpl extends MapAttributesImpl implements Ma
                 null,
                 null,
                 null,
-                false,
+                null,
                 null,
                 fillColor,
                 borderColor,

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAttributesImpl.java
@@ -22,10 +22,11 @@ public class MapAttributesImpl implements MapAttributes {
     private final String icon;
     private final MapVisibilityImpl iconVisibility;
     private final CustomColor iconColor;
+    private final Boolean hasMarker;
     private final MapMarkerOptionsImpl markerOptions;
     private final CustomColor fillColor;
     private final CustomColor borderColor;
-    private final float borderWidth;
+    private final Float borderWidth;
 
     public MapAttributesImpl(
             int priority,
@@ -37,10 +38,11 @@ public class MapAttributesImpl implements MapAttributes {
             String icon,
             MapVisibilityImpl iconVisibility,
             CustomColor iconColor,
+            Boolean hasMarker,
             MapMarkerOptionsImpl markerOptions,
             CustomColor fillColor,
             CustomColor borderColor,
-            float borderWidth) {
+            Float borderWidth) {
         this.priority = priority;
         this.level = level;
         this.label = label;
@@ -50,6 +52,7 @@ public class MapAttributesImpl implements MapAttributes {
         this.icon = icon;
         this.iconVisibility = iconVisibility;
         this.iconColor = iconColor;
+        this.hasMarker = hasMarker;
         this.markerOptions = markerOptions;
         this.fillColor = fillColor;
         this.borderColor = borderColor;
@@ -102,6 +105,11 @@ public class MapAttributesImpl implements MapAttributes {
     }
 
     @Override
+    public Optional<Boolean> getHasMarker() {
+        return Optional.ofNullable(hasMarker);
+    }
+
+    @Override
     public Optional<MapMarkerOptions> getMarkerOptions() {
         return Optional.ofNullable(markerOptions);
     }
@@ -118,7 +126,7 @@ public class MapAttributesImpl implements MapAttributes {
 
     @Override
     public Optional<Float> getBorderWidth() {
-        return Optional.of(borderWidth);
+        return Optional.ofNullable(borderWidth);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAttributesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
@@ -19,6 +19,7 @@ public final class MapLocationAttributesImpl extends MapAttributesImpl implement
             String icon,
             MapVisibilityImpl iconVisibility,
             CustomColor iconColor,
+            Boolean hasMarker,
             MapMarkerOptionsImpl markerOptions) {
         super(
                 priority,
@@ -30,6 +31,7 @@ public final class MapLocationAttributesImpl extends MapAttributesImpl implement
                 icon,
                 iconVisibility,
                 iconColor,
+                hasMarker,
                 markerOptions,
                 null,
                 null,

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
@@ -35,6 +35,6 @@ public final class MapLocationAttributesImpl extends MapAttributesImpl implement
                 markerOptions,
                 null,
                 null,
-                0f);
+                null);
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapMarkerOptionsImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapMarkerOptionsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
@@ -16,6 +16,20 @@ public final class MapPathAttributesImpl extends MapAttributesImpl implements Ma
             MapVisibilityImpl labelVisibility,
             CustomColor labelColor,
             TextShadow labelShadow) {
-        super(priority, level, label, labelVisibility, labelColor, labelShadow, null, null, null, null, null, null, 0f);
+        super(
+                priority,
+                level,
+                label,
+                labelVisibility,
+                labelColor,
+                labelShadow,
+                null,
+                null,
+                null,
+                false,
+                null,
+                null,
+                null,
+                0f);
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
@@ -26,10 +26,10 @@ public final class MapPathAttributesImpl extends MapAttributesImpl implements Ma
                 null,
                 null,
                 null,
-                false,
                 null,
                 null,
                 null,
-                0f);
+                null,
+                null);
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapVisibilityImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapVisibilityImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/MapAttributesResolver.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/MapAttributesResolver.java
@@ -50,6 +50,16 @@ public final class MapAttributesResolver {
     }
 
     private <T> T getAttribute(Function<MapAttributes, Optional<T>> attributeGetter) {
+        // Check if there is a override provider for this feature or category
+        // and if it has the attribute we're looking for, use it
+        Optional<MapAttributes> overrideAttributes = Services.MapData.getOverrideAttributesForFeature(feature);
+        if (overrideAttributes.isPresent()) {
+            Optional<T> attribute = attributeGetter.apply(overrideAttributes.get());
+            if (attribute.isPresent()) {
+                return attribute.get();
+            }
+        }
+
         // Check if the feature has overridden this attribute
         Optional<T> featureAttribute = getFromFeature(attributeGetter);
         if (featureAttribute.isPresent()) {
@@ -92,6 +102,20 @@ public final class MapAttributesResolver {
 
     private <F, T> T getInheritedValue(
             Function<F, Optional<T>> valueGetter, Function<MapAttributes, Optional<F>> attributeGetter) {
+        // Check if there is a override provider for this feature or category
+        // and if it has the attribute we're looking for, use it
+        Optional<MapAttributes> overrideAttributes = Services.MapData.getOverrideAttributesForFeature(feature);
+        if (overrideAttributes.isPresent()) {
+            Optional<F> attribute = attributeGetter.apply(overrideAttributes.get());
+            if (attribute.isPresent()) {
+                // We got the attribute, but do we got the value?
+                Optional<T> value = valueGetter.apply(attribute.get());
+                if (value.isPresent()) {
+                    return value.get();
+                }
+            }
+        }
+
         // Check if the feature has overridden this attribute
         Optional<F> featureValue = getFromFeature(attributeGetter);
         if (featureValue.isPresent()) {

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/MapAttributesResolver.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/MapAttributesResolver.java
@@ -42,6 +42,7 @@ public final class MapAttributesResolver {
                 resolver.getResolvedMapVisibility(MapAttributes::getIconVisibility),
                 resolver.getAttribute(MapAttributes::getIconColor),
                 resolver.getAttribute(MapAttributes::getIconDecoration),
+                resolver.getAttribute(MapAttributes::getHasMarker),
                 resolver.getResolvedMarkerOptions(MapAttributes::getMarkerOptions),
                 resolver.getAttribute(MapAttributes::getFillColor),
                 resolver.getAttribute(MapAttributes::getBorderColor),

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/MapAttributesResolver.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/MapAttributesResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.resolving;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/OverrideMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/OverrideMapAttributes.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.attributes.resolving;
+
+import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapDecoration;
+import com.wynntils.services.mapdata.attributes.type.MapMarkerOptions;
+import com.wynntils.services.mapdata.attributes.type.MapVisibility;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.TextShadow;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+// This is a special class of MapAttributes. It is used to combine multiple MapAttributes into one, provided
+// by override providers. The order of priority as to which MapAttributes are used is determined by the original
+// order of the MapAttributes passed to the constructor.
+public final class OverrideMapAttributes implements MapAttributes {
+    private final List<MapAttributes> attributes;
+
+    private OverrideMapAttributes(List<MapAttributes> attributes) {
+        this.attributes = attributes;
+    }
+
+    public static Optional<MapAttributes> from(List<MapAttributes> attributes) {
+        return attributes == null || attributes.isEmpty()
+                ? Optional.empty()
+                : Optional.of(new OverrideMapAttributes(attributes));
+    }
+
+    public <T> Optional<T> resolveAttribute(Function<MapAttributes, Optional<T>> valueGetter) {
+        for (MapAttributes attribute : attributes) {
+            Optional<T> value = valueGetter.apply(attribute);
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Integer> getPriority() {
+        return resolveAttribute(MapAttributes::getPriority);
+    }
+
+    @Override
+    public Optional<Integer> getLevel() {
+        return resolveAttribute(MapAttributes::getLevel);
+    }
+
+    @Override
+    public Optional<String> getLabel() {
+        return resolveAttribute(MapAttributes::getLabel);
+    }
+
+    @Override
+    public Optional<MapVisibility> getLabelVisibility() {
+        return resolveAttribute(MapAttributes::getLabelVisibility);
+    }
+
+    @Override
+    public Optional<CustomColor> getLabelColor() {
+        return resolveAttribute(MapAttributes::getLabelColor);
+    }
+
+    @Override
+    public Optional<TextShadow> getLabelShadow() {
+        return resolveAttribute(MapAttributes::getLabelShadow);
+    }
+
+    @Override
+    public Optional<String> getIconId() {
+        return resolveAttribute(MapAttributes::getIconId);
+    }
+
+    @Override
+    public Optional<MapVisibility> getIconVisibility() {
+        return resolveAttribute(MapAttributes::getIconVisibility);
+    }
+
+    @Override
+    public Optional<CustomColor> getIconColor() {
+        return resolveAttribute(MapAttributes::getIconColor);
+    }
+
+    @Override
+    public Optional<MapDecoration> getIconDecoration() {
+        return resolveAttribute(MapAttributes::getIconDecoration);
+    }
+
+    @Override
+    public Optional<Boolean> getHasMarker() {
+        return resolveAttribute(MapAttributes::getHasMarker);
+    }
+
+    @Override
+    public Optional<MapMarkerOptions> getMarkerOptions() {
+        return resolveAttribute(MapAttributes::getMarkerOptions);
+    }
+
+    @Override
+    public Optional<CustomColor> getFillColor() {
+        return resolveAttribute(MapAttributes::getFillColor);
+    }
+
+    @Override
+    public Optional<CustomColor> getBorderColor() {
+        return resolveAttribute(MapAttributes::getBorderColor);
+    }
+
+    @Override
+    public Optional<Float> getBorderWidth() {
+        return resolveAttribute(MapAttributes::getBorderWidth);
+    }
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMapAttributes.java
@@ -19,6 +19,7 @@ public record ResolvedMapAttributes(
         ResolvedMapVisibility iconVisibility,
         CustomColor iconColor,
         MapDecoration iconDecoration,
+        boolean hasMarker,
         ResolvedMarkerOptions markerOptions,
         CustomColor fillColor,
         CustomColor borderColor,

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMapAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.resolving;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMapVisibility.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMapVisibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.resolving;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMarkerOptions.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/resolving/ResolvedMarkerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.resolving;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface MapAreaAttributes extends MapAttributes {
     static List<String> getUnsupportedAttributes() {
-        return List.of("iconId", "iconVisibility", "iconColor", "iconDecoration", "markerOptions");
+        return List.of("iconId", "iconVisibility", "iconColor", "iconDecoration", "hasMarker", "markerOptions");
     }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAreaAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAttributes.java
@@ -60,10 +60,13 @@ public interface MapAttributes {
 
     // endregion
 
-    // region Marker Attributes
+    // region MapLocation Marker Attributes
+
+    // Whether the marker is enabled on the map
+    // (the marker may still not be visible, depending on the marker options)
+    Optional<Boolean> getHasMarker();
 
     // The options of the marker in the world
-    // This is only supported for MapLocations
     Optional<MapMarkerOptions> getMarkerOptions();
 
     // endregion

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapDecoration.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapDecoration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapLocationAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapMarkerOptions.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapMarkerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
@@ -13,6 +13,7 @@ public interface MapPathAttributes extends MapAttributes {
                 "iconVisibility",
                 "iconColor",
                 "iconDecoration",
+                "hasMarker",
                 "markerOptions",
                 "fillColor",
                 "borderWidth",

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/type/MapPathAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.attributes.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/builtin/CombatLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/builtin/CombatLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/builtin/FoundChestLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/builtin/FoundChestLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/builtin/PlaceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/builtin/PlaceLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/builtin/ServiceLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/builtin/ServiceLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/builtin/TerritoryArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/builtin/TerritoryArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/builtin/WaypointLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/builtin/WaypointLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapAreaImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapAreaImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapLocationImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapLocationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapPathImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapPathImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/type/MapArea.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/type/MapArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/type/MapFeature.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/type/MapFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/type/MapLocation.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/type/MapLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/type/MapPath.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/type/MapPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.features.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/impl/MapCategoryImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/impl/MapCategoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/impl/MapIconImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/impl/MapIconImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.impl;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/BuiltInProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/BuiltInProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CombatListProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CombatListProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/LootChestsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/LootChestsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/MapIconsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/MapIconsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlaceListProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlaceListProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/PlayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/ServiceListProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/ServiceListProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/TerritoryProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/TerritoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/WaypointsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.builtin;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/json/JsonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.json;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/type/MapDataOverrideProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/type/MapDataOverrideProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/type/MapDataOverrideProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/type/MapDataOverrideProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.mapdata.providers.type;
+
+import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.type.MapDataProvidedType;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public interface MapDataOverrideProvider {
+    /**
+     * Get the attributes that are overriden by this provider.
+     *
+     * @return The attributes that are overriden by this provider.
+     */
+    MapAttributes getOverrideAttributes();
+
+    /**
+     * Get the feature ids that are overriden by this provider.
+     *
+     * @return The feature ids that are overriden by this provider.
+     */
+    Stream<String> getOverridenFeatureIds();
+
+    /**
+     * Get the category ids that are overriden by this provider.
+     *
+     * @return The category ids that are overriden by this provider.
+     */
+    Stream<String> getOverridenCategoryIds();
+
+    void onChange(Consumer<MapDataProvidedType> callback);
+}

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/type/MapDataProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/type/MapDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.providers.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapCategory.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapDataProvidedType.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapDataProvidedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.type;

--- a/common/src/main/java/com/wynntils/services/mapdata/type/MapIcon.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/type/MapIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.mapdata.type;

--- a/common/src/main/java/com/wynntils/utils/render/Texture.java
+++ b/common/src/main/java/com/wynntils/utils/render/Texture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render;

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedFontRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.buffered;

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedRenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedRenderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.buffered;

--- a/common/src/main/java/com/wynntils/utils/render/buffered/CustomRenderType.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/CustomRenderType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.buffered;

--- a/common/src/main/java/com/wynntils/utils/render/type/AbstractTexture.java
+++ b/common/src/main/java/com/wynntils/utils/render/type/AbstractTexture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.type;

--- a/common/src/main/java/com/wynntils/utils/type/BoundingBox.java
+++ b/common/src/main/java/com/wynntils/utils/type/BoundingBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/type/BoundingCircle.java
+++ b/common/src/main/java/com/wynntils/utils/type/BoundingCircle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/type/BoundingPolygon.java
+++ b/common/src/main/java/com/wynntils/utils/type/BoundingPolygon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;

--- a/common/src/main/java/com/wynntils/utils/type/BoundingShape.java
+++ b/common/src/main/java/com/wynntils/utils/type/BoundingShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.type;


### PR DESCRIPTION
Essentially, this is what I've been planning to replace https://github.com/Wynntils/Wynntils/pull/2947 with.

The current implementation is still hacky, as the point of this PR is not to port MarkerModel, but introduce the system/concept behind the idea.

If this system is accepted, here is the list of work that needs to be done. This list is also helpful for understanding how other marker model providers would be ported.
- `MarkerModel` becomes `UserMarkerService`, only handling user marked waypoints
- `USER_WAYPOINT_PROVIDER` users are now interacting with UserMarkerService, effectively eliminating `MarkerProvider` and `MarkerOptions`, the old setting class behind markers 
- Every other marker provider that is currently registered to marker model is ported to `MapDataOverrideProvider`, as they are other models, they can work out how/when they want to apply their marker overrides (eg. `LootrunModel` registers a temporary `MapDataOverrideProvider` when the user is in a lootrun)