### PR TITLE
fix: Lookup your own info on world join [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/players/PlayerModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PlayerModel.java
@@ -116,6 +116,11 @@ public final class PlayerModel extends Model {
         }
         if (event.getNewState() == WorldState.WORLD) {
             clearGhostCache();
+
+            // Lookup self info here as PlayerJoinedWorldEvent will only be posted for self when off world
+            Player player = McUtils.player();
+            if (player == null || player.getUUID() == null) return;
+            loadUser(player.getUUID(), player.getScoreboardName());
         }
     }
 


### PR DESCRIPTION
Missed this in https://github.com/Wynntils/Wynntils/pull/2982 didn't realise that your own info wasn't looked up when not on world