### PR TITLE
fix: Add some missing stats and rerolls to gear viewing

### DIFF
--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -110,7 +110,13 @@ public final class GearModel extends Model {
         WynnItemParseResult result = WynnItemParser.parseInternalRolls(gearInfo, itemData);
 
         return GearInstance.create(
-                gearInfo, result.identifications(), result.powders(), 0, Optional.empty(), false, Optional.empty());
+                gearInfo,
+                result.identifications(),
+                result.powders(),
+                result.rerolls(),
+                Optional.empty(),
+                false,
+                Optional.empty());
     }
 
     public CraftedGearItem parseCraftedGearItem(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
@@ -155,7 +155,7 @@ public final class StatListOrderer {
             MiscStatKind.HEALTH,
             MiscStatKind.STEALING,
             MiscStatKind.HEALTH_REGEN_RAW,
-            MiscStatKind.MAX_MANA,
+            MiscStatKind.MAX_MANA_RAW,
             MiscStatKind.HEALING_EFFICIENCY,
             MiscStatKind.SLOW_ENEMY,
             MiscStatKind.WEAKEN_ENEMY);

--- a/common/src/main/java/com/wynntils/models/stats/builders/DefenceStatBuilder.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/DefenceStatBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.builders;
@@ -26,7 +26,7 @@ public final class DefenceStatBuilder extends StatBuilder<DefenceStatType> {
         }
 
         callback.accept(new DefenceStatType(
-                "DEFENCE_ELEMENTAL", "Elemental Defence", "elementalDefence", "ELEMENTALDEFENSE", StatUnit.PERCENT));
+                "DEFENCE_ELEMENTAL", "Elemental Defence", "elementalDefence", "ELEMENTAL_DEFENSE", StatUnit.PERCENT));
 
         // Special case for the "defenceToMobs" tome stat
         callback.accept(new DefenceStatType(

--- a/common/src/main/java/com/wynntils/models/stats/builders/MiscStatKind.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/MiscStatKind.java
@@ -17,7 +17,7 @@ public enum MiscStatKind {
     LIFE_STEAL("Life Steal", StatUnit.PER_3_S, "lifeSteal"),
     MANA_REGEN("Mana Regen", StatUnit.PER_5_S, "manaRegen"),
     MANA_STEAL("Mana Steal", StatUnit.PER_3_S, "manaSteal"),
-    MAX_MANA("Max Mana", StatUnit.RAW, "maxMana"),
+    MAX_MANA("Max Mana", StatUnit.RAW, "maxMana", "MAX_MANA"),
 
     // Movement
     WALK_SPEED("Walk Speed", StatUnit.PERCENT, "walkSpeed", "SPEED"),
@@ -32,8 +32,8 @@ public enum MiscStatKind {
     EXPLODING("Exploding", StatUnit.PERCENT, "exploding"),
     POISON("Poison", StatUnit.PER_3_S, "poison"),
     KNOCKBACK("Knockback", StatUnit.PERCENT, "knockback"),
-    SLOW_ENEMY("Slow Enemy", StatUnit.PERCENT, "slowEnemy"),
-    WEAKEN_ENEMY("Weaken Enemy", StatUnit.PERCENT, "weakenEnemy"),
+    SLOW_ENEMY("Slow Enemy", StatUnit.PERCENT, "slowEnemy", "SLOW_ENEMY"),
+    WEAKEN_ENEMY("Weaken Enemy", StatUnit.PERCENT, "weakenEnemy", "WEAKEN_ENEMY"),
 
     // Bonuses for emeralds, XP, loot and gathering
     STEALING("Stealing", StatUnit.PERCENT, "stealing", "EMERALDSTEALING"),

--- a/common/src/main/java/com/wynntils/models/stats/builders/MiscStatKind.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/MiscStatKind.java
@@ -17,7 +17,7 @@ public enum MiscStatKind {
     LIFE_STEAL("Life Steal", StatUnit.PER_3_S, "lifeSteal"),
     MANA_REGEN("Mana Regen", StatUnit.PER_5_S, "manaRegen"),
     MANA_STEAL("Mana Steal", StatUnit.PER_3_S, "manaSteal"),
-    MAX_MANA("Max Mana", StatUnit.RAW, "maxMana", "MAX_MANA"),
+    MAX_MANA_RAW("Max Mana", StatUnit.RAW, "rawMaxMana", "MAX_MANA"),
 
     // Movement
     WALK_SPEED("Walk Speed", StatUnit.PERCENT, "walkSpeed", "SPEED"),

--- a/common/src/main/java/com/wynntils/models/stats/builders/SkillStatBuilder.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/SkillStatBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.builders;
@@ -16,6 +16,12 @@ public final class SkillStatBuilder extends StatBuilder<SkillStatType> {
     public void buildStats(Consumer<SkillStatType> callback) {
         for (Skill skill : Skill.values()) {
             String internalName = (skill.getApiName() + "Points").toUpperCase(Locale.ROOT);
+
+            // Still uses the American spelling internally
+            if (skill == Skill.DEFENCE) {
+                internalName = "DEFENSEPOINTS";
+            }
+
             String apiName = "raw" + StringUtils.capitalized(skill.getApiName());
 
             SkillStatType statType = new SkillStatType(

--- a/common/src/main/java/com/wynntils/models/stats/builders/SpellStatBuilder.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/SpellStatBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.builders;
@@ -11,7 +11,6 @@ import com.wynntils.models.stats.type.StatUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
 
 public final class SpellStatBuilder extends StatBuilder<SpellStatType> {
@@ -48,7 +47,7 @@ public final class SpellStatBuilder extends StatBuilder<SpellStatType> {
 
     private SpellStatType buildSpellStat(SpellType spellType, StatUnit unit) {
         String apiUnit = unit == StatUnit.RAW ? "raw" : "";
-        String loreUnit = apiUnit.toUpperCase(Locale.ROOT);
+        String loreUnit = unit == StatUnit.RAW ? "RAW" : "PCT";
         int spellNumber = spellType.getSpellNumber();
         String spellNumberString =
                 switch (spellNumber) {
@@ -63,7 +62,7 @@ public final class SpellStatBuilder extends StatBuilder<SpellStatType> {
                 "SPELL_" + spellType.name() + "_COST_" + unit.name(),
                 getStatNameForSpell(spellType.getName()),
                 apiUnit + spellNumberString + "SpellCost",
-                "SPELL_COST_" + loreUnit + (loreUnit.isEmpty() ? "" : "_") + spellNumber,
+                "SPELL_COST_" + loreUnit + "_" + spellNumber,
                 unit,
                 spellType);
     }

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
@@ -42,7 +42,8 @@ public record WynnItemParseResult(
         Optional<ShinyStat> shinyStat,
         boolean allRequirementsMet,
         Optional<SetInstance> setInstance) {
-    public static WynnItemParseResult fromInternallRoll(List<StatActualValue> identifications, List<Powder> powders) {
+    public static WynnItemParseResult fromInternallRoll(
+            List<StatActualValue> identifications, List<Powder> powders, int rerolls) {
         return new WynnItemParseResult(
                 null,
                 null,
@@ -57,7 +58,7 @@ public record WynnItemParseResult(
                 List.of(),
                 powders,
                 0,
-                0,
+                rerolls,
                 0,
                 0,
                 Optional.empty(),

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -497,7 +497,7 @@ public final class WynnItemParser {
                 : 0;
 
         // Shiny stats are not available from internal roll lore (on other players)
-        return WynnItemParseResult.fromInternallRoll(identifications, powders);
+        return WynnItemParseResult.fromInternallRoll(identifications, powders, rerolls);
     }
 
     public static CraftedItemParseResults parseCraftedItem(ItemStack itemStack) {


### PR DESCRIPTION
We already parsed the rerolls just never used it, not sure if there was a reason or just a mistake

Rerolls & spell % cost
![image](https://github.com/user-attachments/assets/f5f5bed2-b3c9-4b79-8647-a84c392cbd28)

Max Mana
![image](https://github.com/user-attachments/assets/cad75d95-73fb-4297-825d-f07d05da7fba)

Slow and weaken enemy
![image](https://github.com/user-attachments/assets/0784fa90-8f3c-4dfc-b4f2-a18a1d22ccb9)

Elemental Defence
![image](https://github.com/user-attachments/assets/4689a436-0f6b-49a9-9523-80b01a8c0ac2)

Defence Skill Points
![image](https://github.com/user-attachments/assets/af09e974-73c6-48d8-a92d-be2893e357f6)

