### PR TITLE
chore: Disable custom lootrun beacons until tracking issues fixed [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
@@ -5,11 +5,13 @@
 package com.wynntils.features.combat;
 
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.properties.StartDisabled;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 
+@StartDisabled
 @ConfigCategory(Category.COMBAT)
 public class CustomLootrunBeaconsFeature extends Feature {
     @Persisted


### PR DESCRIPTION
Opted to disable the feature rather than disable the remove original option but if others think it shouldn't be done this way then can easily change