### PR TITLE
fix: Add raw max mana to legacy stat ordering [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatListOrderer.java
@@ -67,7 +67,7 @@ public final class StatListOrderer {
             "MISC_LIFE_STEAL",
             "MISC_MANA_REGEN",
             "MISC_MANA_STEAL",
-            "MISC_MAX_MANA",
+            "MISC_MAX_MANA_RAW",
             "", // delimiter
             "DAMAGE_ANY_ALL_RAW",
             "DAMAGE_ANY_ALL_PERCENT",


### PR DESCRIPTION
Forgot this didn't just use the enum and had to be manually changed