### PR TITLE
feat: Allow set compass / open map/wiki for world discoveries [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/activities/discoveries/DiscoveryModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/discoveries/DiscoveryModel.java
@@ -40,8 +40,8 @@ public final class DiscoveryModel extends Model {
     }
 
     public void openDiscoveryOnMap(DiscoveryInfo discoveryInfo) {
-        if (discoveryInfo.type() == DiscoveryType.SECRET) {
-            locateSecretDiscovery(discoveryInfo.name(), DiscoveryOpenAction.MAP);
+        if (discoveryInfo.type() != DiscoveryType.TERRITORY) {
+            locateDiscovery(discoveryInfo.name(), DiscoveryOpenAction.MAP);
             return;
         }
 
@@ -55,8 +55,8 @@ public final class DiscoveryModel extends Model {
     }
 
     public void setDiscoveryCompass(DiscoveryInfo discoveryInfo) {
-        if (discoveryInfo.type() == DiscoveryType.SECRET) {
-            locateSecretDiscovery(discoveryInfo.name(), DiscoveryOpenAction.COMPASS);
+        if (discoveryInfo.type() != DiscoveryType.TERRITORY) {
+            locateDiscovery(discoveryInfo.name(), DiscoveryOpenAction.COMPASS);
             return;
         }
 
@@ -70,7 +70,7 @@ public final class DiscoveryModel extends Model {
         }
     }
 
-    public void openSecretDiscoveryWiki(DiscoveryInfo discoveryInfo) {
+    public void openDiscoveryWiki(DiscoveryInfo discoveryInfo) {
         Managers.Net.openLink(UrlId.LINK_WIKI_LOOKUP, Map.of("title", discoveryInfo.name()));
     }
 
@@ -208,7 +208,7 @@ public final class DiscoveryModel extends Model {
         return storage.getTooltip(type);
     }
 
-    private void locateSecretDiscovery(String name, DiscoveryOpenAction action) {
+    private void locateDiscovery(String name, DiscoveryOpenAction action) {
         ApiResponse apiResponse = Managers.Net.callApi(UrlId.API_WIKI_DISCOVERY_QUERY, Map.of("name", name));
         apiResponse.handleJsonObject(json -> {
             if (json.has("error")) { // Returns error if page does not exist

--- a/common/src/main/java/com/wynntils/screens/activities/widgets/DiscoveryButton.java
+++ b/common/src/main/java/com/wynntils/screens/activities/widgets/DiscoveryButton.java
@@ -92,8 +92,8 @@ public class DiscoveryButton extends WynntilsButton implements TooltipProvider {
             Models.Discovery.setDiscoveryCompass(discoveryInfo);
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_MIDDLE) {
             Models.Discovery.openDiscoveryOnMap(discoveryInfo);
-        } else if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT && discoveryInfo.type() == DiscoveryType.SECRET) {
-            Models.Discovery.openSecretDiscoveryWiki(discoveryInfo);
+        } else if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT && discoveryInfo.type() != DiscoveryType.TERRITORY) {
+            Models.Discovery.openDiscoveryWiki(discoveryInfo);
         }
 
         return true;
@@ -124,7 +124,7 @@ public class DiscoveryButton extends WynntilsButton implements TooltipProvider {
             }
         }
 
-        if (discoveryInfo.type() == DiscoveryType.SECRET
+        if (discoveryInfo.type() != DiscoveryType.TERRITORY
                 || Models.Territory.getTerritoryProfile(discoveryInfo.name()) != null) {
             lines.add(Component.empty());
             lines.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.leftClickToSetCompass")
@@ -135,7 +135,7 @@ public class DiscoveryButton extends WynntilsButton implements TooltipProvider {
                     .withStyle(ChatFormatting.YELLOW));
         }
 
-        if (discoveryInfo.type() == DiscoveryType.SECRET) {
+        if (discoveryInfo.type() != DiscoveryType.TERRITORY) {
             lines.add(Component.translatable("screens.wynntils.wynntilsDiscoveries.rightClickToOpenWiki")
                     .withStyle(ChatFormatting.BOLD)
                     .withStyle(ChatFormatting.GOLD));


### PR DESCRIPTION
World discoveries seem to have pages on the Wynncraft Wiki most of the time, meaning we can add all secret discovery-exclusive actions (set compass, show on map, open wiki) to them as well