### PR TITLE
fix: Update profession progress on failed gathers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MaterialAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MaterialAnnotator.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.models.items.annotators.game;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.GameItemAnnotator;
 import com.wynntils.handlers.item.ItemAnnotation;
@@ -25,18 +24,8 @@ public final class MaterialAnnotator implements GameItemAnnotator {
         String materialSource = matcher.group(1);
         String resourceType = matcher.group(2);
         String tierIndicator = matcher.group(3);
-        int tier =
-                switch (tierIndicator) {
-                    case "§8✫" -> 1;
-                    case "✫§8" -> 2;
-                    case "✫" -> 3;
-                    default -> {
-                        WynntilsMod.warn("Cannot parse tier from material: " + name);
-                        yield 1;
-                    }
-                };
 
-        MaterialProfile materialProfile = MaterialProfile.lookup(materialSource, resourceType, tier);
+        MaterialProfile materialProfile = MaterialProfile.lookup(materialSource, resourceType, tierIndicator);
         if (materialProfile == null) return null;
 
         return new MaterialItem(materialProfile);

--- a/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
+++ b/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
@@ -7,26 +7,21 @@ package com.wynntils.models.profession;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
-import com.wynntils.core.components.Models;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
-import com.wynntils.handlers.labels.event.TextDisplayChangedEvent;
-import com.wynntils.mc.event.ContainerSetSlotEvent;
-import com.wynntils.models.items.items.game.MaterialItem;
-import com.wynntils.models.profession.event.ProfessionNodeGatheredEvent;
+import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
 import com.wynntils.models.profession.event.ProfessionXpGainEvent;
+import com.wynntils.models.profession.label.GatheringNodeHarvestLabelInfo;
+import com.wynntils.models.profession.label.GatheringNodeHarvestLabelParser;
 import com.wynntils.models.profession.label.GatheringNodeLabelParser;
 import com.wynntils.models.profession.label.GatheringStationLabelParser;
 import com.wynntils.models.profession.type.HarvestInfo;
 import com.wynntils.models.profession.type.ProfessionProgress;
 import com.wynntils.models.profession.type.ProfessionType;
 import com.wynntils.utils.mc.LoreUtils;
-import com.wynntils.utils.mc.PosUtils;
-import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.type.TimedSet;
-import com.wynntils.utils.type.TimedValue;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,21 +31,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraft.core.Position;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public class ProfessionModel extends Model {
-    // §7x1 [+3952§f Ⓒ§7 Woodcutting XP] §6[14.64%]
-    private static final Pattern PROFESSION_NODE_EXPERIENCE_PATTERN = Pattern.compile(
-            "(§.x[\\d\\.]+ )?(§.)?\\[\\+(§d)?(?<gain>\\d+)§f [ⓀⒸⒷⒿⒺⒹⓁⒶⒼⒻⒾⒽ]§7 (?<name>.+) XP\\] §6\\[(?<current>[\\d.]+)%\\]");
-
-    // §a+1§2 Dernic Wood§6 [§e✫§8✫✫§6]
-    private static final Pattern PROFESSION_NODE_HARVEST_PATTERN =
-            Pattern.compile("§a\\+\\d+§2 (?<type>.+) (?<material>.+)§6 \\[§e✫((?:§8)?✫(?:§8)?)✫§6\\]");
-
     // §dx2.0 §7[+§d28 §fⒺ §7Scribing XP] §6[56%]
     private static final Pattern PROFESSION_CRAFT_PATTERN = Pattern.compile(
             "(§dx[\\d\\.]+ )?§7\\[\\+(§d)?(?<gain>\\d+) §f[ⓀⒸⒷⒿⒺⒹⓁⒶⒼⒻⒾⒽ] §7(?<name>.+) XP\\] §6\\[(?<current>[\\d.]+)%\\]");
@@ -66,21 +51,19 @@ public class ProfessionModel extends Model {
     @Persisted
     private final Storage<Integer> professionDryStreak = new Storage<>(0);
 
-    private Pair<Long, MaterialItem> lastHarvestItemGain = Pair.of(0L, null);
+    private long lastGatherTime = 0L;
     private HarvestInfo lastHarvest;
 
-    private final TimedSet<Position> gatheredNodes = new TimedSet<>(10, TimeUnit.SECONDS, true);
+    private final TimedSet<Integer> harvestIds = new TimedSet<>(MAX_HARVEST_LABEL_AGE, TimeUnit.MILLISECONDS, true);
     private Map<ProfessionType, ProfessionProgress> professionProgressMap = new ConcurrentHashMap<>();
     private final Map<ProfessionType, TimedSet<Float>> rawXpGainInLastMinute = new HashMap<>();
-
-    private final TimedValue<StyledText> lastProfessionLabel =
-            new TimedValue<>(MAX_HARVEST_LABEL_AGE, TimeUnit.MILLISECONDS);
 
     public ProfessionModel() {
         super(List.of());
 
         Handlers.Label.registerParser(new GatheringNodeLabelParser());
         Handlers.Label.registerParser(new GatheringStationLabelParser());
+        Handlers.Label.registerParser(new GatheringNodeHarvestLabelParser());
 
         for (ProfessionType pt : ProfessionType.values()) {
             rawXpGainInLastMinute.put(pt, new TimedSet<>(1, TimeUnit.MINUTES, true));
@@ -88,62 +71,16 @@ public class ProfessionModel extends Model {
     }
 
     @SubscribeEvent
-    public void onContainerSetSlot(ContainerSetSlotEvent.Post event) {
-        Optional<MaterialItem> materialItem = Models.Item.asWynnItem(event.getItemStack(), MaterialItem.class);
+    public void onLabelIdentified(LabelIdentifiedEvent event) {
+        if (event.getLabelInfo() instanceof GatheringNodeHarvestLabelInfo gatheringInfo) {
+            if (harvestIds.stream()
+                    .anyMatch(id -> id == event.getLabelInfo().getEntity().getId())) {
+                if (gatheringInfo.getMaterialProfile().isEmpty()) return;
 
-        if (materialItem.isEmpty()) return;
-
-        lastHarvestItemGain = Pair.of(System.currentTimeMillis(), materialItem.get());
-    }
-
-    @SubscribeEvent
-    public void onLabelSpawn(TextDisplayChangedEvent.Text event) {
-        StyledText label = event.getText();
-
-        // Profession labels are 1-text, multi-line
-        StyledText[] lines = label.split("\n");
-
-        // We only care about multi-line labels
-        if (lines.length < 2) return;
-
-        for (StyledText line : lines) {
-            Matcher professionNodeExperienceMatcher = line.getMatcher(PROFESSION_NODE_EXPERIENCE_PATTERN);
-            if (professionNodeExperienceMatcher.matches()) {
-                Vec3 entityPosition = event.getTextDisplay().position();
-
-                if (gatheredNodes.stream().anyMatch(position -> PosUtils.isSame(position, entityPosition))) {
-                    // We already recorded this XP gain, ignore it.
-                    continue;
-                }
-
-                ProfessionType profession = ProfessionType.fromString(professionNodeExperienceMatcher.group("name"));
-
-                // Woodcutting labels can move during "display", so position based checks don't always work
-                if (profession == ProfessionType.WOODCUTTING && lastProfessionLabel.matches(line)) {
-                    continue;
-                }
-
-                lastProfessionLabel.set(line);
-                gatheredNodes.put(entityPosition);
-
-                WynntilsMod.postEvent(new ProfessionXpGainEvent(
-                        profession,
-                        Float.parseFloat(professionNodeExperienceMatcher.group("gain")),
-                        Float.parseFloat(professionNodeExperienceMatcher.group("current"))));
-
-                ProfessionNodeGatheredEvent.LabelShown gatherEvent = new ProfessionNodeGatheredEvent.LabelShown();
-                WynntilsMod.postEvent(gatherEvent);
-
-                continue;
-            }
-
-            Matcher professionNodeHarvestMatcher = line.getMatcher(PROFESSION_NODE_HARVEST_PATTERN);
-            if (professionNodeHarvestMatcher.matches()) {
-                if (lastHarvestItemGain.a() + MAX_HARVEST_LABEL_AGE >= System.currentTimeMillis()
-                        && lastHarvestItemGain.b() != null) {
-                    MaterialItem materialItem = lastHarvestItemGain.b();
-                    lastHarvest = new HarvestInfo(lastHarvestItemGain.a(), materialItem.getMaterialProfile());
-                    lastHarvestItemGain = Pair.of(0L, null);
+                if (lastGatherTime + MAX_HARVEST_LABEL_AGE >= System.currentTimeMillis()) {
+                    lastHarvest = new HarvestInfo(
+                            lastGatherTime, gatheringInfo.getMaterialProfile().get());
+                    lastGatherTime = 0L;
 
                     if (lastHarvest.materialProfile().getTier() == 3) {
                         professionDryStreak.store(0);
@@ -152,6 +89,11 @@ public class ProfessionModel extends Model {
                     }
                 }
             }
+
+            harvestIds.put(gatheringInfo.getEntity().getId());
+            lastGatherTime = System.currentTimeMillis();
+            WynntilsMod.postEvent(new ProfessionXpGainEvent(
+                    gatheringInfo.getProfessionType(), gatheringInfo.getXpGain(), gatheringInfo.getCurrentXp()));
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelInfo.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.profession.label;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.labels.type.LabelInfo;
+import com.wynntils.models.profession.type.MaterialProfile;
+import com.wynntils.models.profession.type.ProfessionType;
+import com.wynntils.utils.mc.type.Location;
+import java.util.Optional;
+import net.minecraft.world.entity.Entity;
+
+public class GatheringNodeHarvestLabelInfo extends LabelInfo {
+    private final ProfessionType professionType;
+    private final float xpGain;
+    private final float currentXp;
+    private final Optional<MaterialProfile> materialProfile;
+
+    public GatheringNodeHarvestLabelInfo(
+            StyledText label,
+            Location location,
+            Entity entity,
+            ProfessionType professionType,
+            float xpGain,
+            float currentXp,
+            Optional<MaterialProfile> materialProfile) {
+        super(label, location, entity);
+        this.professionType = professionType;
+        this.xpGain = xpGain;
+        this.currentXp = currentXp;
+        this.materialProfile = materialProfile;
+    }
+
+    public ProfessionType getProfessionType() {
+        return professionType;
+    }
+
+    public float getXpGain() {
+        return xpGain;
+    }
+
+    public float getCurrentXp() {
+        return currentXp;
+    }
+
+    public Optional<MaterialProfile> getMaterialProfile() {
+        return materialProfile;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
@@ -21,7 +21,7 @@ public class GatheringNodeHarvestLabelParser implements LabelParser<GatheringNod
 
     // §a+1§2 Dernic Wood§6 [§e✫§8✫✫§6]
     private static final Pattern HARVEST_PATTERN =
-            Pattern.compile("§a\\+\\d+§2 (?<type>.+) (?<material>.+)§6 \\[(?<tier>§e✫(?:§8)?✫(?:§8)?✫)§6\\]");
+            Pattern.compile("§a\\+\\d+§2 (?<type>.+) (?<material>.+)§6 \\[§e✫((?:§8)?✫(?:§8)?)✫§6\\]");
 
     @Override
     public GatheringNodeHarvestLabelInfo getInfo(StyledText label, Location location, Entity entity) {
@@ -42,15 +42,9 @@ public class GatheringNodeHarvestLabelParser implements LabelParser<GatheringNod
                 if (materialMatcher.matches()) {
                     String type = materialMatcher.group("type");
                     String material = materialMatcher.group("material");
-                    String tierGroup = materialMatcher.group("tier");
-                    int tier =
-                            switch (tierGroup) {
-                                case "§e✫✫§8✫" -> 2;
-                                case "§e✫✫✫" -> 3;
-                                default -> 1;
-                            };
+                    String tierGroup = materialMatcher.group(3);
 
-                    gatheredMaterial = Optional.ofNullable(MaterialProfile.lookup(type, material, tier));
+                    gatheredMaterial = Optional.ofNullable(MaterialProfile.lookup(type, material, tierGroup));
                 }
             }
 

--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
@@ -50,7 +50,7 @@ public class GatheringNodeHarvestLabelParser implements LabelParser<GatheringNod
                                 default -> 1;
                             };
 
-                    gatheredMaterial = Optional.of(MaterialProfile.lookup(type, material, tier));
+                    gatheredMaterial = Optional.ofNullable(MaterialProfile.lookup(type, material, tier));
                 }
             }
 

--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.profession.label;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.labels.type.LabelParser;
+import com.wynntils.models.profession.type.MaterialProfile;
+import com.wynntils.models.profession.type.ProfessionType;
+import com.wynntils.utils.mc.type.Location;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.entity.Entity;
+
+public class GatheringNodeHarvestLabelParser implements LabelParser<GatheringNodeHarvestLabelInfo> {
+    // §7x1 [+3952§f Ⓒ§7 Woodcutting XP] §6[14.64%]
+    private static final Pattern EXPERIENCE_PATTERN = Pattern.compile(
+            "(§.x[\\d\\.]+ )?(§.)?\\[\\+(§d)?(?<gain>\\d+)§f [ⓀⒸⒷⒿⒺⒹⓁⒶⒼⒻⒾⒽ]§7 (?<name>.+) XP\\] §6\\[(?<current>[\\d.]+)%\\]");
+
+    // §a+1§2 Dernic Wood§6 [§e✫§8✫✫§6]
+    private static final Pattern HARVEST_PATTERN =
+            Pattern.compile("§a\\+\\d+§2 (?<type>.+) (?<material>.+)§6 \\[(?<tier>§e✫(?:§8)?✫(?:§8)?✫)§6\\]");
+
+    @Override
+    public GatheringNodeHarvestLabelInfo getInfo(StyledText label, Location location, Entity entity) {
+        StyledText[] lines = label.split("\n");
+
+        Matcher experienceMatcher = lines[0].getMatcher(EXPERIENCE_PATTERN);
+
+        if (experienceMatcher.matches()) {
+            ProfessionType profession = ProfessionType.fromString(experienceMatcher.group("name"));
+            float gain = Float.parseFloat(experienceMatcher.group("gain"));
+            float current = Float.parseFloat(experienceMatcher.group("current"));
+
+            Optional<MaterialProfile> gatheredMaterial = Optional.empty();
+
+            if (lines.length == 2) {
+                Matcher materialMatcher = lines[1].getMatcher(HARVEST_PATTERN);
+
+                if (materialMatcher.matches()) {
+                    String type = materialMatcher.group("type");
+                    String material = materialMatcher.group("material");
+                    String tierGroup = materialMatcher.group("tier");
+                    int tier =
+                            switch (tierGroup) {
+                                case "§e✫✫§8✫" -> 2;
+                                case "§e✫✫✫" -> 3;
+                                default -> 1;
+                            };
+
+                    gatheredMaterial = Optional.of(MaterialProfile.lookup(type, material, tier));
+                }
+            }
+
+            return new GatheringNodeHarvestLabelInfo(
+                    label, location, entity, profession, gain, current, gatheredMaterial);
+        }
+
+        return null;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/profession/type/MaterialProfile.java
+++ b/common/src/main/java/com/wynntils/models/profession/type/MaterialProfile.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.profession.type;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.utils.type.Pair;
 import java.util.Collection;
 import java.util.List;
@@ -81,7 +82,7 @@ public final class MaterialProfile {
         this.tier = tier;
     }
 
-    public static MaterialProfile lookup(String sourceMaterialName, String resourceTypeName, int tier) {
+    public static MaterialProfile lookup(String sourceMaterialName, String resourceTypeName, String tier) {
         SourceMaterial sourceMaterial = SOURCE_MATERIALS.values().stream()
                 .flatMap(Collection::stream)
                 .filter(material -> material.name().equals(sourceMaterialName))
@@ -92,7 +93,7 @@ public final class MaterialProfile {
         ResourceType resourceType = ResourceType.fromString(resourceTypeName);
         if (resourceType == null) return null;
 
-        return new MaterialProfile(resourceType, sourceMaterial, tier);
+        return new MaterialProfile(resourceType, sourceMaterial, parseTier(tier));
     }
 
     public static Optional<Pair<MaterialType, SourceMaterial>> findByMaterialName(
@@ -166,6 +167,18 @@ public final class MaterialProfile {
         public MaterialType getMaterialType() {
             return materialType;
         }
+    }
+
+    private static int parseTier(String tierIndicator) {
+        return switch (tierIndicator) {
+            case "§8✫" -> 1;
+            case "✫§8" -> 2;
+            case "✫" -> 3;
+            default -> {
+                WynntilsMod.warn("Cannot parse tier from: " + tierIndicator);
+                yield 1;
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
Bit of a rework to how we handle the labels, using the entity id to keep track of which nodes we've already checked instead of the position and getting the material profile from just the label instead of a combination of inventory and label.

The labels from harvesting no longer seem to move as seen in https://github.com/Wynntils/Wynntils/issues/2586 so that issue shouldn't appear again, I tested that exact tree shown in the issue and it did not trigger twice.

Does not fully close https://github.com/Wynntils/Wynntils/issues/2817 as it doesn't handle the alternate resources, will follow up with that soon