### PR TITLE
fix: Fix lootruns with notes not being able to be saved

### DIFF
--- a/common/src/main/java/com/wynntils/services/lootrunpaths/LootrunPathFileParser.java
+++ b/common/src/main/java/com/wynntils/services/lootrunpaths/LootrunPathFileParser.java
@@ -126,8 +126,8 @@ public final class LootrunPathFileParser {
                         note.component(), McUtils.mc().player.registryAccess());
 
                 // Parse the JSON string back into a JSON object
-                JsonObject noteObject = JsonParser.parseString(noteString).getAsJsonObject();
-                noteJson.add("note", noteObject);
+                JsonElement noteElement = JsonParser.parseString(noteString);
+                noteJson.add("note", noteElement);
                 notes.add(noteJson);
             }
             json.add("notes", notes);


### PR DESCRIPTION
I am not sure if the previous fix to this issue ever worked, or it was broken by 1.21/1.21.1. I know that 1.21 changed component serialization to not always be a json object, as it's useless data sending `{"text":"value"}` when `value` is just fine, if the component had no styling.