### PR TITLE
fix: Update lootrun beacon tracking after patch (Does not fix tracking 5+ beacons)

### DIFF
--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -83,6 +83,8 @@ public final class ActivityModel extends Model {
     private static final Pattern TRACKING_PATTERN = Pattern.compile("^.*§(?:#.{8}|.)§lCLICK TO (UN)?TRACK$");
     private static final Pattern OVERALL_PROGRESS_PATTERN = Pattern.compile("^\\S*§7(\\d+) of (\\d+) completed$");
 
+    public static final int BEACON_COLOR_CUSTOM_MODEL_DATA = 79;
+
     private static final ScoreboardPart TRACKER_SCOREBOARD_PART = new ActivityTrackerScoreboardPart();
     private static final ContentBookQueries CONTAINER_QUERIES = new ContentBookQueries();
     private static final DialogueHistoryQueries DIALOGUE_HISTORY_QUERIES = new DialogueHistoryQueries();

--- a/common/src/main/java/com/wynntils/models/activities/beacons/ActivityBeaconKind.java
+++ b/common/src/main/java/com/wynntils/models/activities/beacons/ActivityBeaconKind.java
@@ -15,16 +15,16 @@ import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.CustomModelData;
 
 public enum ActivityBeaconKind implements BeaconKind {
-    QUEST(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x29CC96)),
-    STORYLINE_QUEST(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x33B33B)),
-    MINI_QUEST(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xB38FAD)),
-    WORLD_EVENT(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00BDBF)),
-    DISCOVERY(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xA1C3E6)),
-    CAVE(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF8C19)),
-    DUNGEON(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xCC6677)),
-    RAID(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xD6401E)),
-    BOSS_ALTAR(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xF2D349)),
-    LOOTRUN_CAMP(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x3399CC));
+    QUEST(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x29CC96)),
+    STORYLINE_QUEST(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x33B33B)),
+    MINI_QUEST(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xB38FAD)),
+    WORLD_EVENT(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00BDBF)),
+    DISCOVERY(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xA1C3E6)),
+    CAVE(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF8C19)),
+    DUNGEON(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xCC6677)),
+    RAID(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xD6401E)),
+    BOSS_ALTAR(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xF2D349)),
+    LOOTRUN_CAMP(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x3399CC));
 
     private final int customModelData;
     private final CustomColor customColor;

--- a/common/src/main/java/com/wynntils/models/beacons/BeaconModel.java
+++ b/common/src/main/java/com/wynntils/models/beacons/BeaconModel.java
@@ -6,6 +6,7 @@ package com.wynntils.models.beacons;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.RemoveEntitiesEvent;
 import com.wynntils.mc.event.SetEntityDataEvent;
@@ -36,7 +37,6 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public class BeaconModel extends Model {
-    public static final int COLOR_CUSTOM_MODEL_DATA = 79;
     private static final ResourceLocation MARKER_FONT = ResourceLocation.withDefaultNamespace("marker");
     private static final List<BeaconKind> beaconRegistry = new ArrayList<>();
     private static final List<BeaconMarkerKind> beaconMarkerRegistry = new ArrayList<>();
@@ -149,7 +149,8 @@ public class BeaconModel extends Model {
             int customColor = potionContents.customColor().orElse(CommonColors.WHITE.asInt());
 
             // Log the color if it's likely to be a new beacon kind
-            if (customModel == COLOR_CUSTOM_MODEL_DATA) {
+            if (customModel == Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA
+                    || customModel == Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA) {
                 WynntilsMod.warn("Unknown beacon kind: " + customModel + " " + customColor);
             }
         }

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -132,6 +132,8 @@ public class LootrunModel extends Model {
     private static final int LOOTRUN_MASTER_REWARDS_RADIUS = 20;
     private static final String LOOTRUN_MASTER_NAME = "Lootrun Master";
 
+    public static final int BEACON_COLOR_CUSTOM_MODEL_DATA = 83;
+
     private static final LootrunScoreboardPart LOOTRUN_SCOREBOARD_PART = new LootrunScoreboardPart();
 
     private static final LootrunBeaconMarkerProvider LOOTRUN_BEACON_COMPASS_PROVIDER =

--- a/common/src/main/java/com/wynntils/models/lootrun/beacons/LootrunBeaconKind.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/beacons/LootrunBeaconKind.java
@@ -15,17 +15,17 @@ import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.CustomModelData;
 
 public enum LootrunBeaconKind implements BeaconKind {
-    GREEN(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00FF80), CommonColors.GREEN),
-    YELLOW(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFFFF33), CommonColors.YELLOW),
-    BLUE(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x5C5CE6), CommonColors.BLUE),
-    PURPLE(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF00FF), CommonColors.PURPLE),
-    GRAY(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xBFBFBF), CommonColors.LIGHT_GRAY),
-    ORANGE(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF9500), CommonColors.ORANGE),
-    RED(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF0000), CommonColors.RED),
-    DARK_GRAY(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x808080), CommonColors.GRAY),
-    WHITE(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CommonColors.WHITE, CommonColors.WHITE),
-    AQUA(Models.Beacon.COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x55FFFF), CommonColors.AQUA),
-    RAINBOW(80, CommonColors.WHITE, CommonColors.RAINBOW);
+    GREEN(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00FF80), CommonColors.GREEN),
+    YELLOW(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFFFF33), CommonColors.YELLOW),
+    BLUE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x5C5CE6), CommonColors.BLUE),
+    PURPLE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF00FF), CommonColors.PURPLE),
+    GRAY(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xBFBFBF), CommonColors.LIGHT_GRAY),
+    ORANGE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF9500), CommonColors.ORANGE),
+    RED(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF0000), CommonColors.RED),
+    DARK_GRAY(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x808080), CommonColors.GRAY),
+    WHITE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CommonColors.WHITE, CommonColors.WHITE),
+    AQUA(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x55FFFF), CommonColors.AQUA),
+    RAINBOW(84, CommonColors.WHITE, CommonColors.RAINBOW);
 
     // These values are used to identify the beacon kind
     private final int customModelData;


### PR DESCRIPTION
![2024-11-29_21 45 22](https://github.com/user-attachments/assets/883c25de-9776-4f38-8fb4-9d58c2d77800)
