### PR TITLE
feat: change item stat color lerping [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
@@ -22,7 +22,7 @@ public final class ColorScaleUtils {
             0f,
             TextColor.fromLegacyFormat(ChatFormatting.RED),
             40f,
-            TextColor.fromLegacyFormat(ChatFormatting.Gold), //Orange
+            TextColor.fromLegacyFormat(ChatFormatting.GOLD), //Orange
             70f,
             TextColor.fromLegacyFormat(ChatFormatting.YELLOW),
             90f,
@@ -34,7 +34,7 @@ public final class ColorScaleUtils {
             20f,
             TextColor.fromLegacyFormat(ChatFormatting.RED),
             50f,
-            TextColor.fromLegacyFormat(ChatFormatting.Gold), //Orange
+            TextColor.fromLegacyFormat(ChatFormatting.GOLD), //Orange
             80f,
             TextColor.fromLegacyFormat(ChatFormatting.YELLOW),
             95f,

--- a/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
@@ -22,7 +22,7 @@ public final class ColorScaleUtils {
             0f,
             TextColor.fromLegacyFormat(ChatFormatting.RED),
             40f,
-            TextColor.fromRgb(0xEE8D24),
+            TextColor.fromLegacyFormat(ChatFormatting.Gold), //Orange
             70f,
             TextColor.fromLegacyFormat(ChatFormatting.YELLOW),
             90f,
@@ -34,7 +34,7 @@ public final class ColorScaleUtils {
             20f,
             TextColor.fromLegacyFormat(ChatFormatting.RED),
             50f,
-            TextColor.fromRgb(0x#EE8D24),
+            TextColor.fromLegacyFormat(ChatFormatting.Gold), //Orange
             80f,
             TextColor.fromLegacyFormat(ChatFormatting.YELLOW),
             95f,

--- a/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
@@ -21,6 +21,8 @@ public final class ColorScaleUtils {
     private static final NavigableMap<Float, TextColor> LERP_MAP = new TreeMap<>(Map.of(
             0f,
             TextColor.fromLegacyFormat(ChatFormatting.RED),
+            40f,
+            TextColor.fromRgb(0xEE8D24),
             70f,
             TextColor.fromLegacyFormat(ChatFormatting.YELLOW),
             90f,
@@ -29,11 +31,13 @@ public final class ColorScaleUtils {
             TextColor.fromLegacyFormat(ChatFormatting.AQUA)));
 
     private static final NavigableMap<Float, TextColor> FLAT_MAP = new TreeMap<>(Map.of(
-            30f,
+            20f,
             TextColor.fromLegacyFormat(ChatFormatting.RED),
+            50f,
+            TextColor.fromRgb(0x#EE8D24),
             80f,
             TextColor.fromLegacyFormat(ChatFormatting.YELLOW),
-            96f,
+            95f,
             TextColor.fromLegacyFormat(ChatFormatting.GREEN),
             Float.MAX_VALUE,
             TextColor.fromLegacyFormat(ChatFormatting.AQUA)));


### PR DESCRIPTION
Color Scale Changes

Following the suggestion I made awhile back I decided to make a pull request to implement my suggestions. I will also explain my reasoning for the changes below. 

Currently I think that the system has its issues and poorly reflects certain scaling well, when color lerp is turned off. This is mainly seen with the Yellow category which makes up 50% of an entire stats roll, making it hard to tell the difference between crappy and decent rolls by color alone.

To compensate for this I think that orange should be added to the color scaling system. Internally the color is called Gold, but the hex value is classified as a type of light orange.

The rationale behind my pull request is that one should easily be able to tell the quality of a roll by a glance, simply due to the color. So I think the colors should denote the following.
Red denotes terrible/defective, Orange denotes crappy, Yellow denotes decent, Green denotes good, and Blue denotes godly/perfect.

Before this change the color ranges when color lerp scaling is disabled, has red as 0-30%, yellow as 30-80%, green as 80-96%, and blue as 96-100% on an individual stats roll.
This fork makes it so the stat scaling is changed in a manner which makes 
Red 0-20%, Orange 20-50%, Yellow 50-80%, Green 80-95% and Blue is 95-100%

This pull request thus makes 3 major changes, First is the lowering of red to 0-20%, as a means to more easily mirror green and blue rolls together. Since 16+4%= 20%. 2nd is the addition of orange, which takes 10% from red and 20% from yellow, allowing it to mirror yellow. 3rd I tweaked blue scaling from 96%+ to 95+% which is based on both the general benchmark for 2 stars being 95+% roll, along with the general community sentiment of Blue rolls being 95%+.

This color scaling system is somewhat based upon Wynncrafts on the internal star system for high stat rolls. Generally the stars denote certain ranges, 1 star marks a roll as 80%+, 2 stars marks 95%+, and 3 stars a perfect roll.

This means stars within Wynncraft only denote rolls which Wynntils identify as green, blue, and perfect. Meaning there is no real definite benchmark besides the arbitrary choice, which makes a distinction between red and yellow rolls. This also means that there is no real reason why oranges have their own category when color lerp is turned off, since it's already a thing when enabled.

My hope of this tweak is to make the quality of rolls a little more clear overall.
