### PR TITLE
fix: Fix quick casts and horse mounting using wrong player rotation

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
@@ -177,7 +177,7 @@ public class HorseMountFeature extends Feature {
                     }
                     McUtils.sendPacket(new ServerboundSetCarriedItemPacket(horseInventorySlot));
                     McUtils.sendSequencedPacket(id -> new ServerboundUseItemPacket(
-                            InteractionHand.MAIN_HAND, id, player.getXRot(), player.getYRot()));
+                            InteractionHand.MAIN_HAND, id, player.getYRot(), player.getXRot()));
 
                     trySummonAndMountHorse(horseInventorySlot, attempts - 1);
                 },

--- a/common/src/main/java/com/wynntils/models/spells/type/SpellDirection.java
+++ b/common/src/main/java/com/wynntils/models/spells/type/SpellDirection.java
@@ -14,8 +14,8 @@ public enum SpellDirection {
     RIGHT(() -> McUtils.sendSequencedPacket(id -> new ServerboundUseItemPacket(
             InteractionHand.MAIN_HAND,
             id,
-            McUtils.player().getXRot(),
-            McUtils.player().getYRot()))),
+            McUtils.player().getYRot(),
+            McUtils.player().getXRot()))),
     LEFT(() -> McUtils.sendPacket(new ServerboundSwingPacket(InteractionHand.MAIN_HAND)));
 
     private final Runnable sendPacketRunnable;


### PR DESCRIPTION
I don't know how this has gone unnoticed until now

![image](https://github.com/user-attachments/assets/2ceb9166-2f9c-45d2-958e-6d3bc072912e)
