### PR TITLE
fix: Fix quick casts blocking casts on world change [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -91,6 +91,7 @@ public class QuickCastFeature extends Feature {
     @SubscribeEvent
     public void onHeldItemChange(ChangeCarriedItemEvent event) {
         SPELL_PACKET_QUEUE.clear();
+        lastSpellTick = 0;
     }
 
     private void castFirstSpell() {
@@ -171,6 +172,7 @@ public class QuickCastFeature extends Feature {
     @SubscribeEvent
     public void onWorldChange(WorldStateEvent e) {
         SPELL_PACKET_QUEUE.clear();
+        lastSpellTick = 0;
     }
 
     private static void sendCancelReason(MutableComponent reason) {


### PR DESCRIPTION
reset `lastSpellTick` on world change (player's tickCounter reset) and on hold item change