### PR TITLE
fix: More quick casting fixes

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -92,6 +92,7 @@ public class QuickCastFeature extends Feature {
     public void onHeldItemChange(ChangeCarriedItemEvent event) {
         SPELL_PACKET_QUEUE.clear();
         lastSpellTick = 0;
+        packetCountdown = 0;
     }
 
     private void castFirstSpell() {
@@ -174,6 +175,7 @@ public class QuickCastFeature extends Feature {
     public void onWorldChange(WorldStateEvent e) {
         SPELL_PACKET_QUEUE.clear();
         lastSpellTick = 0;
+        packetCountdown = 0;
     }
 
     private static void sendCancelReason(MutableComponent reason) {

--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -165,6 +165,7 @@ public class QuickCastFeature extends Feature {
         lastSpellTick = McUtils.player().tickCount;
 
         if (SPELL_PACKET_QUEUE.isEmpty()) {
+            lastSpellTick = 0;
             packetCountdown = Math.max(packetCountdown, spellCooldown.get());
         }
     }


### PR DESCRIPTION
Resets `lastSpellTick` after a spell has completed so that only `spellCooldown` will affect the next spell instead of the left/right click delay too.

Also resets `packetCountdown` on world change and item swap too