### PR TITLE
fix: Ignore None guild resource value in filters [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/territories/type/GuildResourceValues.java
+++ b/common/src/main/java/com/wynntils/models/territories/type/GuildResourceValues.java
@@ -56,24 +56,37 @@ public enum GuildResourceValues {
     }
 
     public GuildResourceValues getFilterNext(boolean limited) {
+        // ordinal has 1 subtracted as we are using normalValues which has NONE removed
         if (limited) {
             // If is HIGH, go back to LOW since limited
-            return ordinal() == 3 ? values()[1] : values()[(ordinal() + 1) % values().length];
+            return (ordinal() - 1) == 3
+                    ? normalValues()[1]
+                    : normalValues()[((ordinal() - 1) + 1) % normalValues().length];
         } else {
-            return values()[(ordinal() + 1) % values().length];
+            return normalValues()[((ordinal() - 1) + 1) % normalValues().length];
         }
     }
 
     public GuildResourceValues getFilterPrevious(boolean limited) {
+        // ordinal has 1 subtracted as we are using normalValues which has NONE removed
         if (limited) {
             // If is LOW, go back to HIGH since limited
-            return ordinal() == 1 ? values()[3] : values()[(ordinal() + values().length - 1) % values().length];
+            return (ordinal() - 1) == 1
+                    ? normalValues()[3]
+                    : normalValues()[((ordinal() - 1) + normalValues().length - 1) % normalValues().length];
         } else {
-            return values()[(ordinal() + values().length - 1) % values().length];
+            return normalValues()[((ordinal() - 1) + normalValues().length - 1) % normalValues().length];
         }
     }
 
     public int getLevel() {
         return level;
+    }
+
+    // This should be used instead of values() in almost all places as the NONE value is only used for parsing
+    // the rare occasion when a territory has a None treasury, but in most scenarios where values is used we are
+    // only interested in these values
+    public static GuildResourceValues[] normalValues() {
+        return new GuildResourceValues[] {VERY_LOW, LOW, MEDIUM, HIGH, VERY_HIGH};
     }
 }

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/widgets/quickfilters/TerritoryDefenseQuickFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/widgets/quickfilters/TerritoryDefenseQuickFilterWidget.java
@@ -26,13 +26,14 @@ public class TerritoryDefenseQuickFilterWidget extends TerritoryQuickFilterWidge
     protected void forwardClick() {
         // Cycle between null and the guild resource values
         if (guildResourceValues == null) {
-            guildResourceValues = GuildResourceValues.values()[0];
+            guildResourceValues = GuildResourceValues.normalValues()[0];
         } else {
-            int index = guildResourceValues.ordinal() + 1;
-            if (index >= GuildResourceValues.values().length) {
+            // ordinal has 1 subtracted as we are using normalValues which has NONE removed
+            int index = (guildResourceValues.ordinal() - 1) + 1;
+            if (index >= GuildResourceValues.normalValues().length) {
                 guildResourceValues = null;
             } else {
-                guildResourceValues = GuildResourceValues.values()[index];
+                guildResourceValues = GuildResourceValues.normalValues()[index];
             }
         }
     }
@@ -41,13 +42,14 @@ public class TerritoryDefenseQuickFilterWidget extends TerritoryQuickFilterWidge
     protected void backwardClick() {
         // Cycle between null and the guild resource values
         if (guildResourceValues == null) {
-            guildResourceValues = GuildResourceValues.values()[GuildResourceValues.values().length - 1];
+            guildResourceValues = GuildResourceValues.normalValues()[GuildResourceValues.normalValues().length - 1];
         } else {
-            int index = guildResourceValues.ordinal() - 1;
+            // ordinal has 1 subtracted as we are using normalValues which has NONE removed
+            int index = (guildResourceValues.ordinal() - 1) - 1;
             if (index < 0) {
                 guildResourceValues = null;
             } else {
-                guildResourceValues = GuildResourceValues.values()[index];
+                guildResourceValues = GuildResourceValues.normalValues()[index];
             }
         }
     }

--- a/common/src/main/java/com/wynntils/services/itemfilter/statproviders/territory/TerritoryDefenseStatProvider.java
+++ b/common/src/main/java/com/wynntils/services/itemfilter/statproviders/territory/TerritoryDefenseStatProvider.java
@@ -21,7 +21,7 @@ public class TerritoryDefenseStatProvider extends TerritoryStatProvider<String> 
 
     @Override
     public List<String> getValidInputs() {
-        return Arrays.stream(GuildResourceValues.values())
+        return Arrays.stream(GuildResourceValues.normalValues())
                 .map(GuildResourceValues::getAsString)
                 .map(s -> s.replace(" ", ""))
                 .toList();


### PR DESCRIPTION
Should've been done when the NONE value was added with https://github.com/Wynntils/Wynntils/pull/2843

https://github.com/user-attachments/assets/44209e4c-c483-4f2c-b481-d444f3724549

