### PR TITLE
fix: Don't render own cape if option disabled [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/services/cosmetics/CosmeticsService.java
+++ b/common/src/main/java/com/wynntils/services/cosmetics/CosmeticsService.java
@@ -6,8 +6,10 @@ package com.wynntils.services.cosmetics;
 
 import com.mojang.blaze3d.platform.NativeImage;
 import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Service;
+import com.wynntils.features.embellishments.WynntilsCosmeticsFeature;
 import com.wynntils.models.players.WynntilsUser;
 import com.wynntils.models.players.type.CosmeticInfo;
 import com.wynntils.services.cosmetics.type.WynntilsCapeLayer;
@@ -69,9 +71,16 @@ public class CosmeticsService extends Service {
 
     public boolean shouldRenderCape(Player player, boolean elytra) {
         if (player.isInvisible() || !player.isModelPartShown(PlayerModelPart.CAPE)) return false;
-
-        if (Models.Player.getUser(player.getUUID()) == null || getUserCosmeticTexture(player.getUUID()) == null)
+        if (Models.Player.getUser(player.getUUID()) == null || getUserCosmeticTexture(player.getUUID()) == null) {
             return false;
+        }
+
+        if (McUtils.player().is(player)
+                && !Managers.Feature.getFeatureInstance(WynntilsCosmeticsFeature.class)
+                        .renderOwnCape
+                        .get()) {
+            return false;
+        }
 
         CosmeticInfo cosmetics = Models.Player.getUser(player.getUUID()).cosmetics();
         return (elytra ? cosmetics.hasElytra() : cosmetics.hasCape());

--- a/common/src/main/java/com/wynntils/services/cosmetics/CosmeticsService.java
+++ b/common/src/main/java/com/wynntils/services/cosmetics/CosmeticsService.java
@@ -86,15 +86,6 @@ public class CosmeticsService extends Service {
         return (elytra ? cosmetics.hasElytra() : cosmetics.hasCape());
     }
 
-    // TODO: implement ear rendering
-    public boolean shouldRenderEars(AbstractClientPlayer player) {
-        if (player.isInvisible()) return false;
-
-        if (Models.Player.getUser(player.getUUID()) == null) return false;
-
-        return Models.Player.getUser(player.getUUID()).cosmetics().hasEars();
-    }
-
     public ResourceLocation getCapeTexture(Player player) {
         ResourceLocation[] textures = getUserCosmeticTexture(player.getUUID());
         if (textures == null) return null;


### PR DESCRIPTION

https://github.com/user-attachments/assets/cf0c1ba2-3123-48db-b7c2-e97ae851de18

Config should probably be moved to the Service when those can have configs.

Also removed the `shouldRenderEars` method as the new cosmetics won't have ear support 