### PR TITLE
feat: Open item guide links on official item guide instead of data.wynntils.com [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/UrlId.java
+++ b/common/src/main/java/com/wynntils/core/net/UrlId.java
@@ -55,7 +55,7 @@ public enum UrlId {
     DATA_WYNNCRAFT_LEADERBOARD("dataWynncraftLeaderboard"),
     LINK_WIKI_LOOKUP("linkWikiLookup"),
     LINK_WYNNCRAFT_PLAYER_STATS("linkWynncraftPlayerStats"),
-    LINK_WYNNDATA_ITEM_LOOKUP("linkWynndataItemLookup"),
+    LINK_WYNNCRAFT_ITEM_LOOKUP("linkWynncraftItemLookup"),
     LINK_WYNNTILS_DISCORD_INVITE("linkWynntilsDiscordInvite"),
     LINK_WYNNTILS_PATREON("linkWynntilsPatreon"),
     LINK_WYNNTILS_REGISTER_ACCOUNT("linkWynntilsRegisterAccount"),

--- a/common/src/main/java/com/wynntils/screens/guides/gear/GuideGearItemStackButton.java
+++ b/common/src/main/java/com/wynntils/screens/guides/gear/GuideGearItemStackButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.gear;
@@ -75,7 +75,7 @@ public class GuideGearItemStackButton extends WynntilsButton {
         String unformattedName =
                 StyledText.fromComponent(itemStack.getHoverName()).getStringWithoutFormatting();
         if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
-            Managers.Net.openLink(UrlId.LINK_WYNNDATA_ITEM_LOOKUP, Map.of("itemname", unformattedName));
+            Managers.Net.openLink(UrlId.LINK_WYNNCRAFT_ITEM_LOOKUP, Map.of("itemname", unformattedName));
             return true;
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
             Services.Favorites.toggleFavorite(unformattedName);

--- a/common/src/main/java/com/wynntils/screens/guides/ingredient/GuideIngredientItemStackButton.java
+++ b/common/src/main/java/com/wynntils/screens/guides/ingredient/GuideIngredientItemStackButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2024.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.ingredient;
@@ -90,7 +90,7 @@ public class GuideIngredientItemStackButton extends WynntilsButton {
 
         String unformattedName = itemStack.getIngredientInfo().name();
         if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
-            Managers.Net.openLink(UrlId.LINK_WYNNDATA_ITEM_LOOKUP, Map.of("itemname", unformattedName));
+            Managers.Net.openLink(UrlId.LINK_WYNNCRAFT_ITEM_LOOKUP, Map.of("itemname", unformattedName));
             return true;
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
             Services.Favorites.toggleFavorite(unformattedName);

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2673,7 +2673,7 @@
   "screens.wynntils.wynntilsGuides.itemGuide.available": "Available Items",
   "screens.wynntils.wynntilsGuides.itemGuide.favorite": "Shift + Left click to favorite",
   "screens.wynntils.wynntilsGuides.itemGuide.name": "Item Guide",
-  "screens.wynntils.wynntilsGuides.itemGuide.open": "Shift + Right Click to open on WynnData",
+  "screens.wynntils.wynntilsGuides.itemGuide.open": "Shift + Right Click to open on the web Item Guide",
   "screens.wynntils.wynntilsGuides.itemGuide.unfavorite": "Shift + Left click to unfavorite",
   "screens.wynntils.wynntilsGuides.name": "Guides",
   "screens.wynntils.wynntilsGuides.powder.name": "Powder Guide",

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -262,17 +262,17 @@
   },
   {
     "arguments": [
-      "username"
-    ],
-    "id": "linkWynncraftPlayerStats",
-    "url": "https://wynncraft.com/stats/player/%{username}"
-  },
-  {
-    "arguments": [
       "itemname"
     ],
     "id": "linkWynncraftItemLookup",
     "url": "https://wynncraft.com/item/%{itemname}"
+  },
+  {
+    "arguments": [
+      "username"
+    ],
+    "id": "linkWynncraftPlayerStats",
+    "url": "https://wynncraft.com/stats/player/%{username}"
   },
   {
     "id": "linkWynntilsDiscordInvite",

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": 12
+    "version": 13
   },
   {
     "id": "apiAthenaAuthPublicKey",
@@ -271,8 +271,8 @@
     "arguments": [
       "itemname"
     ],
-    "id": "linkWynndataItemLookup",
-    "url": "https://data.wynntils.com/i/%{itemname}"
+    "id": "linkWynncraftItemLookup",
+    "url": "https://wynncraft.com/item/%{itemname}"
   },
   {
     "id": "linkWynntilsDiscordInvite",

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -275,6 +275,13 @@
     "url": "https://wynncraft.com/stats/player/%{username}"
   },
   {
+    "arguments": [
+      "itemname"
+    ],
+    "id": "linkWynndataItemLookup",
+    "url": "https://data.wynntils.com/i/%{itemname}"
+  },
+  {
     "id": "linkWynntilsDiscordInvite",
     "url": "https://discord.gg/SZuNem8"
   },


### PR DESCRIPTION
`data.wynntils.com` is currently dead and pretty sure it was outdated anyway so since Wynn has their own item guide we should just link to that instead

Merge with https://github.com/Wynntils/Static-Storage/pull/215