### PR TITLE
fix: User-edited chat items with invalid powders causes crash

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
@@ -159,7 +159,10 @@ public class PowderDataTransformer extends DataTransformer<PowderData> {
             }
 
             // Add the powder to the data
-            data.add(new Pair<>(Powder.fromElement(Element.fromEncodingId(element)), tier));
+            Powder powder = Powder.fromElement(Element.fromEncodingId(element));
+            if (powder != null) { // Sometimes null when users mess with custom encoding
+                data.add(new Pair<>(powder, tier));
+            }
         }
 
         return ErrorOr.of(new PowderData(powderSlots, data));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/PowderDataTransformer.java
@@ -160,9 +160,10 @@ public class PowderDataTransformer extends DataTransformer<PowderData> {
 
             // Add the powder to the data
             Powder powder = Powder.fromElement(Element.fromEncodingId(element));
-            if (powder != null) { // Sometimes null when users mess with custom encoding
-                data.add(new Pair<>(powder, tier));
+            if (powder == null) { // Sometimes null when users mess with custom encoding
+                return ErrorOr.error("Invalid powder element encoding: " + element);
             }
+            data.add(new Pair<>(powder, tier));
         }
 
         return ErrorOr.of(new PowderData(powderSlots, data));


### PR DESCRIPTION
Ticket #1916, fixes powders being null in the ItemInstance. Also fixes null powders being included in the powder count.