### PR TITLE
fix: Update Heart of the Pack (Altruism) range and name [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/RangeVisualizerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/RangeVisualizerFeature.java
@@ -143,7 +143,7 @@ public class RangeVisualizerFeature extends Feature {
         return switch (majorIdName) {
             case "Taunt" -> Pair.of(CommonColors.ORANGE.withAlpha(TRANSPARENCY), 12f);
             case "Saviour’s Sacrifice" -> Pair.of(CommonColors.WHITE.withAlpha(TRANSPARENCY), 8f);
-            case "Heart of the Pack" -> Pair.of(CommonColors.PINK.withAlpha(TRANSPARENCY), 8.1f);
+            case "Altruism" -> Pair.of(CommonColors.PINK.withAlpha(TRANSPARENCY), 12f);
             case "Guardian" -> Pair.of(CommonColors.RED.withAlpha(TRANSPARENCY), 7.9f);
             default -> null;
         };

--- a/common/src/main/java/com/wynntils/models/raid/type/RaidKind.java
+++ b/common/src/main/java/com/wynntils/models/raid/type/RaidKind.java
@@ -17,7 +17,7 @@ public enum RaidKind {
                     "Beserk", Map.of(1, "Explosive Impact"),
                     "Lightbearer", Map.of(3, "Transcendence"),
                     "Pestilent", Map.of(3, "Plague"),
-                    "Bedrock", Map.of(3, "Heart of the Pack"))),
+                    "Bedrock", Map.of(3, "Altruism"))),
     ORPHIONS_NEXUS_OF_LIGHT(
             "Orphion's Nexus of Light",
             StyledText.fromString("§f§kOrphion's Nexus of §lLight"),
@@ -34,7 +34,7 @@ public enum RaidKind {
             Map.of(
                     "Intrepid",
                             Map.of(
-                                    1, "Heart of the Pack",
+                                    1, "Altruism",
                                     2, "Greed",
                                     3, "Guardian"),
                     "Stonewalker", Map.of(3, "Explosive Impact"))),
@@ -43,7 +43,7 @@ public enum RaidKind {
             StyledText.fromString("§9§lThe §1§k§lNameless§9§l Anomaly"),
             Pattern.compile("^Survive.$"),
             Map.of(
-                    "Fading", Map.of(1, "Heart of the Pack"),
+                    "Fading", Map.of(1, "Altruism"),
                     "Hollowed", Map.of(2, "Guardian"),
                     "Sojourner", Map.of(2, "Freerunner"),
                     "Hopeless", Map.of(2, "Fission"),


### PR DESCRIPTION
This won't actually work in game until the API updates

![image](https://github.com/user-attachments/assets/e7db621d-e45d-4e22-85c1-53b30a8cf5ae)
