### PR TITLE
fix: Fix quick cast keybinds crashing if no gear instance [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
@@ -164,7 +164,7 @@ public class GearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return gearInstance.meetsRequirements();
+        return gearInstance != null && gearInstance.meetsRequirements();
     }
 
     @Override


### PR DESCRIPTION
https://athena.wynntils.com/crash/view/c18e0806361cad68e160fa1558ac630a