### PR TITLE
feat: Annotate Outer Void items [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -67,6 +67,7 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new CharmAnnotator());
         Handlers.Item.registerAnnotator(new IngredientAnnotator());
         Handlers.Item.registerAnnotator(new MaterialAnnotator());
+        Handlers.Item.registerAnnotator(new OuterVoidItemAnnotator());
         Handlers.Item.registerAnnotator(new UnknownGearAnnotator());
 
         // Then alphabetically
@@ -82,7 +83,6 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new HorseAnnotator());
         Handlers.Item.registerAnnotator(new InsulatorAnnotator());
         Handlers.Item.registerAnnotator(new MultiHealthPotionAnnotator());
-        Handlers.Item.registerAnnotator(new OuterVoidItemAnnotator());
         Handlers.Item.registerAnnotator(new PotionAnnotator());
         Handlers.Item.registerAnnotator(new PowderAnnotator());
         Handlers.Item.registerAnnotator(new RuneAnnotator());

--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -28,7 +28,7 @@ import com.wynntils.models.items.annotators.game.InsulatorAnnotator;
 import com.wynntils.models.items.annotators.game.MaterialAnnotator;
 import com.wynntils.models.items.annotators.game.MiscAnnotator;
 import com.wynntils.models.items.annotators.game.MultiHealthPotionAnnotator;
-import com.wynntils.models.items.annotators.game.OuterVoidDropAnnotator;
+import com.wynntils.models.items.annotators.game.OuterVoidItemAnnotator;
 import com.wynntils.models.items.annotators.game.PotionAnnotator;
 import com.wynntils.models.items.annotators.game.PowderAnnotator;
 import com.wynntils.models.items.annotators.game.RuneAnnotator;
@@ -82,7 +82,7 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new HorseAnnotator());
         Handlers.Item.registerAnnotator(new InsulatorAnnotator());
         Handlers.Item.registerAnnotator(new MultiHealthPotionAnnotator());
-        Handlers.Item.registerAnnotator(new OuterVoidDropAnnotator());
+        Handlers.Item.registerAnnotator(new OuterVoidItemAnnotator());
         Handlers.Item.registerAnnotator(new PotionAnnotator());
         Handlers.Item.registerAnnotator(new PowderAnnotator());
         Handlers.Item.registerAnnotator(new RuneAnnotator());

--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -28,6 +28,7 @@ import com.wynntils.models.items.annotators.game.InsulatorAnnotator;
 import com.wynntils.models.items.annotators.game.MaterialAnnotator;
 import com.wynntils.models.items.annotators.game.MiscAnnotator;
 import com.wynntils.models.items.annotators.game.MultiHealthPotionAnnotator;
+import com.wynntils.models.items.annotators.game.OuterVoidDropAnnotator;
 import com.wynntils.models.items.annotators.game.PotionAnnotator;
 import com.wynntils.models.items.annotators.game.PowderAnnotator;
 import com.wynntils.models.items.annotators.game.RuneAnnotator;
@@ -81,6 +82,7 @@ public class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new HorseAnnotator());
         Handlers.Item.registerAnnotator(new InsulatorAnnotator());
         Handlers.Item.registerAnnotator(new MultiHealthPotionAnnotator());
+        Handlers.Item.registerAnnotator(new OuterVoidDropAnnotator());
         Handlers.Item.registerAnnotator(new PotionAnnotator());
         Handlers.Item.registerAnnotator(new PowderAnnotator());
         Handlers.Item.registerAnnotator(new RuneAnnotator());

--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items;

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/OuterVoidDropAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/OuterVoidDropAnnotator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.annotators.game;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.item.GameItemAnnotator;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.items.items.game.OuterVoidItem;
+import com.wynntils.utils.mc.LoreUtils;
+import java.util.List;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+
+public class OuterVoidDropAnnotator implements GameItemAnnotator {
+    private static final Pattern OUTER_VOID_TAG = Pattern.compile(
+            "§#cc66bbff\uE060\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE037\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE044\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE045\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE038\uDAFF\uDFFF\uE033\uDAFF\uDFFF\uE062\uDAFF\uDFB0§f\uE013\uE007\uE004 \uE00E\uE014\uE013\uE004\uE011 \uE015\uE00E\uE008\uE003\uDB00\uDC02");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
+        List<StyledText> lore = LoreUtils.getLore(itemStack);
+        if (lore.isEmpty()) return null;
+
+        if (lore.getFirst().matches(OUTER_VOID_TAG)) {
+            GearTier gearTier = GearTier.fromStyledText(name);
+
+            return new OuterVoidItem(gearTier);
+        }
+
+        return null;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/OuterVoidItemAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/OuterVoidItemAnnotator.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
-public class OuterVoidDropAnnotator implements GameItemAnnotator {
+public class OuterVoidItemAnnotator implements GameItemAnnotator {
     private static final Pattern OUTER_VOID_TAG = Pattern.compile(
             "§#cc66bbff\uE060\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE037\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE044\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE045\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE038\uDAFF\uDFFF\uE033\uDAFF\uDFFF\uE062\uDAFF\uDFB0§f\uE013\uE007\uE004 \uE00E\uE014\uE013\uE004\uE011 \uE015\uE00E\uE008\uE003\uDB00\uDC02");
 

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/OuterVoidItemAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/OuterVoidItemAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.game;

--- a/common/src/main/java/com/wynntils/models/items/items/game/OuterVoidItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/OuterVoidItem.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2024.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.items.game;
+
+import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.items.properties.GearTierItemProperty;
+
+public class OuterVoidItem extends GameItem implements GearTierItemProperty {
+    private final GearTier gearTier;
+
+    public OuterVoidItem(GearTier gearTier) {
+        this.gearTier = gearTier;
+    }
+
+    @Override
+    public GearTier getGearTier() {
+        return gearTier;
+    }
+
+    @Override
+    public String toString() {
+        return "OuterVoidItem{" + "gearTier=" + gearTier + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/items/items/game/OuterVoidItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/OuterVoidItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;


### PR DESCRIPTION
![2024-12-31_17 14 02](https://github.com/user-attachments/assets/c532bfad-6309-4c53-83c2-222a0fd845eb)
![2024-12-31_17 14 05](https://github.com/user-attachments/assets/de117718-e339-48be-817c-ba43d2b9fb2a)

The 2 unique items in the 2nd screenshot are annotated as UnknownGearItem so can't really do anything about that unless we make this annotator a higher priority but I don't think that makes sense.

This is just to get the item highlight on them, don't think there's anything else we can do with them at the moment