### PR TITLE
fix: Rework lootrun beacon tracking to support 4+ beacons

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
@@ -1,17 +1,16 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
 
+import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
-import com.wynntils.core.consumers.features.properties.StartDisabled;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 
-@StartDisabled
 @ConfigCategory(Category.COMBAT)
 public class CustomLootrunBeaconsFeature extends Feature {
     @Persisted
@@ -19,4 +18,11 @@ public class CustomLootrunBeaconsFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> showAdditionalTextInWorld = new Config<>(true);
+
+    @Override
+    protected void onConfigUpdate(Config<?> config) {
+        if (config == removeOriginalBeacons) {
+            Models.Lootrun.toggleBeacons(removeOriginalBeacons.get());
+        }
+    }
 }

--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities;
@@ -82,8 +82,6 @@ public final class ActivityModel extends Model {
     private static final Pattern REWARD_PATTERN = Pattern.compile("^§d\uDB00\uDC04(?<newline>- )?§7\\+?(?<reward>.+)$");
     private static final Pattern TRACKING_PATTERN = Pattern.compile("^.*§(?:#.{8}|.)§lCLICK TO (UN)?TRACK$");
     private static final Pattern OVERALL_PROGRESS_PATTERN = Pattern.compile("^\\S*§7(\\d+) of (\\d+) completed$");
-
-    public static final int BEACON_COLOR_CUSTOM_MODEL_DATA = 79;
 
     private static final ScoreboardPart TRACKER_SCOREBOARD_PART = new ActivityTrackerScoreboardPart();
     private static final ContentBookQueries CONTAINER_QUERIES = new ContentBookQueries();

--- a/common/src/main/java/com/wynntils/models/activities/beacons/ActivityBeaconKind.java
+++ b/common/src/main/java/com/wynntils/models/activities/beacons/ActivityBeaconKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities.beacons;
@@ -15,16 +15,16 @@ import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.CustomModelData;
 
 public enum ActivityBeaconKind implements BeaconKind {
-    QUEST(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x29CC96)),
-    STORYLINE_QUEST(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x33B33B)),
-    MINI_QUEST(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xB38FAD)),
-    WORLD_EVENT(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00BDBF)),
-    DISCOVERY(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xA1C3E6)),
-    CAVE(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF8C19)),
-    DUNGEON(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xCC6677)),
-    RAID(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xD6401E)),
-    BOSS_ALTAR(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xF2D349)),
-    LOOTRUN_CAMP(Models.Activity.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x3399CC));
+    QUEST(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x29CC96)),
+    STORYLINE_QUEST(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x33B33B)),
+    MINI_QUEST(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xB38FAD)),
+    WORLD_EVENT(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00BDBF)),
+    DISCOVERY(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xA1C3E6)),
+    CAVE(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF8C19)),
+    DUNGEON(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xCC6677)),
+    RAID(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xD6401E)),
+    BOSS_ALTAR(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xF2D349)),
+    LOOTRUN_CAMP(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x3399CC));
 
     private final int customModelData;
     private final CustomColor customColor;

--- a/common/src/main/java/com/wynntils/models/activities/beacons/ActivityBeaconMarkerKind.java
+++ b/common/src/main/java/com/wynntils/models/activities/beacons/ActivityBeaconMarkerKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities.beacons;
@@ -21,7 +21,7 @@ public enum ActivityBeaconMarkerKind implements BeaconMarkerKind {
     LOOTRUN_CAMP("\uE005");
 
     private static final String MARKER_PREFIX = "\uDAFF\uDFF8[\uE010-\uE014]\uDAFF\uDFDE";
-    private static final String MARKER_SUFFIX = "(\n\\d+m (\uE000|\uE001)?)?";
+    private static final String MARKER_SUFFIX = "\n(\\d+m (§[a-z0-9])?(\uE000|\uE001)?)?";
 
     private final Pattern iconPattern;
 

--- a/common/src/main/java/com/wynntils/models/beacons/type/BeaconMarker.java
+++ b/common/src/main/java/com/wynntils/models/beacons/type/BeaconMarker.java
@@ -1,9 +1,12 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.beacons.type;
 
+import com.wynntils.utils.colors.CustomColor;
+import java.util.Optional;
 import net.minecraft.world.phys.Vec3;
 
-public record BeaconMarker(Vec3 position, BeaconMarkerKind beaconMarkerKind) {}
+public record BeaconMarker(
+        Vec3 position, BeaconMarkerKind beaconMarkerKind, Optional<Integer> distance, Optional<CustomColor> color) {}

--- a/common/src/main/java/com/wynntils/models/beacons/type/BeaconMarkerKind.java
+++ b/common/src/main/java/com/wynntils/models/beacons/type/BeaconMarkerKind.java
@@ -1,11 +1,47 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.beacons.type;
 
 import com.wynntils.core.text.StyledText;
+import com.wynntils.utils.colors.CustomColor;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
 
 public interface BeaconMarkerKind {
+    Pattern MARKER_DISTANCE_PATTERN = Pattern.compile("\n(\\d+)m (§[a-z0-9])?(\uE000|\uE001)?");
+    Pattern MARKER_COLOR_PATTERN = Pattern.compile("§((?:#)?([a-z0-9]{1,8}))");
+
     boolean matches(StyledText styledText);
+
+    default Optional<Integer> getDistance(StyledText styledText) {
+        Optional<Integer> distanceOpt = Optional.empty();
+
+        Matcher distanceMatcher = styledText.getMatcher(MARKER_DISTANCE_PATTERN);
+        if (distanceMatcher.find()) {
+            distanceOpt = Optional.of(Integer.parseInt(distanceMatcher.group(1)));
+        }
+
+        return distanceOpt;
+    }
+
+    default Optional<CustomColor> getCustomColor(StyledText styledText) {
+        Optional<CustomColor> colorOpt = Optional.empty();
+
+        Matcher colorMatcher = styledText.getMatcher(MARKER_COLOR_PATTERN);
+        if (colorMatcher.find()) {
+            String colorStr = colorMatcher.group(1);
+
+            if (colorStr.startsWith("#")) {
+                colorOpt = Optional.of(CustomColor.fromHexString(colorMatcher.group(1)));
+            } else {
+                colorOpt = Optional.of(CustomColor.fromChatFormatting(ChatFormatting.getByCode(colorStr.charAt(0))));
+            }
+        }
+
+        return colorOpt;
+    }
 }

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -458,7 +458,7 @@ public class LootrunModel extends Model {
         double oldBeaconDistanceToPlayer = closestBeacon == null
                 ? Double.MAX_VALUE
                 : VectorUtils.distanceIgnoringY(
-                closestBeacon.position(), McUtils.mc().player.position());
+                        closestBeacon.position(), McUtils.mc().player.position());
         if (newBeaconDistanceToPlayer < BEACON_REMOVAL_RADIUS
                 && newBeaconDistanceToPlayer <= oldBeaconDistanceToPlayer) {
             setClosestBeacon(event.getBeacon());
@@ -563,7 +563,7 @@ public class LootrunModel extends Model {
         }
 
         boolean foundBeacon = updateTaskLocationPrediction(
-                beaconPair.a(), lootrunMarker, beaconMarker.distance().get())
+                        beaconPair.a(), lootrunMarker, beaconMarker.distance().get())
                 || beacons.containsKey(beaconPair.a().beaconKind());
 
         entity.setRendered(!foundBeacon || !shouldHide);

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.lootrun;
@@ -24,7 +24,9 @@ import com.wynntils.handlers.particle.type.ParticleType;
 import com.wynntils.mc.event.SetEntityDataEvent;
 import com.wynntils.mc.extension.EntityExtension;
 import com.wynntils.models.beacons.event.BeaconEvent;
+import com.wynntils.models.beacons.event.BeaconMarkerEvent;
 import com.wynntils.models.beacons.type.Beacon;
+import com.wynntils.models.beacons.type.BeaconMarker;
 import com.wynntils.models.character.event.CharacterUpdateEvent;
 import com.wynntils.models.containers.event.MythicFoundEvent;
 import com.wynntils.models.gear.type.GearTier;
@@ -32,6 +34,7 @@ import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.items.game.InsulatorItem;
 import com.wynntils.models.items.items.game.SimulatorItem;
 import com.wynntils.models.lootrun.beacons.LootrunBeaconKind;
+import com.wynntils.models.lootrun.beacons.LootrunBeaconMarkerKind;
 import com.wynntils.models.lootrun.event.LootrunBeaconSelectedEvent;
 import com.wynntils.models.lootrun.event.LootrunFinishedEvent;
 import com.wynntils.models.lootrun.event.LootrunFinishedEventBuilder;
@@ -57,7 +60,6 @@ import com.wynntils.utils.type.Pair;
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -77,6 +79,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 import org.joml.Vector2d;
+import org.joml.Vector3d;
 
 /** A model dedicated to lootruns (the Wynncraft lootrun runs).
  * Don't confuse this with {@link com.wynntils.services.lootrunpaths.LootrunPathsService}.
@@ -128,10 +131,14 @@ public class LootrunModel extends Model {
     // Beacon positions are sometimes off by a few blocks
     private static final int TASK_POSITION_ERROR = 3;
 
+    // Sometimes the calculated distance between the player and a task is greater than the distance on the marker
+    private static final int TASK_DISTANCE_ERROR = 15;
+
+    // Task markers lose their distance number when the player is around this blocks away from the task
+    private static final int MARKER_DISTANCE_THRESHOLD = 17;
+
     private static final int LOOTRUN_MASTER_REWARDS_RADIUS = 20;
     private static final String LOOTRUN_MASTER_NAME = "Lootrun Master";
-
-    public static final int BEACON_COLOR_CUSTOM_MODEL_DATA = 83;
 
     private static final LootrunScoreboardPart LOOTRUN_SCOREBOARD_PART = new LootrunScoreboardPart();
 
@@ -182,6 +189,8 @@ public class LootrunModel extends Model {
     @Persisted
     private final Storage<Map<String, List<MissionType>>> missionStorage = new Storage<>(new TreeMap<>());
 
+    private List<Pair<Beacon<LootrunBeaconKind>, EntityExtension>> activeBeacons = new ArrayList<>();
+
     public LootrunModel(MarkerModel markerModel) {
         super(List.of(markerModel));
 
@@ -191,6 +200,10 @@ public class LootrunModel extends Model {
 
         for (LootrunBeaconKind beaconKind : LootrunBeaconKind.values()) {
             Models.Beacon.registerBeacon(beaconKind);
+        }
+
+        for (LootrunBeaconMarkerKind markerKind : LootrunBeaconMarkerKind.values()) {
+            Models.Beacon.registerBeaconMarker(markerKind);
         }
     }
 
@@ -421,19 +434,13 @@ public class LootrunModel extends Model {
         lootrunningState = LootrunningState.NOT_RUNNING;
         taskType = null;
         beacons = new HashMap<>();
+        activeBeacons = new ArrayList<>();
         LOOTRUN_BEACON_COMPASS_PROVIDER.reloadTaskMarkers();
 
         selectedBeacons = new TreeMap<>();
 
         challenges = CappedValue.EMPTY;
         timeLeft = 0;
-    }
-
-    @SubscribeEvent
-    public void onBeaconMoved(BeaconEvent.Moved event) {
-        Beacon beacon = event.getNewBeacon();
-        if (!(beacon.beaconKind() instanceof LootrunBeaconKind)) return;
-        updateTaskLocationPrediction(beacon);
     }
 
     // When we get close to a beacon, it gets removed.
@@ -451,7 +458,7 @@ public class LootrunModel extends Model {
         double oldBeaconDistanceToPlayer = closestBeacon == null
                 ? Double.MAX_VALUE
                 : VectorUtils.distanceIgnoringY(
-                        closestBeacon.position(), McUtils.mc().player.position());
+                closestBeacon.position(), McUtils.mc().player.position());
         if (newBeaconDistanceToPlayer < BEACON_REMOVAL_RADIUS
                 && newBeaconDistanceToPlayer <= oldBeaconDistanceToPlayer) {
             setClosestBeacon(event.getBeacon());
@@ -460,6 +467,8 @@ public class LootrunModel extends Model {
             beacons.remove(lootrunBeaconKind);
             LOOTRUN_BEACON_COMPASS_PROVIDER.reloadTaskMarkers();
         }
+
+        activeBeacons.removeIf(beaconPair -> beaconPair.a().beaconKind() == lootrunBeaconKind);
     }
 
     @SubscribeEvent
@@ -467,16 +476,108 @@ public class LootrunModel extends Model {
         Beacon beacon = event.getBeacon();
         if (!(beacon.beaconKind() instanceof LootrunBeaconKind)) return;
 
+        EntityExtension entity = ((EntityExtension) event.getEntity());
+
         // FIXME: Feature-model dependency
         CustomLootrunBeaconsFeature feature = Managers.Feature.getFeatureInstance(CustomLootrunBeaconsFeature.class);
         if (feature.removeOriginalBeacons.get() && feature.isEnabled()) {
             // Only set this once they are added.
-            // This is cleaner than posting an event on render,
-            // but a change in the config will only have effect on newly placed beacons.
-            ((EntityExtension) event.getEntity()).setRendered(false);
+            // This is cleaner than posting an event on render
+            entity.setRendered(false);
         }
 
-        updateTaskLocationPrediction(beacon);
+        activeBeacons.add(Pair.of(beacon, entity));
+    }
+
+    @SubscribeEvent
+    public void onBeaconMoved(BeaconEvent.Moved event) {
+        Beacon beacon = event.getNewBeacon();
+        if (!(beacon.beaconKind() instanceof LootrunBeaconKind lootrunBeaconKind)) return;
+
+        Pair<Beacon<LootrunBeaconKind>, EntityExtension> oldPair = null;
+
+        for (Pair<Beacon<LootrunBeaconKind>, EntityExtension> activeBeacon : activeBeacons) {
+            if (activeBeacon.a().beaconKind() == lootrunBeaconKind) {
+                oldPair = activeBeacon;
+                break;
+            }
+        }
+
+        if (oldPair == null) return;
+
+        Pair<Beacon<LootrunBeaconKind>, EntityExtension> newPair = Pair.of(beacon, oldPair.b());
+
+        activeBeacons.remove(oldPair);
+        activeBeacons.add(newPair);
+    }
+
+    @SubscribeEvent
+    public void onBeaconMarkerAdded(BeaconMarkerEvent.Added event) {
+        BeaconMarker beaconMarker = event.getBeaconMarker();
+        if (!(beaconMarker.beaconMarkerKind() instanceof LootrunBeaconMarkerKind lootrunMarker)) return;
+
+        EntityExtension entity = (EntityExtension) event.getEntity();
+
+        // FIXME: Feature-model dependency
+        CustomLootrunBeaconsFeature feature = Managers.Feature.getFeatureInstance(CustomLootrunBeaconsFeature.class);
+        boolean shouldHide = feature.removeOriginalBeacons.get() && feature.isEnabled();
+        if (shouldHide) {
+            // Only set this once they are added.
+            // This is cleaner than posting an event on render
+            entity.setRendered(false);
+        }
+
+        // This will happen when getting close to the beacon so if we are close to the marker then we know why
+        // there is no distance and can ignore it
+        if (beaconMarker.distance().isEmpty()) {
+            if (event.getEntity().position().distanceTo(McUtils.player().position()) >= MARKER_DISTANCE_THRESHOLD) {
+                WynntilsMod.warn("Lootrun beacon has no distance");
+                entity.setRendered(true);
+            }
+
+            return;
+        }
+
+        if (beaconMarker.color().isEmpty()) {
+            WynntilsMod.warn("Lootrun beacon has no color");
+            entity.setRendered(true);
+            return;
+        }
+
+        Pair<Beacon<LootrunBeaconKind>, EntityExtension> beaconPair = null;
+
+        for (Pair<Beacon<LootrunBeaconKind>, EntityExtension> activeBeacon : activeBeacons) {
+            if (activeBeacon
+                    .a()
+                    .beaconKind()
+                    .getCustomColor()
+                    .equals(beaconMarker.color().get())) {
+                beaconPair = activeBeacon;
+                break;
+            }
+        }
+
+        if (beaconPair == null) {
+            entity.setRendered(true);
+            return;
+        }
+
+        boolean foundBeacon = updateTaskLocationPrediction(
+                beaconPair.a(), lootrunMarker, beaconMarker.distance().get())
+                || beacons.containsKey(beaconPair.a().beaconKind());
+
+        entity.setRendered(!foundBeacon || !shouldHide);
+        beaconPair.b().setRendered(!foundBeacon || !shouldHide);
+    }
+
+    // The marker is constantly remade so only the beacon visibility needs to be changed
+    public void toggleBeacons(boolean visible) {
+        for (Pair<Beacon<LootrunBeaconKind>, EntityExtension> beaconPair : activeBeacons) {
+            // Only change visibility if it has been found, otherwise we need to keep the vanilla beacon
+            if (beacons.containsKey(beaconPair.a().beaconKind())) {
+                beaconPair.b().setRendered(!visible);
+            }
+        }
     }
 
     public int getBeaconCount(LootrunBeaconKind color) {
@@ -657,24 +758,36 @@ public class LootrunModel extends Model {
 
             // We selected a beacon, so other beacons are no longer relevant.
             beacons.clear();
+            activeBeacons.clear();
             setClosestBeacon(null);
             LOOTRUN_BEACON_COMPASS_PROVIDER.reloadTaskMarkers();
             return;
         }
     }
 
-    private void updateTaskLocationPrediction(Beacon beacon) {
-        if (!(beacon.beaconKind() instanceof LootrunBeaconKind color)) return;
+    private boolean updateTaskLocationPrediction(Beacon beacon, LootrunBeaconMarkerKind lootrunMarker, int distance) {
+        if (!(beacon.beaconKind() instanceof LootrunBeaconKind color)) return false;
 
-        Set<TaskLocation> currentTaskLocations = possibleTaskLocations;
-        if (currentTaskLocations == null || currentTaskLocations.isEmpty()) {
-            WynntilsMod.warn("No task locations found. Using fallback, all locations.");
-            currentTaskLocations =
-                    taskLocations.values().stream().flatMap(Collection::stream).collect(Collectors.toUnmodifiableSet());
-        }
-        if (currentTaskLocations == null || currentTaskLocations.isEmpty()) {
-            WynntilsMod.warn("Fallback failed, no task locations found!");
-            return;
+        boolean foundTask = false;
+        // Get the tasks found from particles as we know for certain there is a task there and it may include
+        // unknown tasks
+        Set<TaskLocation> currentTaskLocations = possibleTaskLocations.stream()
+                .filter(possibleTask -> possibleTask.taskType() == lootrunMarker.getTaskType())
+                .collect(Collectors.toSet());
+
+        // Due to Wynncraft culling particles, after 5 or more beacon choices (sometimes less) we are no longer able
+        // to rely on those for getting possible locations so we use the gathered task locations instead and we can
+        // filter them based on the marker provided. The distance from the marker is also used to filter far
+        // away tasks so whilst it would be ideal to only get tasks from current location this is fine for now.
+        taskLocations.values().forEach(hashSet -> {
+            currentTaskLocations.addAll(hashSet.stream()
+                    .filter(task -> task.taskType() == lootrunMarker.getTaskType())
+                    .collect(Collectors.toSet()));
+        });
+
+        if (currentTaskLocations.isEmpty()) {
+            WynntilsMod.warn("No task locations found!");
+            return foundTask;
         }
 
         List<TaskPrediction> usedTaskLocations = beacons.entrySet().stream()
@@ -684,7 +797,7 @@ public class LootrunModel extends Model {
 
         Map<Double, TaskLocation> predictionScores = new TreeMap<>();
         for (TaskLocation currentTaskLocation : currentTaskLocations) {
-            Pair<Double, TaskLocation> prediction = calculatePredictionScore(beacon, currentTaskLocation);
+            Pair<Double, TaskLocation> prediction = calculatePredictionScore(beacon, currentTaskLocation, distance);
             if (prediction == null) continue;
 
             predictionScores.put(prediction.a(), prediction.b());
@@ -696,7 +809,8 @@ public class LootrunModel extends Model {
             Double predictionValue = entry.getKey();
 
             TaskPrediction oldPrediction = beacons.get(color);
-            TaskPrediction newTaskPrediction = new TaskPrediction(beacon, closestTaskLocation, predictionValue);
+            TaskPrediction newTaskPrediction =
+                    new TaskPrediction(beacon, lootrunMarker, distance, closestTaskLocation, predictionValue);
 
             // If the prediction is the same, don't update.
             if (oldPrediction != null
@@ -705,7 +819,7 @@ public class LootrunModel extends Model {
                     // The prediction is the same, but the score is better, so update.
                     beacons.put(color, newTaskPrediction);
                 }
-                return;
+                return true;
             }
 
             // The prediction is a location where another colored beacon is already at
@@ -718,11 +832,15 @@ public class LootrunModel extends Model {
                 // We predict that we are closer to the task location than the other beacon.
                 // Overwrite the other beacon's prediction.
                 if (newTaskPrediction.predictionScore() < usedTaskPrediction.predictionScore()) {
+                    foundTask = true;
                     beacons.put(color, newTaskPrediction);
                     beacons.remove(usedTaskPrediction.beacon().beaconKind());
 
                     // Update the other beacon's prediction.
-                    updateTaskLocationPrediction(usedTaskPrediction.beacon());
+                    updateTaskLocationPrediction(
+                            usedTaskPrediction.beacon(),
+                            usedTaskPrediction.lootrunMarker(),
+                            usedTaskPrediction.distance());
                     break;
                 } else {
                     // We predict that the other beacon is closer to the task location than us.
@@ -733,14 +851,17 @@ public class LootrunModel extends Model {
 
             // The prediction is not used by another beacon.
             beacons.put(color, newTaskPrediction);
+            foundTask = true;
             break;
         }
 
         // Finally, update the markers.
         LOOTRUN_BEACON_COMPASS_PROVIDER.reloadTaskMarkers();
+        return foundTask;
     }
 
-    private Pair<Double, TaskLocation> calculatePredictionScore(Beacon beacon, TaskLocation currentTaskLocation) {
+    private Pair<Double, TaskLocation> calculatePredictionScore(
+            Beacon beacon, TaskLocation currentTaskLocation, int markerDistance) {
         // Player Location
         Vector2d playerPosition = new Vector2d(
                 McUtils.player().position().x(), McUtils.player().position().z());
@@ -768,6 +889,26 @@ public class LootrunModel extends Model {
                 || taskLocationDistanceToPlayer < beaconPositionToTask) {
             // The beacon is not between the player and the task location, but further away.
             return null;
+        } else {
+            // Player Location including Y
+            Vector3d playerPosition3d = new Vector3d(
+                    McUtils.player().position().x(),
+                    McUtils.player().position().y(),
+                    McUtils.player().position().z());
+            // Task Location including Y
+            Vector3d taskLocationPosition3d = new Vector3d(
+                    currentTaskLocation.location().x(),
+                    currentTaskLocation.location().y(),
+                    currentTaskLocation.location().z());
+
+            // Check the difference between the task and the player and the distance provided by the marker
+            double taskLocationDistanceToPlayer3d = taskLocationPosition3d.distance(playerPosition3d);
+            double distanceDiff = Math.abs(taskLocationDistanceToPlayer3d - markerDistance);
+
+            if (distanceDiff > TASK_DISTANCE_ERROR) {
+                // Difference is too different from the given distance from the beacon marker
+                return null;
+            }
         }
 
         // Heron's formula

--- a/common/src/main/java/com/wynntils/models/lootrun/beacons/LootrunBeaconKind.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/beacons/LootrunBeaconKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.lootrun.beacons;
@@ -15,17 +15,17 @@ import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.CustomModelData;
 
 public enum LootrunBeaconKind implements BeaconKind {
-    GREEN(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00FF80), CommonColors.GREEN),
-    YELLOW(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFFFF33), CommonColors.YELLOW),
-    BLUE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x5C5CE6), CommonColors.BLUE),
-    PURPLE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF00FF), CommonColors.PURPLE),
-    GRAY(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xBFBFBF), CommonColors.LIGHT_GRAY),
-    ORANGE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF9500), CommonColors.ORANGE),
-    RED(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF0000), CommonColors.RED),
-    DARK_GRAY(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x808080), CommonColors.GRAY),
-    WHITE(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CommonColors.WHITE, CommonColors.WHITE),
-    AQUA(Models.Lootrun.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x55FFFF), CommonColors.AQUA),
-    RAINBOW(84, CommonColors.WHITE, CommonColors.RAINBOW);
+    GREEN(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00FF80), CommonColors.GREEN),
+    YELLOW(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFFFF33), CommonColors.YELLOW),
+    BLUE(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x5C5CE6), CommonColors.BLUE),
+    PURPLE(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF00FF), CommonColors.PURPLE),
+    GRAY(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xBFBFBF), CommonColors.LIGHT_GRAY),
+    ORANGE(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF9500), CommonColors.ORANGE),
+    RED(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0xFF0000), CommonColors.RED),
+    DARK_GRAY(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x808080), CommonColors.GRAY),
+    WHITE(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CommonColors.WHITE, CommonColors.WHITE),
+    AQUA(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x55FFFF), CommonColors.AQUA),
+    RAINBOW(Models.Beacon.BEACON_COLOR_CUSTOM_MODEL_DATA, CustomColor.fromInt(0x00F000), CommonColors.RAINBOW);
 
     // These values are used to identify the beacon kind
     private final int customModelData;
@@ -64,6 +64,20 @@ public enum LootrunBeaconKind implements BeaconKind {
         }
 
         return null;
+    }
+
+    public static LootrunBeaconKind fromColor(CustomColor color) {
+        for (LootrunBeaconKind beaconKind : values()) {
+            if (beaconKind.getCustomColor().equals(color)) {
+                return beaconKind;
+            }
+        }
+
+        return null;
+    }
+
+    public CustomColor getCustomColor() {
+        return customColor;
     }
 
     public CustomColor getDisplayColor() {

--- a/common/src/main/java/com/wynntils/models/lootrun/beacons/LootrunBeaconMarkerKind.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/beacons/LootrunBeaconMarkerKind.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © Wynntils 2024-2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.lootrun.beacons;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.models.beacons.type.BeaconMarkerKind;
+import com.wynntils.models.lootrun.type.LootrunTaskType;
+import java.util.regex.Pattern;
+
+public enum LootrunBeaconMarkerKind implements BeaconMarkerKind {
+    SLAY("\uE00B", LootrunTaskType.SLAY),
+    TARGET("\uE00C", LootrunTaskType.SLAY),
+    DEFEND("\uE00D", LootrunTaskType.DEFEND),
+    SPELUNK("\uE00E", LootrunTaskType.LOOT),
+    DESTROY("\uE00F", LootrunTaskType.DESTROY);
+
+    private static final String MARKER_PREFIX = "\uDAFF\uDFF8[\uE010-\uE014]\uDAFF\uDFDE";
+    private static final String MARKER_SUFFIX = "\n(\\d+m (§[a-z0-9])?(\uE000|\uE001)?)?";
+
+    private final Pattern iconPattern;
+    private final LootrunTaskType taskType;
+
+    LootrunBeaconMarkerKind(String iconCharacter, LootrunTaskType taskType) {
+        this.iconPattern = Pattern.compile(
+                MARKER_PREFIX + "§(?:#)?(?:[a-z0-9]{1,8})\uE000(§r)?\uDAFF\uDFE6" + iconCharacter + MARKER_SUFFIX);
+        this.taskType = taskType;
+    }
+
+    public LootrunTaskType getTaskType() {
+        return taskType;
+    }
+
+    @Override
+    public boolean matches(StyledText styledText) {
+        return styledText.matches(iconPattern);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/lootrun/type/TaskPrediction.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/type/TaskPrediction.java
@@ -1,9 +1,15 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.lootrun.type;
 
 import com.wynntils.models.beacons.type.Beacon;
+import com.wynntils.models.lootrun.beacons.LootrunBeaconMarkerKind;
 
-public record TaskPrediction(Beacon beacon, TaskLocation taskLocation, double predictionScore) {}
+public record TaskPrediction(
+        Beacon beacon,
+        LootrunBeaconMarkerKind lootrunMarker,
+        int distance,
+        TaskLocation taskLocation,
+        double predictionScore) {}


### PR DESCRIPTION
Can now track more than 4 beacons again, uses the vanilla marker to filter out tasks based on type and then compares calculated distance to task against the vanilla distance to check accuracy of prediction.

If no task is found, the vanilla beacon is kept.

/class no longer required to update the remove original beacons config

![2025-01-06_17 42 16](https://github.com/user-attachments/assets/16b7425a-1cce-4885-ae0e-611cfffeb43c)
