### PR TITLE
fix: Mark config and storage saving as synchronized [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.config;
@@ -177,7 +177,7 @@ public final class ConfigManager extends Manager {
                 .toList();
     }
 
-    public void saveConfig() {
+    public synchronized void saveConfig() {
         // Requesting to save before we have read the old config? Just skip it
         if (configObject == null) return;
 

--- a/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.storage;
@@ -160,7 +160,7 @@ public final class StorageManager extends Manager {
         });
     }
 
-    private void writeToJson() {
+    private synchronized void writeToJson() {
         JsonObject storageJson = new JsonObject();
 
         // Save upfixers


### PR DESCRIPTION
While looking into storage files not being written, this is a race I could think of. I honestly don't think this causes the infrequent issue of long storage files cutting off, but from everything I can see, we correctly open, flush and close streams.