### PR TITLE
fix: Hide default overhealth bar and background when disabled [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/matchers/HealthBarSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/matchers/HealthBarSegmentMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.characterstats.actionbar.matchers;
@@ -30,7 +30,7 @@ public class HealthBarSegmentMatcher implements ActionBarSegmentMatcher {
 
     // These are the characters that build the health bar, collected from the resource pack
     private static final List<String> HEALTH_BAR_CHARS =
-            List.of("\uE020-\uE028", "\uE030-\uE038", "\uE040-\uE048", "\uE051-\uE058");
+            List.of("\uE020-\uE028", "\uE030-\uE038", "\uE040-\uE048", "\uE050-\uE058");
 
     // The health bar should have 10 spacer+bar pairs
     private static final Pattern HEALTH_BAR_PATTERN =


### PR DESCRIPTION
That was an easier fix than expected

https://github.com/user-attachments/assets/223a200e-64f0-442f-a3b4-3bf9bca2db9a

