### PR TITLE
fix: Make MapXAttributesImpl have custom deserializers instead of MapFeatures to avoid type issues

### DIFF
--- a/common/src/main/java/com/wynntils/core/json/JsonManager.java
+++ b/common/src/main/java/com/wynntils/core/json/JsonManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.json;
@@ -16,6 +16,12 @@ import com.wynntils.core.components.Manager;
 import com.wynntils.core.crowdsource.CrowdSourcedData;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.services.itemrecord.type.SavedItem;
+import com.wynntils.services.mapdata.attributes.impl.MapAreaAttributesImpl;
+import com.wynntils.services.mapdata.attributes.impl.MapLocationAttributesImpl;
+import com.wynntils.services.mapdata.attributes.impl.MapPathAttributesImpl;
+import com.wynntils.services.mapdata.providers.json.JsonProvider;
+import com.wynntils.services.mapdata.type.MapCategory;
+import com.wynntils.services.mapdata.type.MapIcon;
 import com.wynntils.utils.EnumUtils;
 import com.wynntils.utils.FileUtils;
 import com.wynntils.utils.colors.CustomColor;
@@ -40,6 +46,11 @@ public final class JsonManager extends Manager {
             .registerTypeAdapter(StyledText.class, new StyledText.StyledTextSerializer())
             .registerTypeAdapter(CrowdSourcedData.class, new CrowdSourcedData.CrowdSourceDataSerializer())
             .registerTypeAdapter(SavedItem.class, new SavedItem.SavedItemSerializer())
+            .registerTypeAdapter(MapLocationAttributesImpl.class, new JsonProvider.JsonAttributeSerializer())
+            .registerTypeAdapter(MapAreaAttributesImpl.class, new JsonProvider.JsonAttributeSerializer())
+            .registerTypeAdapter(MapPathAttributesImpl.class, new JsonProvider.JsonAttributeSerializer())
+            .registerTypeHierarchyAdapter(MapCategory.class, new JsonProvider.JsonCategorySerializer())
+            .registerTypeHierarchyAdapter(MapIcon.class, new JsonProvider.JsonIconSerializer())
             .registerTypeAdapterFactory(new EnumUtils.EnumTypeAdapterFactory<>())
             .enableComplexMapKeySerialization()
             .setPrettyPrinting()

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAreaAttributesImpl.java
@@ -35,4 +35,8 @@ public final class MapAreaAttributesImpl extends MapAttributesImpl implements Ma
                 borderColor,
                 borderWidth);
     }
+
+    public MapAreaAttributesImpl(MapAttributesImpl attributes) {
+        super(attributes);
+    }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapAttributesImpl.java
@@ -59,6 +59,24 @@ public class MapAttributesImpl implements MapAttributes {
         this.borderWidth = borderWidth;
     }
 
+    public MapAttributesImpl(MapAttributesImpl attributes) {
+        this(
+                attributes.priority,
+                attributes.level,
+                attributes.label,
+                attributes.labelVisibility,
+                attributes.labelColor,
+                attributes.labelShadow,
+                attributes.icon,
+                attributes.iconVisibility,
+                attributes.iconColor,
+                attributes.hasMarker,
+                attributes.markerOptions,
+                attributes.fillColor,
+                attributes.borderColor,
+                attributes.borderWidth);
+    }
+
     @Override
     public Optional<String> getLabel() {
         return Optional.ofNullable(label);

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapLocationAttributesImpl.java
@@ -37,4 +37,8 @@ public final class MapLocationAttributesImpl extends MapAttributesImpl implement
                 null,
                 null);
     }
+
+    public MapLocationAttributesImpl(MapAttributesImpl attributes) {
+        super(attributes);
+    }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/attributes/impl/MapPathAttributesImpl.java
@@ -32,4 +32,8 @@ public final class MapPathAttributesImpl extends MapAttributesImpl implements Ma
                 null,
                 null);
     }
+
+    public MapPathAttributesImpl(MapAttributesImpl attributes) {
+        super(attributes);
+    }
 }

--- a/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapAreaImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapAreaImpl.java
@@ -12,7 +12,10 @@ import com.wynntils.utils.type.BoundingPolygon;
 import java.util.List;
 import java.util.Optional;
 
-public final class MapAreaImpl implements MapArea {
+/**
+ * Implementation of {@link MapArea}. Extend this class, if a serializable subclass is desired.
+ */
+public class MapAreaImpl implements MapArea {
     private final String featureId;
     private final String categoryId;
     private final MapAreaAttributesImpl attributes;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapLocationImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapLocationImpl.java
@@ -11,6 +11,9 @@ import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Implementation of {@link MapLocation}. Extend this class, if a serializable subclass is desired.
+ */
 public class MapLocationImpl implements MapLocation {
     private final String featureId;
     private final String categoryId;

--- a/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapPathImpl.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/features/impl/MapPathImpl.java
@@ -11,7 +11,10 @@ import com.wynntils.utils.mc.type.Location;
 import java.util.List;
 import java.util.Optional;
 
-public final class MapPathImpl implements MapPath {
+/**
+ * Implementation of {@link MapPath}. Extend this class, if a serializable subclass is desired.
+ */
+public class MapPathImpl implements MapPath {
     private final String featureId;
     private final String categoryId;
     private final MapPathAttributesImpl attributes;


### PR DESCRIPTION
This is the best of two worlds, now the MapFeatureImpl classes can be extended safely whenever we want a serializable/deserializable type, without having to worry that their type is always MapXImpl (as that is the best we could do with GSON's type hierarchy adapters). With this approach, we get to safely and correctly deserialize attributes.

This change does remove the old feature deserializer's featureId -> id and categoryId -> category mapping, which I actually find to be okay, as now the json representation is even closer to the classes themselves.