### PR TITLE
feat: Updates to crowd sourcing [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/crowdsource/CrowdSourcedDataManager.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/CrowdSourcedDataManager.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 public class CrowdSourcedDataManager extends Manager {
     public static final CrowdSourcedDataGameVersion CURRENT_GAME_VERSION =
-            CrowdSourcedDataGameVersion.VERSION_210_BETA_2;
+            CrowdSourcedDataGameVersion.VERSION_211_RELEASE;
 
     @Persisted
     private final Storage<CrowdSourcedData> collectedData = new Storage<>(new CrowdSourcedData());

--- a/common/src/main/java/com/wynntils/core/crowdsource/CrowdSourcedDataManager.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/CrowdSourcedDataManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.crowdsource;
@@ -11,6 +11,7 @@ import com.wynntils.core.crowdsource.type.CrowdSourcedDataGameVersion;
 import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
+import com.wynntils.crowdsource.FastTravelLocationDataCollector;
 import com.wynntils.crowdsource.LootrunLocationDataCollector;
 import com.wynntils.crowdsource.NpcLocationDataCollector;
 import com.wynntils.crowdsource.ProfessionNodeLocationDataCollector;
@@ -74,6 +75,7 @@ public class CrowdSourcedDataManager extends Manager {
         registerCollector(
                 CrowdSourcedDataType.PROFESSION_CRAFTING_STATION_LOCATIONS,
                 new ProfessionStationLocationDataCollector());
+        registerCollector(CrowdSourcedDataType.FAST_TRAVEL_LOCATIONS, new FastTravelLocationDataCollector());
     }
 
     private void registerCollector(CrowdSourcedDataType crowdSourcedDataType, CrowdSourcedDataCollector<?> collector) {

--- a/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataGameVersion.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataGameVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.crowdsource.type;

--- a/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataGameVersion.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataGameVersion.java
@@ -15,7 +15,8 @@ public enum CrowdSourcedDataGameVersion {
     VERSION_204_RELEASE("2.0.4 Release"),
     VERSION_204_RELEASE_2("2.0.4 Release #2"), // Bugfixes in the mod
     VERSION_210_BETA("2.1 Beta"),
-    VERSION_210_BETA_2("2.1 Beta #2"); // Bugfixes in the mod
+    VERSION_210_BETA_2("2.1 Beta #2"), // Bugfixes in the mod
+    VERSION_211_RELEASE("2.1.1");
 
     private final String readableVersion;
 

--- a/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataType.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataType.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.crowdsource.type;
 
 import com.google.common.base.CaseFormat;
 import com.wynntils.core.crowdsource.datatype.LootrunTaskLocation;
+import com.wynntils.models.npc.label.FastTravelLabelInfo;
 import com.wynntils.models.npc.label.NpcLabelInfo;
 import com.wynntils.models.profession.label.ProfessionCraftingStationLabelInfo;
 import com.wynntils.models.profession.label.ProfessionGatheringNodeLabelInfo;
@@ -18,7 +19,8 @@ public enum CrowdSourcedDataType {
     LOOTRUN_TASK_LOCATIONS(LootrunTaskLocation.class),
     NPC_LOCATIONS(NpcLabelInfo.class),
     PROFESSION_NODE_LOCATIONS(ProfessionGatheringNodeLabelInfo.class),
-    PROFESSION_CRAFTING_STATION_LOCATIONS(ProfessionCraftingStationLabelInfo.class);
+    PROFESSION_CRAFTING_STATION_LOCATIONS(ProfessionCraftingStationLabelInfo.class),
+    FAST_TRAVEL_LOCATIONS(FastTravelLabelInfo.class);
 
     private final Class<? extends Comparable<?>> dataClass;
 

--- a/common/src/main/java/com/wynntils/crowdsource/FastTravelLocationDataCollector.java
+++ b/common/src/main/java/com/wynntils/crowdsource/FastTravelLocationDataCollector.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.crowdsource;
+
+import com.wynntils.core.crowdsource.CrowdSourcedDataCollector;
+import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
+import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
+import com.wynntils.models.npc.label.FastTravelLabelInfo;
+import net.neoforged.bus.api.SubscribeEvent;
+
+public class FastTravelLocationDataCollector extends CrowdSourcedDataCollector<FastTravelLabelInfo> {
+    @SubscribeEvent
+    public void onLabelIdentified(LabelIdentifiedEvent event) {
+        if (event.getLabelInfo() instanceof FastTravelLabelInfo fastTravelLabelInfo) {
+            // Seaskipper locations are collected as NPC locations instead
+            if (fastTravelLabelInfo.getName().equals("V.S.S. Seaskipper")) return;
+
+            collect(fastTravelLabelInfo);
+        }
+    }
+
+    @Override
+    protected CrowdSourcedDataType getDataType() {
+        return CrowdSourcedDataType.FAST_TRAVEL_LOCATIONS;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/npc/NpcModel.java
+++ b/common/src/main/java/com/wynntils/models/npc/NpcModel.java
@@ -1,11 +1,12 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.npc;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
+import com.wynntils.models.npc.label.FastTravelLabelParser;
 import com.wynntils.models.npc.label.NpcLabelParser;
 import java.util.List;
 
@@ -14,5 +15,6 @@ public class NpcModel extends Model {
         super(List.of());
 
         Handlers.Label.registerParser(new NpcLabelParser());
+        Handlers.Label.registerParser(new FastTravelLabelParser());
     }
 }

--- a/common/src/main/java/com/wynntils/models/npc/label/FastTravelLabelInfo.java
+++ b/common/src/main/java/com/wynntils/models/npc/label/FastTravelLabelInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.npc.label;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.labels.type.LabelInfo;
+import com.wynntils.utils.mc.type.Location;
+import net.minecraft.world.entity.Entity;
+
+public class FastTravelLabelInfo extends LabelInfo {
+    private final String destination;
+
+    public FastTravelLabelInfo(StyledText label, String name, Location location, Entity entity, String destination) {
+        super(label, name, location, entity);
+        this.destination = destination;
+    }
+
+    @Override
+    public String toString() {
+        return "FastTravelLabelInfo{" + "destination='"
+                + destination + '\'' + ", label="
+                + label + ", name='"
+                + name + '\'' + ", location="
+                + location + ", entity="
+                + entity + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/npc/label/FastTravelLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/npc/label/FastTravelLabelParser.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.npc.label;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.labels.type.LabelParser;
+import com.wynntils.utils.mc.type.Location;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.world.entity.Entity;
+
+public class FastTravelLabelParser implements LabelParser<FastTravelLabelInfo> {
+    private static final Pattern FAST_TRAVEL_LABEL_PATTERN = Pattern.compile(
+            "§#8193ffff\uE060\uDAFF\uDFFF\uE035\uDAFF\uDFFF\uE030\uDAFF\uDFFF\uE042\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE030\uDAFF\uDFFF\uE045\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE03B\uDAFF\uDFFF\uE062\uDAFF\uDFBE§0\uE005\uE000\uE012\uE013 \uE013\uE011\uE000\uE015\uE004\uE00B\uDB00\uDC02§#8193ffff\n§#f9e79eff(?<name>.+)\n§0 \n§7\uE01C §oTo (?:the )?(?<destination>.+)§r§7 \uE01C.*",
+            Pattern.DOTALL);
+
+    public FastTravelLabelInfo getInfo(StyledText label, Location location, Entity entity) {
+        Matcher fastTravelMatcher = FAST_TRAVEL_LABEL_PATTERN.matcher(label.getString());
+        if (fastTravelMatcher.matches()) {
+            String name = fastTravelMatcher.group("name");
+
+            String destination = fastTravelMatcher.group("destination");
+
+            return new FastTravelLabelInfo(label, name, location, entity, destination);
+        }
+
+        return null;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/npc/label/NpcLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/npc/label/NpcLabelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.npc.label;

--- a/common/src/main/java/com/wynntils/models/npc/label/NpcLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/npc/label/NpcLabelParser.java
@@ -14,11 +14,14 @@ import net.minecraft.world.entity.Entity;
 public class NpcLabelParser implements LabelParser<NpcLabelInfo> {
     // Test in NpcLabelParser_NPC_LABEL_PATTERN
     private static final Pattern NPC_LABEL_PATTERN =
-            Pattern.compile("^(?:(?<icon>§..+)\n)?§d(?<name>[^§]+)(?:\n(?<description>§..+))?$", Pattern.DOTALL);
+            Pattern.compile("^§f(?<icon>.)\n§(?:c|d)(?<name>[a-zA-Z ]*)(?:§f)?\n§7(?<description>.*)$", Pattern.DOTALL);
 
     // Special cases
-    private static final Pattern TRADE_MARKET_LABEL_PATTERN = Pattern.compile("^§cTrade Market$");
     private static final Pattern HOUSING_LABEL_PATTERN = Pattern.compile("^§fClick §7to go to your housing plot$");
+    private static final Pattern BOOTH_SHOP_LABEL_PATTERN =
+            Pattern.compile("^(§b.*'(s)?§7 Shop.*|§f\uE000 Click §7to set up booth)$", Pattern.DOTALL);
+    private static final Pattern SEASKIPPER_LABEL_PATTERN =
+            Pattern.compile("^§6V.S.S. Seaskipper\n§7Right-click to Sail\n§0À$");
 
     public NpcLabelInfo getInfo(StyledText label, Location location, Entity entity) {
         Matcher matcher = NPC_LABEL_PATTERN.matcher(label.getString());
@@ -32,12 +35,16 @@ public class NpcLabelParser implements LabelParser<NpcLabelInfo> {
                     matcher.group("description"));
         }
 
-        if (label.matches(TRADE_MARKET_LABEL_PATTERN)) {
-            return new NpcLabelInfo(label, "Trade Market", location.offset(0, -1, 0), entity);
-        }
-
         if (label.matches(HOUSING_LABEL_PATTERN)) {
             return new NpcLabelInfo(label, "Housing", location, entity);
+        }
+
+        if (label.matches(BOOTH_SHOP_LABEL_PATTERN)) {
+            return new NpcLabelInfo(label, "Booth Shop", location.offset(0, -1, 0), entity);
+        }
+
+        if (label.matches(SEASKIPPER_LABEL_PATTERN)) {
+            return new NpcLabelInfo(label, "Seaskipper", location.offset(0, -1, 0), entity);
         }
 
         return null;

--- a/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
+++ b/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
@@ -13,10 +13,10 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
 import com.wynntils.models.profession.event.ProfessionXpGainEvent;
+import com.wynntils.models.profession.label.CraftingStationLabelParser;
 import com.wynntils.models.profession.label.GatheringNodeHarvestLabelInfo;
 import com.wynntils.models.profession.label.GatheringNodeHarvestLabelParser;
 import com.wynntils.models.profession.label.GatheringNodeLabelParser;
-import com.wynntils.models.profession.label.GatheringStationLabelParser;
 import com.wynntils.models.profession.type.HarvestInfo;
 import com.wynntils.models.profession.type.ProfessionProgress;
 import com.wynntils.models.profession.type.ProfessionType;
@@ -62,7 +62,7 @@ public class ProfessionModel extends Model {
         super(List.of());
 
         Handlers.Label.registerParser(new GatheringNodeLabelParser());
-        Handlers.Label.registerParser(new GatheringStationLabelParser());
+        Handlers.Label.registerParser(new CraftingStationLabelParser());
         Handlers.Label.registerParser(new GatheringNodeHarvestLabelParser());
 
         for (ProfessionType pt : ProfessionType.values()) {

--- a/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
+++ b/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.profession;

--- a/common/src/main/java/com/wynntils/models/profession/label/CraftingStationLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/CraftingStationLabelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.profession.label;

--- a/common/src/main/java/com/wynntils/models/profession/label/CraftingStationLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/CraftingStationLabelParser.java
@@ -12,14 +12,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.world.entity.Entity;
 
-public class GatheringStationLabelParser implements LabelParser<ProfessionCraftingStationLabelInfo> {
+public class CraftingStationLabelParser implements LabelParser<ProfessionCraftingStationLabelInfo> {
     // Note: The lines are multi-line, so we use ^ to match the start of the line (without $ to match the end)
-    private static final Pattern GATHERING_STATION_LABEL_PATTERN =
+    private static final Pattern CRAFTING_STATION_LABEL_PATTERN =
             Pattern.compile("^§f[ⓀⒸⒷⒿⒺⒹⓁⒶⒼⒻⒾⒽ] §6§l(.+)§f [ⓀⒸⒷⒿⒺⒹⓁⒶⒼⒻⒾⒽ]");
 
     @Override
     public ProfessionCraftingStationLabelInfo getInfo(StyledText label, Location location, Entity entity) {
-        Matcher matcher = label.getMatcher(GATHERING_STATION_LABEL_PATTERN);
+        Matcher matcher = label.getMatcher(CRAFTING_STATION_LABEL_PATTERN);
         if (matcher.find()) {
             ProfessionType professionType = ProfessionType.fromString(matcher.group(1));
             if (professionType == null) return null;

--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeLabelParser.java
@@ -16,14 +16,15 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.world.entity.Entity;
 
 public class GatheringNodeLabelParser implements LabelParser<ProfessionGatheringNodeLabelInfo> {
-    // Note: At the moment, only "Dernic" tier does not have the types consistently as a suffix
-    private static final Pattern GATHERING_NODE_LABEL = Pattern.compile("^§(.)(.+?)(:?\\s(Fish|Seed|Ore|Wood))?\n$");
+    // A few nodes have an extra suffix so handle them here so that SourceMaterial does not need a "node name" field
+    private static final Pattern GATHERING_NODE_LABEL = Pattern.compile(
+            "^§(.)(.+?)(?= Roots| Seed| Fish| Eel)?(?: Roots| Seed| Fish| Eel)?\n§(a✔|c✖)§f .§7 .+ Lv\\. Min: §f\\d+(\n\n§8Left-Click for .+\nRight-Click for .+)?$");
 
     @Override
     public ProfessionGatheringNodeLabelInfo getInfo(StyledText label, Location location, Entity entity) {
         if (label.isEmpty()) return null;
 
-        Matcher matcher = StyledText.fromPart(label.getFirstPart()).getMatcher(GATHERING_NODE_LABEL);
+        Matcher matcher = label.getMatcher(GATHERING_NODE_LABEL);
         if (matcher.matches()) {
             Optional<Pair<MaterialProfile.MaterialType, MaterialProfile.SourceMaterial>> materialLookup =
                     MaterialProfile.findByMaterialName(

--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeLabelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.profession.label;

--- a/common/src/main/java/com/wynntils/models/profession/type/MaterialProfile.java
+++ b/common/src/main/java/com/wynntils/models/profession/type/MaterialProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.profession.type;

--- a/common/src/main/java/com/wynntils/models/profession/type/MaterialProfile.java
+++ b/common/src/main/java/com/wynntils/models/profession/type/MaterialProfile.java
@@ -28,6 +28,7 @@ public final class MaterialProfile {
                     new SourceMaterial("Diamond", 80),
                     new SourceMaterial("Molten", 90),
                     new SourceMaterial("Voidstone", 100),
+                    new SourceMaterial("Larbonic Geode", 105),
                     new SourceMaterial("Dernic", 110)),
             MaterialType.LOG,
             List.of(
@@ -40,6 +41,8 @@ public final class MaterialProfile {
                     new SourceMaterial("Dark", 60),
                     new SourceMaterial("Light", 70),
                     new SourceMaterial("Pine", 80),
+                    new SourceMaterial("Flerisi Tree", 85),
+                    new SourceMaterial("Flerisi Trunk", 85),
                     new SourceMaterial("Avo", 90),
                     new SourceMaterial("Sky", 100),
                     new SourceMaterial("Dernic", 110)),
@@ -56,6 +59,7 @@ public final class MaterialProfile {
                     new SourceMaterial("Rice", 80),
                     new SourceMaterial("Sorghum", 90),
                     new SourceMaterial("Hemp", 100),
+                    new SourceMaterial("Voidgloom", 105),
                     new SourceMaterial("Dernic", 110)),
             MaterialType.FISH,
             List.of(
@@ -68,6 +72,7 @@ public final class MaterialProfile {
                     new SourceMaterial("Koi", 60),
                     new SourceMaterial("Gylia", 70),
                     new SourceMaterial("Bass", 80),
+                    new SourceMaterial("Abyssal Matter", 90),
                     new SourceMaterial("Molten", 90),
                     new SourceMaterial("Starfish", 100),
                     new SourceMaterial("Dernic", 110)));

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -69,6 +69,8 @@
   "core.wynntils.category.uncategorized": "Uncategorized",
   "core.wynntils.category.utilities": "Utilities",
   "core.wynntils.category.wynntils": "Wynntils",
+  "crowdSourcedDataType.wynntils.fastTravelLocations.description": "Collects the locations of fast travels. A fast travel location is collected when a fast travel nametag is loaded.",
+  "crowdSourcedDataType.wynntils.fastTravelLocations.name": "Fast Travel Locations",
   "crowdSourcedDataType.wynntils.lootrunTaskLocations.description": "Collects the location of lootrun tasks. Used for predicting lootrun locations. A lootrun location is collected when a player selects a task during a lootrun.",
   "crowdSourcedDataType.wynntils.lootrunTaskLocations.name": "Lootrun Task Locations and Type",
   "crowdSourcedDataType.wynntils.npcLocations.description": "Collects the locations of NPCs. An NPC location is collected when an NPC nametag is loaded.",

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 import com.wynntils.features.chat.GuildRankReplacementFeature;

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -931,8 +931,17 @@ public class TestRegex {
     public void NpcLabelParser_NPC_LABEL_PATTERN() {
         PatternTester p = new PatternTester(NpcLabelParser.class, "NPC_LABEL_PATTERN");
 
-        p.shouldMatch("§dLootrun Master\n§7Start a Lootrun");
+        p.shouldMatch("§f\uE000\n§dArmour Merchant\n§7NPC");
+        p.shouldMatch("§f\uE002\n§dBlacksmith\n§7Sell and repair items");
+        p.shouldMatch("§f\uE001\n§dEmerald Merchant\n§7NPC");
         p.shouldMatch("§f\uE003\n§dItem Identifier\n§7NPC");
+        p.shouldMatch("§f\uE000\n§dLiquid Merchant\n§7NPC");
+        p.shouldMatch("§f\uE000\n§dPotion Merchant\n§7NPC");
+        p.shouldMatch("§f\uE004\n§dPowder Master\n§7NPC");
+        p.shouldMatch("§f\uE000\n§dScroll Merchant\n§7NPC");
+        p.shouldMatch("§f\uE000\n§dTool Merchant\n§7NPC");
+        p.shouldMatch("§f\uE000\n§dWeapon Merchant\n§7NPC");
+        p.shouldMatch("§f\uE008\n§cTrade Market§f\n§7Buy & sell items\non the market");
     }
 
     @Test


### PR DESCRIPTION
This makes a few changes to crowd sourcing, mainly for NPCs.

NPC pattern is more strict, it now requires the TextDisplay to include an icon, all the services we currently display on the map have an icon so this is no problem. The special cases, housing, booth shop and seaskipper are too different from the normal pattern so those have to have special cases. Seaskipper is collected as an NPC and not a fast travel as the fast travel TextDisplay does not show at every seaskipper.

Gathering node pattern is made more strict and is also changed to support all resource types, certain ones did not match previously. Alternate resource types were also added to MaterialProfile to ensure they can be collected.

A fast travel crowd sourcing option has also been added but this could be removed as there are not many of them and I think I caught them all when I tried out this crowd sourcing version. 3 places to my knowledge do have the fast travel TextDisplay's so those I added manually, they are the Troms-Ragni tunnel, the Thesead-Eltom "shortcut" and the newly added teleporter by the Outer Void camp to the Void Village. This also collects where the fast travel will take you so that will allow us to easily implement a future feature (with MapData perhaps) to display where the fast travel will take you as that is quite a common feature request.

I have a manually collected services available at https://github.com/ShadowCat117/Static-Storage/tree/crowd-sourced-services which can be used to see the updated locations using the java properties to override urls.json. This is likely missing many locations, so should not be used in the mod but it's a start for collected data.