### PR TITLE
fix: Fix PoiProviders crashing the game if the set URL was incorrect [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.map;
@@ -195,16 +195,22 @@ public class PoiService extends Service {
 
     public void loadCustomPoiProviders() {
         for (CustomPoiProvider poiProvider : customPoiProviders.get()) {
-            Managers.Net.download(poiProvider.getUrl(), poiProvider.getName()).handleJsonArray(elements -> {
-                List<CustomPoi> pois = new ArrayList<>();
+            try {
+                Managers.Net.download(poiProvider.getUrl(), poiProvider.getName())
+                        .handleJsonArray(elements -> {
+                            List<CustomPoi> pois = new ArrayList<>();
 
-                for (JsonElement jsonElement : elements) {
-                    CustomPoi poi = JsonManager.GSON.fromJson(jsonElement, CustomPoi.class);
-                    pois.add(poi);
-                }
+                            for (JsonElement jsonElement : elements) {
+                                CustomPoi poi = JsonManager.GSON.fromJson(jsonElement, CustomPoi.class);
+                                pois.add(poi);
+                            }
 
-                providedCustomPois.put(poiProvider, ImmutableList.copyOf(pois));
-            });
+                            providedCustomPois.put(poiProvider, ImmutableList.copyOf(pois));
+                        });
+            } catch (IllegalArgumentException exception) {
+                WynntilsMod.warn(
+                        "Failed to load custom POIs from " + poiProvider.getUrl() + ": " + exception.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
While initially it also made sense to just wrap onStorageLoad in error handling, storage loading related failures should likely be raised to upper levels, and terminate the game if necessary. This is a special use case of onStorageLoad, where even a failure leaves no incorrect state.