### PR TITLE
fix: Fix the minecraft_effect_duration function crashing if the effect name contains invalid characters [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
@@ -11,6 +11,7 @@ import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.type.Location;
 import java.util.List;
+import net.minecraft.ResourceLocationException;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
@@ -69,7 +70,12 @@ public class MinecraftFunctions {
         @Override
         public Integer getValue(FunctionArguments arguments) {
             String effectName = arguments.getArgument("effectName").getStringValue();
-            ResourceLocation effectLocation = ResourceLocation.withDefaultNamespace(effectName);
+            ResourceLocation effectLocation;
+            try {
+                effectLocation = ResourceLocation.withDefaultNamespace(effectName);
+            } catch (ResourceLocationException e) {
+                return -1; // Effect name contains invalid characters
+            }
 
             Holder<MobEffect> effectHolder =
                     BuiltInRegistries.MOB_EFFECT.getHolder(effectLocation).orElse(null);


### PR DESCRIPTION
This pull request fixes a function crash that disables the function temporarily when the `minecraft_effect_duration` function receives an argument that contains invalid characters (such as `:`)