### PR TITLE
fix: Make sure item tooltips are cached properly

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.tooltips;
@@ -43,6 +43,8 @@ import org.lwjgl.glfw.GLFW;
 
 @ConfigCategory(Category.TOOLTIPS)
 public class ItemStatInfoFeature extends Feature {
+    public final IdentificationDecorator IDENTIFICATION_DECORATOR = new IdentificationDecorator();
+
     private final Set<WynnItem> brokenItems = new HashSet<>();
 
     @Persisted
@@ -173,7 +175,9 @@ public class ItemStatInfoFeature extends Feature {
         return map;
     }
 
-    public class IdentificationDecorator implements TooltipIdentificationDecorator {
+    public final class IdentificationDecorator implements TooltipIdentificationDecorator {
+        private IdentificationDecorator() {}
+
         @Override
         public MutableComponent getSuffix(
                 StatActualValue statActualValue, StatPossibleValues possibleValues, TooltipStyle style) {

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.tooltip;
@@ -14,6 +14,7 @@ import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import com.wynntils.utils.type.Pair;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import net.minecraft.network.chat.Component;
 
@@ -49,7 +50,9 @@ public abstract class TooltipBuilder {
 
         // Identification lines are rendered differently depending on current class, requested
         // style and provided decorator. If all match, use cache.
-        if (currentClass != cachedCurrentClass || cachedStyle != style || cachedDecorator != decorator) {
+        if (currentClass != cachedCurrentClass
+                || !Objects.equals(cachedStyle, style)
+                || !Objects.equals(cachedDecorator, decorator)) {
             identifications = getIdentificationLines(currentClass, style, decorator);
             identificationsCache = identifications;
             cachedCurrentClass = currentClass;

--- a/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
+++ b/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
@@ -1,17 +1,17 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items;
 
 import com.wynntils.core.components.Handlers;
-import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.properties.CraftedItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.items.properties.NamedItemProperty;
+import com.wynntils.utils.mc.TooltipUtils;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -48,16 +48,24 @@ public class FakeItemStack extends ItemStack {
 
     @Override
     public List<Component> getTooltipLines(Item.TooltipContext context, Player player, TooltipFlag isAdvanced) {
+        // 1. Firstly, cache a tooltip builder with the item's data
+        //    This will be used by TooltipUtils to generate the tooltip
         TooltipBuilder tooltipBuilder = null;
+
         if (wynnItem instanceof IdentifiableItemProperty<?, ?> identifiableItem) {
-            tooltipBuilder = Handlers.Tooltip.buildNew(identifiableItem, false, true);
+            tooltipBuilder = wynnItem.getData()
+                    .getOrCalculate(
+                            WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(identifiableItem, false, true));
+
         } else if (wynnItem instanceof CraftedItemProperty craftedItemProperty) {
-            tooltipBuilder = Handlers.Tooltip.buildNew(craftedItemProperty);
+            tooltipBuilder = wynnItem.getData()
+                    .getOrCalculate(WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(craftedItemProperty));
         }
 
         if (tooltipBuilder == null) return List.of();
 
-        List<Component> tooltip = tooltipBuilder.getTooltipLines(Models.Character.getClassType());
+        // 2. Now that the tooltip builder is cached, generate the tooltip
+        List<Component> tooltip = TooltipUtils.getWynnItemTooltip(this, wynnItem);
         // Add a line describing the source of this fake stack
         tooltip.add(
                 1, Component.literal(source).withStyle(ChatFormatting.DARK_GRAY).withStyle(ChatFormatting.ITALIC));

--- a/common/src/main/java/com/wynntils/utils/mc/TooltipUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/TooltipUtils.java
@@ -75,15 +75,15 @@ public final class TooltipUtils {
                 .getOrCalculate(
                         WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.fromParsedItemStack(itemStack, itemInfo));
         if (builder == null) return null;
-        ItemStatInfoFeature isif = Managers.Feature.getFeatureInstance(ItemStatInfoFeature.class);
+        ItemStatInfoFeature feature = Managers.Feature.getFeatureInstance(ItemStatInfoFeature.class);
 
         IdentificationDecorator decorator =
-                isif.identificationDecorations.get() ? isif.new IdentificationDecorator() : null;
+                feature.identificationDecorations.get() ? feature.IDENTIFICATION_DECORATOR : null;
         TooltipStyle currentIdentificationStyle = new TooltipStyle(
-                isif.identificationsOrdering.get(),
-                isif.groupIdentifications.get(),
-                isif.showBestValueLastAlways.get(),
-                isif.showStars.get(),
+                feature.identificationsOrdering.get(),
+                feature.groupIdentifications.get(),
+                feature.showBestValueLastAlways.get(),
+                feature.showStars.get(),
                 false // this only applies to crafted items
                 );
         LinkedList<Component> tooltips = new LinkedList<>(
@@ -91,7 +91,7 @@ public final class TooltipUtils {
 
         // Update name depending on overall percentage; this needs to be done every rendering
         // for rainbow/defective effects
-        if (isif.overallPercentageInName.get() && itemInfo.hasOverallValue()) {
+        if (feature.overallPercentageInName.get() && itemInfo.hasOverallValue()) {
             updateItemName(itemInfo, tooltips);
         }
         return tooltips;


### PR DESCRIPTION
Fixes  #3079.

This PR doesn't fix a single issue, rather, it fixes two of them:
1. The general logic behind TooltipUtils caching was there, but it did not use Objects.equals :(. This unfortunately made it so the tooltips were never pulled from the cache.
2. FakeItemStack (aka, chat items, and more) had special tooltip building logic, basically they once built a fake tooltip, then it was parsed and rebuilt by ItemStatInfoFeature with slightly different tooltip options. This made the cache to be invalidated every render, and made it so item tooltips were calculated more than one times per render for these items. Now, FakeItemStack generates it's tooltips in a standard way (as every other feature does), making it actually use the cache. Fixing multiple generations per render makes no sense now, as it's mostly part of the design of the system, and with caching present, this virtually presents no overhead.