### PR TITLE
fix: Fix territory management buttons not being clickable [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -126,7 +126,7 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
                 110,
                 holder));
 
-        this.addRenderableWidget(
+        this.addRenderableOnly(
                 new GuildOverallProductionWidget(getRenderX() - 190, getRenderY() + 10, 200, 150, holder));
 
         // Back button in the sidebar

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.territorymanagement;


### PR DESCRIPTION
Widget was eating the click events, another one of those cases of why has this only just become an issue, likely a 1.21.4 change with mouse events