### PR TITLE
fix: Fix screens rendering a dark overlay above ui [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -62,6 +62,13 @@ public abstract class WynntilsScreen extends Screen implements TextboxScreen {
         super.render(guiGraphics, mouseX, mouseY, partialTick);
     }
 
+    // All of our screens, with one exception, render in game so do not use the panorama and renderMenuBackground causes
+    // rendering issues so only render the blur
+    @Override
+    public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        renderBlurredBackground();
+    }
+
     @Override
     public final boolean mouseClicked(double mouseX, double mouseY, int button) {
         try {

--- a/common/src/main/java/com/wynntils/screens/colorpicker/ColorPickerScreen.java
+++ b/common/src/main/java/com/wynntils/screens/colorpicker/ColorPickerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.colorpicker;
@@ -140,7 +140,7 @@ public final class ColorPickerScreen extends WynntilsScreen {
 
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderUtils.drawTexturedRect(
                 guiGraphics.pose(), Texture.COLOR_PICKER_BACKGROUND, getTranslationX(), getTranslationY());

--- a/common/src/main/java/com/wynntils/screens/colorpicker/ColorPickerScreen.java
+++ b/common/src/main/java/com/wynntils/screens/colorpicker/ColorPickerScreen.java
@@ -140,7 +140,7 @@ public final class ColorPickerScreen extends WynntilsScreen {
 
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        renderBlurredBackground();
+        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
 
         RenderUtils.drawTexturedRect(
                 guiGraphics.pose(), Texture.COLOR_PICKER_BACKGROUND, getTranslationX(), getTranslationY());

--- a/common/src/main/java/com/wynntils/screens/guildlog/GuildLogScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guildlog/GuildLogScreen.java
@@ -97,7 +97,7 @@ public class GuildLogScreen extends WynntilsScreen implements WrappedScreen {
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         PoseStack poseStack = guiGraphics.pose();
-        renderBlurredBackground();
+        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
 
         RenderUtils.drawTexturedRect(poseStack, Texture.GUILD_LOG_BACKGROUND, getTranslationX(), getTranslationY());
         FontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/screens/guildlog/GuildLogScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guildlog/GuildLogScreen.java
@@ -97,7 +97,7 @@ public class GuildLogScreen extends WynntilsScreen implements WrappedScreen {
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         PoseStack poseStack = guiGraphics.pose();
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderUtils.drawTexturedRect(poseStack, Texture.GUILD_LOG_BACKGROUND, getTranslationX(), getTranslationY());
         FontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
@@ -113,7 +113,7 @@ public final class ItemSharingScreen extends WynntilsScreen {
 
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        renderBlurredBackground();
+        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
 
         RenderUtils.drawTexturedRect(guiGraphics.pose(), Texture.ITEM_SHARING_BACKGROUND, backgroundX, backgroundY);
     }

--- a/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.itemsharing;
@@ -113,7 +113,7 @@ public final class ItemSharingScreen extends WynntilsScreen {
 
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderUtils.drawTexturedRect(guiGraphics.pose(), Texture.ITEM_SHARING_BACKGROUND, backgroundX, backgroundY);
     }

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -27,7 +27,6 @@ import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.MapRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
-import com.wynntils.utils.render.buffered.BufferedRenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.PointerType;
 import com.wynntils.utils.render.type.TextShadow;
@@ -151,8 +150,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                 Texture.FULLSCREEN_MAP_BORDER.height());
     }
 
-    protected void renderGradientBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+    protected void renderBlurredBackground() {
+        super.renderBlurredBackground();
     }
 
     protected void renderPois(
@@ -363,9 +362,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                         mapHeight);
 
         // Background black void color
-        BufferedRenderUtils.drawRect(
+        RenderUtils.drawRect(
                 poseStack,
-                BUFFER_SOURCE,
                 CommonColors.BLACK,
                 renderX + renderedBorderXOffset,
                 renderY + renderedBorderYOffset,

--- a/common/src/main/java/com/wynntils/screens/maps/IconFilterScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/IconFilterScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;
@@ -144,7 +144,7 @@ public final class IconFilterScreen extends WynntilsGridLayoutScreen {
 
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderUtils.drawScalingTexturedRect(
                 guiGraphics.pose(),

--- a/common/src/main/java/com/wynntils/screens/maps/IconFilterScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/IconFilterScreen.java
@@ -144,7 +144,7 @@ public final class IconFilterScreen extends WynntilsGridLayoutScreen {
 
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        renderBlurredBackground();
+        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
 
         RenderUtils.drawScalingTexturedRect(
                 guiGraphics.pose(),

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;
@@ -392,7 +392,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         PoseStack poseStack = guiGraphics.pose();
 
-        renderGradientBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
 

--- a/common/src/main/java/com/wynntils/screens/maps/PoiManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiManagementScreen.java
@@ -445,7 +445,7 @@ public final class PoiManagementScreen extends WynntilsGridLayoutScreen {
 
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        renderBlurredBackground();
+        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
 
         RenderUtils.drawScalingTexturedRect(
                 guiGraphics.pose(),

--- a/common/src/main/java/com/wynntils/screens/maps/PoiManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiManagementScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;
@@ -445,7 +445,7 @@ public final class PoiManagementScreen extends WynntilsGridLayoutScreen {
 
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderUtils.drawScalingTexturedRect(
                 guiGraphics.pose(),

--- a/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
@@ -357,7 +357,7 @@ public final class WynntilsBookSettingsScreen extends WynntilsScreen {
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         if (McUtils.mc().level == null) {
-            renderBlurredBackground();
+            renderPanorama(guiGraphics, partialTick);
         }
     }
 

--- a/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.settings;
@@ -357,7 +357,7 @@ public final class WynntilsBookSettingsScreen extends WynntilsScreen {
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         if (McUtils.mc().level == null) {
-            super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+            renderBlurredBackground();
         }
     }
 

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -289,7 +289,7 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
 
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        renderBlurredBackground();
+        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
 
         // Screen background
         RenderUtils.drawTexturedRect(

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.territorymanagement;
@@ -289,7 +289,7 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
 
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         // Screen background
         RenderUtils.drawTexturedRect(


### PR DESCRIPTION
The `renderBackground` in the Screen class has both `renderBlurredBackground` and `renderMenuBackground` with the latter being the problematic one so just don't bother calling it and only do the blurred background, as far as I can tell there's not a noticeable difference between rendering it or not.

Using BufferedRenderUtils does fix the issue also but doesn't seem to be perfect (Poicreationscreen background seems to brighten once you input coordinates so have reverted that change) and it also isn't working with scissor masks so this is better than that solution for now