### PR TITLE
fix: Fix screens rendering a dark overlay above ui [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -62,6 +62,13 @@ public abstract class WynntilsScreen extends Screen implements TextboxScreen {
         super.render(guiGraphics, mouseX, mouseY, partialTick);
     }
 
+    // All of our screens, with one exception, render in game so do not use the panorama and renderMenuBackground causes
+    // rendering issues so only render the blur
+    @Override
+    public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        renderBlurredBackground();
+    }
+
     @Override
     public final boolean mouseClicked(double mouseX, double mouseY, int button) {
         try {

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -27,7 +27,6 @@ import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.MapRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
-import com.wynntils.utils.render.buffered.BufferedRenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.PointerType;
 import com.wynntils.utils.render.type.TextShadow;
@@ -151,8 +150,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                 Texture.FULLSCREEN_MAP_BORDER.height());
     }
 
-    protected void renderGradientBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+    protected void renderBlurredBackground() {
+        super.renderBlurredBackground();
     }
 
     protected void renderPois(
@@ -363,9 +362,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                         mapHeight);
 
         // Background black void color
-        BufferedRenderUtils.drawRect(
+        RenderUtils.drawRect(
                 poseStack,
-                BUFFER_SOURCE,
                 CommonColors.BLACK,
                 renderX + renderedBorderXOffset,
                 renderY + renderedBorderYOffset,

--- a/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/PoiCreationScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.maps;
@@ -392,7 +392,7 @@ public final class PoiCreationScreen extends AbstractMapScreen {
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         PoseStack poseStack = guiGraphics.pose();
 
-        renderGradientBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderBlurredBackground();
 
         RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
 

--- a/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/settings/WynntilsBookSettingsScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.settings;
@@ -357,7 +357,7 @@ public final class WynntilsBookSettingsScreen extends WynntilsScreen {
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         if (McUtils.mc().level == null) {
-            super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+            renderPanorama(guiGraphics, partialTick);
         }
     }
 


### PR DESCRIPTION
The `renderBackground` in the Screen class has both `renderBlurredBackground` and `renderMenuBackground` with the latter being the problematic one so just override it in `WynntilsScreen` so that we only ever call the blur method. The only screen we have that renders the panorama is the settings screen if accessed via ModMenu or NeoForge's config menu so that's the only exception.

Using BufferedRenderUtils does fix the issue also but doesn't seem to be perfect (Poicreationscreen background seems to brighten once you have a valid poi so have reverted that change) and it also isn't working with scissor masks so this is better than that solution for now