### PR TITLE
fix: Fix lootrun beacon tracking

### DIFF
--- a/common/src/main/java/com/wynntils/mc/event/EntityPositionSyncEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/EntityPositionSyncEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;
@@ -8,11 +8,11 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.Event;
 
-public class TeleportEntityEvent extends Event {
+public class EntityPositionSyncEvent extends Event {
     private final Entity entity;
     private final Vec3 newPosition;
 
-    public TeleportEntityEvent(Entity entity, Vec3 newPosition) {
+    public EntityPositionSyncEvent(Entity entity, Vec3 newPosition) {
         this.entity = entity;
         this.newPosition = newPosition;
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -589,7 +589,7 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
             method =
                     "handleEntityPositionSync(Lnet/minecraft/network/protocol/game/ClientboundEntityPositionSyncPacket;)V",
             at = @At("RETURN"))
-    private void handleMoveEntity(ClientboundEntityPositionSyncPacket packet, CallbackInfo ci) {
+    private void handleEntityPositionSync(ClientboundEntityPositionSyncPacket packet, CallbackInfo ci) {
         if (!isRenderThread()) return;
 
         Entity entity = McUtils.mc().level.getEntity(packet.id());

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -20,6 +20,7 @@ import com.wynntils.mc.event.CommandSentEvent;
 import com.wynntils.mc.event.CommandsAddedEvent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.mc.event.ContainerSetSlotEvent;
+import com.wynntils.mc.event.EntityPositionSyncEvent;
 import com.wynntils.mc.event.LocalSoundEvent;
 import com.wynntils.mc.event.MenuEvent;
 import com.wynntils.mc.event.MobEffectEvent;
@@ -37,7 +38,6 @@ import com.wynntils.mc.event.SetPlayerTeamEvent;
 import com.wynntils.mc.event.SetSpawnEvent;
 import com.wynntils.mc.event.SetXpEvent;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
-import com.wynntils.mc.event.TeleportEntityEvent;
 import com.wynntils.mc.event.TitleSetTextEvent;
 import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
 import com.wynntils.utils.mc.McUtils;
@@ -595,7 +595,7 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
         Entity entity = McUtils.mc().level.getEntity(packet.id());
         if (entity == null) return;
 
-        MixinHelper.post(new TeleportEntityEvent(entity, packet.values().position()));
+        MixinHelper.post(new EntityPositionSyncEvent(entity, packet.values().position()));
     }
 
     @ModifyArg(

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -60,6 +60,7 @@ import net.minecraft.network.protocol.game.ClientboundCommandsPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
+import net.minecraft.network.protocol.game.ClientboundEntityPositionSyncPacket;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -83,7 +84,6 @@ import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
 import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
-import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
 import net.minecraft.network.syncher.SynchedEntityData;
@@ -586,19 +586,16 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
     }
 
     @Inject(
-            method = "handleTeleportEntity(Lnet/minecraft/network/protocol/game/ClientboundTeleportEntityPacket;)V",
+            method =
+                    "handleEntityPositionSync(Lnet/minecraft/network/protocol/game/ClientboundEntityPositionSyncPacket;)V",
             at = @At("RETURN"))
-    private void handleTeleportEntity(ClientboundTeleportEntityPacket packet, CallbackInfo ci) {
+    private void handleMoveEntity(ClientboundEntityPositionSyncPacket packet, CallbackInfo ci) {
         if (!isRenderThread()) return;
 
         Entity entity = McUtils.mc().level.getEntity(packet.id());
         if (entity == null) return;
 
-        Vec3 position = new Vec3(
-                packet.change().position().x(),
-                packet.change().position().y(),
-                packet.change().position().z());
-        MixinHelper.post(new TeleportEntityEvent(entity, position));
+        MixinHelper.post(new TeleportEntityEvent(entity, packet.values().position()));
     }
 
     @ModifyArg(

--- a/common/src/main/java/com/wynntils/models/beacons/BeaconModel.java
+++ b/common/src/main/java/com/wynntils/models/beacons/BeaconModel.java
@@ -7,9 +7,9 @@ package com.wynntils.models.beacons;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.mc.event.EntityPositionSyncEvent;
 import com.wynntils.mc.event.RemoveEntitiesEvent;
 import com.wynntils.mc.event.SetEntityDataEvent;
-import com.wynntils.mc.event.TeleportEntityEvent;
 import com.wynntils.models.beacons.event.BeaconEvent;
 import com.wynntils.models.beacons.event.BeaconMarkerEvent;
 import com.wynntils.models.beacons.type.Beacon;
@@ -91,7 +91,7 @@ public class BeaconModel extends Model {
     }
 
     @SubscribeEvent
-    public void onEntityTeleport(TeleportEntityEvent event) {
+    public void onEntityPositionSync(EntityPositionSyncEvent event) {
         Beacon movedBeacon = beacons.get(event.getEntity().getId());
         BeaconMarker movedBeaconMarker = beaconMarkers.get(event.getEntity().getId());
         if (movedBeacon != null) {


### PR DESCRIPTION
Beacons aren't moved with the `ClientboundTeleportEntityPacket` packet anymore