### PR TITLE
fix: Don't show failed downloads on connect if ignore option checked [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
@@ -106,7 +106,8 @@ public class WynncraftButtonFeature extends Feature {
                 wynncraftServer,
                 titleScreen.width / 2 + 104,
                 titleScreen.height / 4 + 48 + 24,
-                Managers.Download.graphState().error());
+                Managers.Download.graphState().error(),
+                ignoreFailedDownloads.get());
         titleScreen.addRenderableWidget(wynncraftButton);
     }
 
@@ -136,14 +137,22 @@ public class WynncraftButtonFeature extends Feature {
         private final ServerData serverData;
         private final ServerIcon serverIcon;
         private final boolean showWarning;
+        private final boolean ignoreFailedDownloads;
 
-        WynncraftButton(Screen backScreen, ServerData serverData, int x, int y, boolean showWarning) {
+        WynncraftButton(
+                Screen backScreen,
+                ServerData serverData,
+                int x,
+                int y,
+                boolean showWarning,
+                boolean ignoreFailedDownloads) {
             super(x, y, 20, 20, Component.literal(""), WynncraftButton::onPress, Button.DEFAULT_NARRATION);
             this.serverData = serverData;
 
             this.serverIcon = new ServerIcon(serverData);
             this.serverIcon.loadResource(false);
             this.showWarning = showWarning;
+            this.ignoreFailedDownloads = ignoreFailedDownloads;
         }
 
         @Override
@@ -192,7 +201,7 @@ public class WynncraftButtonFeature extends Feature {
             if (!(button instanceof WynncraftButton wynncraftButton)) return;
             if (!Managers.Download.graphState().finished()) return;
 
-            if (wynncraftButton.showWarning) {
+            if (wynncraftButton.showWarning && !wynncraftButton.ignoreFailedDownloads) {
                 McUtils.mc().setScreen(DownloadScreen.create(McUtils.mc().screen, wynncraftButton.serverData));
             } else {
                 connectToServer(wynncraftButton.serverData);

--- a/common/src/main/java/com/wynntils/screens/downloads/widgets/DownloadWidget.java
+++ b/common/src/main/java/com/wynntils/screens/downloads/widgets/DownloadWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.downloads.widgets;
@@ -79,7 +79,15 @@ public class DownloadWidget extends AbstractWidget {
             int innerRadius = (int) (outerRadius * 0.85f);
 
             RenderUtils.drawArc(
-                    guiGraphics.pose(), CommonColors.BLACK, getX() + getWidth() - height, arcY, 0, 0.8f, innerRadius, outerRadius, offset);
+                    guiGraphics.pose(),
+                    CommonColors.BLACK,
+                    getX() + getWidth() - height,
+                    arcY,
+                    0,
+                    0.8f,
+                    innerRadius,
+                    outerRadius,
+                    offset);
         }
 
         if (isHovered) {

--- a/common/src/main/java/com/wynntils/screens/downloads/widgets/DownloadWidget.java
+++ b/common/src/main/java/com/wynntils/screens/downloads/widgets/DownloadWidget.java
@@ -79,7 +79,7 @@ public class DownloadWidget extends AbstractWidget {
             int innerRadius = (int) (outerRadius * 0.85f);
 
             RenderUtils.drawArc(
-                    guiGraphics.pose(), CommonColors.BLACK, getX(), arcY, 0, 0.8f, innerRadius, outerRadius, offset);
+                    guiGraphics.pose(), CommonColors.BLACK, getX() + getWidth() - height, arcY, 0, 0.8f, innerRadius, outerRadius, offset);
         }
 
         if (isHovered) {


### PR DESCRIPTION
The ignore option currently is only used for disabling auto connect but it should be used here too

Have also moved the arc on download widgets to the right side, I meant to put it there originally but forgot to move it after I got the size right