### PR TITLE
fix: Check for ItemStack before posting transform event [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/ItemStackLayerRenderStateMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemStackLayerRenderStateMixin.java
@@ -42,7 +42,7 @@ public abstract class ItemStackLayerRenderStateMixin {
 
         if (field_55345 instanceof ItemStackRenderStateExtension extension) {
             if (extension.getItemStack() == null) return;
-            
+
             MixinHelper.post(new GroundItemEntityTransformEvent(poseStack, extension.getItemStack()));
         }
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/ItemStackLayerRenderStateMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemStackLayerRenderStateMixin.java
@@ -41,6 +41,8 @@ public abstract class ItemStackLayerRenderStateMixin {
         if (field_55345.displayContext != ItemDisplayContext.GROUND) return;
 
         if (field_55345 instanceof ItemStackRenderStateExtension extension) {
+            if (extension.getItemStack() == null) return;
+            
             MixinHelper.post(new GroundItemEntityTransformEvent(poseStack, extension.getItemStack()));
         }
     }


### PR DESCRIPTION
Some type of item render is triggering the event without an ItemStack and causing a NPE but it's not the ones we use for the feature as that's working fine.

(Turned off mythic check to showcase it working fine)
![2025-02-01_18 24 39](https://github.com/user-attachments/assets/39dcc28f-a3a7-4429-befa-91f3b9007425)
