### PR TITLE
fix: Add named tasks v2 to urls.json

### DIFF
--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -159,6 +159,11 @@
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/lootrun_tasks_named.json"
   },
   {
+    "id": "dataStaticLootrunTasksNamedV2",
+    "md5": "c8a56fdbc7a0fd65750ed6c343e0e0fd",
+    "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/lootrun_tasks_named_v2.json"
+  },
+  {
     "id": "dataStaticMajorIds",
     "md5": "38bb5299f66016271f5bf3a1f49ec0ae",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Data-Storage/major_ids.json"


### PR DESCRIPTION
There's always something, since it's a new field we needed to include it and I forgot :(