### PR TITLE
fix: make ScreenMixin.wrapScreenErrorPre non-static [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -108,7 +108,7 @@ public abstract class ScreenMixin implements ScreenExtension {
             method = "Lnet/minecraft/client/gui/screens/Screen;fillCrashDetails(Lnet/minecraft/CrashReport;)V",
             at = @At("HEAD"),
             cancellable = true)
-    private static void wrapScreenErrorPre(CrashReport crashReport, CallbackInfo ci) {
+    private void wrapScreenErrorPre(CrashReport crashReport, CallbackInfo ci) {
         if (!(Minecraft.getInstance().screen instanceof WynntilsScreen wynntilsScreen)) return;
 
         // This is too involved in error handling to worth risk sending events


### PR DESCRIPTION
the target `fillCrashDetails` isn't static