### PR TITLE
fix: removed dark circle when mouse leaves container for item identifier, blacksmith, gear viewer, etc

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -148,7 +148,7 @@ public class ItemHighlightFeature extends Feature {
     public final Config<Float> hotbarOpacity = new Config<>(.5f);
 
     @SubscribeEvent(priority = EventPriority.HIGH)
-    public void onRenderSlot(SlotRenderEvent.Pre e) {
+    public void onRenderSlot(SlotRenderEvent.Post e) {
         if (!inventoryHighlightEnabled.get()) return;
 
         CustomColor color = getHighlightColor(e.getSlot().getItem(), false);


### PR DESCRIPTION
not a super robust fix but it works for me