### PR TITLE
fix: Parse version on client

### DIFF
--- a/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
@@ -43,9 +43,33 @@ public class UpdatesFeature extends Feature {
                         return;
                     }
 
-                    if (Objects.equals(version, WynntilsMod.getVersion())) {
-                        WynntilsMod.info("Mod is on latest version, not attempting update reminder or auto-update.");
+                    String[] newVersionParts = version.split("\\.");
+                    String[] currentVersionParts = WynntilsMod.getVersion().split("\\.");
+
+                    if (newVersionParts.length == 0 || currentVersionParts.length == 0 || newVersionParts.length != currentVersionParts.length) {
+                        WynntilsMod.info("Version schema mismatch, not attempting update reminder or auto-update.");
+                        WynntilsMod.info("New version: " + version + ", current version: " + WynntilsMod.getVersion());
                         return;
+                    }
+
+                    for (int i = 0; i < newVersionParts.length; i++) {
+                        int newPart = Integer.parseInt(newVersionParts[i]);
+                        int currentPart = Integer.parseInt(currentVersionParts[i]);
+
+                        if (newPart < currentPart) {
+                            WynntilsMod.info("New version is older than current version, not attempting update reminder or auto-update.");
+                            return;
+                        }
+                        if (newPart == currentPart) {
+                            if (i == newVersionParts.length - 1) {
+                                WynntilsMod.info("New version is the same as current version, not attempting update reminder or auto-update.");
+                                return;
+                            }
+                            continue;
+                        }
+                        if (newPart > currentPart) {
+                            break;
+                        }
                     }
 
                     if (updateReminder.get()) {

--- a/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
@@ -42,36 +42,10 @@ public class UpdatesFeature extends Feature {
                         return;
                     }
 
-                    String currentVersion = WynntilsMod.getVersion();
-                    String[] newVersionParts = version.replace("v", "").split("\\.");
-                    String[] currentVersionParts =
-                            currentVersion.replace("v", "").split("\\.");
-
-                    if (newVersionParts.length == 0
-                            || currentVersionParts.length == 0
-                            || newVersionParts.length != currentVersionParts.length) {
-                        WynntilsMod.info("Version schema mismatch, not attempting update reminder or auto-update.");
-                        WynntilsMod.info("New version: " + version + ", current version: " + currentVersion);
+                    if (!Services.Update.isNewerVersion(version)) {
+                        WynntilsMod.info("New version (" + version + ") is older than current version ("
+                                + WynntilsMod.getVersion() + "), not attempting update reminder or auto-update.");
                         return;
-                    }
-
-                    for (int i = 0; i < newVersionParts.length; i++) {
-                        int newPart = Integer.parseInt(newVersionParts[i]);
-                        int currentPart = Integer.parseInt(currentVersionParts[i]);
-
-                        if (newPart < currentPart) {
-                            WynntilsMod.info("New version (" + version + ") is older than current version ("
-                                    + currentVersion + "), not attempting update reminder or auto-update.");
-                            return;
-                        }
-                        if (newPart == currentPart && i == newVersionParts.length - 1) {
-                            WynntilsMod.info("New version (" + version + ") is the same as current version ("
-                                    + currentVersion + "), not attempting update reminder or auto-update.");
-                            return;
-                        }
-                        if (newPart > currentPart) {
-                            break;
-                        }
                     }
 
                     if (WynntilsMod.isDevelopmentEnvironment()) {

--- a/common/src/main/java/com/wynntils/services/athena/UpdateService.java
+++ b/common/src/main/java/com/wynntils/services/athena/UpdateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.athena;
@@ -59,13 +59,13 @@ public final class UpdateService extends Service {
     public boolean isNewerVersion(String version) {
         String currentVersion = WynntilsMod.getVersion();
         String[] newVersionParts = version.replace("v", "").split("\\.");
-        String[] currentVersionParts =
-                currentVersion.replace("v", "").split("\\.");
+        String[] currentVersionParts = currentVersion.replace("v", "").split("\\.");
 
         if (newVersionParts.length == 0
                 || currentVersionParts.length == 0
                 || newVersionParts.length != currentVersionParts.length) {
-            WynntilsMod.warn("Version schema mismatch for new version: " + version + ", current version: " + currentVersion);
+            WynntilsMod.warn(
+                    "Version schema mismatch for new version: " + version + ", current version: " + currentVersion);
             return false;
         }
 

--- a/common/src/main/java/com/wynntils/services/athena/UpdateService.java
+++ b/common/src/main/java/com/wynntils/services/athena/UpdateService.java
@@ -33,6 +33,9 @@ public final class UpdateService extends Service {
         super(List.of());
     }
 
+    /**
+     * @return A future that will complete with the latest remote build version, which may or may not be *older* than the current version.
+     */
     public CompletableFuture<String> getLatestBuild() {
         CompletableFuture<String> future = new CompletableFuture<>();
 
@@ -51,6 +54,33 @@ public final class UpdateService extends Service {
                     future.complete(null);
                 });
         return future;
+    }
+
+    public boolean isNewerVersion(String version) {
+        String currentVersion = WynntilsMod.getVersion();
+        String[] newVersionParts = version.replace("v", "").split("\\.");
+        String[] currentVersionParts =
+                currentVersion.replace("v", "").split("\\.");
+
+        if (newVersionParts.length == 0
+                || currentVersionParts.length == 0
+                || newVersionParts.length != currentVersionParts.length) {
+            WynntilsMod.warn("Version schema mismatch for new version: " + version + ", current version: " + currentVersion);
+            return false;
+        }
+
+        for (int i = 0; i < newVersionParts.length; i++) {
+            int newPart = Integer.parseInt(newVersionParts[i]);
+            int currentPart = Integer.parseInt(currentVersionParts[i]);
+
+            if (newPart > currentPart) {
+                return true;
+            } else if (newPart < currentPart) {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     private String getStream() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4e82a065-f87c-41dd-ad1c-c6df29101b7b)
![image](https://github.com/user-attachments/assets/7daf2df1-5f5b-4fd4-9e1d-8330419fc1d5)
![image](https://github.com/user-attachments/assets/5ecf04b5-a112-4810-a4ad-4e96a1765d2c)

In the middle of testing the server decided to start sending me 2.4.18 as the latest. No idea why. I did these in middle-bottom-top order.

This just checks so that we aren't going backwards on the client. /wynntils update still forces whatever jar the server has.