### PR TITLE
fix: Make lootrun mission overlay default position visible [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/lootrun/LootrunMissionsOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/lootrun/LootrunMissionsOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays.lootrun;
@@ -34,7 +34,7 @@ public class LootrunMissionsOverlay extends TextOverlay {
     public LootrunMissionsOverlay() {
         super(
                 new OverlayPosition(
-                        270,
+                        80,
                         5,
                         VerticalAlignment.TOP,
                         HorizontalAlignment.LEFT,


### PR DESCRIPTION
Thought this was fixed ages ago but apparently not. Puts it just above the beacons overlay

![image](https://github.com/user-attachments/assets/bf76c818-93a3-4fe2-9c33-3783b5e66c0f)

