### PR TITLE
fix: Render world markers perfectly aligned

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/WorldMarkersFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldMarkersFeature.java
@@ -297,8 +297,10 @@ public class WorldMarkersFeature extends Feature {
                     RenderUtils.drawScalingTexturedRect(
                             event.getPoseStack(),
                             icon.getResourceLocation(),
-                            displayPositionX - iconRenderScale.get() * icon.getWidth() / 2,
-                            displayPositionY - iconRenderScale.get() * (icon.getHeight() + backgroundHeight / 2 + 3f),
+                            displayPositionX - iconRenderScale.get() * icon.getWidth() / 2f,
+                            displayPositionY
+                                    - iconRenderScale.get() * icon.getHeight()
+                                    - textRenderScale.get() * (backgroundHeight / 2f + 2f),
                             0,
                             iconRenderScale.get() * icon.getWidth(),
                             iconRenderScale.get() * icon.getHeight(),
@@ -313,32 +315,29 @@ public class WorldMarkersFeature extends Feature {
                     RenderUtils.drawRect(
                             event.getPoseStack(),
                             CommonColors.BLACK.withAlpha(textBackgroundOpacity.get()),
-                            displayPositionX - textRenderScale.get() * (backgroundWidth / 2 + 2),
-                            displayPositionY - textRenderScale.get() * (backgroundHeight / 2 + 2),
+                            displayPositionX - textRenderScale.get() * (backgroundWidth / 2f + 2f),
+                            displayPositionY - textRenderScale.get() * (backgroundHeight / 2f + 2f),
                             0,
-                            textRenderScale.get() * (backgroundWidth + 3),
-                            textRenderScale.get() * (backgroundHeight + 2));
+                            textRenderScale.get() * (backgroundWidth + 3f),
+                            textRenderScale.get() * (backgroundHeight + 2f));
                 }
 
-                int textYOffset = 0;
                 if (resolvedMarkerOptions.hasDistance()) {
                     FontRenderer.getInstance()
                             .renderAlignedTextInBox(
                                     event.getPoseStack(),
                                     StyledText.fromString(renderedDistanceText),
-                                    displayPositionX - textRenderScale.get() * backgroundWidth,
-                                    displayPositionX + textRenderScale.get() * backgroundWidth,
-                                    displayPositionY - textRenderScale.get() * backgroundHeight,
-                                    displayPositionY + textRenderScale.get() * backgroundHeight,
+                                    displayPositionX - textRenderScale.get() * (backgroundWidth / 2f),
+                                    displayPositionX + textRenderScale.get() * (backgroundWidth / 2f),
+                                    displayPositionY - textRenderScale.get() * (backgroundHeight / 2f),
+                                    displayPositionY + textRenderScale.get() * (backgroundHeight / 2f),
                                     0,
                                     resolvedMapAttributes.labelColor().withAlpha((float)
                                             renderedMapLocation.visibility),
                                     HorizontalAlignment.CENTER,
-                                    VerticalAlignment.MIDDLE,
+                                    VerticalAlignment.TOP,
                                     textShadow.get(),
                                     textRenderScale.get());
-
-                    textYOffset += FontRenderer.getInstance().getFont().lineHeight;
                 }
 
                 if (resolvedMarkerOptions.hasLabel()) {
@@ -346,15 +345,15 @@ public class WorldMarkersFeature extends Feature {
                             .renderAlignedTextInBox(
                                     event.getPoseStack(),
                                     StyledText.fromString(resolvedMapAttributes.label()),
-                                    displayPositionX - textRenderScale.get() * backgroundWidth,
-                                    displayPositionX + textRenderScale.get() * backgroundWidth,
-                                    displayPositionY - textRenderScale.get() * backgroundHeight + textYOffset,
-                                    displayPositionY + textRenderScale.get() * backgroundHeight + textYOffset,
+                                    displayPositionX - textRenderScale.get() * (backgroundWidth / 2f),
+                                    displayPositionX + textRenderScale.get() * (backgroundWidth / 2f),
+                                    displayPositionY - textRenderScale.get() * (backgroundHeight / 2f),
+                                    displayPositionY + textRenderScale.get() * (backgroundHeight / 2f),
                                     0,
                                     resolvedMapAttributes.labelColor().withAlpha((float)
                                             renderedMapLocation.visibility),
                                     HorizontalAlignment.CENTER,
-                                    VerticalAlignment.MIDDLE,
+                                    VerticalAlignment.BOTTOM,
                                     textShadow.get(),
                                     textRenderScale.get());
                 }

--- a/common/src/main/java/com/wynntils/features/map/WorldMarkersFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldMarkersFeature.java
@@ -378,14 +378,14 @@ public class WorldMarkersFeature extends Feature {
                         event.getPoseStack(),
                         icon.getResourceLocation(),
                         displayPositionX
-                                - textRenderScale.get() * icon.getWidth() / 2
-                                + pointerOffsetX * (1 - textRenderScale.get()),
+                                - iconRenderScale.get() * icon.getWidth() / 2
+                                + pointerOffsetX * (1 - iconRenderScale.get()),
                         displayPositionY
-                                - textRenderScale.get() * icon.getHeight() / 2
-                                + pointerOffsetY * (1 - textRenderScale.get()),
+                                - iconRenderScale.get() * icon.getHeight() / 2
+                                + pointerOffsetY * (1 - iconRenderScale.get()),
                         0,
-                        textRenderScale.get() * icon.getWidth(),
-                        textRenderScale.get() * icon.getHeight(),
+                        iconRenderScale.get() * icon.getWidth(),
+                        iconRenderScale.get() * icon.getHeight(),
                         icon.getWidth(),
                         icon.getHeight());
                 RenderSystem.setShaderColor(1, 1, 1, 1);
@@ -399,12 +399,17 @@ public class WorldMarkersFeature extends Feature {
                 poseStack.translate(-pointerDisplayPositionX, -pointerDisplayPositionY, 0);
 
                 Texture pointerTexture = Texture.POINTER;
-                BufferedRenderUtils.drawTexturedRect(
+                BufferedRenderUtils.drawScalingTexturedRect(
                         poseStack,
                         BUFFER_SOURCE,
-                        pointerTexture,
+                        pointerTexture.resource(),
                         pointerDisplayPositionX - pointerTexture.width() / 2f,
-                        pointerDisplayPositionY - pointerTexture.height() / 2f);
+                        pointerDisplayPositionY - pointerTexture.height() / 2f,
+                        0,
+                        iconRenderScale.get() * pointerTexture.width(),
+                        iconRenderScale.get() * pointerTexture.height(),
+                        pointerTexture.width(),
+                        pointerTexture.height());
 
                 BUFFER_SOURCE.endBatch();
                 poseStack.popPose();

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
@@ -88,6 +88,11 @@ public class CategoriesProvider extends BuiltInProvider {
                 public Optional<String> getIconId() {
                     return Optional.of(MapIconsProvider.FALLBACK_ICON_ID);
                 }
+
+                @Override
+                public Optional<MapMarkerOptions> getMarkerOptions() {
+                    return Optional.of(new MapMarkerOptionsBuilder().withHasLabel(false));
+                }
             });
         }
     }
@@ -352,12 +357,7 @@ public class CategoriesProvider extends BuiltInProvider {
 
                 @Override
                 public Optional<CustomColor> getLabelColor() {
-                    return Optional.of(
-                            switch (placeType) {
-                                case PROVINCE -> CommonColors.DARK_AQUA;
-                                case CITY -> CommonColors.YELLOW;
-                                case TOWN_OR_PLACE -> CommonColors.WHITE;
-                            });
+                    return Optional.of(getPlaceColor());
                 }
 
                 @Override
@@ -374,7 +374,23 @@ public class CategoriesProvider extends BuiltInProvider {
                                 case TOWN_OR_PLACE -> PLACE_VISIBILITY;
                             });
                 }
+
+                @Override
+                public Optional<MapMarkerOptions> getMarkerOptions() {
+                    return Optional.of(new MapMarkerOptionsBuilder()
+                            .withHasDistance(true)
+                            .withHasLabel(true)
+                            .withBeaconColor(getPlaceColor()));
+                }
             });
+        }
+
+        private CustomColor getPlaceColor() {
+            return switch (placeType) {
+                case PROVINCE -> CommonColors.DARK_AQUA;
+                case CITY -> CommonColors.YELLOW;
+                case TOWN_OR_PLACE -> CommonColors.WHITE;
+            };
         }
     }
 

--- a/common/src/main/java/com/wynntils/services/usermarker/UserMarkerService.java
+++ b/common/src/main/java/com/wynntils/services/usermarker/UserMarkerService.java
@@ -10,7 +10,6 @@ import com.wynntils.core.mod.event.WynntilsInitEvent;
 import com.wynntils.services.mapdata.MapDataService;
 import com.wynntils.services.mapdata.attributes.DefaultMapAttributes;
 import com.wynntils.services.mapdata.attributes.MapAttributesBuilder;
-import com.wynntils.services.mapdata.attributes.MapMarkerOptionsBuilder;
 import com.wynntils.services.mapdata.attributes.impl.MapLocationAttributesImpl;
 import com.wynntils.services.mapdata.attributes.type.MapAttributes;
 import com.wynntils.services.mapdata.attributes.type.MapLocationAttributes;
@@ -34,9 +33,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class UserMarkerService extends Service {
     private static final MapAttributesBuilder MARKED_MAP_FEATURE_ATTRIBUTES = new MapAttributesBuilder()
             .setHasMarker(true)
+            .setPriority(1000)
             .setIconVisibility(DefaultMapAttributes.ICON_ALWAYS)
-            .setLabelVisibility(DefaultMapAttributes.LABEL_ALWAYS)
-            .setMarkerOptions(new MapMarkerOptionsBuilder().withHasLabel(false).build());
+            .setLabelVisibility(DefaultMapAttributes.LABEL_ALWAYS);
 
     // These are map features that already exist in the map data, and are "marked" by the user
     private final Set<MapLocation> userOverridenMapLocations = new CopyOnWriteArraySet<>();


### PR DESCRIPTION
This should fix the math behind rendering, so scaling/positioning works as expected.
![2025-02-14_18-06](https://github.com/user-attachments/assets/52981006-1ec6-4daf-b507-dc76ace6c303)
![2025-02-14_18-07](https://github.com/user-attachments/assets/cf99ce9d-9b48-4b06-a220-2db7af006a95)
![2025-02-14_18-07_1](https://github.com/user-attachments/assets/76a6d2a7-218c-4e73-b69e-02002b2a38b5)
