### PR TITLE
fix: Fix item slot rendering issues from 1.21.4 port

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/DurabilityArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/DurabilityArcFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -38,7 +38,7 @@ public class DurabilityArcFeature extends Feature {
     }
 
     @SubscribeEvent
-    public void onRenderSlot(SlotRenderEvent.Pre e) {
+    public void onRenderSlot(SlotRenderEvent.CountPre e) {
         if (!renderDurabilityArcInventories.get()) return;
         RenderSystem.enableDepthTest();
         drawDurabilityArc(e.getPoseStack(), e.getSlot().getItem(), e.getSlot().x, e.getSlot().y, false);

--- a/common/src/main/java/com/wynntils/features/inventory/DurabilityArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/DurabilityArcFeature.java
@@ -32,20 +32,18 @@ public class DurabilityArcFeature extends Feature {
     public final Config<Boolean> renderDurabilityArcHotbar = new Config<>(true);
 
     @SubscribeEvent
-    public void onRenderHotbarSlot(HotbarSlotRenderEvent.Pre e) {
+    public void onRenderHotbarSlot(HotbarSlotRenderEvent.CountPre e) {
         if (!renderDurabilityArcHotbar.get()) return;
-        drawDurabilityArc(e.getPoseStack(), e.getItemStack(), e.getX(), e.getY(), true);
+        drawDurabilityArc(e.getPoseStack(), e.getItemStack(), e.getX(), e.getY());
     }
 
     @SubscribeEvent
     public void onRenderSlot(SlotRenderEvent.CountPre e) {
         if (!renderDurabilityArcInventories.get()) return;
-        RenderSystem.enableDepthTest();
-        drawDurabilityArc(e.getPoseStack(), e.getSlot().getItem(), e.getSlot().x, e.getSlot().y, false);
-        RenderSystem.disableDepthTest();
+        drawDurabilityArc(e.getPoseStack(), e.getSlot().getItem(), e.getSlot().x, e.getSlot().y);
     }
 
-    private void drawDurabilityArc(PoseStack poseStack, ItemStack itemStack, int slotX, int slotY, boolean hotbar) {
+    private void drawDurabilityArc(PoseStack poseStack, ItemStack itemStack, int slotX, int slotY) {
         Optional<DurableItemProperty> durableItemOpt =
                 Models.Item.asWynnItemProperty(itemStack, DurableItemProperty.class);
         if (durableItemOpt.isEmpty()) return;
@@ -58,6 +56,8 @@ public class DurabilityArcFeature extends Feature {
         CustomColor color = CustomColor.fromInt(colorInt).withAlpha(160);
 
         // draw
-        RenderUtils.drawArc(poseStack, color, slotX, slotY, hotbar ? 0 : 200, durabilityFraction, 6, 8);
+        RenderSystem.enableDepthTest();
+        RenderUtils.drawArc(poseStack, color, slotX, slotY, 100, durabilityFraction, 6, 8);
+        RenderSystem.disableDepthTest();
     }
 }

--- a/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
@@ -32,20 +32,18 @@ public class EmeraldPouchFillArcFeature extends Feature {
     public final Config<Boolean> renderFillArcInventory = new Config<>(true);
 
     @SubscribeEvent
-    public void onRenderHotbarSlot(HotbarSlotRenderEvent.Pre e) {
+    public void onRenderHotbarSlot(HotbarSlotRenderEvent.CountPre e) {
         if (!renderFillArcHotbar.get()) return;
-        drawFilledArc(e.getPoseStack(), e.getItemStack(), e.getX(), e.getY(), true);
+        drawFilledArc(e.getPoseStack(), e.getItemStack(), e.getX(), e.getY());
     }
 
     @SubscribeEvent
     public void onRenderSlot(SlotRenderEvent.CountPre e) {
         if (!renderFillArcInventory.get()) return;
-        RenderSystem.enableDepthTest();
-        drawFilledArc(e.getPoseStack(), e.getSlot().getItem(), e.getSlot().x, e.getSlot().y, false);
-        RenderSystem.disableDepthTest();
+        drawFilledArc(e.getPoseStack(), e.getSlot().getItem(), e.getSlot().x, e.getSlot().y);
     }
 
-    private void drawFilledArc(PoseStack poseStack, ItemStack itemStack, int slotX, int slotY, boolean hotbar) {
+    private void drawFilledArc(PoseStack poseStack, ItemStack itemStack, int slotX, int slotY) {
         Optional<EmeraldPouchItem> optionalItem = Models.Item.asWynnItem(itemStack, EmeraldPouchItem.class);
 
         if (optionalItem.isEmpty()) return;
@@ -62,6 +60,8 @@ public class EmeraldPouchFillArcFeature extends Feature {
         float ringFraction = Math.min(1f, capacityFraction);
 
         // draw
-        RenderUtils.drawArc(poseStack, color, slotX - 2, slotY - 2, hotbar ? 0 : 200, ringFraction, 8, 10);
+        RenderSystem.enableDepthTest();
+        RenderUtils.drawArc(poseStack, color, slotX - 2, slotY - 2, 100, ringFraction, 8, 10);
+        RenderSystem.disableDepthTest();
     }
 }

--- a/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -38,7 +38,7 @@ public class EmeraldPouchFillArcFeature extends Feature {
     }
 
     @SubscribeEvent
-    public void onRenderSlot(SlotRenderEvent.Pre e) {
+    public void onRenderSlot(SlotRenderEvent.CountPre e) {
         if (!renderFillArcInventory.get()) return;
         RenderSystem.enableDepthTest();
         drawFilledArc(e.getPoseStack(), e.getSlot().getItem(), e.getSlot().x, e.getSlot().y, false);

--- a/common/src/main/java/com/wynntils/features/inventory/ItemFavoriteFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemFavoriteFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -24,8 +24,8 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.properties.NamedItemProperty;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.buffered.BufferedRenderUtils;
 import com.wynntils.utils.wynn.ContainerUtils;
 import com.wynntils.utils.wynn.WynnUtils;
 import java.util.Optional;
@@ -96,7 +96,7 @@ public class ItemFavoriteFeature extends Feature {
     }
 
     @SubscribeEvent
-    public void onRenderSlot(SlotRenderEvent.Post event) {
+    public void onRenderSlot(SlotRenderEvent.CountPre event) {
         if (Models.Container.getCurrentContainer() instanceof FullscreenContainerProperty) return;
 
         ItemStack itemStack = event.getSlot().getItem();
@@ -124,13 +124,14 @@ public class ItemFavoriteFeature extends Feature {
         return isFavorite;
     }
 
-    private static void renderFavoriteItem(SlotRenderEvent.Post event) {
-        RenderUtils.drawScalingTexturedRect(
+    private static void renderFavoriteItem(SlotRenderEvent.CountPre event) {
+        BufferedRenderUtils.drawScalingTexturedRect(
                 event.getPoseStack(),
+                event.getGuiGraphics().bufferSource,
                 Texture.FAVORITE_ICON.resource(),
                 event.getSlot().x + 10,
                 event.getSlot().y,
-                399,
+                200,
                 9,
                 9,
                 Texture.FAVORITE_ICON.width(),

--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -148,7 +148,7 @@ public class ItemHighlightFeature extends Feature {
     public final Config<Float> hotbarOpacity = new Config<>(.5f);
 
     @SubscribeEvent(priority = EventPriority.HIGH)
-    public void onRenderSlot(SlotRenderEvent.Pre e) {
+    public void onRenderSlot(SlotRenderEvent.CountPre e) {
         if (!inventoryHighlightEnabled.get()) return;
 
         CustomColor color = getHighlightColor(e.getSlot().getItem(), false);
@@ -161,7 +161,7 @@ public class ItemHighlightFeature extends Feature {
                 color.withAlpha(inventoryOpacity.get()),
                 e.getSlot().x - 1,
                 e.getSlot().y - 1,
-                200,
+                100,
                 18,
                 18,
                 highlightTexture.get().ordinal() * 18,

--- a/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
@@ -1,10 +1,9 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
 
-import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
@@ -20,13 +19,14 @@ import com.wynntils.mc.event.DropHeldItemEvent;
 import com.wynntils.models.containers.type.FullscreenContainerProperty;
 import com.wynntils.models.items.items.game.MultiHealthPotionItem;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.buffered.BufferedRenderUtils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.ClickType;
@@ -70,7 +70,7 @@ public class ItemLockFeature extends Feature {
                 continue;
             }
 
-            renderLockedSlot(event.getPoseStack(), abstractContainerScreen, lockedSlot.get());
+            renderLockedSlot(event.getGuiGraphics(), abstractContainerScreen, lockedSlot.get());
         }
     }
 
@@ -130,9 +130,11 @@ public class ItemLockFeature extends Feature {
         }
     }
 
-    private void renderLockedSlot(PoseStack poseStack, AbstractContainerScreen<?> containerScreen, Slot lockedSlot) {
-        RenderUtils.drawTexturedRect(
-                poseStack,
+    private void renderLockedSlot(
+            GuiGraphics guiGraphics, AbstractContainerScreen<?> containerScreen, Slot lockedSlot) {
+        BufferedRenderUtils.drawTexturedRect(
+                guiGraphics.pose(),
+                guiGraphics.bufferSource,
                 Texture.ITEM_LOCK.resource(),
                 ((containerScreen.leftPos + lockedSlot.x)) + 12,
                 ((containerScreen.topPos + lockedSlot.y)) - 4,

--- a/common/src/main/java/com/wynntils/utils/render/buffered/BufferedRenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/buffered/BufferedRenderUtils.java
@@ -285,6 +285,34 @@ public final class BufferedRenderUtils {
                 texture.height());
     }
 
+    public static void drawTexturedRect(
+            PoseStack poseStack,
+            MultiBufferSource bufferSource,
+            ResourceLocation tex,
+            float x,
+            float y,
+            float z,
+            float width,
+            float height,
+            int textureWidth,
+            int textureHeight) {
+        drawTexturedRect(
+                poseStack,
+                bufferSource,
+                tex,
+                x,
+                y,
+                z,
+                width,
+                height,
+                0,
+                0,
+                (int) width,
+                (int) height,
+                textureWidth,
+                textureHeight);
+    }
+
     private static void drawTexturedRect(
             PoseStack poseStack,
             MultiBufferSource bufferSource,


### PR DESCRIPTION
This fixes all our slot rendering, item favourites, locked slots, highlights etc to all work as it did pre 1.21.4 as far as I can tell, no textures getting cut off or dark backgrounds.

Current
![image](https://github.com/user-attachments/assets/075be3a3-2fb4-47ed-9944-8df577d967e9)

Fix
![image](https://github.com/user-attachments/assets/8a8747d2-af73-4d37-b290-587f3dae2231)

Current
![image](https://github.com/user-attachments/assets/e6a29927-dc94-4c28-a195-07fe4c9d8b6f)

Fix
![image](https://github.com/user-attachments/assets/08566500-ae67-43ee-9006-1de9d68c399d)

Current
![image](https://github.com/user-attachments/assets/63fcd7ff-d9a5-49a4-a1e4-5d835c9c9fdd)

Fix
![image](https://github.com/user-attachments/assets/2cb984c2-002c-45c4-be42-a4f998cdfd69)

Current
![image](https://github.com/user-attachments/assets/c4297ab8-d136-40ad-875b-156b933874ee)

Fix
![image](https://github.com/user-attachments/assets/f5b9f826-286e-4196-bfa1-4970cef6d39b)
