### PR TITLE
fix: Remove ugly/useless save option from WaypointsService

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/WaypointCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/WaypointCreationScreen.java
@@ -911,7 +911,7 @@ public final class WaypointCreationScreen extends AbstractMapScreen {
 
     private void saveWaypoint() {
         if (oldWaypoint != null) {
-            Services.Waypoints.removeWaypoint(oldWaypoint, true);
+            Services.Waypoints.removeWaypoint(oldWaypoint);
         }
 
         Services.Waypoints.addWaypoint(waypoint);

--- a/common/src/main/java/com/wynntils/screens/maps/WaypointManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/WaypointManagementScreen.java
@@ -562,10 +562,10 @@ public final class WaypointManagementScreen extends WynntilsScreen {
         populateWaypoints();
     }
 
-    public void deleteWaypoint(WaypointLocation waypointToDelete, boolean save) {
+    public void deleteWaypoint(WaypointLocation waypointToDelete) {
         int deletedWaypointIndex = Services.Waypoints.getWaypoints().indexOf(waypointToDelete);
 
-        Services.Waypoints.removeWaypoint(waypointToDelete, save);
+        Services.Waypoints.removeWaypoint(waypointToDelete);
 
         deletedWaypoints.add(waypointToDelete);
         deletedIndexes.add(deletedWaypointIndex);
@@ -930,7 +930,7 @@ public final class WaypointManagementScreen extends WynntilsScreen {
 
     private void deleteSelectedWaypoints() {
         for (WaypointLocation waypoint : selectedWaypoints) {
-            deleteWaypoint(waypoint, false);
+            deleteWaypoint(waypoint);
         }
 
         McUtils.sendMessageToClient(Component.translatable(

--- a/common/src/main/java/com/wynntils/screens/maps/widgets/WaypointManagerWidget.java
+++ b/common/src/main/java/com/wynntils/screens/maps/widgets/WaypointManagerWidget.java
@@ -86,7 +86,7 @@ public class WaypointManagerWidget extends AbstractWidget {
 
         deleteButton = new Button.Builder(
                         Component.translatable("screens.wynntils.waypointManagementGui.delete"), (button) -> {
-                            managementScreen.deleteWaypoint(waypoint, true);
+                            managementScreen.deleteWaypoint(waypoint);
                         })
                 .pos(x + width - 20 - 40, y)
                 .size(40, 20)

--- a/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/WaypointsService.java
@@ -114,11 +114,9 @@ public class WaypointsService extends Service {
         waypoints.touched();
     }
 
-    public void removeWaypoint(WaypointLocation waypoint, boolean save) {
+    public void removeWaypoint(WaypointLocation waypoint) {
         waypoints.get().remove(waypoint);
-        if (save) {
-            waypoints.touched();
-        }
+        waypoints.touched();
         WAYPOINTS_PROVIDER.updateWaypoints(waypoints.get());
     }
 


### PR DESCRIPTION
It is no longer needed. Storages can be "touched" multiple times, they are saved on a schedule, not instantly.