### PR TITLE
fix: Fix container search arc rendering [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -187,7 +187,7 @@ public class ContainerSearchFeature extends Feature {
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)
-    public void onRenderSlot(SlotRenderEvent.Pre e) {
+    public void onRenderSlot(SlotRenderEvent.CountPre e) {
         ItemStack itemStack = e.getSlot().getItem();
         Optional<WynnItem> wynnItemOpt = Models.Item.getWynnItem(itemStack);
         if (wynnItemOpt.isEmpty()) return;
@@ -196,7 +196,7 @@ public class ContainerSearchFeature extends Feature {
         if (result == null || !result) return;
 
         RenderSystem.enableDepthTest();
-        RenderUtils.drawArc(e.getPoseStack(), highlightColor.get(), e.getSlot().x, e.getSlot().y, 200, 1f, 6, 8);
+        RenderUtils.drawArc(e.getPoseStack(), highlightColor.get(), e.getSlot().x, e.getSlot().y, 100, 1f, 6, 8);
         RenderSystem.disableDepthTest();
     }
 

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;


### PR DESCRIPTION
Same change as https://github.com/Wynntils/Wynntils/pull/3136 just forgot this one place for slot rendering

Current
![image](https://github.com/user-attachments/assets/b5a92672-6e28-4bbe-ada8-79b9cd025112)

Fix
![image](https://github.com/user-attachments/assets/44132f4e-9b49-4790-88d8-5f0a17ab5e52)
