### PR TITLE
fix: Do not cast ticks function to int [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/MinecraftFunctions.java
@@ -45,10 +45,10 @@ public class MinecraftFunctions {
         }
     }
 
-    public static class TicksFunction extends Function<Integer> {
+    public static class TicksFunction extends Function<Long> {
         @Override
-        public Integer getValue(FunctionArguments arguments) {
-            return (int) McUtils.mc().level.getGameTime();
+        public Long getValue(FunctionArguments arguments) {
+            return McUtils.mc().level.getGameTime();
         }
     }
 


### PR DESCRIPTION
https://discord.com/channels/394189072635133952/1023353867158687744/1345540407613718609 for details
Essentially worlds can stay up for longer than the 32 bit int limit for ticks now, so casting causes overflow and negative world time