### PR TITLE
fix: Emerald count is detached in emerald merchants [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -32,6 +32,7 @@ import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.Arrays;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -94,8 +95,12 @@ public class InventoryEmeraldCountFeature extends Feature {
             topTextureX -= Texture.BANK_PANEL.width() + 10;
         }
 
-        if (event.getScreen().renderables.stream().anyMatch(w -> w instanceof BulkBuyWidget)) {
-            topTextureX -= Texture.BULK_BUY_PANEL.width() + 1;
+        for (Renderable r : event.getScreen().renderables) {
+            if (r instanceof BulkBuyWidget bulkBuyWidget) {
+                topTextureX -= (int) ((Texture.BULK_BUY_PANEL.width() + 1)
+                        * bulkBuyWidget.getAnimationPercentage().getAnimationWithoutUpdate());
+                break; // usually only one bulk buy widget is present, but just in case
+            }
         }
         // endregion
 

--- a/common/src/main/java/com/wynntils/screens/bulkbuy/widgets/BulkBuyWidget.java
+++ b/common/src/main/java/com/wynntils/screens/bulkbuy/widgets/BulkBuyWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.bulkbuy.widgets;
@@ -131,6 +131,10 @@ public class BulkBuyWidget extends AbstractWidget {
 
     public void setBulkBoughtItem(BulkBuyFeature.BulkBoughtItem bulkBoughtItem) {
         this.bulkBoughtItem = bulkBoughtItem;
+    }
+
+    public AnimationPercentage getAnimationPercentage() {
+        return animationPercentage;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/utils/render/type/AnimationPercentage.java
+++ b/common/src/main/java/com/wynntils/utils/render/type/AnimationPercentage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils.render.type;
@@ -22,6 +22,9 @@ public final class AnimationPercentage {
         this.openingDuration = openingDuration;
     }
 
+    /**
+     * @return Animation percentage between 0 and 1, continuously updating for use in render methods.
+     */
     public double getAnimation() {
         if (openingDuration.isZero() || openingDuration.isNegative()) return 1;
         if (openingProgress == 0) {
@@ -37,6 +40,13 @@ public final class AnimationPercentage {
         }
         lastTime = Instant.now();
         return applyTransformation(openingProgress);
+    }
+
+    /**
+     * @return Animation percentage between 0 and 1, without updating the animation.
+     */
+    public double getAnimationWithoutUpdate() {
+        return openingProgress;
     }
 
     public void addOpeningProgress(double openingProgress) {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/f852a88f-a6e2-4258-86d5-c2c1c4eb1131)

After:
![2025-03-02_12-57-25](https://github.com/user-attachments/assets/d78ad478-48e9-4fff-b27f-3e0d59b49e73)