### PR TITLE
fix: Fix chat functionality on non-Wynncraft servers [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/ChatListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ChatListenerMixin.java
@@ -6,7 +6,7 @@ package com.wynntils.mc.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.events.MixinHelper;
 import com.wynntils.mc.event.ClientsideMessageEvent;
 import net.minecraft.client.gui.components.ChatComponent;
 import net.minecraft.client.multiplayer.chat.ChatListener;
@@ -25,7 +25,7 @@ public abstract class ChatListenerMixin {
                                     "Lnet/minecraft/client/gui/components/ChatComponent;addMessage(Lnet/minecraft/network/chat/Component;)V"))
     private void onSystemMessage(ChatComponent instance, Component component, Operation<Void> operation) {
         ClientsideMessageEvent event = new ClientsideMessageEvent(component);
-        WynntilsMod.postEvent(event);
+        MixinHelper.post(event);
 
         if (!event.isCanceled()) {
             operation.call(instance, component);

--- a/common/src/main/java/com/wynntils/mc/mixin/LightTextureMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LightTextureMixin.java
@@ -5,7 +5,7 @@
 package com.wynntils.mc.mixin;
 
 import com.mojang.blaze3d.pipeline.TextureTarget;
-import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.events.MixinHelper;
 import com.wynntils.mc.event.LightmapEvent;
 import net.minecraft.client.renderer.LightTexture;
 import org.spongepowered.asm.mixin.Final;
@@ -24,7 +24,7 @@ public class LightTextureMixin {
     @Inject(method = "updateLightTexture", at = @At("HEAD"), cancellable = true)
     private void updateLightmap(float partialTicks, CallbackInfo ci) {
         final LightmapEvent lightmapEvent = new LightmapEvent();
-        WynntilsMod.postEvent(lightmapEvent);
+        MixinHelper.post(lightmapEvent);
 
         if (lightmapEvent.isCanceled()) {
             this.target.clear();

--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -56,7 +56,7 @@ public abstract class ScreenMixin implements ScreenExtension {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;init()V"))
     private void onScreenInitPre(CallbackInfo ci) {
         // This is called whenever a screen is re-inited (e.g. when the window is resized)
-        MixinHelper.postAlways(new ScreenInitEvent.Pre((Screen) (Object) this, false));
+        MixinHelper.post(new ScreenInitEvent.Pre((Screen) (Object) this, false));
     }
 
     @Inject(method = "rebuildWidgets()V", at = @At("RETURN"))

--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -56,7 +56,7 @@ public abstract class ScreenMixin implements ScreenExtension {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;init()V"))
     private void onScreenInitPre(CallbackInfo ci) {
         // This is called whenever a screen is re-inited (e.g. when the window is resized)
-        MixinHelper.post(new ScreenInitEvent.Pre((Screen) (Object) this, false));
+        MixinHelper.postAlways(new ScreenInitEvent.Pre((Screen) (Object) this, false));
     }
 
     @Inject(method = "rebuildWidgets()V", at = @At("RETURN"))


### PR DESCRIPTION
The event in `ChatListenerMixin` was set to always fire instead of only firing while online Wynncraft, which stopped chat messages from appearing if the player was on a different server. The change in `ScreenMixin` was done to prevent chat tab buttons from appearing outside of Wynncraft when the Minecraft window was resized while chat was open.