### PR TITLE
fix: Rainbow Beacon Count

### DIFF
--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -931,10 +931,10 @@ public class LootrunModel extends Model {
 
         if (color == LootrunBeaconKind.RAINBOW) {
             if (rainbowAmount.get().getOrDefault(Models.Character.getId(), -1) != -1) {
-                Integer oldCount = rainbowBeaconCountStorage.get().getOrDefault(Models.Character.getId(), 0);
-
-                int newCount = Math.max(oldCount + rainbowAmount.get().get(Models.Character.getId()), 0);
-                rainbowBeaconCountStorage.get().put(Models.Character.getId(), newCount);
+                rainbowBeaconCountStorage.get().put(
+                        Models.Character.getId(),
+                        Math.max(rainbowAmount.get().get(Models.Character.getId()), 0)
+                );
                 rainbowBeaconCountStorage.touched();
             } else {
                 WynntilsMod.warn("Completed rainbow beacon challenge but had no rainbow amount");

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -933,7 +933,7 @@ public class LootrunModel extends Model {
             if (rainbowAmount.get().getOrDefault(Models.Character.getId(), -1) != -1) {
                 rainbowBeaconCountStorage.get().put(
                         Models.Character.getId(),
-                        Math.max(rainbowAmount.get().get(Models.Character.getId()), 0)
+                        rainbowAmount.get().getOrDefault(Models.Character.getId(), 0)
                 );
                 rainbowBeaconCountStorage.touched();
             } else {

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -931,10 +931,9 @@ public class LootrunModel extends Model {
 
         if (color == LootrunBeaconKind.RAINBOW) {
             if (rainbowAmount.get().getOrDefault(Models.Character.getId(), -1) != -1) {
-                rainbowBeaconCountStorage.get().put(
-                        Models.Character.getId(),
-                        rainbowAmount.get().getOrDefault(Models.Character.getId(), 0)
-                );
+                rainbowBeaconCountStorage
+                        .get()
+                        .put(Models.Character.getId(), rainbowAmount.get().getOrDefault(Models.Character.getId(), 0));
                 rainbowBeaconCountStorage.touched();
             } else {
                 WynntilsMod.warn("Completed rainbow beacon challenge but had no rainbow amount");

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -931,10 +931,11 @@ public class LootrunModel extends Model {
 
         if (color == LootrunBeaconKind.RAINBOW) {
             if (rainbowAmount.get().getOrDefault(Models.Character.getId(), -1) != -1) {
-                rainbowBeaconCountStorage.get().put(
-                        Models.Character.getId(),
-                        Math.max(rainbowAmount.get().get(Models.Character.getId()), 0)
-                );
+                rainbowBeaconCountStorage
+                        .get()
+                        .put(
+                                Models.Character.getId(),
+                                Math.max(rainbowAmount.get().get(Models.Character.getId()), 0));
                 rainbowBeaconCountStorage.touched();
             } else {
                 WynntilsMod.warn("Completed rainbow beacon challenge but had no rainbow amount");


### PR DESCRIPTION
Previously, the Rainbow Beacon Count would be added to the old count, which is not how rainbow beacons work. Instead, every rainbow beacon completely overwrites the previous count.