### PR TITLE
feat: Add back tier specific colour to aspect tier annotation [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -210,6 +210,12 @@ public class ItemTextOverlayFeature extends Feature {
     }
 
     private final class AspectOverlay implements TextOverlayInfo {
+        private static final CustomColor TIER_1_HIGHLIGHT_COLOR =
+                CustomColor.fromChatFormatting(ChatFormatting.DARK_GRAY);
+        private static final CustomColor TIER_2_HIGHLIGHT_COLOR = new CustomColor(205, 127, 50);
+        private static final CustomColor TIER_3_HIGHLIGHT_COLOR = new CustomColor(192, 192, 192);
+        private static final CustomColor TIER_4_HIGHLIGHT_COLOR = new CustomColor(255, 215, 0);
+
         private final AspectItem item;
 
         private AspectOverlay(AspectItem item) {
@@ -218,11 +224,17 @@ public class ItemTextOverlayFeature extends Feature {
 
         @Override
         public TextOverlay getTextOverlay() {
+            CustomColor highlightColor =
+                    switch (item.getAspectTier()) {
+                        case 2 -> TIER_2_HIGHLIGHT_COLOR;
+                        case 3 -> TIER_3_HIGHLIGHT_COLOR;
+                        case 4 -> TIER_4_HIGHLIGHT_COLOR;
+                        default -> TIER_1_HIGHLIGHT_COLOR;
+                    };
             String text = valueToString(item.getAspectTier(), aspectTierRomanNumerals.get());
 
-            TextRenderSetting style = TextRenderSetting.DEFAULT
-                    .withCustomColor(CustomColor.fromChatFormatting(ChatFormatting.DARK_AQUA))
-                    .withTextShadow(aspectShadow.get());
+            TextRenderSetting style =
+                    TextRenderSetting.DEFAULT.withCustomColor(highlightColor).withTextShadow(aspectShadow.get());
 
             return new TextOverlay(new TextRenderTask(text, style), -1, 1, 0.75f);
         }


### PR DESCRIPTION
Apparently people liked the different colours for tiers so just brings that back after they were removed with https://github.com/Wynntils/Wynntils/pull/3155

![image](https://github.com/user-attachments/assets/3699e889-f11d-464e-a8e4-78d574b3efea)
