### PR TITLE
feat: Add option to only show page name in quick jump button tooltips [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
@@ -6,7 +6,9 @@ package com.wynntils.features.inventory;
 
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
+import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
@@ -36,6 +38,9 @@ import org.lwjgl.glfw.GLFW;
 public class PersonalStorageUtilitiesFeature extends Feature {
     private static final int STORAGE_TYPE_SLOT = 47;
     private static final Pattern PAGE_PATTERN = Pattern.compile("§7- §f.*§8 Page (\\d+)");
+
+    @Persisted
+    public final Config<Boolean> onlyShowName = new Config<>(false);
 
     private boolean quickJumping = false;
     private int currentPage = 1;

--- a/common/src/main/java/com/wynntils/screens/container/widgets/PersonalStorageUtilitiesWidget.java
+++ b/common/src/main/java/com/wynntils/screens/container/widgets/PersonalStorageUtilitiesWidget.java
@@ -133,7 +133,7 @@ public class PersonalStorageUtilitiesWidget extends AbstractWidget {
         int renderY = getY() + 23;
 
         for (int i = 0; i < container.getFinalPage(); i++) {
-            quickJumpButtons.add(new QuickJumpButton(renderX, renderY, i + 1, this));
+            quickJumpButtons.add(new QuickJumpButton(renderX, renderY, i + 1, feature.onlyShowName.get(), this));
 
             renderX += BUTTON_SPACING;
 

--- a/common/src/main/java/com/wynntils/screens/container/widgets/QuickJumpButton.java
+++ b/common/src/main/java/com/wynntils/screens/container/widgets/QuickJumpButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.container.widgets;
@@ -23,12 +23,14 @@ import net.minecraft.network.chat.Component;
 
 public class QuickJumpButton extends WynntilsButton {
     private final int destination;
+    private final boolean onlyShowName;
     private final PersonalStorageUtilitiesWidget parent;
 
-    public QuickJumpButton(int x, int y, int destination, PersonalStorageUtilitiesWidget parent) {
+    public QuickJumpButton(int x, int y, int destination, boolean onlyShowName, PersonalStorageUtilitiesWidget parent) {
         super(x, y, 16, 16, Component.literal("Container Quick Jump Button"));
 
         this.destination = destination;
+        this.onlyShowName = onlyShowName;
         this.parent = parent;
     }
 
@@ -50,13 +52,15 @@ public class QuickJumpButton extends WynntilsButton {
                         TextShadow.NORMAL);
 
         if (isHovered) {
+            Component nameTooltip = onlyShowName
+                    ? Component.literal(Models.Bank.getPageName(destination))
+                    : Component.translatable(
+                            "feature.wynntils.personalStorageUtilities.clickToJump",
+                            Models.Bank.getPageName(destination));
+
             McUtils.mc()
                     .screen
-                    .setTooltipForNextRenderPass(Lists.transform(
-                            List.of(Component.translatable(
-                                    "feature.wynntils.personalStorageUtilities.clickToJump",
-                                    Models.Bank.getPageName(destination))),
-                            Component::getVisualOrderText));
+                    .setTooltipForNextRenderPass(Lists.transform(List.of(nameTooltip), Component::getVisualOrderText));
         }
     }
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1161,6 +1161,8 @@
   "feature.wynntils.personalStorageUtilities.clickToJump": "Click to jump to %s",
   "feature.wynntils.personalStorageUtilities.description": "Adds the ability to set custom names for your personal storage containers and quick jump to any page.",
   "feature.wynntils.personalStorageUtilities.name": "Personal Storage Utilities",
+  "feature.wynntils.personalStorageUtilities.onlyShowName.description": "Should the tooltip for quick jump buttons include the \"Click to jump to\" text?",
+  "feature.wynntils.personalStorageUtilities.onlyShowName.name": "Only Show Page Name",
   "feature.wynntils.personalStorageUtilities.page": "Page %d",
   "feature.wynntils.playerArmorHiding.description": "Adds the ability to hide other players' armor.",
   "feature.wynntils.playerArmorHiding.hideBoots.description": "Should players' boots be hidden?",


### PR DESCRIPTION
Disabled
![image](https://github.com/user-attachments/assets/2cb8661a-6d67-42b7-80eb-d9f527e5ed14)

Enabled
![image](https://github.com/user-attachments/assets/b5fd647b-9166-4d5d-8dd2-33c4e6eb54b1)
