### PR TITLE
fix: Miscellaneous lootrun changes [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/crowdsource/LootrunLocationDataCollector.java
+++ b/common/src/main/java/com/wynntils/crowdsource/LootrunLocationDataCollector.java
@@ -1,28 +1,25 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.crowdsource;
 
-import com.wynntils.core.components.Models;
 import com.wynntils.core.crowdsource.CrowdSourcedDataCollector;
 import com.wynntils.core.crowdsource.datatype.LootrunTaskLocation;
 import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
 import com.wynntils.models.lootrun.event.LootrunBeaconSelectedEvent;
 import com.wynntils.models.lootrun.type.LootrunLocation;
 import com.wynntils.models.lootrun.type.LootrunTaskType;
-import java.util.Optional;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public class LootrunLocationDataCollector extends CrowdSourcedDataCollector<LootrunTaskLocation> {
     @SubscribeEvent
     public void onLootrunTaskSelected(LootrunBeaconSelectedEvent event) {
-        Optional<LootrunTaskType> currentTaskTypeOpt = Models.Lootrun.getTaskType();
-        if (currentTaskTypeOpt.isEmpty()) return;
+        if (event.getTaskType() == LootrunTaskType.UNKNOWN) return;
 
         collect(new LootrunTaskLocation(
                 LootrunLocation.UNKNOWN,
-                currentTaskTypeOpt.get(),
+                event.getTaskType(),
                 event.getTaskLocation().location()));
     }
 

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -219,6 +219,7 @@ public class LootrunModel extends Model {
     private final Storage<Map<String, List<MissionType>>> missionStorage = new Storage<>(new TreeMap<>());
 
     private List<Pair<Beacon<LootrunBeaconKind>, EntityExtension>> activeBeacons = new ArrayList<>();
+    private Map<LootrunBeaconKind, LootrunTaskType> activeTaskTypes = new HashMap<>();
 
     public LootrunModel(MarkerModel markerModel) {
         super(List.of(markerModel));
@@ -535,6 +536,7 @@ public class LootrunModel extends Model {
         taskType = null;
         beacons = new HashMap<>();
         activeBeacons = new ArrayList<>();
+        activeTaskTypes = new HashMap<>();
         LOOTRUN_BEACON_COMPASS_PROVIDER.reloadTaskMarkers();
 
         selectedBeacons = new TreeMap<>();
@@ -661,6 +663,8 @@ public class LootrunModel extends Model {
             entity.setRendered(true);
             return;
         }
+
+        activeTaskTypes.putIfAbsent(beaconPair.a().beaconKind(), lootrunMarker.getTaskType());
 
         boolean foundBeacon = updateTaskLocationPrediction(
                         beaconPair.a(), lootrunMarker, beaconMarker.distance().get())
@@ -909,7 +913,9 @@ public class LootrunModel extends Model {
             selectedBeaconsStorage.touched();
             setLastTaskBeaconColor(color);
             WynntilsMod.postEvent(new LootrunBeaconSelectedEvent(
-                    closestBeacon, beacons.get(closestBeacon.beaconKind()).taskLocation()));
+                    closestBeacon,
+                    beacons.get(closestBeacon.beaconKind()).taskLocation(),
+                    activeTaskTypes.getOrDefault(closestBeacon.beaconKind(), LootrunTaskType.UNKNOWN)));
 
             possibleTaskLocations = new HashSet<>();
 
@@ -917,6 +923,7 @@ public class LootrunModel extends Model {
             beacons.clear();
             vibrantBeacons.clear();
             activeBeacons.clear();
+            activeTaskTypes.clear();
             setClosestBeacon(null);
             expectOrangeBeacon = false;
             expectRainbowBeacon = false;

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -1015,7 +1015,8 @@ public class LootrunModel extends Model {
         // Get the tasks found from particles as we know for certain there is a task there and it may include
         // unknown tasks
         Set<TaskLocation> currentTaskLocations = possibleTaskLocations.stream()
-                .filter(possibleTask -> possibleTask.taskType() == lootrunMarker.getTaskType())
+                .filter(possibleTask -> possibleTask.taskType() == lootrunMarker.getTaskType()
+                        || possibleTask.taskType() == LootrunTaskType.UNKNOWN)
                 .collect(Collectors.toSet());
 
         // Due to Wynncraft culling particles, after 5 or more beacon choices (sometimes less) we are no longer able

--- a/common/src/main/java/com/wynntils/models/lootrun/event/LootrunBeaconSelectedEvent.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/event/LootrunBeaconSelectedEvent.java
@@ -1,20 +1,23 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.lootrun.event;
 
 import com.wynntils.models.beacons.type.Beacon;
+import com.wynntils.models.lootrun.type.LootrunTaskType;
 import com.wynntils.models.lootrun.type.TaskLocation;
 import net.neoforged.bus.api.Event;
 
 public class LootrunBeaconSelectedEvent extends Event {
     private final Beacon beacon;
     private final TaskLocation taskLocation;
+    private final LootrunTaskType taskType;
 
-    public LootrunBeaconSelectedEvent(Beacon beacon, TaskLocation taskLocation) {
+    public LootrunBeaconSelectedEvent(Beacon beacon, TaskLocation taskLocation, LootrunTaskType taskType) {
         this.beacon = beacon;
         this.taskLocation = taskLocation;
+        this.taskType = taskType;
     }
 
     public Beacon getBeacon() {
@@ -23,5 +26,9 @@ public class LootrunBeaconSelectedEvent extends Event {
 
     public TaskLocation getTaskLocation() {
         return taskLocation;
+    }
+
+    public LootrunTaskType getTaskType() {
+        return taskType;
     }
 }

--- a/common/src/main/java/com/wynntils/models/lootrun/markers/LootrunBeaconMarkerProvider.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/markers/LootrunBeaconMarkerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.lootrun.markers;
@@ -34,7 +34,7 @@ public class LootrunBeaconMarkerProvider implements MarkerProvider<MarkerPoi> {
             newTaskMarkers.add(new MarkerInfo(
                     EnumUtils.toNiceString(entry.getKey()) + " Beacon",
                     new StaticLocationSupplier(entry.getValue().taskLocation().location()),
-                    entry.getValue().taskLocation().taskType().getTexture(),
+                    entry.getValue().lootrunMarker().getTaskType().getTexture(),
                     entry.getKey().getDisplayColor(),
                     CommonColors.WHITE,
                     entry.getKey().getDisplayColor(),


### PR DESCRIPTION
ac9962d380426dfe0805d7a2bc2d862919fd290c Fixes lootrun crowd sourcing to support target tasks.

Sample data
```
        "lootrunTaskLocations": [
          {
            "region": "unknown",
            "lootrunTaskType": "loot",
            "location": {
              "x": 1264,
              "y": 146,
              "z": -4646
            }
          },
          {
            "region": "unknown",
            "lootrunTaskType": "target",
            "location": {
              "x": 1428,
              "y": 141,
              "z": -4579
            }
          },
          {
            "region": "unknown",
            "lootrunTaskType": "destroy",
            "location": {
              "x": 924,
              "y": 108,
              "z": -4689
            }
          }
        ],
```

66eb9797bb2ba5f3b3e6d35d0ae4274c2cc88919 Includes unknown tasks found by particles when updating predictions.

f2762e0e40515580f80d875ffc4aa3d87bff985d Makes it so unknown tasks will show their task type in the marker