### PR TITLE
chore: Bump crowd source version [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/crowdsource/CrowdSourcedDataManager.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/CrowdSourcedDataManager.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 public class CrowdSourcedDataManager extends Manager {
     public static final CrowdSourcedDataGameVersion CURRENT_GAME_VERSION =
-            CrowdSourcedDataGameVersion.VERSION_211_RELEASE;
+            CrowdSourcedDataGameVersion.VERSION_211_PATCH_6;
 
     @Persisted
     private final Storage<CrowdSourcedData> collectedData = new Storage<>(new CrowdSourcedData());

--- a/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataGameVersion.java
+++ b/common/src/main/java/com/wynntils/core/crowdsource/type/CrowdSourcedDataGameVersion.java
@@ -16,7 +16,8 @@ public enum CrowdSourcedDataGameVersion {
     VERSION_204_RELEASE_2("2.0.4 Release #2"), // Bugfixes in the mod
     VERSION_210_BETA("2.1 Beta"),
     VERSION_210_BETA_2("2.1 Beta #2"), // Bugfixes in the mod
-    VERSION_211_RELEASE("2.1.1");
+    VERSION_211_RELEASE("2.1.1"),
+    VERSION_211_PATCH_6("2.1.1 Patch #6"); // Bugfixes in the mod & some pois changed
 
     private final String readableVersion;
 

--- a/common/src/main/java/com/wynntils/crowdsource/NpcLocationDataCollector.java
+++ b/common/src/main/java/com/wynntils/crowdsource/NpcLocationDataCollector.java
@@ -1,9 +1,10 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.crowdsource;
 
+import com.wynntils.core.components.Models;
 import com.wynntils.core.crowdsource.CrowdSourcedDataCollector;
 import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
 import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
@@ -13,6 +14,8 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class NpcLocationDataCollector extends CrowdSourcedDataCollector<NpcLabelInfo> {
     @SubscribeEvent
     public void onLabelIdentified(LabelIdentifiedEvent event) {
+        if (Models.WorldState.onHousing()) return;
+
         if (event.getLabelInfo() instanceof NpcLabelInfo npcLabelInfo) {
             collect(npcLabelInfo);
         }

--- a/common/src/main/java/com/wynntils/crowdsource/ProfessionStationLocationDataCollector.java
+++ b/common/src/main/java/com/wynntils/crowdsource/ProfessionStationLocationDataCollector.java
@@ -1,9 +1,10 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.crowdsource;
 
+import com.wynntils.core.components.Models;
 import com.wynntils.core.crowdsource.CrowdSourcedDataCollector;
 import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
 import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
@@ -14,6 +15,8 @@ public class ProfessionStationLocationDataCollector
         extends CrowdSourcedDataCollector<ProfessionCraftingStationLabelInfo> {
     @SubscribeEvent
     public void onLabelIdentified(LabelIdentifiedEvent event) {
+        if (Models.WorldState.onHousing()) return;
+
         if (event.getLabelInfo() instanceof ProfessionCraftingStationLabelInfo labelInfo) {
             collect(labelInfo);
         }

--- a/common/src/main/java/com/wynntils/models/npc/label/NpcLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/npc/label/NpcLabelParser.java
@@ -37,7 +37,7 @@ public class NpcLabelParser implements LabelParser<NpcLabelInfo> {
         }
 
         if (label.matches(HOUSING_LABEL_PATTERN)) {
-            return new NpcLabelInfo(label, "Housing", location, entity);
+            return new NpcLabelInfo(label, "Housing Balloon", location, entity);
         }
 
         if (label.matches(BOOTH_SHOP_LABEL_PATTERN)) {


### PR DESCRIPTION
Some crafting station locations in Thesead were changed in the recent patch and also the housing balloon name now matches the existing `services.json` file.

If all goes to plan I'm hoping to start asking for crowd sourcing data soon after the next version release, just writing up a script to convert the data to the correct format atm.

We also now don't collect npcs or crafting stations whilst on housing so that we don't have to filter them out later