### PR TITLE
chore: Update spotless plugins for java 21 [skip ci]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -71,13 +71,13 @@ devauth_version=1.2.1
 
 # Spotless
 # Check for latest at https://plugins.gradle.org/plugin/com.diffplug.spotless
-spotless_version=6.25.0
+spotless_version=7.0.2
 
 # Check for latest at https://plugins.gradle.org/plugin/com.palantir.java-format-spotless
-spotless_palantir_version=2.47.0
+spotless_palantir_version=2.58.0
 
 # Check for latest at https://github.com/google/gson/releases
-spotless_gson_version=2.11.0
+spotless_gson_version=2.12.1
 
 # Check for latest at https://groovy.jfrog.io/ui/native/plugins-release/org/codehaus/groovy/groovy-eclipse-integration/4.9.0
 spotless_greclipse_version=4.27


### PR DESCRIPTION
palantir-java-format 2.57.0 has official Java 21 support.

Whoever merges please undraft #3173 and review/merge too.