### PR TITLE
refactor: Use dedicated ping packets for PingService [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
@@ -6,7 +6,6 @@ package com.wynntils.mc.event;
 
 import com.wynntils.core.events.EventThread;
 import net.neoforged.bus.api.Event;
-import net.neoforged.bus.api.ICancellableEvent;
 
 @EventThread(EventThread.Type.IO)
 public class PongReceivedEvent extends Event {

--- a/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
@@ -4,9 +4,11 @@
  */
 package com.wynntils.mc.event;
 
+import com.wynntils.core.events.EventThread;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
+@EventThread(EventThread.Type.ANY)
 public class PongReceivedEvent extends Event implements ICancellableEvent {
     private final long time;
 

--- a/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
@@ -9,7 +9,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
 @EventThread(EventThread.Type.IO)
-public class PongReceivedEvent extends Event implements ICancellableEvent {
+public class PongReceivedEvent extends Event {
     private final long time;
 
     public PongReceivedEvent(long time) {

--- a/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2022-2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+public class PongReceivedEvent extends Event implements ICancellableEvent {
+    private final long time;
+
+    public PongReceivedEvent(long time) {
+        this.time = time;
+    }
+
+    public long getTime() {
+        return time;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PongReceivedEvent.java
@@ -8,7 +8,7 @@ import com.wynntils.core.events.EventThread;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
-@EventThread(EventThread.Type.ANY)
+@EventThread(EventThread.Type.IO)
 public class PongReceivedEvent extends Event implements ICancellableEvent {
     private final long time;
 

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -664,8 +664,7 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
     }
 
     @Inject(
-            method =
-                "handlePongResponse(Lnet/minecraft/network/protocol/ping/ClientboundPongResponsePacket;)V",
+            method = "handlePongResponse(Lnet/minecraft/network/protocol/ping/ClientboundPongResponsePacket;)V",
             at = @At("RETURN"))
     private void handlePongResponsePost(ClientboundPongResponsePacket packet, CallbackInfo ci) {
         PongReceivedEvent event = new PongReceivedEvent(packet.time());

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -670,8 +670,5 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
     private void handlePongResponsePost(ClientboundPongResponsePacket packet, CallbackInfo ci) {
         PongReceivedEvent event = new PongReceivedEvent(packet.time());
         MixinHelper.post(event);
-        if (event.isCanceled()) {
-            ci.cancel();
-        }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -665,7 +665,7 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
 
     @Inject(
             method =
-                    "Lnet/minecraft/client/multiplayer/ClientPacketListener;handlePongResponse(Lnet/minecraft/network/protocol/ping/ClientboundPongResponsePacket;)V",
+                "handlePongResponse(Lnet/minecraft/network/protocol/ping/ClientboundPongResponsePacket;)V",
             at = @At("RETURN"))
     private void handlePongResponsePost(ClientboundPongResponsePacket packet, CallbackInfo ci) {
         PongReceivedEvent event = new PongReceivedEvent(packet.time());

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -28,6 +28,7 @@ import com.wynntils.mc.event.ParticleAddedEvent;
 import com.wynntils.mc.event.PlayerInfoEvent;
 import com.wynntils.mc.event.PlayerInfoFooterChangedEvent;
 import com.wynntils.mc.event.PlayerTeleportEvent;
+import com.wynntils.mc.event.PongReceivedEvent;
 import com.wynntils.mc.event.RemoveEntitiesEvent;
 import com.wynntils.mc.event.ScoreboardEvent;
 import com.wynntils.mc.event.ScoreboardSetDisplayObjectiveEvent;
@@ -86,6 +87,7 @@ import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
+import net.minecraft.network.protocol.ping.ClientboundPongResponsePacket;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.flag.FeatureFlagSet;
@@ -659,5 +661,17 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
 
         MixinHelper.post(
                 new ChunkReceivedEvent(packet.getX(), packet.getZ(), packet.getChunkData(), packet.getLightData()));
+    }
+
+    @Inject(
+            method =
+                    "Lnet/minecraft/client/multiplayer/ClientPacketListener;handlePongResponse(Lnet/minecraft/network/protocol/ping/ClientboundPongResponsePacket;)V",
+            at = @At("RETURN"))
+    private void handlePongResponsePost(ClientboundPongResponsePacket packet, CallbackInfo ci) {
+        PongReceivedEvent event = new PongReceivedEvent(packet.time());
+        MixinHelper.post(event);
+        if (event.isCanceled()) {
+            ci.cancel();
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/services/ping/PingService.java
+++ b/common/src/main/java/com/wynntils/services/ping/PingService.java
@@ -5,7 +5,7 @@
 package com.wynntils.services.ping;
 
 import com.wynntils.core.components.Service;
-import com.wynntils.mc.event.PacketEvent;
+import com.wynntils.mc.event.PongReceivedEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.utils.mc.McUtils;
@@ -14,7 +14,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import net.minecraft.Util;
-import net.minecraft.network.protocol.ping.ClientboundPongResponsePacket;
 import net.minecraft.network.protocol.ping.ServerboundPingRequestPacket;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -39,9 +38,8 @@ public class PingService extends Service {
     }
 
     @SubscribeEvent
-    public void onPongReceived(PacketEvent.PacketReceivedEvent<?> event) {
-        if (!(event.getPacket() instanceof ClientboundPongResponsePacket(long time))) return;
-        lastPing = (int) (Util.getMillis() - time);
+    public void onPongReceived(PongReceivedEvent event) {
+        lastPing = (int) (Util.getMillis() - event.getTime());
     }
 
     private void sendPingPacket() {

--- a/common/src/main/java/com/wynntils/services/ping/PingService.java
+++ b/common/src/main/java/com/wynntils/services/ping/PingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.ping;
@@ -13,15 +13,15 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import net.minecraft.network.protocol.game.ClientboundCommandSuggestionsPacket;
-import net.minecraft.network.protocol.game.ServerboundCommandSuggestionPacket;
+import net.minecraft.Util;
+import net.minecraft.network.protocol.ping.ClientboundPongResponsePacket;
+import net.minecraft.network.protocol.ping.ServerboundPingRequestPacket;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public class PingService extends Service {
     private static final int MS_PER_PING = 1000;
     private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
-    private long lastPingSent = 0;
     private int lastPing = 0;
 
     public PingService() {
@@ -38,22 +38,14 @@ public class PingService extends Service {
         }
     }
 
-    // We are specifically looking for the packet itself, not it's processing. This is why we are using the PacketEvent.
     @SubscribeEvent
-    public void onCommandSuggestions(PacketEvent.PacketReceivedEvent<?> event) {
-        if (!(event.getPacket() instanceof ClientboundCommandSuggestionsPacket packet)) return;
-        if (packet.id() != -1) return;
-
-        lastPing = (int) (System.currentTimeMillis() - lastPingSent);
-
-        // We also need to cancel the packet, as it would be unexpected to Minecraft.
-        event.setCanceled(true);
+    public void onPongReceived(PacketEvent.PacketReceivedEvent<?> event) {
+        if (!(event.getPacket() instanceof ClientboundPongResponsePacket(long time))) return;
+        lastPing = (int) (Util.getMillis() - time);
     }
 
     private void sendPingPacket() {
-        // We use -1 as the id, as it is not used by Minecraft.
-        McUtils.sendPacket(new ServerboundCommandSuggestionPacket(-1, ""));
-        lastPingSent = System.currentTimeMillis();
+        McUtils.sendPacket(new ServerboundPingRequestPacket(Util.getMillis()));
     }
 
     public int getPing() {


### PR DESCRIPTION
Uses dedicated packets as seen in vanilla's PingDebugMonitor. The Util import is needed to keep the pings not overflowing. When the player activates the debug ping screen, F3+3, the ping function and service will also immediately update with all received pings, in realtime every tick.

Do not merge until #3172 is in, otherwise spotless will break on the java 21+ instanceof pattern