### PR TITLE
fix: Add shutdown hook for storage saving [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/storage/StorageManager.java
@@ -54,6 +54,8 @@ public final class StorageManager extends Manager {
 
         userStorageFile = new File(
                 STORAGE_DIR, UndashedUuid.toString(McUtils.mc().getUser().getProfileId()) + FILE_SUFFIX);
+
+        addShutdownHook();
     }
 
     public void initComponents() {
@@ -97,6 +99,10 @@ public final class StorageManager extends Manager {
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void addShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(this::writeToJson));
     }
 
     @SubscribeEvent


### PR DESCRIPTION
_Hopefully_ will be the actual fix for large storage files failing to save. Not sure if we want to do this for configs too but since those aren't saved on a schedule I don't think the issue is as likely to occur