### PR TITLE
fix: Temporary patch to fix nol tracking

### DIFF
--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -373,7 +373,7 @@ public class RaidModel extends Model {
     // It will be called multiple times after completing a challenge so we use completedCurrentChallenge to only
     // post the event and save timers once.
     public void completeChallenge() {
-        if (!completedCurrentChallenge) {
+        if (!completedCurrentChallenge && !inBossFight()) {
             long roomTime = System.currentTimeMillis() - roomStartTime;
             roomTimers.put(currentRoom, roomTime);
             roomStartTime = System.currentTimeMillis();


### PR DESCRIPTION
Tomorrows patch is going to separate the 2 boss fights in nexus of light, the raid tracking is not currently set up for this, fortunately I did start reworking it last week to support this but I don't think it will be done in time.

Although I can't know for certain until actually playing the patch, if it works how I expect then this should fix the issue that the change will cause.

![image](https://github.com/user-attachments/assets/eb913b59-f984-4d69-81a2-11b19c147355)
