### PR TITLE
feat: Add option to show own nametag in 3rd person [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -7,7 +7,6 @@ package com.wynntils.features.players;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
-import com.wynntils.core.consumers.screens.WynntilsScreen;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
@@ -33,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
@@ -130,10 +129,8 @@ public class CustomNametagRendererFeature extends Feature {
     @SubscribeEvent
     public void onCameraCheck(GetCameraEntityEvent e) {
         if (!showOwnNametag.get()) return;
-        // Don't render in container screens (inventory, cosmetic preview feature) or our custom screens (Wynntils menu)
-        if (McUtils.mc().screen instanceof AbstractContainerScreen || McUtils.mc().screen instanceof WynntilsScreen) {
-            return;
-        }
+        // Only render when a screen is not open or in the chat screen
+        if (McUtils.mc().screen != null && !(McUtils.mc().screen instanceof ChatScreen)) return;
 
         // We don't need to check if the entity is the local player as that is already done in
         // LivingEntityRenderer.shouldShowName

--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -7,6 +7,7 @@ package com.wynntils.features.players;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.screens.WynntilsScreen;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
@@ -14,6 +15,7 @@ import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.EntityNameTagRenderEvent;
+import com.wynntils.mc.event.GetCameraEntityEvent;
 import com.wynntils.mc.event.PlayerNametagRenderEvent;
 import com.wynntils.mc.event.RenderLevelEvent;
 import com.wynntils.mc.extension.EntityRenderStateExtension;
@@ -31,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
@@ -51,6 +54,9 @@ public class CustomNametagRendererFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> hideAllNametags = new Config<>(false);
+
+    @Persisted
+    public final Config<Boolean> showOwnNametag = new Config<>(false);
 
     @Persisted
     public final Config<Boolean> hidePlayerNametags = new Config<>(false);
@@ -119,6 +125,19 @@ public class CustomNametagRendererFeature extends Feature {
         if (hideNametagBackground.get()) {
             event.setBackgroundOpacity(0f);
         }
+    }
+
+    @SubscribeEvent
+    public void onCameraCheck(GetCameraEntityEvent e) {
+        if (!showOwnNametag.get()) return;
+        // Don't render in container screens (inventory, cosmetic preview feature) or our custom screens (Wynntils menu)
+        if (McUtils.mc().screen instanceof AbstractContainerScreen || McUtils.mc().screen instanceof WynntilsScreen) {
+            return;
+        }
+
+        // We don't need to check if the entity is the local player as that is already done in
+        // LivingEntityRenderer.shouldShowName
+        e.setEntity(null);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/mc/event/GetCameraEntityEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/GetCameraEntityEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.world.entity.Entity;
+import net.neoforged.bus.api.Event;
+
+public class GetCameraEntityEvent extends Event {
+    private Entity entity;
+
+    public GetCameraEntityEvent(Entity entity) {
+        this.entity = entity;
+    }
+
+    public void setEntity(Entity entity) {
+        this.entity = entity;
+    }
+
+    public Entity getEntity() {
+        return entity;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/LivingEntityRendererMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/LivingEntityRendererMixin.java
@@ -4,11 +4,13 @@
  */
 package com.wynntils.mc.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.GetCameraEntityEvent;
 import com.wynntils.mc.event.PlayerRenderEvent;
 import com.wynntils.mc.event.RenderTranslucentCheckEvent;
 import com.wynntils.utils.colors.CommonColors;
@@ -18,6 +20,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.client.renderer.entity.state.PlayerRenderState;
+import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -89,5 +92,19 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntityRenderStat
 
         PlayerRenderEvent event = new PlayerRenderEvent(playerRenderState, matrixStack, buffer, packedLight);
         MixinHelper.post(event);
+    }
+
+    @ModifyExpressionValue(
+            method = "shouldShowName(Lnet/minecraft/world/entity/LivingEntity;D)Z",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/Minecraft;getCameraEntity()Lnet/minecraft/world/entity/Entity;"))
+    private Entity getCameraEntity(Entity entity) {
+        GetCameraEntityEvent cameraEntityEvent = new GetCameraEntityEvent(entity);
+        MixinHelper.post(cameraEntityEvent);
+
+        return cameraEntityEvent.getEntity();
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -440,6 +440,8 @@
   "feature.wynntils.customNametagRenderer.showGearOnHover.name": "Show Player's Gear on Hover",
   "feature.wynntils.customNametagRenderer.showLeaderboardBadges.description": "Should the top nine players in each leaderboard have badges above their names?",
   "feature.wynntils.customNametagRenderer.showLeaderboardBadges.name": "Show Leaderboard Badges Above Nametag",
+  "feature.wynntils.customNametagRenderer.showOwnNametag.description": "Should your own nametag be shown in 3rd person?",
+  "feature.wynntils.customNametagRenderer.showOwnNametag.name": "Shown Own Nametag",
   "feature.wynntils.customNametagRenderer.showWynntilsMarker.description": "Should a player's nametag have a marker indicating that they are using Wynntils?",
   "feature.wynntils.customNametagRenderer.showWynntilsMarker.name": "Show Wynntils Marker on Nametag",
   "feature.wynntils.customPlayerListOverlay.description": "Should the default player list be replaced?",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -441,7 +441,7 @@
   "feature.wynntils.customNametagRenderer.showLeaderboardBadges.description": "Should the top nine players in each leaderboard have badges above their names?",
   "feature.wynntils.customNametagRenderer.showLeaderboardBadges.name": "Show Leaderboard Badges Above Nametag",
   "feature.wynntils.customNametagRenderer.showOwnNametag.description": "Should your own nametag be shown in 3rd person?",
-  "feature.wynntils.customNametagRenderer.showOwnNametag.name": "Shown Own Nametag",
+  "feature.wynntils.customNametagRenderer.showOwnNametag.name": "Show Own Nametag",
   "feature.wynntils.customNametagRenderer.showWynntilsMarker.description": "Should a player's nametag have a marker indicating that they are using Wynntils?",
   "feature.wynntils.customNametagRenderer.showWynntilsMarker.name": "Show Wynntils Marker on Nametag",
   "feature.wynntils.customPlayerListOverlay.description": "Should the default player list be replaced?",


### PR DESCRIPTION
Often requested feature for people who want to see their own leaderboard badges (sadly I don't have 1 to show)

![2025-03-29_20 34 56](https://github.com/user-attachments/assets/c6c19f93-773b-4165-981d-f3f9f66bb9fa)

Doesn't appear in inventory or other screens where we render the player.
![2025-03-29_20 34 59](https://github.com/user-attachments/assets/73feabba-e56a-4ac6-874c-79df20ad7a4c)
![2025-03-29_20 35 08](https://github.com/user-attachments/assets/93373978-1941-4f99-bd47-eeb031c9b7bd)
![2025-03-29_20 35 11](https://github.com/user-attachments/assets/5d90cc4e-f753-4051-9db0-d7800b3206a0)
