### PR TITLE
chore: Add HTML parsing to StyledTextUtils [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
@@ -8,9 +8,12 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
+import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.type.Pair;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -20,6 +23,7 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 
 public final class StyledTextUtils {
     private static final Pattern COORDINATE_PATTERN =
@@ -28,6 +32,10 @@ public final class StyledTextUtils {
     // Note: Post Wynncraft 2.1, the hover text is inconsistent, sometimes "'s" is white, sometimes it's gray
     public static final Pattern NICKNAME_PATTERN =
             Pattern.compile("§f(?<nick>.+?)(§7)?'s?(§7)? real username is §f(?<username>.+)");
+
+    private static final Pattern CLASS_PATTERN = Pattern.compile("class=['\"](.*?)['\"]");
+    private static final Pattern STYLE_PATTERN = Pattern.compile("style=['\"](.*?)['\"]");
+    private static final Pattern TOKEN_PATTERN = Pattern.compile("(<span[^>]*>|</span>|[^<]+)");
 
     private static final String NEWLINE_PREPARATION = "\n";
     private static final Pattern NEWLINE_WRAP_PATTERN = Pattern.compile("\uDAFF\uDFFC\uE001\uDB00\uDC06");
@@ -91,6 +99,147 @@ public final class StyledTextUtils {
         }
 
         return newLines;
+    }
+
+    /**
+     * This will parse a HTML String into StyledText.
+     * The rules for this parsing are based on the API documentation https://docs.wynncraft.com/docs/#api-markup-parser
+     *
+     * @param htmlString The HTML string to parse
+     * @return The input parsed into StyledText
+     */
+    public static StyledText parseHtml(String htmlString) {
+        if (htmlString.trim().equals("</br>")) {
+            return StyledText.EMPTY;
+        }
+
+        List<StyledTextPart> parts = new ArrayList<>();
+        Deque<Style> styles = new ArrayDeque<>();
+        styles.push(Style.EMPTY);
+        Style currentStyle = Style.EMPTY;
+
+        StringBuilder plainText = new StringBuilder();
+
+        Matcher matcher = TOKEN_PATTERN.matcher(htmlString);
+
+        while (matcher.find()) {
+            String token = matcher.group();
+
+            if (token.startsWith("<span")) {
+                if (!plainText.isEmpty()) {
+                    parts.add(new StyledTextPart(plainText.toString(), currentStyle, null, Style.EMPTY));
+                    plainText = new StringBuilder();
+                }
+
+                Style parentStyle = styles.peek();
+                Style newStyle = Style.EMPTY.withColor(parentStyle.getColor());
+
+                Matcher classMatcher = CLASS_PATTERN.matcher(token);
+                if (classMatcher.find()) {
+                    String fontName = classMatcher.group(1).trim();
+                    ResourceLocation font =
+                            switch (fontName) {
+                                case "font-ascii", "font-default" -> ResourceLocation.withDefaultNamespace("default");
+                                case "font-common" -> ResourceLocation.withDefaultNamespace("common");
+                                case "font-five" -> ResourceLocation.withDefaultNamespace("language/five");
+                                case "font-wynnic" -> ResourceLocation.withDefaultNamespace("language/wynnic");
+                                case "font-high_gavelian" ->
+                                    ResourceLocation.withDefaultNamespace("language/high_gavelian");
+                                default -> {
+                                    WynntilsMod.warn("Unknown font in HTML parsing: " + fontName);
+                                    yield ResourceLocation.withDefaultNamespace("default");
+                                }
+                            };
+                    newStyle = newStyle.withFont(font);
+                }
+
+                Matcher styleMatcher = STYLE_PATTERN.matcher(token);
+                if (styleMatcher.find()) {
+                    String style = styleMatcher.group(1);
+
+                    for (String styleEntry : style.split(";")) {
+                        styleEntry = styleEntry.trim();
+
+                        if (styleEntry.isEmpty()) continue;
+
+                        String[] stylePair = styleEntry.split(":");
+                        String styleKey = stylePair[0].trim();
+                        String styleValue = stylePair[1].trim();
+
+                        switch (styleKey) {
+                            case "text-decoration" -> {
+                                if (styleValue.equals("underline")) {
+                                    newStyle = newStyle.withUnderlined(true);
+                                } else if (styleValue.equals("line-through")) {
+                                    newStyle = newStyle.withStrikethrough(true);
+                                } else {
+                                    WynntilsMod.warn("Unknown text decoration type in HTML parsing: " + styleValue);
+                                }
+                            }
+                            case "font-style" -> {
+                                if (styleValue.equals("italic")) {
+                                    newStyle = newStyle.withItalic(true);
+                                } else {
+                                    WynntilsMod.warn("Unknown font style type in HTML parsing: " + styleValue);
+                                }
+                            }
+                            case "font-weight" -> {
+                                if (styleValue.equals("bolder")) {
+                                    newStyle = newStyle.withBold(true);
+                                } else {
+                                    WynntilsMod.warn("Unknown font weight type in HTML parsing: " + styleValue);
+                                }
+                            }
+                            case "color" -> {
+                                newStyle = newStyle.withColor(
+                                        CustomColor.fromHexString(styleValue).asInt());
+                            }
+                            case "margin-left" -> {
+                                if (styleValue.equals("7.5px")) {
+                                    // FIXME: Currently a guess, there are no items with this margin but it is
+                                    // a possible value according to the docs
+                                    plainText.append("À");
+                                } else if (styleValue.equals("20px")) {
+                                    plainText.append("ÀÀÀÀ");
+                                } else {
+                                    WynntilsMod.warn("Unexpected margin-left in HTML parsing: " + styleValue);
+                                }
+                            }
+                            default -> {
+                                WynntilsMod.warn("Unknown style type in HTML parsing: " + styleKey);
+                            }
+                        }
+                    }
+                }
+
+                styles.push(newStyle);
+                currentStyle = newStyle;
+            } else if (token.startsWith("</span>")) {
+                if (!plainText.isEmpty()) {
+                    parts.add(new StyledTextPart(plainText.toString(), currentStyle, null, Style.EMPTY));
+                    plainText = new StringBuilder();
+                }
+
+                if (!styles.isEmpty()) {
+                    styles.pop();
+                }
+
+                Style parentStyle = styles.isEmpty() ? Style.EMPTY : styles.peek();
+                if (!parentStyle.equals(currentStyle)) {
+                    parts.add(new StyledTextPart("", parentStyle, null, Style.EMPTY));
+                }
+
+                currentStyle = parentStyle;
+            } else {
+                plainText.append(token);
+            }
+        }
+
+        if (!plainText.isEmpty()) {
+            parts.add(new StyledTextPart(plainText.toString(), currentStyle, null, Style.EMPTY));
+        }
+
+        return StyledText.fromParts(parts);
     }
 
     /**


### PR DESCRIPTION
HTML parsing extracted from https://github.com/Wynntils/Wynntils/pull/3158 and moved to StyledTextUtils with added tests