### PR TITLE
chore: Add getters for inBuffRoom and inIntermissionRoom to RaidModel [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -477,6 +477,14 @@ public class RaidModel extends Model {
         return roomNum <= currentRaid.getRaidKind().getBossCount() + challengeCount;
     }
 
+    public boolean isInBuffRoom() {
+        return inBuffRoom;
+    }
+
+    public boolean isInIntermissionRoom() {
+        return inIntermissionRoom;
+    }
+
     public void setTimeLeft(int seconds) {
         timeLeft = seconds;
     }


### PR DESCRIPTION
We don't have a use for this but external mods like the SEQ mod apparently had a check for being in the 3rd buff room which used to be handled by the removed RaidRoomType enum