### PR TITLE
fix: Reset time left, challenges and party raid buffs on raid finish

### DIFF
--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -349,6 +349,9 @@ public class RaidModel extends Model {
 
         currentRaid = null;
         completedCurrentChallenge = false;
+        timeLeft = 0;
+        challenges = CappedValue.EMPTY;
+        partyRaidBuffs.clear();
     }
 
     public RaidInfo getCurrentRaid() {
@@ -531,6 +534,9 @@ public class RaidModel extends Model {
 
         currentRaid = null;
         completedCurrentChallenge = false;
+        timeLeft = 0;
+        challenges = CappedValue.EMPTY;
+        partyRaidBuffs.clear();
     }
 
     private void checkForNewPersonalBest() {


### PR DESCRIPTION
Causes a lot of log spam since the range visualizer expects a raid to exist if a players name exists in the partyRaidBuffs list