### PR TITLE
chore: Post event on raid start [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -26,6 +26,7 @@ import com.wynntils.models.items.items.game.TomeItem;
 import com.wynntils.models.raid.event.RaidChallengeEvent;
 import com.wynntils.models.raid.event.RaidEndedEvent;
 import com.wynntils.models.raid.event.RaidNewBestTimeEvent;
+import com.wynntils.models.raid.event.RaidStartedEvent;
 import com.wynntils.models.raid.raids.NestOfTheGrootslangsRaid;
 import com.wynntils.models.raid.raids.OrphionsNexusOfLightRaid;
 import com.wynntils.models.raid.raids.RaidKind;
@@ -128,6 +129,8 @@ public class RaidModel extends Model {
             if (raidKind != null) {
                 currentRaid = new RaidInfo(raidKind);
                 completedCurrentChallenge = false;
+
+                WynntilsMod.postEvent(new RaidStartedEvent(raidKind));
             }
         } else if (styledText.matches(RAID_COMPLETED_PATTERN)) {
             completeRaid();

--- a/common/src/main/java/com/wynntils/models/raid/event/RaidStartedEvent.java
+++ b/common/src/main/java/com/wynntils/models/raid/event/RaidStartedEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.raid.event;
+
+import com.wynntils.models.raid.raids.RaidKind;
+import net.neoforged.bus.api.Event;
+
+public class RaidStartedEvent extends Event {
+    private final RaidKind raidKind;
+
+    public RaidStartedEvent(RaidKind raidKind) {
+        this.raidKind = raidKind;
+    }
+
+    public RaidKind getRaidKind() {
+        return raidKind;
+    }
+}


### PR DESCRIPTION
Another change needed for compatibility with the seq mod, they currently have their own event for raids starting but they used `RaidKind.fromTitle` to post it which we now handle in the private `getRaidFromTitle` method which should remain private