### PR TITLE
refactor: Store lootrun details as a separate class [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -41,6 +41,7 @@ import com.wynntils.models.lootrun.event.LootrunFinishedEventBuilder;
 import com.wynntils.models.lootrun.markers.LootrunBeaconMarkerProvider;
 import com.wynntils.models.lootrun.particle.LootrunTaskParticleVerifier;
 import com.wynntils.models.lootrun.scoreboard.LootrunScoreboardPart;
+import com.wynntils.models.lootrun.type.LootrunDetails;
 import com.wynntils.models.lootrun.type.LootrunLocation;
 import com.wynntils.models.lootrun.type.LootrunTaskType;
 import com.wynntils.models.lootrun.type.LootrunningState;
@@ -179,7 +180,6 @@ public class LootrunModel extends Model {
     // particles can accurately show task locations
     private Set<TaskLocation> possibleTaskLocations = new HashSet<>();
 
-    private Map<LootrunBeaconKind, Integer> selectedBeacons = new TreeMap<>();
     private int timeLeft = 0;
     private CappedValue challenges = CappedValue.EMPTY;
 
@@ -189,35 +189,7 @@ public class LootrunModel extends Model {
 
     // Data to be persisted
     @Persisted
-    private final Storage<Map<String, Map<LootrunBeaconKind, Integer>>> selectedBeaconsStorage =
-            new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, LootrunBeaconKind>> lastTaskBeaconColorStorage = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, Boolean>> lastTaskVibrantBeaconStorage = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, Beacon<LootrunBeaconKind>>> closestBeaconStorage = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, Integer>> redBeaconTaskCountStorage = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, List<Integer>>> orangeBeaconCountsStorage = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, Integer>> orangeAmount = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, Integer>> rainbowBeaconCountStorage = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, Integer>> rainbowAmount = new Storage<>(new TreeMap<>());
-
-    @Persisted
-    private final Storage<Map<String, List<MissionType>>> missionStorage = new Storage<>(new TreeMap<>());
+    private final Storage<Map<String, LootrunDetails>> lootrunDetailsStorage = new Storage<>(new TreeMap<>());
 
     private List<Pair<Beacon<LootrunBeaconKind>, EntityExtension>> activeBeacons = new ArrayList<>();
     private Map<LootrunBeaconKind, LootrunTaskType> activeTaskTypes = new HashMap<>();
@@ -308,13 +280,8 @@ public class LootrunModel extends Model {
     public void onCharacterChange(CharacterUpdateEvent event) {
         String id = Models.Character.getId();
 
-        selectedBeaconsStorage.get().putIfAbsent(id, new TreeMap<>());
-        selectedBeacons = selectedBeaconsStorage.get().get(id);
-
-        selectedBeaconsStorage.touched();
-
-        missionStorage.get().putIfAbsent(id, new ArrayList<>());
-        missionStorage.touched();
+        lootrunDetailsStorage.get().putIfAbsent(id, new LootrunDetails());
+        lootrunDetailsStorage.touched();
     }
 
     @SubscribeEvent
@@ -423,8 +390,8 @@ public class LootrunModel extends Model {
 
             if (orangeMatcher.find()) {
                 expectOrangeBeacon = false;
-                orangeAmount.get().put(Models.Character.getId(), Integer.parseInt(orangeMatcher.group(1)));
-                orangeAmount.touched();
+                getCurrentLootrunDetails().setOrangeAmount(Integer.parseInt(orangeMatcher.group(1)));
+                lootrunDetailsStorage.touched();
             }
         }
 
@@ -433,8 +400,8 @@ public class LootrunModel extends Model {
 
             if (rainbowMatcher.find()) {
                 expectRainbowBeacon = false;
-                rainbowAmount.get().put(Models.Character.getId(), Integer.parseInt(rainbowMatcher.group(1)));
-                rainbowAmount.touched();
+                getCurrentLootrunDetails().setOrangeAmount(Integer.parseInt(rainbowMatcher.group(1)));
+                lootrunDetailsStorage.touched();
             }
         }
     }
@@ -539,8 +506,6 @@ public class LootrunModel extends Model {
         activeBeacons = new ArrayList<>();
         activeTaskTypes = new HashMap<>();
         LOOTRUN_BEACON_COMPASS_PROVIDER.reloadTaskMarkers();
-
-        selectedBeacons = new TreeMap<>();
 
         challenges = CappedValue.EMPTY;
         timeLeft = 0;
@@ -686,16 +651,16 @@ public class LootrunModel extends Model {
     }
 
     public int getBeaconCount(LootrunBeaconKind color) {
-        return selectedBeacons.getOrDefault(color, 0);
+        return getCurrentLootrunDetails().getSelectedBeacons().getOrDefault(color, 0);
     }
 
     public String getMissionStatus(int index, boolean colored) {
-        List<MissionType> missions = missionStorage.get().getOrDefault(Models.Character.getId(), new ArrayList<>());
+        List<MissionType> missions = getCurrentLootrunDetails().getMissions();
         if (index < 0 || index >= missions.size()) {
             return colored ? MissionType.UNKNOWN.getColoredName() : MissionType.UNKNOWN.getName();
         }
 
-        MissionType mission = missionStorage.get().get(Models.Character.getId()).get(index);
+        MissionType mission = getCurrentLootrunDetails().getMissions().get(index);
         return colored ? mission.getColoredName() : mission.getName();
     }
 
@@ -708,7 +673,7 @@ public class LootrunModel extends Model {
     }
 
     public Map<LootrunBeaconKind, TaskPrediction> getBeacons() {
-        return beacons;
+        return Collections.unmodifiableMap(beacons);
     }
 
     public boolean isBeaconVibrant(LootrunBeaconKind lootrunBeaconKind) {
@@ -742,123 +707,93 @@ public class LootrunModel extends Model {
     }
 
     public LootrunBeaconKind getLastTaskBeaconColor() {
-        return lastTaskBeaconColorStorage.get().get(Models.Character.getId());
+        return getCurrentLootrunDetails().getLastTaskBeaconColor();
     }
 
     public boolean wasLastBeaconVibrant() {
-        return lastTaskVibrantBeaconStorage.get().getOrDefault(Models.Character.getId(), false);
+        return getCurrentLootrunDetails().getLastTaskVibrantBeacon();
     }
 
     public Beacon getClosestBeacon() {
-        return closestBeaconStorage.get().get(Models.Character.getId());
+        return getCurrentLootrunDetails().getClosestBeacon();
     }
 
     public int getRedBeaconTaskCount() {
-        return redBeaconTaskCountStorage.get().getOrDefault(Models.Character.getId(), 0);
+        return getCurrentLootrunDetails().getRedBeaconTaskCount();
     }
 
     public int getActiveOrangeBeacons() {
-        return orangeBeaconCountsStorage
-                .get()
-                .getOrDefault(Models.Character.getId(), new ArrayList<>())
-                .size();
+        return getCurrentLootrunDetails().getOrangeBeaconCounts().size();
     }
 
     public int getChallengesTillNextOrangeExpires() {
-        List<Integer> orangeBeaconCounts =
-                orangeBeaconCountsStorage.get().getOrDefault(Models.Character.getId(), new ArrayList<>());
+        List<Integer> orangeBeaconCounts = getCurrentLootrunDetails().getOrangeBeaconCounts();
 
         if (orangeBeaconCounts.isEmpty()) {
             return 0;
         } else {
-            return Collections.min(
-                    orangeBeaconCountsStorage.get().getOrDefault(Models.Character.getId(), new ArrayList<>()));
+            return Collections.min(orangeBeaconCounts);
         }
     }
 
     public int getActiveRainbowBeacons() {
-        return rainbowBeaconCountStorage.get().getOrDefault(Models.Character.getId(), 0);
+        return getCurrentLootrunDetails().getRainbowBeaconCount();
     }
 
     private void setLastTaskBeaconColor(LootrunBeaconKind lootrunBeaconKind) {
-        if (lootrunBeaconKind == null) {
-            lastTaskBeaconColorStorage.get().remove(Models.Character.getId());
-            lastTaskVibrantBeaconStorage.get().remove(Models.Character.getId());
-        } else {
-            lastTaskBeaconColorStorage.get().put(Models.Character.getId(), lootrunBeaconKind);
-            lastTaskVibrantBeaconStorage
-                    .get()
-                    .put(Models.Character.getId(), vibrantBeacons.contains(lootrunBeaconKind));
-        }
-
-        lastTaskBeaconColorStorage.touched();
-        lastTaskVibrantBeaconStorage.touched();
+        getCurrentLootrunDetails().setLastTaskBeaconColor(lootrunBeaconKind);
+        getCurrentLootrunDetails().setLastTaskVibrantBeacon(vibrantBeacons.contains(lootrunBeaconKind));
+        lootrunDetailsStorage.touched();
     }
 
     private void setClosestBeacon(Beacon beacon) {
-        if (beacon == null) {
-            closestBeaconStorage.get().remove(Models.Character.getId());
-        } else {
-            closestBeaconStorage.get().put(Models.Character.getId(), beacon); // can be null safely
-        }
-
-        closestBeaconStorage.touched();
+        getCurrentLootrunDetails().setClosestBeacon(beacon);
+        lootrunDetailsStorage.touched();
     }
 
     private void resetBeaconStorage() {
-        selectedBeacons = new TreeMap<>();
-
-        selectedBeaconsStorage.get().put(Models.Character.getId(), selectedBeacons);
-        selectedBeaconsStorage.touched();
+        getCurrentLootrunDetails().setSelectedBeacons(new TreeMap<>());
+        lootrunDetailsStorage.touched();
     }
 
     private void newBeacons() {
         possibleTaskLocations.clear();
         vibrantBeacons.clear();
 
-        orangeAmount.get().remove(Models.Character.getId());
-        orangeAmount.touched();
-
-        rainbowAmount.get().remove(Models.Character.getId());
-        rainbowAmount.touched();
+        getCurrentLootrunDetails().setOrangeAmount(-1);
+        getCurrentLootrunDetails().setRainbowAmount(-1);
+        lootrunDetailsStorage.touched();
 
         expectOrangeBeacon = false;
         expectRainbowBeacon = false;
     }
 
     public void addToRedBeaconTaskCount(int changeAmount) {
-        Integer oldCount = redBeaconTaskCountStorage.get().getOrDefault(Models.Character.getId(), 0);
+        int oldCount = getCurrentLootrunDetails().getRedBeaconTaskCount();
 
         int newCount = Math.max(oldCount + changeAmount, 0);
-        redBeaconTaskCountStorage.get().put(Models.Character.getId(), newCount);
-        redBeaconTaskCountStorage.touched();
+        getCurrentLootrunDetails().setRedBeaconTaskCount(newCount);
+        lootrunDetailsStorage.touched();
     }
 
     private void resetBeaconCounts() {
-        redBeaconTaskCountStorage.get().remove(Models.Character.getId());
-        redBeaconTaskCountStorage.touched();
-
-        orangeBeaconCountsStorage.get().remove(Models.Character.getId());
-        orangeBeaconCountsStorage.touched();
-
-        rainbowBeaconCountStorage.get().remove(Models.Character.getId());
-        rainbowBeaconCountStorage.touched();
+        getCurrentLootrunDetails().setRedBeaconTaskCount(0);
+        getCurrentLootrunDetails().setOrangeBeaconCounts(new ArrayList<>());
+        getCurrentLootrunDetails().setRainbowBeaconCount(0);
+        lootrunDetailsStorage.touched();
     }
 
     private void resetMissions() {
-        missionStorage.get().putIfAbsent(Models.Character.getId(), new ArrayList<>());
-        missionStorage.get().get(Models.Character.getId()).clear();
-        missionStorage.touched();
+        getCurrentLootrunDetails().setMissions(new ArrayList<>());
+        lootrunDetailsStorage.touched();
     }
 
     private void addMission(MissionType mission) {
-        List<MissionType> missions =
-                missionStorage.get().computeIfAbsent(Models.Character.getId(), k -> new ArrayList<>());
-        if (!missions.contains(mission)) {
-            missions.add(mission);
+        if (!getCurrentLootrunDetails().getMissions().contains(mission)) {
+            getCurrentLootrunDetails().addMission(mission);
         }
 
-        missionStorage.touched();
+        lootrunDetailsStorage.touched();
 
         expectMissionComplete = false;
     }
@@ -910,8 +845,9 @@ public class LootrunModel extends Model {
                 && closestBeacon != null
                 && closestBeacon.beaconKind() instanceof LootrunBeaconKind color) {
             WynntilsMod.info("Selected a " + color + " beacon at " + closestBeacon.position());
-            selectedBeacons.put(color, selectedBeacons.getOrDefault(closestBeacon.beaconKind(), 0) + 1);
-            selectedBeaconsStorage.touched();
+            getCurrentLootrunDetails().incrementBeaconCount(color);
+            lootrunDetailsStorage.touched();
+
             setLastTaskBeaconColor(color);
             WynntilsMod.postEvent(new LootrunBeaconSelectedEvent(
                     closestBeacon,
@@ -936,34 +872,31 @@ public class LootrunModel extends Model {
 
     private void challengeCompleted() {
         LootrunBeaconKind color = getLastTaskBeaconColor();
+        LootrunDetails lootrunDetails = getCurrentLootrunDetails();
 
         if (color == LootrunBeaconKind.RAINBOW) {
-            if (rainbowAmount.get().getOrDefault(Models.Character.getId(), -1) != -1) {
-                Integer oldCount = rainbowBeaconCountStorage.get().getOrDefault(Models.Character.getId(), 0);
+            if (lootrunDetails.getRainbowAmount() != -1) {
+                int oldCount = lootrunDetails.getRainbowBeaconCount();
 
-                int newCount = Math.max(oldCount + rainbowAmount.get().get(Models.Character.getId()), 0);
-                rainbowBeaconCountStorage.get().put(Models.Character.getId(), newCount);
-                rainbowBeaconCountStorage.touched();
+                int newCount = Math.max(oldCount + lootrunDetails.getRainbowAmount(), 0);
+                lootrunDetails.setRainbowAmount(newCount);
             } else {
                 WynntilsMod.warn("Completed rainbow beacon challenge but had no rainbow amount");
             }
         } else if (color == LootrunBeaconKind.ORANGE) {
-            if (orangeAmount.get().getOrDefault(Models.Character.getId(), -1) != -1) {
-                List<Integer> orangeList =
-                        orangeBeaconCountsStorage.get().getOrDefault(Models.Character.getId(), new ArrayList<>());
+            if (lootrunDetails.getOrangeAmount() != -1) {
+                List<Integer> orangeList = getCurrentLootrunDetails().getOrangeBeaconCounts();
 
-                orangeList.add(orangeAmount.get().get(Models.Character.getId()));
-                orangeBeaconCountsStorage.get().put(Models.Character.getId(), orangeList);
-                orangeBeaconCountsStorage.touched();
+                orangeList.add(lootrunDetails.getOrangeAmount());
+                lootrunDetails.setOrangeBeaconCounts(orangeList);
             } else {
                 WynntilsMod.warn("Completed orange beacon challenge but had no orange amount");
             }
         }
 
-        orangeAmount.get().put(Models.Character.getId(), -1);
-        orangeAmount.touched();
-        rainbowAmount.get().put(Models.Character.getId(), -1);
-        rainbowAmount.touched();
+        lootrunDetails.setOrangeAmount(-1);
+        lootrunDetails.setRainbowAmount(-1);
+        lootrunDetailsStorage.get().put(Models.Character.getId(), lootrunDetails);
     }
 
     private void challengeFailed() {
@@ -973,23 +906,21 @@ public class LootrunModel extends Model {
             addMission(MissionType.FAILED);
         }
 
-        orangeAmount.get().put(Models.Character.getId(), -1);
-        orangeAmount.touched();
-        rainbowAmount.get().put(Models.Character.getId(), -1);
-        rainbowAmount.touched();
+        getCurrentLootrunDetails().setOrangeAmount(-1);
+        getCurrentLootrunDetails().setRainbowAmount(-1);
+        lootrunDetailsStorage.touched();
     }
 
     private void reduceBeaconCounts() {
-        Integer oldRainbowCount = rainbowBeaconCountStorage.get().getOrDefault(Models.Character.getId(), 0);
+        LootrunDetails lootrunDetails = getCurrentLootrunDetails();
+        int oldRainbowCount = lootrunDetails.getRainbowBeaconCount();
 
         if (oldRainbowCount > 0) {
             int newCount = oldRainbowCount - 1;
-            rainbowBeaconCountStorage.get().put(Models.Character.getId(), newCount);
-            rainbowBeaconCountStorage.touched();
+            lootrunDetails.setRainbowBeaconCount(newCount);
         }
 
-        List<Integer> orangeCounts =
-                orangeBeaconCountsStorage.get().getOrDefault(Models.Character.getId(), new ArrayList<>());
+        List<Integer> orangeCounts = new ArrayList<>(lootrunDetails.getOrangeBeaconCounts());
 
         if (!orangeCounts.isEmpty()) {
             ListIterator<Integer> orangeIterator = orangeCounts.listIterator();
@@ -1005,8 +936,9 @@ public class LootrunModel extends Model {
             }
         }
 
-        orangeBeaconCountsStorage.get().put(Models.Character.getId(), orangeCounts);
-        orangeBeaconCountsStorage.touched();
+        lootrunDetails.setOrangeBeaconCounts(orangeCounts);
+
+        lootrunDetailsStorage.get().put(Models.Character.getId(), lootrunDetails);
     }
 
     private boolean updateTaskLocationPrediction(Beacon beacon, LootrunBeaconMarkerKind lootrunMarker, int distance) {
@@ -1241,5 +1173,9 @@ public class LootrunModel extends Model {
             lootrunFailedBuilder = null;
             return;
         }
+    }
+
+    private LootrunDetails getCurrentLootrunDetails() {
+        return lootrunDetailsStorage.get().getOrDefault(Models.Character.getId(), new LootrunDetails());
     }
 }

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -400,7 +400,7 @@ public class LootrunModel extends Model {
 
             if (rainbowMatcher.find()) {
                 expectRainbowBeacon = false;
-                getCurrentLootrunDetails().setOrangeAmount(Integer.parseInt(rainbowMatcher.group(1)));
+                getCurrentLootrunDetails().setRainbowAmount(Integer.parseInt(rainbowMatcher.group(1)));
                 lootrunDetailsStorage.touched();
             }
         }

--- a/common/src/main/java/com/wynntils/models/lootrun/type/LootrunDetails.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/type/LootrunDetails.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.lootrun.type;
+
+import com.wynntils.models.beacons.type.Beacon;
+import com.wynntils.models.lootrun.beacons.LootrunBeaconKind;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class LootrunDetails {
+    private Map<LootrunBeaconKind, Integer> selectedBeacons = new TreeMap<>();
+    private LootrunBeaconKind lastTaskBeaconColor = null;
+    private boolean lastTaskVibrantBeacon = false;
+    private Beacon<LootrunBeaconKind> closestBeacon = null;
+    private int redBeaconTaskCount = 0;
+    private List<Integer> orangeBeaconCounts = new ArrayList<>();
+    private int orangeAmount = -1;
+    private int rainbowBeaconCount = 0;
+    private int rainbowAmount = -1;
+    private List<MissionType> missions = new ArrayList<>();
+
+    public Map<LootrunBeaconKind, Integer> getSelectedBeacons() {
+        return Collections.unmodifiableMap(selectedBeacons);
+    }
+
+    public void setSelectedBeacons(Map<LootrunBeaconKind, Integer> selectedBeacons) {
+        this.selectedBeacons = new TreeMap<>(selectedBeacons);
+    }
+
+    public void incrementBeaconCount(LootrunBeaconKind color) {
+        selectedBeacons.put(color, selectedBeacons.getOrDefault(closestBeacon.beaconKind(), 0) + 1);
+    }
+
+    public LootrunBeaconKind getLastTaskBeaconColor() {
+        return lastTaskBeaconColor;
+    }
+
+    public void setLastTaskBeaconColor(LootrunBeaconKind lastTaskBeaconColor) {
+        this.lastTaskBeaconColor = lastTaskBeaconColor;
+    }
+
+    public boolean getLastTaskVibrantBeacon() {
+        return lastTaskVibrantBeacon;
+    }
+
+    public void setLastTaskVibrantBeacon(boolean lastTaskVibrantBeacon) {
+        this.lastTaskVibrantBeacon = lastTaskVibrantBeacon;
+    }
+
+    public Beacon<LootrunBeaconKind> getClosestBeacon() {
+        return closestBeacon;
+    }
+
+    public void setClosestBeacon(Beacon<LootrunBeaconKind> closestBeacon) {
+        this.closestBeacon = closestBeacon;
+    }
+
+    public int getRedBeaconTaskCount() {
+        return redBeaconTaskCount;
+    }
+
+    public void setRedBeaconTaskCount(int redBeaconTaskCount) {
+        this.redBeaconTaskCount = redBeaconTaskCount;
+    }
+
+    public List<Integer> getOrangeBeaconCounts() {
+        return Collections.unmodifiableList(orangeBeaconCounts);
+    }
+
+    public void setOrangeBeaconCounts(List<Integer> orangeBeaconCounts) {
+        this.orangeBeaconCounts = new ArrayList<>(orangeBeaconCounts);
+    }
+
+    public int getOrangeAmount() {
+        return orangeAmount;
+    }
+
+    public void setOrangeAmount(int orangeAmount) {
+        this.orangeAmount = orangeAmount;
+    }
+
+    public int getRainbowBeaconCount() {
+        return rainbowBeaconCount;
+    }
+
+    public void setRainbowBeaconCount(int rainbowBeaconCount) {
+        this.rainbowBeaconCount = rainbowBeaconCount;
+    }
+
+    public int getRainbowAmount() {
+        return rainbowAmount;
+    }
+
+    public void setRainbowAmount(int rainbowAmount) {
+        this.rainbowAmount = rainbowAmount;
+    }
+
+    public List<MissionType> getMissions() {
+        return Collections.unmodifiableList(missions);
+    }
+
+    public void setMissions(List<MissionType> missions) {
+        this.missions = new ArrayList<>(missions);
+    }
+
+    public void addMission(MissionType newMission) {
+        missions.add(newMission);
+    }
+}


### PR DESCRIPTION
Stores all active lootrun info into a single `LootrunDetails` class so no more need for 10 different storages. Unfortunately this does mean any in progress lootruns will have their data lost but it's for the best.

I've only done a quick short run to test it and it seemed fine but if you want to test it yourself be sure to apply the fix from https://github.com/Wynntils/Wynntils/pull/3211 locally