### PR TITLE
fix: Account for scale in TextOverlays when rendering new lines [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
@@ -103,7 +103,7 @@ public abstract class TextOverlay extends DynamicOverlay {
                             this.textShadow.get(),
                             textScale);
 
-            renderY += FontRenderer.getInstance().getFont().lineHeight;
+            renderY += FontRenderer.getInstance().getFont().lineHeight * textScale;
         }
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2e43a23-a92e-4e53-97c1-349fe6930f1e)