### PR TITLE
fix: Chat pattern for private messages with moderators [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
@@ -30,7 +30,7 @@ public enum RecipientType {
             "Party"),
     // Test in RecipientType_PRIVATE_foregroundPattern and RecipientType_PRIVATE_backgroundPattern
     PRIVATE(
-            "^§6((\uDAFF\uDFFC\uE007\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) .* \uE003 .*:§6 §f.*$",
+            "^§6((\uDAFF\uDFFC\uE007\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) .* \uE003 .*:(§6)? §f.*$",
             "^§8\uDAFF\uDFFC.* .* \uE003 .*:§8 .*$",
             "Private"),
     SHOUT("^§5.* \\[[A-Z0-9]+\\] shouts: §d.*$", "^(§8)?.* \\[[A-Z0-9]+\\] shouts: §7.*$", "Shout"),

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -693,6 +693,7 @@ public class TestRegex {
     @Test
     public void RecipientType_PRIVATE_foregroundpattern() {
         PatternTester p = new PatternTester(RecipientType.PRIVATE, "foregroundPattern");
+        p.shouldMatch("§6\uDAFF\uDFFC\uE007\uDAFF\uDFFF\uE002\uDAFF\uDFFE 42nao \uE003 Soulbound: §ftest");
         p.shouldMatch(
                 "§6\uDAFF\uDFFC\uE007\uDAFF\uDFFF\uE002\uDAFF\uDFFE §#ffe600ff§obol§6 \uE003 §#ffe600ff§obol§r§#ffe600ff:§6 §ftest");
         p.shouldMatch(


### PR DESCRIPTION
Fix for this issue: #3189 

Now messages to moderators displayed in orange (§6) are also listed in the private tab.