### PR TITLE
fix: Chat tabs will no longer render outside of Wynncraft

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -56,7 +56,7 @@ public abstract class ScreenMixin implements ScreenExtension {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;init()V"))
     private void onScreenInitPre(CallbackInfo ci) {
         // This is called whenever a screen is re-inited (e.g. when the window is resized)
-        MixinHelper.postAlways(new ScreenInitEvent.Pre((Screen) (Object) this, false));
+        MixinHelper.post(new ScreenInitEvent.Pre((Screen) (Object) this, false));
     }
 
     @Inject(method = "rebuildWidgets()V", at = @At("RETURN"))


### PR DESCRIPTION
Fixing #3171 

Fixed that the chat widgets will be shown outside of the wynncraft server. (tested on gommehd.net)

I did not experience any complications during testing when I used post instead of postAlways.