### PR TITLE
fix: Fix transparent cape rendering [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/services/cosmetics/type/WynntilsCapeLayer.java
+++ b/common/src/main/java/com/wynntils/services/cosmetics/type/WynntilsCapeLayer.java
@@ -63,7 +63,7 @@ public final class WynntilsCapeLayer extends WynntilsLayer {
             poseStack.translate(0.0F, -0.053125F, 0.06875F);
         }
 
-        VertexConsumer vertexConsumer = buffer.getBuffer(RenderType.entitySolid(texture));
+        VertexConsumer vertexConsumer = buffer.getBuffer(RenderType.entityCutout(texture));
         this.getParentModel().copyPropertiesTo(this.model);
         this.model.setupAnim(playerRenderState);
         this.model.renderToBuffer(poseStack, vertexConsumer, packedLight, OverlayTexture.NO_OVERLAY);


### PR DESCRIPTION
Normal capes still render fine, transparent capes don't have the transparent areas filled with black anymore

![Capes](https://github.com/user-attachments/assets/12ed8bb2-b0ca-4b88-ab60-94e0d2d25a52)

Not entirely sure why `entitySolid` worked for pre 1.21.4 tbh.