### PR TITLE
fix: Return early if no lines in gathering node label parser [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/profession/label/GatheringNodeHarvestLabelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.profession.label;
@@ -26,6 +26,8 @@ public class GatheringNodeHarvestLabelParser implements LabelParser<GatheringNod
     @Override
     public GatheringNodeHarvestLabelInfo getInfo(StyledText label, Location location, Entity entity) {
         StyledText[] lines = label.split("\n");
+
+        if (lines.length == 0) return null;
 
         Matcher experienceMatcher = lines[0].getMatcher(EXPERIENCE_PATTERN);
 


### PR DESCRIPTION
Happened to get this on some label as I was walking around

`java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at knot//com.wynntils.models.profession.label.GatheringNodeHarvestLabelParser.getInfo(GatheringNodeHarvestLabelParser.java:30)`