### PR TITLE
fix: Fix and unify Enabled Templates [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
@@ -132,11 +132,14 @@ public abstract class TextOverlay extends DynamicOverlay {
     public final boolean isRendered() {
         // If the enabled template is empty,
         // the overlay is rendered when the player is in the world.
-        if (enabledTemplate.get().isEmpty()) return isRenderedDefault();
+        String template = enabledTemplate.get();
+        if (template.isEmpty()) return isRenderedDefault();
 
         // If the enabled template is not empty,
         // the overlay is rendered when the template is true.
-        ErrorOr<Boolean> enabledOrError = Managers.Function.tryGetRawValueOfType(enabledTemplate.get(), Boolean.class);
+        String formattedTemplate =
+                StyledText.join("", Managers.Function.doFormatLines(template)).getString();
+        ErrorOr<Boolean> enabledOrError = Managers.Function.tryGetRawValueOfType(formattedTemplate, Boolean.class);
         return !enabledOrError.hasError() && enabledOrError.getValue();
     }
 

--- a/common/src/main/java/com/wynntils/overlays/custombars/CustomBarOverlayBase.java
+++ b/common/src/main/java/com/wynntils/overlays/custombars/CustomBarOverlayBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays.custombars;
@@ -12,6 +12,7 @@ import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.HiddenConfig;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.utils.type.ErrorOr;
 
 public abstract class CustomBarOverlayBase extends BarOverlay implements CustomNameProperty {
@@ -46,18 +47,27 @@ public abstract class CustomBarOverlayBase extends BarOverlay implements CustomN
     }
 
     @Override
-    public boolean isRendered() {
-        // If the text template is empty, the overlay is not rendered.
-        if (valueTemplate.get().isEmpty()) return false;
-
+    public final boolean isRendered() {
         // If the enabled template is empty,
         // the overlay is rendered when the player is in the world.
-        if (enabledTemplate.get().isEmpty()) return Models.WorldState.onWorld();
+        String template = enabledTemplate.get();
+        if (template.isEmpty()) return isRenderedDefault();
 
         // If the enabled template is not empty,
-        // the overlay is rendered when the template evaluates to true.
-        ErrorOr<Boolean> enabledOrError = Managers.Function.tryGetRawValueOfType(enabledTemplate.get(), Boolean.class);
+        // the overlay is rendered when the template is true.
+        String formattedTemplate =
+                StyledText.join("", Managers.Function.doFormatLines(template)).getString();
+        ErrorOr<Boolean> enabledOrError = Managers.Function.tryGetRawValueOfType(formattedTemplate, Boolean.class);
         return !enabledOrError.hasError() && enabledOrError.getValue();
+    }
+
+    /**
+     * Returns whether the overlay is rendered with the default (empty) template.
+     *
+     * @return whether the overlay is rendered with the default (empty) template
+     */
+    public boolean isRenderedDefault() {
+        return Models.WorldState.onWorld();
     }
 
     @Override


### PR DESCRIPTION
Trying to add #3235 we found out that enabled template wasn't working with that function when putting & into it, it had to be §. After checking the code it wasn't my code's fault, well kind of, the fault was that enabled template did not get any formatting that normal templates get. This PR adds this proper formatting to enabled templates in CustomBarOverlayBase and TextOverlay, as well as makes the small changes to custom bars that were made to text overlays.

PS. Thanks IntelliJ for suggesting `.toString()` when trying to get String value from StyledText instead of `.getString()` (it took me almost an hour to realize)