### PR TITLE
feat: Support hex color codes in functions and escaping fixes

### DIFF
--- a/common/src/main/java/com/wynntils/commands/FunctionCommand.java
+++ b/common/src/main/java/com/wynntils/commands/FunctionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.commands;
@@ -99,8 +99,8 @@ public class FunctionCommand extends Command {
 
         context.getSource()
                 .sendSuccess(
-                        () -> Component.literal(
-                                "Template calculated: \"%s\" -> [%s]".formatted(template, resultString.getString())),
+                        () -> Component.literal("Template calculated: \"%s§r\" -> [%s§r]"
+                                .formatted(template, resultString.getString())),
                         false);
 
         return 1;

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -299,7 +299,8 @@ public final class FunctionManager extends Manager {
                 }
             }
         }
-        return sb.toString();
+
+        return sb.toString().replaceAll("&(#[0-9A-Fa-f]{8})", "§$1");
     }
 
     private String doEscapeFormat(char escaped) {

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -285,7 +285,7 @@ public final class FunctionManager extends Manager {
     private String parseColorCodes(String toProcess) {
         // For every & symbol, check if the next symbol is a color code and if so, replace it with §
         // But don't do it if a \ precedes the &
-        String validColors = "0123456789abcdefklmnor";
+        String validColors = "0123456789abcdefklmnor#";
         StringBuilder sb = new StringBuilder(toProcess);
         for (int i = 0; i < sb.length(); i++) {
             if (sb.charAt(i) == '&') { // char == &

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -285,7 +285,7 @@ public final class FunctionManager extends Manager {
     private String parseColorCodes(String toProcess) {
         // For every & symbol, check if the next symbol is a color code and if so, replace it with §
         // But don't do it if a \ precedes the &
-        String validColors = "0123456789abcdefklmnor#";
+        String validColors = "0123456789abcdefklmnor";
         StringBuilder sb = new StringBuilder(toProcess);
         for (int i = 0; i < sb.length(); i++) {
             if (sb.charAt(i) == '&') { // char == &

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -273,9 +273,10 @@ public final class FunctionManager extends Manager {
 
         String calculatedString = doFormat(escapedTemplate);
 
-        // Turn escaped {} (`\[\` and `\]\`) back into real {}
+        // Turn escaped {}& (`\[\`, `\]\` `\&\`) back into real {}&
         calculatedString = calculatedString.replace("\\[\\", "{");
         calculatedString = calculatedString.replace("\\]\\", "}");
+        calculatedString = calculatedString.replace("\\&\\", "&");
 
         return Arrays.stream(calculatedString.split("\n"))
                 .map(StyledText::fromString)
@@ -283,14 +284,14 @@ public final class FunctionManager extends Manager {
     }
 
     private String parseColorCodes(String toProcess) {
-        // Replace &<code> with §<code> if not preceded by a backslash (e.g., &a → §a, but \&a stays unchanged)
-        String processed = toProcess.replaceAll("(?<!\\\\)&([0-9a-fA-Fk-oK-OrR])", "§$1");
+        // Replace &<code> with §<code> if not escaped (e.g., &a → §a, but \&\a stays unchanged)
+        // doEscapeFormat preprocesses the string and replaces \& with \&\ so that it doesn't get replaced
+        String processed = toProcess.replaceAll("&(?<!\\\\)([0-9a-fA-Fk-oK-OrR])", "§$1");
 
         // Replace &#AARRGGBB with §#AARRGGBB for hex colors
-        processed = processed.replaceAll("&(#[0-9A-Fa-f]{8})", "§$1");
+        processed = processed.replaceAll("&(?<!\\\\)(#[0-9A-Fa-f]{8})", "§$1");
 
-        // Replace escaped ampersands (e.g., \&a → &a) by removing the escape
-        return processed.replaceAll("\\\\&", "&");
+        return processed;
     }
 
     private String doEscapeFormat(char escaped) {
@@ -304,7 +305,8 @@ public final class FunctionManager extends Manager {
             case 'L' -> EmeraldUnits.LIQUID_EMERALD.getSymbol();
             case 'M' -> "✺";
             case 'H' -> "❤";
-            default -> String.valueOf(escaped);
+            case '&' -> "\\&\\";
+            default -> '\\' + String.valueOf(escaped);
         };
     }
 

--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -283,24 +283,14 @@ public final class FunctionManager extends Manager {
     }
 
     private String parseColorCodes(String toProcess) {
-        // For every & symbol, check if the next symbol is a color code and if so, replace it with §
-        // But don't do it if a \ precedes the &
-        String validColors = "0123456789abcdefklmnor";
-        StringBuilder sb = new StringBuilder(toProcess);
-        for (int i = 0; i < sb.length(); i++) {
-            if (sb.charAt(i) == '&') { // char == &
-                if (i + 1 < sb.length()
-                        && validColors.contains(String.valueOf(sb.charAt(i + 1)))) { // char after is valid color
-                    if (i - 1 < 0 || sb.charAt(i - 1) != '\\') { // & is first char || char before is not \
-                        sb.setCharAt(i, '§');
-                    } else if (sb.charAt(i - 1) == '\\') { // & is preceded by \, just remove the \
-                        sb.deleteCharAt(i - 1);
-                    }
-                }
-            }
-        }
+        // Replace &<code> with §<code> if not preceded by a backslash (e.g., &a → §a, but \&a stays unchanged)
+        String processed = toProcess.replaceAll("(?<!\\\\)&([0-9a-fA-Fk-oK-OrR])", "§$1");
 
-        return sb.toString().replaceAll("&(#[0-9A-Fa-f]{8})", "§$1");
+        // Replace &#AARRGGBB with §#AARRGGBB for hex colors
+        processed = processed.replaceAll("&(#[0-9A-Fa-f]{8})", "§$1");
+
+        // Replace escaped ampersands (e.g., \&a → &a) by removing the escape
+        return processed.replaceAll("\\\\&", "&");
     }
 
     private String doEscapeFormat(char escaped) {

--- a/common/src/main/resources/assets/wynntils/lang/it_it.json
+++ b/common/src/main/resources/assets/wynntils/lang/it_it.json
@@ -1886,7 +1886,6 @@
   "function.wynntils.raidPersonalBestTime.argument.raidName": "Il nome del raid per ottenere il miglior tempo",
   "function.wynntils.raidPersonalBestTime.description": "Il tempo più veloce impiegato per battere il raid specificato in millisecondi",
   "function.wynntils.raidPersonalBestTime.name": "Miglior Tempo Personale del Raid",
-  "function.wynntils.raidRoomTime.argument.roomNum": "Il tipo di stanza per ottenere il tempo impiegato per completare. Uno di CHALLENGE_1, CHALLENGE_2 o CHALLENGE_3",
   "function.wynntils.raidRoomTime.description": "Quanto tempo ci è voluto per completare la stanza del raid specificata in millisecondi",
   "function.wynntils.raidRoomTime.name": "Tempo di Stanza del Raid",
   "function.wynntils.raidTimeRemaining.description": "Quanto tempo rimane per completare il raid in secondi",

--- a/common/src/main/resources/assets/wynntils/lang/zh_cn.json
+++ b/common/src/main/resources/assets/wynntils/lang/zh_cn.json
@@ -1886,7 +1886,6 @@
   "function.wynntils.raidPersonalBestTime.argument.raidName": "获取最佳时间的突袭名称",
   "function.wynntils.raidPersonalBestTime.description": "完成指定突袭的最快时间（毫秒）",
   "function.wynntils.raidPersonalBestTime.name": "突袭个人最佳时间",
-  "function.wynntils.raidRoomTime.argument.roomNum": "获取完成时间的房间类型。CHALLENGE_1、CHALLENGE_2或CHALLENGE_3之一",
   "function.wynntils.raidRoomTime.description": "完成指定突袭房间所需的时间（毫秒）",
   "function.wynntils.raidRoomTime.name": "突袭房间时间",
   "function.wynntils.raidTimeRemaining.description": "完成突袭所剩的时间（秒）",


### PR DESCRIPTION
I don't know when, but vanilla added a way to color text using hex codes by using §# followed by the hex code. Functions did not support such possibility, meaning you were limited to predefined colors. That also means if you for example wanted to compare your held item that had this hex coloring, like Ability Shards, with some plain text with this coloring, then you had to use § symbol as parser did not change & into it.