### PR TITLE
fix: Fix EventThread.IO message filtering [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
+++ b/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
@@ -64,7 +64,9 @@ public class EventBusWrapper extends EventBus {
                 boolean threadOk =
                         switch (threadAnnotation.value()) {
                             case RENDER -> threadName.equals("Render thread");
-                            case IO -> threadName.startsWith("Netty Epoll Client IO #");
+                            case IO ->
+                                threadName.startsWith("Netty Epoll Client IO #")
+                                        || threadName.startsWith("Netty Client IO #");
                             case WORKER -> threadName.toLowerCase(Locale.ROOT).contains("pool");
                             case ANY -> true;
                         };

--- a/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
+++ b/common/src/main/java/com/wynntils/core/events/EventBusWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.events;
@@ -64,7 +64,7 @@ public class EventBusWrapper extends EventBus {
                 boolean threadOk =
                         switch (threadAnnotation.value()) {
                             case RENDER -> threadName.equals("Render thread");
-                            case IO -> threadName.startsWith("Netty Client IO #");
+                            case IO -> threadName.startsWith("Netty Epoll Client IO #");
                             case WORKER -> threadName.toLowerCase(Locale.ROOT).contains("pool");
                             case ANY -> true;
                         };

--- a/common/src/main/java/com/wynntils/core/events/EventThread.java
+++ b/common/src/main/java/com/wynntils/core/events/EventThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.events;
@@ -20,7 +20,7 @@ public @interface EventThread {
 
     enum Type {
         RENDER, // The main thread a.k.a the Render thread
-        IO, // Any Netty Client IO thread
+        IO, // Any Netty Epoll Client IO thread
         WORKER, // A worker thread, from a Minecraft or Wynntils thread pool
         ANY // Any thread at all
     }


### PR DESCRIPTION
I think this is self-explanatory. This likely changed with MC 1.21.x.