### PR TITLE
feat: Add accessory quick filters to item guide, reposition widgets and new keybinds

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -21,10 +21,13 @@ import com.wynntils.screens.activities.WynntilsDiscoveriesScreen;
 import com.wynntils.screens.activities.WynntilsQuestBookScreen;
 import com.wynntils.screens.base.WynntilsMenuScreenBase;
 import com.wynntils.screens.guides.WynntilsGuidesListScreen;
+import com.wynntils.screens.guides.aspect.WynntilsAspectGuideScreen;
+import com.wynntils.screens.guides.charm.WynntilsCharmGuideScreen;
 import com.wynntils.screens.guides.emeraldpouch.WynntilsEmeraldPouchGuideScreen;
 import com.wynntils.screens.guides.gear.WynntilsItemGuideScreen;
 import com.wynntils.screens.guides.ingredient.WynntilsIngredientGuideScreen;
 import com.wynntils.screens.guides.powder.WynntilsPowderGuideScreen;
+import com.wynntils.screens.guides.tome.WynntilsTomeGuideScreen;
 import com.wynntils.screens.overlays.placement.OverlayManagementScreen;
 import com.wynntils.screens.overlays.selection.OverlaySelectionScreen;
 import com.wynntils.screens.wynntilsmenu.WynntilsMenuScreen;
@@ -87,6 +90,27 @@ public class WynntilsContentBookFeature extends Feature {
             GLFW.GLFW_KEY_UNKNOWN,
             true,
             () -> WynntilsMenuScreenBase.openBook(WynntilsIngredientGuideScreen.create()));
+
+    @RegisterKeyBind
+    private final KeyBind openCharmGuide = new KeyBind(
+            "Open Charm Guide",
+            GLFW.GLFW_KEY_UNKNOWN,
+            true,
+            () -> WynntilsMenuScreenBase.openBook(WynntilsCharmGuideScreen.create()));
+
+    @RegisterKeyBind
+    private final KeyBind openTomeGuide = new KeyBind(
+            "Open Tome Guide",
+            GLFW.GLFW_KEY_UNKNOWN,
+            true,
+            () -> WynntilsMenuScreenBase.openBook(WynntilsTomeGuideScreen.create()));
+
+    @RegisterKeyBind
+    private final KeyBind openAspectGuide = new KeyBind(
+            "Open Aspect Guide",
+            GLFW.GLFW_KEY_UNKNOWN,
+            true,
+            () -> WynntilsMenuScreenBase.openBook(WynntilsAspectGuideScreen.create()));
 
     @RegisterKeyBind
     private final KeyBind openEmeraldPouchGuide = new KeyBind(

--- a/common/src/main/java/com/wynntils/screens/guides/aspect/WynntilsAspectGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/aspect/WynntilsAspectGuideScreen.java
@@ -57,9 +57,9 @@ public final class WynntilsAspectGuideScreen
 
         if (searchWidget instanceof ItemSearchWidget itemSearchWidget) {
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new ClassTypeFilterWidget(13 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new ClassTypeFilterWidget(19 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new RarityFilterWidget(29 + offsetX, 101 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new RarityFilterWidget(19 + offsetX, 101 + offsetY, this, itemSearchWidget.getSearchQuery())));
 
             guideSortWidget.setPrimarySortButton(
                     new GuideSortButton(itemSearchWidget.getSearchQuery(), this, TierStatProvider.class));

--- a/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/charm/WynntilsCharmGuideScreen.java
@@ -51,7 +51,7 @@ public final class WynntilsCharmGuideScreen
 
         if (searchWidget instanceof ItemSearchWidget itemSearchWidget) {
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new RarityFilterWidget(29 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new RarityFilterWidget(19 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
 
             guideSortWidget.setSecondarySortButton(
                     new GuideSortButton(itemSearchWidget.getSearchQuery(), this, RarityStatProvider.class));

--- a/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/gear/WynntilsItemGuideScreen.java
@@ -51,9 +51,9 @@ public final class WynntilsItemGuideScreen extends WynntilsGuideScreen<GuideGear
 
         if (searchWidget instanceof ItemSearchWidget itemSearchWidget) {
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new GearTypeFilterWidget(13 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new GearTypeFilterWidget(19 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new RarityFilterWidget(29 + offsetX, 121 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new RarityFilterWidget(19 + offsetX, 121 + offsetY, this, itemSearchWidget.getSearchQuery())));
 
             guideSortWidget.setSecondarySortButton(
                     new GuideSortButton(itemSearchWidget.getSearchQuery(), this, RarityStatProvider.class));

--- a/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/ingredient/WynntilsIngredientGuideScreen.java
@@ -53,9 +53,9 @@ public final class WynntilsIngredientGuideScreen
 
         if (searchWidget instanceof ItemSearchWidget itemSearchWidget) {
             guideFilterWidgets.add(this.addRenderableWidget(new ProfessionTypeFilterWidget(
-                    29 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    47 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new QualityTierFilterWidget(29 + offsetX, 131 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new QualityTierFilterWidget(47 + offsetX, 121 + offsetY, this, itemSearchWidget.getSearchQuery())));
 
             guideSortWidget.setSecondarySortButton(
                     new GuideSortButton(itemSearchWidget.getSearchQuery(), this, QualityTierStatProvider.class));

--- a/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
+++ b/common/src/main/java/com/wynntils/screens/guides/tome/WynntilsTomeGuideScreen.java
@@ -51,9 +51,9 @@ public final class WynntilsTomeGuideScreen extends WynntilsGuideScreen<GuideTome
 
         if (searchWidget instanceof ItemSearchWidget itemSearchWidget) {
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new TomeTypeFilterWidget(29 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new TomeTypeFilterWidget(19 + offsetX, 81 + offsetY, this, itemSearchWidget.getSearchQuery())));
             guideFilterWidgets.add(this.addRenderableWidget(
-                    new RarityFilterWidget(29 + offsetX, 121 + offsetY, this, itemSearchWidget.getSearchQuery())));
+                    new RarityFilterWidget(19 + offsetX, 101 + offsetY, this, itemSearchWidget.getSearchQuery())));
 
             guideSortWidget.setSecondarySortButton(
                     new GuideSortButton(itemSearchWidget.getSearchQuery(), this, RarityStatProvider.class));

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/filters/ClassTypeFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/filters/ClassTypeFilterWidget.java
@@ -24,14 +24,14 @@ public class ClassTypeFilterWidget extends GuideFilterWidget {
     private ClassStatProvider provider;
 
     public ClassTypeFilterWidget(int x, int y, WynntilsGuideScreen guideScreen, ItemSearchQuery searchQuery) {
-        super(x, y, 144, 36, guideScreen);
+        super(x, y, 96, 16, guideScreen);
 
         classTypeButtons.add(new ClassTypeButton(x, y, ClassType.WARRIOR, Texture.SPEAR_FILTER_ICON, searchQuery));
-        classTypeButtons.add(new ClassTypeButton(x + 32, y, ClassType.MAGE, Texture.WAND_FILTER_ICON, searchQuery));
+        classTypeButtons.add(new ClassTypeButton(x + 20, y, ClassType.MAGE, Texture.WAND_FILTER_ICON, searchQuery));
         classTypeButtons.add(
-                new ClassTypeButton(x + 64, y, ClassType.ASSASSIN, Texture.DAGGER_FILTER_ICON, searchQuery));
-        classTypeButtons.add(new ClassTypeButton(x + 96, y, ClassType.ARCHER, Texture.BOW_FILTER_ICON, searchQuery));
-        classTypeButtons.add(new ClassTypeButton(x + 128, y, ClassType.SHAMAN, Texture.RELIK_FILTER_ICON, searchQuery));
+                new ClassTypeButton(x + 40, y, ClassType.ASSASSIN, Texture.DAGGER_FILTER_ICON, searchQuery));
+        classTypeButtons.add(new ClassTypeButton(x + 60, y, ClassType.ARCHER, Texture.BOW_FILTER_ICON, searchQuery));
+        classTypeButtons.add(new ClassTypeButton(x + 80, y, ClassType.SHAMAN, Texture.RELIK_FILTER_ICON, searchQuery));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/filters/GearTypeFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/filters/GearTypeFilterWidget.java
@@ -24,21 +24,25 @@ public class GearTypeFilterWidget extends GuideFilterWidget {
     private GearTypeStatProvider provider;
 
     public GearTypeFilterWidget(int x, int y, WynntilsGuideScreen guideScreen, ItemSearchQuery searchQuery) {
-        super(x, y, 144, 36, guideScreen);
+        super(x, y, 136, 36, guideScreen);
 
-        gearTypeButtons.add(new GearTypeButton(x + 16, y, GearType.HELMET, Texture.HELMET_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(new GearTypeButton(x, y, GearType.HELMET, Texture.HELMET_FILTER_ICON, searchQuery));
         gearTypeButtons.add(
-                new GearTypeButton(x + 48, y, GearType.CHESTPLATE, Texture.CHESTPLATE_FILTER_ICON, searchQuery));
+                new GearTypeButton(x + 20, y, GearType.CHESTPLATE, Texture.CHESTPLATE_FILTER_ICON, searchQuery));
         gearTypeButtons.add(
-                new GearTypeButton(x + 80, y, GearType.LEGGINGS, Texture.LEGGINGS_FILTER_ICON, searchQuery));
-        gearTypeButtons.add(new GearTypeButton(x + 112, y, GearType.BOOTS, Texture.BOOTS_FILTER_ICON, searchQuery));
+                new GearTypeButton(x + 40, y, GearType.LEGGINGS, Texture.LEGGINGS_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(new GearTypeButton(x + 60, y, GearType.BOOTS, Texture.BOOTS_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(new GearTypeButton(x + 80, y, GearType.RING, Texture.RING_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(
+                new GearTypeButton(x + 100, y, GearType.BRACELET, Texture.BRACELET_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(
+                new GearTypeButton(x + 120, y, GearType.NECKLACE, Texture.NECKLACE_FILTER_ICON, searchQuery));
         gearTypeButtons.add(new GearTypeButton(x, y + 20, GearType.SPEAR, Texture.SPEAR_FILTER_ICON, searchQuery));
-        gearTypeButtons.add(new GearTypeButton(x + 32, y + 20, GearType.WAND, Texture.WAND_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(new GearTypeButton(x + 20, y + 20, GearType.WAND, Texture.WAND_FILTER_ICON, searchQuery));
         gearTypeButtons.add(
-                new GearTypeButton(x + 64, y + 20, GearType.DAGGER, Texture.DAGGER_FILTER_ICON, searchQuery));
-        gearTypeButtons.add(new GearTypeButton(x + 96, y + 20, GearType.BOW, Texture.BOW_FILTER_ICON, searchQuery));
-        gearTypeButtons.add(
-                new GearTypeButton(x + 128, y + 20, GearType.RELIK, Texture.RELIK_FILTER_ICON, searchQuery));
+                new GearTypeButton(x + 40, y + 20, GearType.DAGGER, Texture.DAGGER_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(new GearTypeButton(x + 60, y + 20, GearType.BOW, Texture.BOW_FILTER_ICON, searchQuery));
+        gearTypeButtons.add(new GearTypeButton(x + 80, y + 20, GearType.RELIK, Texture.RELIK_FILTER_ICON, searchQuery));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/filters/ProfessionTypeFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/filters/ProfessionTypeFilterWidget.java
@@ -33,24 +33,24 @@ public class ProfessionTypeFilterWidget extends GuideFilterWidget {
     private Map<ProfessionType, ProfessionStatProvider> professionProviderMap;
 
     public ProfessionTypeFilterWidget(int x, int y, WynntilsGuideScreen guideScreen, ItemSearchQuery searchQuery) {
-        super(x, y, 160, 36, guideScreen);
+        super(x, y, 76, 36, guideScreen);
 
         professionTypeButtons.add(
                 new ProfessionTypeButton(x, y, ProfessionType.ALCHEMISM, Texture.ALCHEMISM_FILTER_ICON, searchQuery));
         professionTypeButtons.add(new ProfessionTypeButton(
-                x + 32, y, ProfessionType.ARMOURING, Texture.ARMOURING_FILTER_ICON, searchQuery));
+                x + 20, y, ProfessionType.ARMOURING, Texture.ARMOURING_FILTER_ICON, searchQuery));
         professionTypeButtons.add(
-                new ProfessionTypeButton(x + 64, y, ProfessionType.COOKING, Texture.COOKING_FILTER_ICON, searchQuery));
+                new ProfessionTypeButton(x + 40, y, ProfessionType.COOKING, Texture.COOKING_FILTER_ICON, searchQuery));
         professionTypeButtons.add(new ProfessionTypeButton(
-                x + 96, y, ProfessionType.JEWELING, Texture.JEWELING_FILTER_ICON, searchQuery));
+                x + 60, y, ProfessionType.JEWELING, Texture.JEWELING_FILTER_ICON, searchQuery));
         professionTypeButtons.add(new ProfessionTypeButton(
                 x, y + 20, ProfessionType.SCRIBING, Texture.SCRIBING_FILTER_ICON, searchQuery));
         professionTypeButtons.add(new ProfessionTypeButton(
-                x + 32, y + 20, ProfessionType.TAILORING, Texture.TAILORING_FILTER_ICON, searchQuery));
+                x + 20, y + 20, ProfessionType.TAILORING, Texture.TAILORING_FILTER_ICON, searchQuery));
         professionTypeButtons.add(new ProfessionTypeButton(
-                x + 64, y + 20, ProfessionType.WEAPONSMITHING, Texture.WEAPONSMITHING_FILTER_ICON, searchQuery));
+                x + 40, y + 20, ProfessionType.WEAPONSMITHING, Texture.WEAPONSMITHING_FILTER_ICON, searchQuery));
         professionTypeButtons.add(new ProfessionTypeButton(
-                x + 96, y + 20, ProfessionType.WOODWORKING, Texture.WOODWORKING_FILTER_ICON, searchQuery));
+                x + 60, y + 20, ProfessionType.WOODWORKING, Texture.WOODWORKING_FILTER_ICON, searchQuery));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/filters/QualityTierFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/filters/QualityTierFilterWidget.java
@@ -22,12 +22,12 @@ public class QualityTierFilterWidget extends GuideFilterWidget {
     private QualityTierStatProvider provider;
 
     public QualityTierFilterWidget(int x, int y, WynntilsGuideScreen guideScreen, ItemSearchQuery searchQuery) {
-        super(x, y, 160, 16, guideScreen);
+        super(x, y, 76, 16, guideScreen);
 
         qualityTierButtons.add(new QualityTierButton(x, y, 0, Texture.TIER_0_FILTER_ICON, searchQuery));
-        qualityTierButtons.add(new QualityTierButton(x + 32, y, 1, Texture.TIER_1_FILTER_ICON, searchQuery));
-        qualityTierButtons.add(new QualityTierButton(x + 64, y, 2, Texture.TIER_2_FILTER_ICON, searchQuery));
-        qualityTierButtons.add(new QualityTierButton(x + 96, y, 3, Texture.TIER_3_FILTER_ICON, searchQuery));
+        qualityTierButtons.add(new QualityTierButton(x + 20, y, 1, Texture.TIER_1_FILTER_ICON, searchQuery));
+        qualityTierButtons.add(new QualityTierButton(x + 40, y, 2, Texture.TIER_2_FILTER_ICON, searchQuery));
+        qualityTierButtons.add(new QualityTierButton(x + 60, y, 3, Texture.TIER_3_FILTER_ICON, searchQuery));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/filters/RarityFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/filters/RarityFilterWidget.java
@@ -23,15 +23,15 @@ public class RarityFilterWidget extends GuideFilterWidget {
     private RarityStatProvider provider;
 
     public RarityFilterWidget(int x, int y, WynntilsGuideScreen guideScreen, ItemSearchQuery searchQuery) {
-        super(x, y, 112, 36, guideScreen);
+        super(x, y, 136, 16, guideScreen);
 
         rarityButtons.add(new RarityButton(x, y, GearTier.MYTHIC, Texture.MYTHIC_FILTER_ICON, searchQuery));
-        rarityButtons.add(new RarityButton(x + 32, y, GearTier.FABLED, Texture.FABLED_FILTER_ICON, searchQuery));
-        rarityButtons.add(new RarityButton(x + 64, y, GearTier.LEGENDARY, Texture.LEGENDARY_FILTER_ICON, searchQuery));
-        rarityButtons.add(new RarityButton(x + 96, y, GearTier.SET, Texture.SET_FILTER_ICON, searchQuery));
-        rarityButtons.add(new RarityButton(x + 16, y + 20, GearTier.RARE, Texture.RARE_FILTER_ICON, searchQuery));
-        rarityButtons.add(new RarityButton(x + 48, y + 20, GearTier.UNIQUE, Texture.UNIQUE_FILTER_ICON, searchQuery));
-        rarityButtons.add(new RarityButton(x + 80, y + 20, GearTier.NORMAL, Texture.NORMAL_FILTER_ICON, searchQuery));
+        rarityButtons.add(new RarityButton(x + 20, y, GearTier.FABLED, Texture.FABLED_FILTER_ICON, searchQuery));
+        rarityButtons.add(new RarityButton(x + 40, y, GearTier.LEGENDARY, Texture.LEGENDARY_FILTER_ICON, searchQuery));
+        rarityButtons.add(new RarityButton(x + 60, y, GearTier.SET, Texture.SET_FILTER_ICON, searchQuery));
+        rarityButtons.add(new RarityButton(x + 80, y, GearTier.RARE, Texture.RARE_FILTER_ICON, searchQuery));
+        rarityButtons.add(new RarityButton(x + 100, y, GearTier.UNIQUE, Texture.UNIQUE_FILTER_ICON, searchQuery));
+        rarityButtons.add(new RarityButton(x + 120, y, GearTier.NORMAL, Texture.NORMAL_FILTER_ICON, searchQuery));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/guides/widgets/filters/TomeTypeFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/guides/widgets/filters/TomeTypeFilterWidget.java
@@ -24,21 +24,21 @@ public class TomeTypeFilterWidget extends GuideFilterWidget {
     private TomeTypeStatProvider provider;
 
     public TomeTypeFilterWidget(int x, int y, WynntilsGuideScreen guideScreen, ItemSearchQuery searchQuery) {
-        super(x, y, 112, 36, guideScreen);
+        super(x, y, 136, 16, guideScreen);
 
         tomeTypeButtons.add(new TomeTypeButton(x, y, TomeType.GUILD_TOME, Texture.GUILD_TOME_FILTER_ICON, searchQuery));
         tomeTypeButtons.add(
-                new TomeTypeButton(x + 32, y, TomeType.WEAPON_TOME, Texture.WEAPON_TOME_FILTER_ICON, searchQuery));
+                new TomeTypeButton(x + 20, y, TomeType.WEAPON_TOME, Texture.WEAPON_TOME_FILTER_ICON, searchQuery));
         tomeTypeButtons.add(
-                new TomeTypeButton(x + 64, y, TomeType.ARMOUR_TOME, Texture.ARMOR_TOME_FILTER_ICON, searchQuery));
+                new TomeTypeButton(x + 40, y, TomeType.ARMOUR_TOME, Texture.ARMOR_TOME_FILTER_ICON, searchQuery));
         tomeTypeButtons.add(new TomeTypeButton(
-                x + 96, y, TomeType.MYSTICISM_TOME, Texture.MYSTICISM_TOME_FILTER_ICON, searchQuery));
+                x + 60, y, TomeType.MYSTICISM_TOME, Texture.MYSTICISM_TOME_FILTER_ICON, searchQuery));
+        tomeTypeButtons.add(
+                new TomeTypeButton(x + 80, y, TomeType.MARATHON_TOME, Texture.MARATHON_TOME_FILTER_ICON, searchQuery));
+        tomeTypeButtons.add(
+                new TomeTypeButton(x + 100, y, TomeType.LOOTRUN_TOME, Texture.LOOTRUN_TOME_FILTER_ICON, searchQuery));
         tomeTypeButtons.add(new TomeTypeButton(
-                x + 16, y + 20, TomeType.MARATHON_TOME, Texture.MARATHON_TOME_FILTER_ICON, searchQuery));
-        tomeTypeButtons.add(new TomeTypeButton(
-                x + 48, y + 20, TomeType.LOOTRUN_TOME, Texture.LOOTRUN_TOME_FILTER_ICON, searchQuery));
-        tomeTypeButtons.add(new TomeTypeButton(
-                x + 80, y + 20, TomeType.EXPERTISE_TOME, Texture.EXPERTISE_TOME_FILTER_ICON, searchQuery));
+                x + 120, y, TomeType.EXPERTISE_TOME, Texture.EXPERTISE_TOME_FILTER_ICON, searchQuery));
     }
 
     @Override


### PR DESCRIPTION
Added the textures for the accessory widgets last time but forgot to actually add the filters themselves.

Repositioned all of the filter widgets too, so they fit on one line where possible and keep the widgets left aligned, with the exception of the ingredient guide.

And also added the missing keybinds for opening the newer guides

![image](https://github.com/user-attachments/assets/a09d68d1-da96-469e-86e6-1ca7ad29d2c1)
![image](https://github.com/user-attachments/assets/8efc131e-be94-4828-a632-19136d975878)
![image](https://github.com/user-attachments/assets/6b232d92-5b8c-4ec2-9b32-5a070e405acc)
![image](https://github.com/user-attachments/assets/44fe45e9-39cb-4e2d-924d-827ee9b62e99)
![image](https://github.com/user-attachments/assets/92e120ce-8a9d-47d7-9b33-7ce1bd2de871)
