### PR TITLE
chore: Update setup-gradle to v4

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -77,10 +77,11 @@ jobs:
           java-version: 21
           cache: "gradle"
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: buildDependents -x spotlessCheck -x test
+        run: ./gradlew buildDependents -x spotlessCheck -x test
 
       - name: Upload build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,11 @@ jobs:
           path: .gradle
           key: ${{ runner.os }}-gradle--${{ hashFiles('**/settings.gradle', '**/gradle.properties') }}
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Format with spotless
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: spotlessApply
+        run: ./gradlew spotlessApply
 
       - name: Delete empty files
         run: find $(git ls-files -m) -size 0 -delete
@@ -47,11 +48,7 @@ jobs:
           commit_message: 'ci: spotless formatting'
 
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: buildDependents -x spotlessCheck -x test
+        run: ./gradlew buildDependents -x spotlessCheck -x test
 
       - name: Test with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: test -x spotlessCheck
+        run: ./gradlew test -x spotlessCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,11 @@ jobs:
           java-version: 21
           cache: "gradle"
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: buildDependents -x spotlessCheck -x test
+        run: ./gradlew buildDependents -x spotlessCheck -x test
 
       - name: Upload build
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Hopefully will fix the slow building we've had recently

https://github.com/gradle/actions/releases/tag/v4.0.0

https://github.com/gradle/actions/blob/v4.0.0-rc.1/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated