### PR TITLE
feat: Handle negative stats with stars when calculating internal rolls [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/stats/type/StatType.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/StatType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.type;
@@ -14,11 +14,17 @@ import java.util.Optional;
 // The "internalRollName" is what is used in the json lore of other player's items
 public abstract class StatType {
     // These ranges are used everywhere, except charms
-    private static final List<RangedValue> STAR_INTERNAL_ROLL_RANGES = List.of(
+    private static final List<RangedValue> POSITIVE_STAR_INTERNAL_ROLL_RANGES = List.of(
             RangedValue.of(30, 100), // 0 stars
             RangedValue.of(101, 124), // 1 star
             RangedValue.of(125, 129), // 2 stars
             RangedValue.of(130, 130) // 3 stars
+            );
+    private static final List<RangedValue> NEGATIVE_STAR_INTERNAL_ROLL_RANGES = List.of(
+            RangedValue.of(100, 130), // 0 stars
+            RangedValue.of(75, 99), // 1 star
+            RangedValue.of(71, 74), // 2 stars
+            RangedValue.of(70, 70) // 3 stars
             );
 
     private final String key;
@@ -82,13 +88,13 @@ public abstract class StatType {
                         calculateAsInverted() ? RoundingMode.HALF_DOWN : RoundingMode.HALF_UP,
                         Optional.of(1),
                         Optional.empty(),
-                        treatAsInverted() ? List.of() : STAR_INTERNAL_ROLL_RANGES)
+                        treatAsInverted() ? List.of() : POSITIVE_STAR_INTERNAL_ROLL_RANGES)
                 : new StatCalculationInfo(
                         RangedValue.of(70, 130),
                         calculateAsInverted() ? RoundingMode.HALF_UP : RoundingMode.HALF_DOWN,
                         Optional.empty(),
                         Optional.of(-1),
-                        List.of());
+                        treatAsInverted() ? POSITIVE_STAR_INTERNAL_ROLL_RANGES : NEGATIVE_STAR_INTERNAL_ROLL_RANGES);
     }
 
     /**

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -556,10 +556,7 @@ public final class WynnItemParser {
         }
         int value = StatCalculator.calculateStatValue(internalRoll, possibleValue);
 
-        // Negative values can never show stars
-        int stars = (value > 0)
-                ? StatCalculator.calculateStarsFromInternalRoll(statType, possibleValue.baseValue(), internalRoll)
-                : 0;
+        int stars = StatCalculator.calculateStarsFromInternalRoll(statType, possibleValue.baseValue(), internalRoll);
 
         // In this case, we actually know the exact internal roll
         return new StatActualValue(statType, value, stars, RangedValue.of(internalRoll, internalRoll));


### PR DESCRIPTION
![Stars](https://github.com/user-attachments/assets/5e83b04d-406b-4b37-a2e7-8f17f67e6441)

Recently noticed the line we're meant to add for shared/others items isn't showing the "From chat" or "From playerName" so will fix that separately, ~~likely a 1.21.4 issue~~ caused by the tooltip caching changes actually