### PR TITLE
fix: Display item source on fake items [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 
 public abstract class TooltipBuilder {
@@ -23,6 +24,7 @@ public abstract class TooltipBuilder {
             new TooltipStyle(StatListOrdering.WYNNCRAFT, false, false, true, true);
     protected final List<Component> header;
     protected final List<Component> footer;
+    protected final String source;
 
     // The identificationsCache is only valid if the cached dependencies matchs
     protected ClassType cachedCurrentClass;
@@ -30,9 +32,10 @@ public abstract class TooltipBuilder {
     protected TooltipIdentificationDecorator cachedDecorator;
     protected List<Component> identificationsCache;
 
-    protected TooltipBuilder(List<Component> header, List<Component> footer) {
+    protected TooltipBuilder(List<Component> header, List<Component> footer, String source) {
         this.header = header;
         this.footer = footer;
+        this.source = source;
     }
 
     public List<Component> getTooltipLines(ClassType currentClass) {
@@ -65,6 +68,14 @@ public abstract class TooltipBuilder {
         tooltip.addAll(identifications);
 
         tooltip.addAll(footer);
+
+        if (!source.isEmpty()) {
+            tooltip.add(
+                    1,
+                    Component.literal(source)
+                            .withStyle(ChatFormatting.DARK_GRAY)
+                            .withStyle(ChatFormatting.ITALIC));
+        }
 
         return tooltip;
     }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
@@ -36,10 +36,18 @@ public final class TooltipHandler extends Handler {
     }
 
     /**
-     * Creates a tooltip builder that provides a synthetic header and footer
+     * Creates a tooltip builder that provides a synthetic header and footer with no source
      */
     public IdentifiableTooltipBuilder buildNew(
             IdentifiableItemProperty identifiableItem, boolean hideUnidentified, boolean showItemType) {
+        return buildNew(identifiableItem, hideUnidentified, showItemType, "");
+    }
+
+    /**
+     * Creates a tooltip builder that provides a synthetic header and footer with the given source
+     */
+    public IdentifiableTooltipBuilder buildNew(
+            IdentifiableItemProperty identifiableItem, boolean hideUnidentified, boolean showItemType, String source) {
         IdentifiableTooltipComponent tooltipComponent = identifiableTooltipComponents.get(identifiableItem.getClass());
         if (tooltipComponent == null) {
             throw new IllegalArgumentException("No tooltip component registered for "
@@ -47,20 +55,20 @@ public final class TooltipHandler extends Handler {
         }
 
         return IdentifiableTooltipBuilder.buildNewItem(
-                identifiableItem, tooltipComponent, hideUnidentified, showItemType);
+                identifiableItem, tooltipComponent, hideUnidentified, showItemType, source);
     }
 
     /**
-     * Creates a tooltip builder that provides a synthetic header and footer
+     * Creates a tooltip builder that provides a synthetic header and footer with the given source
      */
-    public CraftedTooltipBuilder buildNew(CraftedItemProperty craftedItemProperty) {
+    public CraftedTooltipBuilder buildNew(CraftedItemProperty craftedItemProperty, String source) {
         CraftedTooltipComponent tooltipComponent = craftedTooltipComponents.get(craftedItemProperty.getClass());
         if (tooltipComponent == null) {
             throw new IllegalArgumentException("No tooltip component registered for "
                     + craftedItemProperty.getClass().getName());
         }
 
-        return CraftedTooltipBuilder.buildNewItem(craftedItemProperty, tooltipComponent);
+        return CraftedTooltipBuilder.buildNewItem(craftedItemProperty, tooltipComponent, source);
     }
 
     /**

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.tooltip.impl.crafted;
@@ -18,16 +18,21 @@ import net.minecraft.world.item.ItemStack;
 public final class CraftedTooltipBuilder extends TooltipBuilder {
     private final CraftedItemProperty craftedItem;
 
-    private CraftedTooltipBuilder(CraftedItemProperty craftedItem, List<Component> header, List<Component> footer) {
-        super(header, footer);
+    private CraftedTooltipBuilder(
+            CraftedItemProperty craftedItem, List<Component> header, List<Component> footer, String source) {
+        super(header, footer, source);
         this.craftedItem = craftedItem;
     }
 
+    private CraftedTooltipBuilder(CraftedItemProperty craftedItem, List<Component> header, List<Component> footer) {
+        this(craftedItem, header, footer, "");
+    }
+
     public static <T extends CraftedItemProperty> CraftedTooltipBuilder buildNewItem(
-            T craftedItem, CraftedTooltipComponent<T> tooltipComponent) {
+            T craftedItem, CraftedTooltipComponent<T> tooltipComponent, String source) {
         List<Component> header = tooltipComponent.buildHeaderTooltip(craftedItem);
         List<Component> footer = tooltipComponent.buildFooterTooltip(craftedItem);
-        return new CraftedTooltipBuilder(craftedItem, header, footer);
+        return new CraftedTooltipBuilder(craftedItem, header, footer, source);
     }
 
     public static CraftedTooltipBuilder fromParsedItemStack(ItemStack itemStack, CraftedItemProperty craftedItem) {

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.tooltip.impl.identifiable;
@@ -24,9 +24,14 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
     private final IdentifiableItemProperty<T, U> itemInfo;
 
     private IdentifiableTooltipBuilder(
-            IdentifiableItemProperty<T, U> itemInfo, List<Component> header, List<Component> footer) {
-        super(header, footer);
+            IdentifiableItemProperty<T, U> itemInfo, List<Component> header, List<Component> footer, String source) {
+        super(header, footer, source);
         this.itemInfo = itemInfo;
+    }
+
+    private IdentifiableTooltipBuilder(
+            IdentifiableItemProperty<T, U> itemInfo, List<Component> header, List<Component> footer) {
+        this(itemInfo, header, footer, "");
     }
 
     /**
@@ -36,13 +41,14 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
             IdentifiableItemProperty<T, U> identifiableItem,
             IdentifiableTooltipComponent<T, U> tooltipComponent,
             boolean hideUnidentified,
-            boolean showItemType) {
+            boolean showItemType,
+            String source) {
         T itemInfo = identifiableItem.getItemInfo();
         U itemInstance = identifiableItem.getItemInstance().orElse(null);
 
         List<Component> header = tooltipComponent.buildHeaderTooltip(itemInfo, itemInstance, hideUnidentified);
         List<Component> footer = tooltipComponent.buildFooterTooltip(itemInfo, itemInstance, showItemType);
-        return new IdentifiableTooltipBuilder(identifiableItem, header, footer);
+        return new IdentifiableTooltipBuilder(identifiableItem, header, footer, source);
     }
 
     /**

--- a/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
+++ b/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
@@ -13,7 +13,6 @@ import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.items.properties.NamedItemProperty;
 import com.wynntils.utils.mc.TooltipUtils;
 import java.util.List;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -55,20 +54,18 @@ public class FakeItemStack extends ItemStack {
         if (wynnItem instanceof IdentifiableItemProperty<?, ?> identifiableItem) {
             tooltipBuilder = wynnItem.getData()
                     .getOrCalculate(
-                            WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(identifiableItem, false, true));
+                            WynnItemData.TOOLTIP_KEY,
+                            () -> Handlers.Tooltip.buildNew(identifiableItem, false, true, source));
 
         } else if (wynnItem instanceof CraftedItemProperty craftedItemProperty) {
             tooltipBuilder = wynnItem.getData()
-                    .getOrCalculate(WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(craftedItemProperty));
+                    .getOrCalculate(
+                            WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(craftedItemProperty, source));
         }
 
         if (tooltipBuilder == null) return List.of();
 
         // 2. Now that the tooltip builder is cached, generate the tooltip
-        List<Component> tooltip = TooltipUtils.getWynnItemTooltip(this, wynnItem);
-        // Add a line describing the source of this fake stack
-        tooltip.add(
-                1, Component.literal(source).withStyle(ChatFormatting.DARK_GRAY).withStyle(ChatFormatting.ITALIC));
-        return tooltip;
+        return TooltipUtils.getWynnItemTooltip(this, wynnItem);
     }
 }


### PR DESCRIPTION
Broke with the tooltip caching

![image](https://github.com/user-attachments/assets/e75d8a66-11df-4721-b852-236f81f8970c)
