### PR TITLE
fix: Make features handle is character bar is not parsed [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
@@ -1,9 +1,10 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
@@ -63,7 +64,13 @@ public class HealthPotionBlockerFeature extends Feature {
         ItemStack itemStack = McUtils.inventory().getSelected();
         if (!isHealingPotion(itemStack)) return false;
 
-        CappedValue health = Models.CharacterStats.getHealth();
+        Optional<CappedValue> healthOpt = Models.CharacterStats.getHealth();
+        if (healthOpt.isEmpty()) {
+            WynntilsMod.warn("No health information available for health potion blocker check.");
+            return false;
+        }
+
+        CappedValue health = healthOpt.get();
         int percentage = health.getPercentageInt();
 
         if (percentage >= threshold.get()) {

--- a/common/src/main/java/com/wynntils/features/combat/LowHealthVignetteFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/LowHealthVignetteFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -15,6 +15,8 @@ import com.wynntils.mc.event.TickEvent;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.RenderUtils;
+import com.wynntils.utils.type.CappedValue;
+import java.util.Optional;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -48,9 +50,13 @@ public class LowHealthVignetteFeature extends Feature {
 
     @SubscribeEvent
     public void onTick(TickEvent event) {
-        float healthProgress = (float) Models.CharacterStats.getHealth().getProgress();
-        float threshold = lowHealthPercentage.get() / 100f;
         shouldRender = false;
+
+        Optional<CappedValue> healthOpt = Models.CharacterStats.getHealth();
+        if (healthOpt.isEmpty()) return;
+
+        float healthProgress = (float) healthOpt.get().getProgress();
+        float threshold = lowHealthPercentage.get() / 100f;
 
         if (healthProgress > threshold) return;
         shouldRender = true;

--- a/common/src/main/java/com/wynntils/features/combat/SpellCastVignetteFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/SpellCastVignetteFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -17,6 +17,7 @@ import com.wynntils.models.spells.event.SpellEvent;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.type.CappedValue;
+import java.util.Optional;
 import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.COMBAT)
@@ -43,7 +44,8 @@ public class SpellCastVignetteFeature extends Feature {
 
     @SubscribeEvent
     public void onSpellCast(SpellEvent.Cast event) {
-        if (Models.CharacterStats.getMana() == CappedValue.EMPTY) {
+        Optional<CappedValue> manaOpt = Models.CharacterStats.getMana();
+        if (manaOpt.isEmpty()) {
             WynntilsMod.warn("Mana is empty, cannot calculate relative cost of spell cast");
             return;
         }
@@ -52,7 +54,7 @@ public class SpellCastVignetteFeature extends Feature {
         if (event.getManaCost() == 0) return;
 
         // Make sure the current mana is never 0 so the whole screen won't be covered in solid blue
-        int currentMana = Math.max(1, Models.CharacterStats.getMana().current());
+        int currentMana = Math.max(1, manaOpt.get().current());
 
         // An relativeCost of 1.0 means we just used all mana we have left
         float relativeCost = Math.min((float) event.getManaCost() / currentMana, maxItensityPercent.get() / 100);

--- a/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
@@ -17,21 +17,21 @@ public class CharacterFunctions {
     public static class CappedManaFunction extends Function<CappedValue> {
         @Override
         public CappedValue getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getMana();
+            return Models.CharacterStats.getMana().orElse(CappedValue.EMPTY);
         }
     }
 
     public static class CappedHealthFunction extends Function<CappedValue> {
         @Override
         public CappedValue getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getHealth();
+            return Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY);
         }
     }
 
     public static class SprintFunction extends Function<CappedValue> {
         @Override
         public CappedValue getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getSprint();
+            return Models.CharacterStats.getSprint().orElse(CappedValue.EMPTY);
         }
     }
 
@@ -116,42 +116,42 @@ public class CharacterFunctions {
     public static class ManaFunction extends Function<Integer> {
         @Override
         public Integer getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getMana().current();
+            return Models.CharacterStats.getMana().orElse(CappedValue.EMPTY).current();
         }
     }
 
     public static class ManaMaxFunction extends Function<Integer> {
         @Override
         public Integer getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getMana().max();
+            return Models.CharacterStats.getMana().orElse(CappedValue.EMPTY).max();
         }
     }
 
     public static class HealthFunction extends Function<Integer> {
         @Override
         public Integer getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getHealth().current();
+            return Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY).current();
         }
     }
 
     public static class HealthMaxFunction extends Function<Integer> {
         @Override
         public Integer getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getHealth().max();
+            return Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY).max();
         }
     }
 
     public static class HealthPctFunction extends Function<Double> {
         @Override
         public Double getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getHealth().getPercentage();
+            return Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY).getPercentage();
         }
     }
 
     public static class ManaPctFunction extends Function<Double> {
         @Override
         public Double getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getMana().getPercentage();
+            return Models.CharacterStats.getMana().orElse(CappedValue.EMPTY).getPercentage();
         }
     }
 
@@ -264,7 +264,7 @@ public class CharacterFunctions {
     public static class CommanderActivatedFunction extends Function<Boolean> {
         @Override
         public Boolean getValue(FunctionArguments arguments) {
-            return Models.Ability.commanderBar.isActive() ? Models.Ability.commanderBar.isActivated() : false;
+            return Models.Ability.commanderBar.isActive() && Models.Ability.commanderBar.isActivated();
         }
     }
 }

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -173,20 +173,24 @@ public final class CharacterStatsModel extends Model {
         return level;
     }
 
-    public CappedValue getHealth() {
-        return health;
+    public Optional<CappedValue> getHealth() {
+        if (health == CappedValue.EMPTY) return Optional.empty();
+        return Optional.of(health);
     }
 
-    public CappedValue getMana() {
-        return mana;
+    public Optional<CappedValue> getMana() {
+        if (mana == CappedValue.EMPTY) return Optional.empty();
+        return Optional.of(mana);
     }
 
-    public CappedValue getSprint() {
-        return sprint;
+    public Optional<CappedValue> getSprint() {
+        if (sprint == CappedValue.EMPTY) return Optional.empty();
+        return Optional.of(sprint);
     }
 
-    public PowderSpecialInfo getPowderSpecialInfo() {
-        return powderSpecialInfo;
+    public Optional<PowderSpecialInfo> getPowderSpecialInfo() {
+        if (powderSpecialInfo == PowderSpecialInfo.EMPTY) return Optional.empty();
+        return Optional.of(powderSpecialInfo);
     }
 
     public void setHideHealth(boolean shouldHide) {

--- a/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
@@ -26,6 +26,7 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.wynn.ItemUtils;
+import java.util.Optional;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -60,12 +61,15 @@ public class PowderSpecialBarOverlay extends Overlay {
     @Override
     public void render(
             GuiGraphics guiGraphics, MultiBufferSource bufferSource, DeltaTracker deltaTracker, Window window) {
-        PowderSpecialInfo powderSpecialInfo = Models.CharacterStats.getPowderSpecialInfo();
-        if (this.onlyIfWeaponHeld.get()
-                && !ItemUtils.isWeapon(McUtils.inventory().getSelected())) return;
-        if (this.hideIfNoCharge.get()
-                && (powderSpecialInfo == PowderSpecialInfo.EMPTY || powderSpecialInfo.charge() == 0f)) return;
+        Optional<PowderSpecialInfo> powderSpecialInfoOpt = Models.CharacterStats.getPowderSpecialInfo();
+        if (this.hideIfNoCharge.get() && powderSpecialInfoOpt.isEmpty()) return;
 
+        if (this.onlyIfWeaponHeld.get()
+                && !ItemUtils.isWeapon(McUtils.inventory().getSelected())) {
+            return;
+        }
+
+        PowderSpecialInfo powderSpecialInfo = powderSpecialInfoOpt.get();
         renderWithSpecificSpecial(
                 guiGraphics.pose(), bufferSource, powderSpecialInfo.charge() * 100f, powderSpecialInfo.powder());
     }

--- a/common/src/main/java/com/wynntils/overlays/gamebars/HealthBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/HealthBarOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays.gamebars;
@@ -51,7 +51,7 @@ public class HealthBarOverlay extends OverflowableBarOverlay {
 
     @Override
     public boolean isActive() {
-        return Models.CharacterStats.getHealth() != CappedValue.EMPTY;
+        return Models.CharacterStats.getHealth().isPresent();
     }
 
     @Override
@@ -61,7 +61,7 @@ public class HealthBarOverlay extends OverflowableBarOverlay {
 
     @Override
     public BossBarProgress progress() {
-        CappedValue health = Models.CharacterStats.getHealth();
+        CappedValue health = Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY);
         return new BossBarProgress(health, (float) health.getProgress());
     }
 

--- a/common/src/main/java/com/wynntils/overlays/gamebars/ManaBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/ManaBarOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays.gamebars;
@@ -46,7 +46,7 @@ public class ManaBarOverlay extends OverflowableBarOverlay {
 
     @Override
     public BossBarProgress progress() {
-        CappedValue mana = Models.CharacterStats.getMana();
+        CappedValue mana = Models.CharacterStats.getMana().orElse(CappedValue.EMPTY);
         return new BossBarProgress(mana, (float) mana.getProgress());
     }
 
@@ -62,7 +62,7 @@ public class ManaBarOverlay extends OverflowableBarOverlay {
 
     @Override
     public boolean isActive() {
-        return Models.CharacterStats.getMana() != CappedValue.EMPTY;
+        return Models.CharacterStats.getMana().isPresent();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/hades/HadesService.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.hades;
@@ -28,6 +28,7 @@ import com.wynntils.services.athena.event.AthenaLoginEvent;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.services.hades.type.PlayerStatus;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.type.CappedValue;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -214,8 +215,12 @@ public final class HadesService extends Service {
             float pY = (float) player.getY();
             float pZ = (float) player.getZ();
 
-            PlayerStatus newStatus =
-                    new PlayerStatus(pX, pY, pZ, Models.CharacterStats.getHealth(), Models.CharacterStats.getMana());
+            PlayerStatus newStatus = new PlayerStatus(
+                    pX,
+                    pY,
+                    pZ,
+                    Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY),
+                    Models.CharacterStats.getMana().orElse(CappedValue.EMPTY));
 
             if (newStatus.equals(lastSentStatus)) {
                 tickCountUntilUpdate = 1;


### PR DESCRIPTION
Although `CappedValue` does have an "EMPTY" state as a singleton, changing the method signature to use Optionals forces the consumers to handle edge cases, whereas before, they could just ignore them.