### PR TITLE
feat: Parse Wynncraft version [skip ci]

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -9,11 +9,18 @@ import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.mc.event.PlayerInfoEvent.PlayerDisplayNameChangeEvent;
 import com.wynntils.mc.event.PlayerInfoEvent.PlayerLogOutEvent;
 import com.wynntils.mc.event.PlayerInfoFooterChangedEvent;
 import com.wynntils.mc.event.PlayerTeleportEvent;
+import com.wynntils.models.worlds.actionbar.matchers.CharacterCreationSegmentMatcher;
+import com.wynntils.models.worlds.actionbar.matchers.CharacterSelectionSegmentMatcher;
+import com.wynntils.models.worlds.actionbar.matchers.WynncraftVersionSegmentMatcher;
+import com.wynntils.models.worlds.actionbar.segments.CharacterCreationSegment;
+import com.wynntils.models.worlds.actionbar.segments.CharacterSelectionSegment;
+import com.wynntils.models.worlds.actionbar.segments.WynncraftVersionSegment;
 import com.wynntils.models.worlds.bossbars.SkipCutsceneBar;
 import com.wynntils.models.worlds.event.CutsceneStartedEvent;
 import com.wynntils.models.worlds.event.StreamModeEvent;
@@ -21,6 +28,7 @@ import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.CutsceneState;
 import com.wynntils.models.worlds.type.ServerRegion;
 import com.wynntils.models.worlds.type.WorldState;
+import com.wynntils.models.worlds.type.WynncraftVersion;
 import com.wynntils.utils.mc.PosUtils;
 import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.List;
@@ -55,10 +63,14 @@ public final class WorldStateModel extends Model {
     private boolean hasJoinedAnyWorld = false;
     private boolean inStream = false;
     private boolean onHousing = false;
+    private WynncraftVersion worldVersion = null;
 
     public WorldStateModel() {
         super(List.of());
 
+        Handlers.ActionBar.registerSegment(new CharacterCreationSegmentMatcher());
+        Handlers.ActionBar.registerSegment(new CharacterSelectionSegmentMatcher());
+        Handlers.ActionBar.registerSegment(new WynncraftVersionSegmentMatcher());
         Handlers.BossBar.registerBar(skipCutsceneBar);
     }
 
@@ -78,6 +90,10 @@ public final class WorldStateModel extends Model {
 
     public boolean isOnBetaServer() {
         return onBetaServer;
+    }
+
+    public WynncraftVersion getWorldVersion() {
+        return worldVersion;
     }
 
     public WorldState getCurrentState() {
@@ -177,6 +193,25 @@ public final class WorldStateModel extends Model {
     }
 
     @SubscribeEvent
+    public void onActionBarUpdate(ActionBarUpdatedEvent event) {
+        event.runIfPresent(CharacterCreationSegment.class, this::onCharacterCreation);
+        event.runIfPresent(CharacterSelectionSegment.class, this::onCharacterSelection);
+        event.runIfPresent(WynncraftVersionSegment.class, this::setWorldVersion);
+    }
+
+    private void onCharacterCreation(CharacterCreationSegment segment) {
+        setState(WorldState.CHARACTER_SELECTION);
+    }
+
+    private void onCharacterSelection(CharacterSelectionSegment segment) {
+        setState(WorldState.CHARACTER_SELECTION);
+    }
+
+    private void setWorldVersion(WynncraftVersionSegment segment) {
+        worldVersion = segment.getWynncraftVersion();
+    }
+
+    @SubscribeEvent
     public void update(PlayerDisplayNameChangeEvent e) {
         if (!e.getId().equals(WORLD_NAME_UUID)) return;
         if (inStream) return;
@@ -222,10 +257,6 @@ public final class WorldStateModel extends Model {
 
     public void cutsceneEnded() {
         cutsceneState = CutsceneState.NOT_IN_CUTSCENE;
-    }
-
-    public void onCharacterSelection() {
-        setState(WorldState.CHARACTER_SELECTION);
     }
 
     /**

--- a/common/src/main/java/com/wynntils/models/worlds/actionbar/matchers/CharacterCreationSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/worlds/actionbar/matchers/CharacterCreationSegmentMatcher.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.actionbar.matchers;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
+import com.wynntils.models.worlds.actionbar.segments.CharacterCreationSegment;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CharacterCreationSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern CHARACTER_CREATION_PATTERN = Pattern.compile(
+            "\uE000 Left-Click to select          \uE002 Scroll up/down to browse          \uE001 Right-Click to return");
+
+    @Override
+    public ActionBarSegment parse(String actionBar) {
+        Matcher matcher = CHARACTER_CREATION_PATTERN.matcher(actionBar);
+        if (!matcher.find()) return null;
+
+        return new CharacterCreationSegment(actionBar);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/actionbar/matchers/CharacterSelectionSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/worlds/actionbar/matchers/CharacterSelectionSegmentMatcher.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.actionbar.matchers;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
+import com.wynntils.models.worlds.actionbar.segments.CharacterSelectionSegment;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CharacterSelectionSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern CHARACTER_CREATION_PATTERN =
+            Pattern.compile("\uE000 Left-Click to play                     \uE001 Right-Click to switch");
+
+    @Override
+    public ActionBarSegment parse(String actionBar) {
+        Matcher matcher = CHARACTER_CREATION_PATTERN.matcher(actionBar);
+        if (!matcher.find()) return null;
+
+        return new CharacterSelectionSegment(actionBar);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/actionbar/matchers/WynncraftVersionSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/worlds/actionbar/matchers/WynncraftVersionSegmentMatcher.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.actionbar.matchers;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
+import com.wynntils.models.worlds.actionbar.segments.WynncraftVersionSegment;
+import com.wynntils.models.worlds.type.WynncraftVersion;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WynncraftVersionSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern VERSION_PATTERN = Pattern.compile(
+            "§8(DEV|v(?<versiongroup>\\d+)\\.(?<majorversion>\\d+)\\.(?<minorversion>\\d+)_(?<revision>\\d+)(?<beta> BETA)?)");
+
+    @Override
+    public ActionBarSegment parse(String actionBar) {
+        Matcher matcher = VERSION_PATTERN.matcher(actionBar);
+        if (!matcher.find()) return null;
+
+        return new WynncraftVersionSegment(
+                actionBar,
+                new WynncraftVersion(
+                        matcher.group("versiongroup"),
+                        matcher.group("majorversion"),
+                        matcher.group("minorversion"),
+                        matcher.group("revision"),
+                        matcher.group("beta") != null));
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/actionbar/segments/CharacterCreationSegment.java
+++ b/common/src/main/java/com/wynntils/models/worlds/actionbar/segments/CharacterCreationSegment.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.actionbar.segments;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+
+public class CharacterCreationSegment extends ActionBarSegment {
+    public CharacterCreationSegment(String segmentText) {
+        super(segmentText);
+    }
+
+    @Override
+    public String toString() {
+        return "CharacterCreationSegment{" + "segmentText='" + segmentText + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/actionbar/segments/CharacterSelectionSegment.java
+++ b/common/src/main/java/com/wynntils/models/worlds/actionbar/segments/CharacterSelectionSegment.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.actionbar.segments;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+
+public class CharacterSelectionSegment extends ActionBarSegment {
+    public CharacterSelectionSegment(String segmentText) {
+        super(segmentText);
+    }
+
+    @Override
+    public String toString() {
+        return "CharacterSelectionSegment{" + "segmentText='" + segmentText + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/actionbar/segments/WynncraftVersionSegment.java
+++ b/common/src/main/java/com/wynntils/models/worlds/actionbar/segments/WynncraftVersionSegment.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.actionbar.segments;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.models.worlds.type.WynncraftVersion;
+
+public class WynncraftVersionSegment extends ActionBarSegment {
+    private final WynncraftVersion wynncraftVersion;
+
+    public WynncraftVersionSegment(String segmentText, WynncraftVersion wynncraftVersion) {
+        super(segmentText);
+        this.wynncraftVersion = wynncraftVersion;
+    }
+
+    public WynncraftVersion getWynncraftVersion() {
+        return wynncraftVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "WynncraftVersionSegment{" + "wynncraftVersion='"
+                + wynncraftVersion + '\'' + ", segmentText='"
+                + segmentText + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/type/WynncraftVersion.java
+++ b/common/src/main/java/com/wynntils/models/worlds/type/WynncraftVersion.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.worlds.type;
+
+public record WynncraftVersion(
+        String versionGroup, String majorVersion, String minorVersion, String revision, boolean isBeta) {
+    @Override
+    public String toString() {
+        return "v" + versionGroup + "." + majorVersion + "." + minorVersion + "_" + revision + (isBeta ? " BETA" : "");
+    }
+}


### PR DESCRIPTION
Not currently used but soon we'll have a system for checking compatibility between Wynntils and Wynncraft versions and take actions depending on compatibility.

The schema given for versioning was `2.{majorUpdate}.{minorUpdate}_{revision}` so little weird that the 2 isn't major, had to just give it the "versionGroup" name but not a huge fan of that name