### PR TITLE
ci: Rework release workflows to use manually set changelog

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
       - beta
+    paths:
+      - 'CHANGELOG.md'
 
 jobs:
-  changelog:
-    name: Generate Changelog
+  set-version:
+    name: Set Version
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.changelog.outputs.tag }}
-      skipped: ${{ steps.changelog.outputs.skipped }}
-      clean_changelog: ${{ steps.changelog.outputs.clean_changelog }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
+      tag: ${{ steps.version.outputs.tag }}
+      skipped: ${{ steps.version.outputs.skipped }}
+      changelog: ${{ steps.version.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,9 +31,9 @@ jobs:
       - name: Set up version.json
         run: echo "{"version":$(git describe --tags --abbrev=0)}" > version.json
 
-      - name: Create changelog
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@v5.2.1
+      - name: Generate version tag
+        id: version
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           github-token: ${{ secrets.PRIVATE_TOKEN }}
           git-user-name: 'WynntilsBot'
@@ -45,6 +46,7 @@ jobs:
           pre-release: true
           pre-release-identifier: beta
           release-count: 5
+          output-file: false
 
       - name: Upload version information
         uses: actions/upload-artifact@v4
@@ -55,7 +57,7 @@ jobs:
 
   build:
     name: Build
-    needs: [ changelog ] # Build needs the new version number
+    needs: [ set-version ] # Build needs the new version number
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -97,38 +99,126 @@ jobs:
     name: Release to Github
     if: ${{ needs.changelog.outputs.skipped != 'true' }}
     runs-on: ubuntu-latest
-    needs: [ build, changelog ]
+    needs: [ build, set-version ]
     steps:
-      - name: Download build
+      - name: Checkout beta branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          ref: beta
+
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build
 
-      - name: Create release and upload files
-        if: ${{ needs.changelog.outputs.skipped != 'true' }}
+      - name: Get previous and current versions
+        id: versions
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
+          echo "previous=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "current=${{ needs.set-version.outputs.tag }}" >> $GITHUB_OUTPUT
+
+      - name: Get current date
+        id: date
+        run: |
+          echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "long=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
+
+      - name: Build GitHub release body
+        id: build_release_body
+        run: |
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "## [${{ steps.versions.outputs.current }}](https://github.com/Wynntils/Wynntils/compare/${{ steps.versions.outputs.previous }}...${{ steps.versions.outputs.current }}) (${{ steps.date.outputs.today }})" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          cat CHANGELOG.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub release
         id: release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.changelog.outputs.tag }}
-          body: ${{ needs.changelog.outputs.changelog }}
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          tag_name: ${{ needs.set-version.outputs.tag }}
+          body: ${{ steps.build_release_body.outputs.content }}
           draft: false
           prerelease: true
           files: |
             **/build/libs/*-fabric+MC-*.jar
             **/build/libs/*-neoforge+MC-*.jar
 
-      - name: Set current date
-        id: date
+      - name: Generate artifact links
+        id: artifact_links
         run: |
-          echo "::set-output name=short::$(date +'%Y-%m-%d')"
-          echo "::set-output name=long::$(date +'%Y-%m-%d %H:%M')"
+          TAG=${{ needs.set-version.outputs.tag }}
+          BASE_URL="https://github.com/Wynntils/Wynntils/releases/download/$TAG"
+
+          FILES=$(find . -path "*/build/libs/*-fabric+MC-*.jar" -or -path "*/build/libs/*-neoforge+MC-*.jar")
+
+          {
+            echo "links<<EOF"
+            for f in $FILES; do
+              NAME=$(basename "$f")
+              URL="$BASE_URL/${NAME//+/%2B}"
+              echo "- [$NAME]($URL)"
+            done
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Post release on Discord
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           embed-color: "9498256"
-          embed-title: ${{format('Wynntils {0}', needs.changelog.outputs.tag)}}
-          embed-description: ${{ needs.changelog.outputs.changelog }}
-          embed-url: ${{ steps.release.outputs.url }}
+          embed-title: ${{ format('Wynntils {0}', needs.set-version.outputs.tag) }}
+          embed-url: https://github.com/Wynntils/Wynntils/releases/tag/${{ needs.set-version.outputs.tag }}
+          embed-description: |
+            ## [${{ steps.versions.outputs.current }}](https://github.com/Wynntils/Wynntils/compare/${{ steps.versions.outputs.previous }}...${{ steps.versions.outputs.current }}) (${{ steps.date.outputs.today }})
+            
+            **Download Links**
+            ${{ steps.artifact_links.outputs.links }}
           embed-timestamp: ${{ steps.date.outputs.long }}
+
+      - name: Post changelog on Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_NOTES_WEBHOOK_URL }}
+        run: |
+          VERSION="${{ needs.set-version.outputs.tag }}"
+          TITLE="# Wynntils ${VERSION} Changelog"
+
+          # Combine title and changelog with proper newlines
+          FULL_CHANGELOG="$TITLE"$'\n\n'"$(cat CHANGELOG.md)"
+
+          # Function to post each chunk
+          post_chunk() {
+            jq -Rs '{content: .}' <<< "$1" | \
+              curl -s -X POST -H "Content-Type: application/json" \
+              -d @- "$WEBHOOK_URL"
+          }
+
+          # Split changelog by newline into array
+          mapfile -t lines <<< "$FULL_CHANGELOG"
+
+          chunk=""
+          chunk_bytes=0
+          max_bytes=1900
+
+          for line in "${lines[@]}"; do
+            # +1 for newline character
+            line_bytes=$(printf "%s\n" "$line" | wc -c)
+
+            if (( chunk_bytes + line_bytes > max_bytes )); then
+              post_chunk "$chunk"
+              chunk=""
+              chunk_bytes=0
+            fi
+
+            chunk+=$'\n'"$line"
+            ((chunk_bytes += line_bytes))
+          done
+
+          # Post final chunk if exists
+          if [[ -n "$chunk" ]]; then
+            post_chunk "$chunk"
+          fi

--- a/.github/workflows/promote-to-beta.yml
+++ b/.github/workflows/promote-to-beta.yml
@@ -25,3 +25,32 @@ jobs:
           github_token: ${{ secrets.PRIVATE_TOKEN }}
           source: 'development'
           target: 'beta'
+
+  clear-changelog:
+    needs: promote-beta
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout beta branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          ref: beta
+
+      - name: Clear Changelog File
+        run: echo "" > CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          commit-message: "chore: Clear changelog"
+          title: "chore: Set changelog for new beta release"
+          body: |
+            This PR resets the `CHANGELOG.md` file to prepare a new beta release.
+            Edit the file with the relevant release notes for the beta release.
+            
+            It is automatically generated and targets the `beta` branch.
+          branch: set-beta-changelog
+          base: beta
+          labels: auto-generated
+          committer: WynntilsBot <admin@wynntils.com>

--- a/.github/workflows/promote-to-release.yml
+++ b/.github/workflows/promote-to-release.yml
@@ -25,3 +25,32 @@ jobs:
           github_token: ${{ secrets.PRIVATE_TOKEN }}
           source: 'main'
           target: 'release'
+
+  clear-changelog:
+    needs: promote-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          ref: release
+
+      - name: Clear Changelog File
+        run: echo "" > CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          commit-message: "chore: Clear changelog"
+          title: "chore: Set changelog for new release"
+          body: |
+            This PR resets the `CHANGELOG.md` file to prepare a new release.
+            Edit the file with the relevant release notes for the release.
+            
+            It is automatically generated and targets the `release` branch.
+          branch: set-changelog
+          base: release
+          labels: auto-generated
+          committer: WynntilsBot <admin@wynntils.com>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
       - release
+    paths:
+      - 'CHANGELOG.md'
 
 jobs:
-  changelog:
-    name: Generate Changelog
+  set-version:
+    name: Set Version
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.changelog.outputs.tag }}
-      skipped: ${{ steps.changelog.outputs.skipped }}
-      clean_changelog: ${{ steps.changelog.outputs.clean_changelog }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
+      tag: ${{ steps.version.outputs.tag }}
+      skipped: ${{ steps.version.outputs.skipped }}
+      changelog: ${{ steps.version.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,9 +31,9 @@ jobs:
       - name: Set up version.json
         run: echo "{"version":$(git describe --tags --abbrev=0)}" > version.json
 
-      - name: Create changelog
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@v5.2.1
+      - name: Generate version tag
+        id: version
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           github-token: ${{ secrets.PRIVATE_TOKEN }}
           git-user-name: 'WynntilsBot'
@@ -44,6 +45,7 @@ jobs:
           skip-git-pull: true
           pre-release: false
           release-count: 5
+          output-file: false
 
       - name: Upload version information
         uses: actions/upload-artifact@v4
@@ -53,7 +55,7 @@ jobs:
 
   build:
     name: Build
-    needs: [changelog] # Build needs the new version number
+    needs: [ set-version ] # Build needs the new version number
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -92,58 +94,153 @@ jobs:
           overwrite: true
 
   release-github:
-    name: Release to Github
-    if: ${{ needs.changelog.outputs.skipped != 'true' }}
+    name: Release to GitHub
+    if: ${{ needs.set-version.outputs.skipped != 'true' }}
     runs-on: ubuntu-latest
-    needs: [ build, changelog ]
+    needs: [ build, set-version ]
     steps:
-      - name: Download build
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          ref: release
+
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build
 
-      - name: Create release and upload files
-        if: ${{ needs.changelog.outputs.skipped != 'true' }}
+      - name: Get previous and current versions
+        id: versions
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
+          echo "previous=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "current=${{ needs.set-version.outputs.tag }}" >> $GITHUB_OUTPUT
+
+      - name: Get current date
+        id: date
+        run: |
+          echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "long=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
+
+      - name: Build GitHub release body
+        id: build_release_body
+        run: |
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "## [${{ steps.versions.outputs.current }}](https://github.com/Wynntils/Wynntils/compare/${{ steps.versions.outputs.previous }}...${{ steps.versions.outputs.current }}) (${{ steps.date.outputs.today }})" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          cat CHANGELOG.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub release
         id: release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.changelog.outputs.tag }}
-          body: ${{ needs.changelog.outputs.changelog }}
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          tag_name: ${{ needs.set-version.outputs.tag }}
+          body: ${{ steps.build_release_body.outputs.content }}
           draft: false
           prerelease: false
           files: |
             **/build/libs/*-fabric+MC-*.jar
             **/build/libs/*-neoforge+MC-*.jar
 
-      - name: Set current date
-        id: date
+      - name: Generate artifact links
+        id: artifact_links
         run: |
-          echo "::set-output name=short::$(date +'%Y-%m-%d')"
-          echo "::set-output name=long::$(date +'%Y-%m-%d %H:%M')"
-            
+          TAG=${{ needs.set-version.outputs.tag }}
+          BASE_URL="https://github.com/Wynntils/Wynntils/releases/download/$TAG"
+
+          FILES=$(find . -path "*/build/libs/*-fabric+MC-*.jar" -or -path "*/build/libs/*-neoforge+MC-*.jar")
+
+          {
+            echo "links<<EOF"
+            for f in $FILES; do
+              NAME=$(basename "$f")
+              URL="$BASE_URL/${NAME//+/%2B}"
+              echo "- [$NAME]($URL)"
+            done
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Post release on Discord
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           embed-color: "9498256"
-          embed-title: ${{format('Wynntils {0}', needs.changelog.outputs.tag)}}
-          embed-description: ${{ needs.changelog.outputs.changelog }}
-          embed-url: ${{ steps.release.outputs.url }}
+          embed-title: ${{ format('Wynntils {0}', needs.set-version.outputs.tag) }}
+          embed-url: https://github.com/Wynntils/Wynntils/releases/tag/${{ needs.set-version.outputs.tag }}
+          embed-description: |
+            ## [${{ steps.versions.outputs.current }}](https://github.com/Wynntils/Wynntils/compare/${{ steps.versions.outputs.previous }}...${{ steps.versions.outputs.current }}) (${{ steps.date.outputs.today }})
+            
+            **Download Links**
+            ${{ steps.artifact_links.outputs.links }}
           embed-timestamp: ${{ steps.date.outputs.long }}
+
+      - name: Post changelog on Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_NOTES_WEBHOOK_URL }}
+        run: |
+          VERSION="${{ needs.set-version.outputs.tag }}"
+          TITLE="# Wynntils ${VERSION} Changelog"
+
+          # Combine title and changelog with proper newlines
+          FULL_CHANGELOG="$TITLE"$'\n\n'"$(cat CHANGELOG.md)"
+
+          # Function to post each chunk
+          post_chunk() {
+            jq -Rs '{content: .}' <<< "$1" | \
+              curl -s -X POST -H "Content-Type: application/json" \
+              -d @- "$WEBHOOK_URL"
+          }
+
+          # Split changelog by newline into array
+          mapfile -t lines <<< "$FULL_CHANGELOG"
+
+          chunk=""
+          chunk_bytes=0
+          max_bytes=1900
+
+          for line in "${lines[@]}"; do
+            # +1 for newline character
+            line_bytes=$(printf "%s\n" "$line" | wc -c)
+
+            if (( chunk_bytes + line_bytes > max_bytes )); then
+              post_chunk "$chunk"
+              chunk=""
+              chunk_bytes=0
+            fi
+
+            chunk+=$'\n'"$line"
+            ((chunk_bytes += line_bytes))
+          done
+
+          # Post final chunk if exists
+          if [[ -n "$chunk" ]]; then
+            post_chunk "$chunk"
+          fi
 
   release-external:
     name: Release to Modrinth and CurseForge
-    if: ${{ needs.changelog.outputs.skipped != 'true' }}
+    if: ${{ needs.set-version.outputs.skipped != 'true' }}
     strategy:
       matrix:
         modloader: [fabric, neoforge]
     runs-on: ubuntu-latest
-    needs: [build, changelog]
+    needs: [build, set-version]
     steps:
       - name: Download build
         uses: actions/download-artifact@v4
         with:
           name: build
+
+      - name: Read raw changelog
+        id: changelog
+        run: |
+          echo "raw<<EOF" >> $GITHUB_OUTPUT
+          cat CHANGELOG.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - uses: Kir-Antipov/mc-publish@v3.3.0
         with:
@@ -157,11 +254,11 @@ jobs:
 
           files: "**/build/libs/*-${{ matrix.modloader }}*.jar"
 
-          name: Wynntils (${{ matrix.modloader }}) ${{ needs.changelog.outputs.tag }}
-          version: ${{ needs.changelog.outputs.tag }}
+          name: Wynntils (${{ matrix.modloader }}) ${{ needs.set-version.outputs.tag }}
+          version: ${{ needs.set-version.outputs.tag }}
           version-type: release
           game-versions: 1.21.4
-          changelog: ${{ needs.changelog.outputs.changelog }}
+          changelog: ${{ steps.changelog.outputs.raw }}
 
           loaders: ${{ matrix.modloader }}
           java: 21


### PR DESCRIPTION
Closes #3233 

We will need a new secret `DISCORD_RELEASE_NOTES_WEBHOOK_URL` for posting in the #release-notes channel on Discord.

I tested this a decent amount (probably too much) and I'm reasonably confident it will work, haven't really worked with workflows that much so it might be quite messy. The only part untested is the Modrinth/Curseforge upload which for obvious reason I cannot test.

The only part I'm not a particular fan of is the posting release notes to Discord, since those messages have to be split to fit the character limit but it does work.

As for how we do releases now, normal prs are the same as normal, except no more [skip ci] and the pr we want to trigger a release from will need the "release" label applied thanks to https://github.com/Wynntils/Wynntils/pull/3283. Once the branch promotion is finished a pr will be opened clearing the existing `CHANGELOG.md` file, from here we will set whatever changelog we want, merge that and then the release happens as normal. We still use conventional commits for version handling we just don't make it save the changelog anymore

![image](https://github.com/user-attachments/assets/1390880f-1f3a-475f-afe6-6f5420a2f1f1)
Poorly stitched together changelog
![changelog](https://github.com/user-attachments/assets/7e391c52-d4d9-4d78-be2f-ec18756b43af)
