### PR TITLE
feat: Make WrappedScreens closable by pressing E

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -133,7 +133,15 @@ public abstract class WynntilsScreen extends Screen implements TextboxScreen {
             }
         }
 
-        return (getFocusedTextInput() != null && getFocusedTextInput().keyPressed(keyCode, scanCode, modifiers))
-                || super.keyPressed(keyCode, scanCode, modifiers);
+        if (getFocusedTextInput() != null) {
+            return getFocusedTextInput().keyPressed(keyCode, scanCode, modifiers);
+        }
+        
+        if (keyCode == GLFW.GLFW_KEY_E) {
+            this.onClose();
+            return true;
+        }
+
+        return super.keyPressed(keyCode, scanCode, modifiers);
     }
 }

--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -6,6 +6,7 @@ package com.wynntils.core.consumers.screens;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.mod.type.CrashType;
+import com.wynntils.handlers.wrappedscreen.WrappedScreen;
 import com.wynntils.screens.base.TextboxScreen;
 import com.wynntils.screens.base.widgets.TextInputBoxWidget;
 import com.wynntils.utils.mc.McUtils;
@@ -137,7 +138,7 @@ public abstract class WynntilsScreen extends Screen implements TextboxScreen {
             return getFocusedTextInput().keyPressed(keyCode, scanCode, modifiers);
         }
 
-        if (this.minecraft.options.keyInventory.matches(keyCode, scanCode)) {
+        if (this instanceof WrappedScreen && this.minecraft.options.keyInventory.matches(keyCode, scanCode)) {
             this.onClose();
             return true;
         }

--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -137,7 +137,7 @@ public abstract class WynntilsScreen extends Screen implements TextboxScreen {
             return getFocusedTextInput().keyPressed(keyCode, scanCode, modifiers);
         }
 
-        if (keyCode == GLFW.GLFW_KEY_E) {
+        if (this.minecraft.options.keyInventory.matches(keyCode, scanCode)) {
             this.onClose();
             return true;
         }

--- a/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
+++ b/common/src/main/java/com/wynntils/core/consumers/screens/WynntilsScreen.java
@@ -136,7 +136,7 @@ public abstract class WynntilsScreen extends Screen implements TextboxScreen {
         if (getFocusedTextInput() != null) {
             return getFocusedTextInput().keyPressed(keyCode, scanCode, modifiers);
         }
-        
+
         if (keyCode == GLFW.GLFW_KEY_E) {
             this.onClose();
             return true;


### PR DESCRIPTION
This makes WynntilsScreen and all of its subclasses be closable by pressing E on your keyboard. This mirrors WynntilsContainerScreen which inherits this behaviour, while WynntilsScreen does not.