### PR TITLE
fix: Fix crash when hide if no charge disabled

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
@@ -73,7 +73,7 @@ public class PowderSpecialBarOverlay extends Overlay {
             return;
         }
 
-        PowderSpecialInfo powderSpecialInfo = powderSpecialInfoOpt.get();
+        PowderSpecialInfo powderSpecialInfo = powderSpecialInfoOpt.orElse(PowderSpecialInfo.EMPTY);
         renderWithSpecificSpecial(
                 guiGraphics.pose(), bufferSource, powderSpecialInfo.charge() * 100f, powderSpecialInfo.powder());
     }

--- a/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
+++ b/common/src/main/java/com/wynntils/utils/render/RenderUtils.java
@@ -824,6 +824,8 @@ public final class RenderUtils {
     }
 
     public static void disableScissor(GuiGraphics guiGraphics) {
+        if (guiGraphics.scissorStack.stack.isEmpty()) return;
+
         guiGraphics.disableScissor();
     }
 

--- a/common/src/main/resources/wynntils.accessWidener
+++ b/common/src/main/resources/wynntils.accessWidener
@@ -14,6 +14,8 @@ accessible field net/minecraft/client/OptionInstance value Ljava/lang/Object;
 accessible field net/minecraft/client/gui/Gui CROSSHAIR_SPRITE Lnet/minecraft/resources/ResourceLocation;
 accessible field net/minecraft/client/gui/Gui chat Lnet/minecraft/client/gui/components/ChatComponent;
 accessible field net/minecraft/client/gui/GuiGraphics bufferSource Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;
+accessible field net/minecraft/client/gui/GuiGraphics scissorStack Lnet/minecraft/client/gui/GuiGraphics$ScissorStack;
+accessible field net/minecraft/client/gui/GuiGraphics$ScissorStack stack Ljava/util/Deque;
 accessible field net/minecraft/client/gui/components/AbstractSelectionList hovered Lnet/minecraft/client/gui/components/AbstractSelectionList$Entry;
 accessible field net/minecraft/client/gui/components/BossHealthOverlay events Ljava/util/Map;
 accessible field net/minecraft/client/gui/components/PlayerTabOverlay visible Z


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Wynntils/issues/3312

`GuiGraphics#disableScissor` throws an exception if there is no scissor active and we always disable it on overlay crash (as minimap can use it) so the overlay crash handling got cancelled since the exception was thrown before it