### PR TITLE
fix: Fix chat being cleared on config reload when chat tabs disabled

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -196,6 +196,8 @@ public class ChatTabsFeature extends Feature {
 
     @Override
     protected void onConfigUpdate(Config<?> config) {
+        if (!isEnabled()) return;
+
         Services.ChatTab.refocusFirstTab();
 
         if ((McUtils.mc().screen instanceof ChatScreen chatScreen)) {


### PR DESCRIPTION
If you have chat tabs disabled, the first time you exit the settings screen and trigger a config reload it will clear chat regardless of whether anything was edited.

I don't think this introduces any new issues with chat tabs but I only use them to mute shouts so not much experience using them