### PR TITLE
fix: Fix NPE when previewing overlays

### DIFF
--- a/common/src/main/java/com/wynntils/screens/overlays/selection/OverlaySelectionScreen.java
+++ b/common/src/main/java/com/wynntils/screens/overlays/selection/OverlaySelectionScreen.java
@@ -213,6 +213,11 @@ public final class OverlaySelectionScreen extends WynntilsScreen {
 
             renderTooltips(guiGraphics, mouseX, mouseY);
         } else {
+            if (selectedOverlay == null) {
+                renderPreview = false;
+                return;
+            }
+
             renderOverlaysCheckbox.render(guiGraphics, mouseX, mouseY, partialTick);
             exitPreviewButton.render(guiGraphics, mouseX, mouseY, partialTick);
 


### PR DESCRIPTION
Fixes an Athena crash report that has been occuring for a few months but every time I look into it I cannot figure out the steps to replicate it, as far as I can tell this should be impossible but clearly it isn't.

It's not a very nice fix but without being able to replicate it I can't find the problem in the logic