### PR TITLE
feat: Improvements to on world join container queries

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -40,7 +40,8 @@ public final class ActionBarHandler extends Handler {
     @SubscribeEvent
     public void onActionBarUpdate(ChatPacketReceivedEvent.GameInfo event) {
         // FIXME: Reverse dependency!
-        if (Models.WorldState.onWorld()) {
+        WorldState currentState = Models.WorldState.getCurrentState();
+        if (currentState == WorldState.WORLD) {
             StyledText packetText = StyledText.fromComponent(event.getMessage());
 
             // Separate the action bar text from the coordinates
@@ -82,7 +83,7 @@ public final class ActionBarHandler extends Handler {
             }
 
             event.setMessage(renderedText.getComponent());
-        } else if (Models.WorldState.getCurrentState() == WorldState.INTERIM) {
+        } else if (currentState == WorldState.INTERIM || currentState == WorldState.CHARACTER_SELECTION) {
             StyledText packetText = StyledText.fromComponent(event.getMessage());
 
             // We can't do any filtering by font here as whilst the navigation text font is always the same, the version

--- a/common/src/main/java/com/wynntils/models/account/AccountModel.java
+++ b/common/src/main/java/com/wynntils/models/account/AccountModel.java
@@ -100,6 +100,7 @@ public final class AccountModel extends Model {
         } else {
             WynntilsMod.info("Skipping silverbull subscription query ("
                     + (silverbullExpiresAt.get() - System.currentTimeMillis()) + " ms left)");
+            return;
         }
 
         queryBuilder.build().executeQuery();

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -133,7 +133,12 @@ public final class CharacterModel extends Model {
     public void handleSelectedCharacter(ItemStack itemStack) {
         if (!parseCharacter(itemStack)) return;
         hasCharacter = true;
-        WynntilsMod.postEvent(new CharacterUpdateEvent());
+        WynntilsMod.info("Selected character " + getCharacterString());
+    }
+
+    public void setSelectedCharacterFromCharacterSelection(ClassType classType, boolean isReskinned, int level) {
+        hasCharacter = true;
+        updateCharacterInfo(classType, isReskinned, level);
         WynntilsMod.info("Selected character " + getCharacterString());
     }
 

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -126,11 +126,15 @@ public final class CharacterModel extends Model {
     @SubscribeEvent
     public void onContainerClick(ContainerClickEvent e) {
         if (inCharacterSelection) {
-            if (!parseCharacter(e.getItemStack())) return;
-            hasCharacter = true;
-            WynntilsMod.postEvent(new CharacterUpdateEvent());
-            WynntilsMod.info("Selected character " + getCharacterString());
+            handleSelectedCharacter(e.getItemStack());
         }
+    }
+
+    public void handleSelectedCharacter(ItemStack itemStack) {
+        if (!parseCharacter(itemStack)) return;
+        hasCharacter = true;
+        WynntilsMod.postEvent(new CharacterUpdateEvent());
+        WynntilsMod.info("Selected character " + getCharacterString());
     }
 
     public void scanCharacterInfo() {

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
+import org.lwjgl.glfw.GLFW;
 
 /**
  * Tracks persistent metadata about the player's selected character, such as
@@ -114,7 +115,8 @@ public final class CharacterModel extends Model {
 
     @SubscribeEvent
     public void onContainerClick(ContainerClickEvent e) {
-        if (Models.WorldState.getCurrentState() == WorldState.CHARACTER_SELECTION) {
+        if (Models.WorldState.getCurrentState() == WorldState.CHARACTER_SELECTION
+                && e.getMouseButton() != GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
             handleSelectedCharacter(e.getItemStack());
         }
     }

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -13,7 +13,6 @@ import com.wynntils.handlers.container.scriptedquery.QueryStep;
 import com.wynntils.handlers.container.scriptedquery.ScriptedContainerQuery;
 import com.wynntils.handlers.container.type.ContainerContent;
 import com.wynntils.mc.event.ContainerClickEvent;
-import com.wynntils.mc.event.MenuEvent.MenuClosedEvent;
 import com.wynntils.models.character.event.CharacterUpdateEvent;
 import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.containers.ContainerModel;
@@ -46,7 +45,6 @@ public final class CharacterModel extends Model {
     private static final int PROFESSION_INFO_SLOT = 17;
     public static final int GUILD_MENU_SLOT = 26;
 
-    private boolean inCharacterSelection;
     private boolean hasCharacter;
 
     private ClassType classType;
@@ -98,22 +96,11 @@ public final class CharacterModel extends Model {
         return false;
     }
 
-    @SubscribeEvent
-    public void onMenuClosed(MenuClosedEvent e) {
-        inCharacterSelection = false;
-    }
-
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onWorldStateChanged(WorldStateEvent e) {
         // Whenever we're leaving a world, clear the current character
         if (e.getOldState() == WorldState.WORLD) {
             hasCharacter = false;
-            // This should not be needed, but have it as a safeguard
-            inCharacterSelection = false;
-        }
-
-        if (e.getNewState() == WorldState.CHARACTER_SELECTION) {
-            inCharacterSelection = true;
         }
 
         if (e.getNewState() == WorldState.WORLD) {
@@ -127,7 +114,7 @@ public final class CharacterModel extends Model {
 
     @SubscribeEvent
     public void onContainerClick(ContainerClickEvent e) {
-        if (inCharacterSelection) {
+        if (Models.WorldState.getCurrentState() == WorldState.CHARACTER_SELECTION) {
             handleSelectedCharacter(e.getItemStack());
         }
     }

--- a/common/src/main/java/com/wynntils/models/character/CharacterModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterModel.java
@@ -57,6 +57,8 @@ public final class CharacterModel extends Model {
     // full character uuid, as presented by Wynncraft in the tooltip.
     private String id = "-";
 
+    private String previousScanId = "";
+
     public CharacterModel() {
         super(List.of());
     }
@@ -143,6 +145,11 @@ public final class CharacterModel extends Model {
     }
 
     public void scanCharacterInfo() {
+        if (id.equals(previousScanId)) {
+            hasCharacter = true;
+            return;
+        }
+
         WynntilsMod.info("Scheduling character info query");
         QueryBuilder queryBuilder = ScriptedContainerQuery.builder("Character Info Query");
         queryBuilder.onError(msg -> WynntilsMod.warn("Error querying Character Info: " + msg));
@@ -156,6 +163,8 @@ public final class CharacterModel extends Model {
         Models.Guild.addGuildContainerQuerySteps(queryBuilder);
 
         queryBuilder.build().executeQuery();
+
+        previousScanId = id;
     }
 
     private void parseCharacterContainer(ContainerContent container) {

--- a/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
@@ -47,6 +47,8 @@ public final class CharacterSelectionModel extends Model {
     public void playWithCharacter(int slot) {
         if (!(Models.Container.getCurrentContainer() instanceof CharacterSelectionContainer characterContainer)) return;
 
+        // ContainerClickEvent will get the air item and not parse the character properly so pass it the correct item
+        Models.Character.handleSelectedCharacter(selectionScreenItems.get(slot));
         ContainerUtils.clickOnSlot(
                 slot, characterContainer.getContainerId(), GLFW.GLFW_MOUSE_BUTTON_LEFT, selectionScreenItems);
     }

--- a/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
+++ b/common/src/main/java/com/wynntils/models/character/CharacterSelectionModel.java
@@ -11,14 +11,16 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
 import com.wynntils.mc.event.ArmSwingEvent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
+import com.wynntils.models.character.actionbar.matchers.CharacterCreationSegmentMatcher;
 import com.wynntils.models.character.actionbar.matchers.CharacterSelectionClassSegmentMatcher;
 import com.wynntils.models.character.actionbar.matchers.CharacterSelectionLevelSegmentMatcher;
+import com.wynntils.models.character.actionbar.matchers.CharacterSelectionSegmentMatcher;
+import com.wynntils.models.character.actionbar.segments.CharacterCreationSegment;
 import com.wynntils.models.character.actionbar.segments.CharacterSelectionClassSegment;
 import com.wynntils.models.character.actionbar.segments.CharacterSelectionLevelSegment;
+import com.wynntils.models.character.actionbar.segments.CharacterSelectionSegment;
 import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.containers.containers.CharacterSelectionContainer;
-import com.wynntils.models.worlds.actionbar.segments.CharacterCreationSegment;
-import com.wynntils.models.worlds.actionbar.segments.CharacterSelectionSegment;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.wynn.ContainerUtils;
 import java.util.ArrayList;
@@ -42,6 +44,8 @@ public final class CharacterSelectionModel extends Model {
     public CharacterSelectionModel() {
         super(List.of());
 
+        Handlers.ActionBar.registerSegment(new CharacterCreationSegmentMatcher());
+        Handlers.ActionBar.registerSegment(new CharacterSelectionSegmentMatcher());
         Handlers.ActionBar.registerSegment(new CharacterSelectionClassSegmentMatcher());
         Handlers.ActionBar.registerSegment(new CharacterSelectionLevelSegmentMatcher());
     }

--- a/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterCreationSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterCreationSegmentMatcher.java
@@ -2,23 +2,23 @@
  * Copyright © Wynntils 2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
-package com.wynntils.models.worlds.actionbar.matchers;
+package com.wynntils.models.character.actionbar.matchers;
 
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
-import com.wynntils.models.worlds.actionbar.segments.CharacterSelectionSegment;
+import com.wynntils.models.character.actionbar.segments.CharacterCreationSegment;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CharacterSelectionSegmentMatcher implements ActionBarSegmentMatcher {
-    private static final Pattern CHARACTER_CREATION_PATTERN =
-            Pattern.compile("\uE000 Left-Click to play                     \uE001 Right-Click to switch");
+public class CharacterCreationSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern CHARACTER_CREATION_PATTERN = Pattern.compile(
+            "\uE000 Left-Click to select          \uE002 Scroll up/down to browse(          \uE001 Right-Click to return)?");
 
     @Override
     public ActionBarSegment parse(String actionBar) {
         Matcher matcher = CHARACTER_CREATION_PATTERN.matcher(actionBar);
         if (!matcher.find()) return null;
 
-        return new CharacterSelectionSegment(actionBar);
+        return new CharacterCreationSegment(actionBar);
     }
 }

--- a/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionClassSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionClassSegmentMatcher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.character.actionbar.matchers;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
+import com.wynntils.models.character.actionbar.segments.CharacterSelectionClassSegment;
+import com.wynntils.models.character.type.ClassType;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CharacterSelectionClassSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern CLASS_CARD_PATTERN =
+            Pattern.compile("\uDAFF\uDF8C\u0001([\uE000-\uE004])\uDB00\uDC0A");
+
+    @Override
+    public ActionBarSegment parse(String actionBar) {
+        Matcher matcher = CLASS_CARD_PATTERN.matcher(actionBar);
+        if (!matcher.find()) return null;
+
+        String classCard = matcher.group(1);
+        ClassType classType = ClassType.fromCharacterSelectionCard(classCard);
+        boolean isReskinned = ClassType.isReskinnedCharacterSelection(classType, classCard);
+
+        return new CharacterSelectionClassSegment(actionBar, classType, isReskinned);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionLevelSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionLevelSegmentMatcher.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.character.actionbar.matchers;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
 import com.wynntils.models.character.actionbar.segments.CharacterSelectionLevelSegment;
@@ -11,16 +12,68 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CharacterSelectionLevelSegmentMatcher implements ActionBarSegmentMatcher {
+    // The start and end characters' high surrogate for the level segment
+    protected static final char POSITIVE_SPACE_HIGH_SURROGATE = '\uDB00';
+    protected static final char NEGATIVE_SPACE_HIGH_SURROGATE = '\uDAFF';
+
+    // A separator between the level characters
+    private static final String SEPARATOR = "\uDAFF\uDFFE";
+
+    // Possible character range for the level segment, collected from the resource pack/font
+    private static final char LEVEL_CHAR_START = '\uE030';
+    private static final char LEVEL_CHAR_END = '\uE039';
+
+    // The expected pattern for the level segment
+    // Allow 6 characters for the level, because the level is 3 digits + 2-3 separator characters
+    // There is also a space character at the start and end of the segment
     private static final Pattern CHARACTER_LEVEL_PATTERN =
-            Pattern.compile("\uDAFF\uDF8C\u0001([\uE000-\uE004])\uDB00\uDC0A");
+            Pattern.compile(".(?<level>([" + LEVEL_CHAR_START + "-" + LEVEL_CHAR_END + "]" + SEPARATOR + "?){1,6}).");
 
     @Override
     public ActionBarSegment parse(String actionBar) {
         Matcher matcher = CHARACTER_LEVEL_PATTERN.matcher(actionBar);
         if (!matcher.find()) return null;
 
-        int level = 106;
+        String segmentText = matcher.group();
 
-        return new CharacterSelectionLevelSegment(actionBar, level);
+        // First unicode character's high surrogate
+        char startChar = segmentText.charAt(0);
+
+        // Last unicode character's high surrogate
+        char endChar = segmentText.charAt(segmentText.length() - 2);
+
+        // Check if the segment text is surrounded by the correct separators
+        boolean validStart = startChar == NEGATIVE_SPACE_HIGH_SURROGATE;
+        boolean validEnd = endChar == POSITIVE_SPACE_HIGH_SURROGATE;
+
+        if (!validStart || !validEnd) return null;
+
+        int level = parseLevel(matcher.group("level"));
+
+        return new CharacterSelectionLevelSegment(matcher.group(), level);
+    }
+
+    private int parseLevel(String levelText) {
+        try {
+            // Remove the separators from the level text
+            levelText = levelText.replace(SEPARATOR, "");
+
+            StringBuilder levelBuilder = new StringBuilder();
+
+            for (char current : levelText.toCharArray()) {
+                if (current >= LEVEL_CHAR_START && current <= LEVEL_CHAR_END) {
+                    // Each character is a digit, so we can just subtract the start character to get the digit
+                    // to get the actual number
+                    levelBuilder.append(current - LEVEL_CHAR_START);
+                } else {
+                    WynntilsMod.warn("Found unexpected character in character selection level segment: " + current);
+                }
+            }
+
+            return Integer.parseInt(levelBuilder.toString());
+        } catch (NumberFormatException e) {
+            WynntilsMod.warn("Failed to parse character selection level from segment: " + levelText);
+            return 0;
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionLevelSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionLevelSegmentMatcher.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.character.actionbar.matchers;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
+import com.wynntils.models.character.actionbar.segments.CharacterSelectionLevelSegment;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CharacterSelectionLevelSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern CHARACTER_LEVEL_PATTERN =
+            Pattern.compile("\uDAFF\uDF8C\u0001([\uE000-\uE004])\uDB00\uDC0A");
+
+    @Override
+    public ActionBarSegment parse(String actionBar) {
+        Matcher matcher = CHARACTER_LEVEL_PATTERN.matcher(actionBar);
+        if (!matcher.find()) return null;
+
+        int level = 106;
+
+        return new CharacterSelectionLevelSegment(actionBar, level);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/matchers/CharacterSelectionSegmentMatcher.java
@@ -2,23 +2,23 @@
  * Copyright © Wynntils 2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
-package com.wynntils.models.worlds.actionbar.matchers;
+package com.wynntils.models.character.actionbar.matchers;
 
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 import com.wynntils.handlers.actionbar.ActionBarSegmentMatcher;
-import com.wynntils.models.worlds.actionbar.segments.CharacterCreationSegment;
+import com.wynntils.models.character.actionbar.segments.CharacterSelectionSegment;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CharacterCreationSegmentMatcher implements ActionBarSegmentMatcher {
-    private static final Pattern CHARACTER_CREATION_PATTERN = Pattern.compile(
-            "\uE000 Left-Click to select          \uE002 Scroll up/down to browse(          \uE001 Right-Click to return)?");
+public class CharacterSelectionSegmentMatcher implements ActionBarSegmentMatcher {
+    private static final Pattern CHARACTER_CREATION_PATTERN =
+            Pattern.compile("\uE000 Left-Click to play                     \uE001 Right-Click to switch");
 
     @Override
     public ActionBarSegment parse(String actionBar) {
         Matcher matcher = CHARACTER_CREATION_PATTERN.matcher(actionBar);
         if (!matcher.find()) return null;
 
-        return new CharacterCreationSegment(actionBar);
+        return new CharacterSelectionSegment(actionBar);
     }
 }

--- a/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterCreationSegment.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterCreationSegment.java
@@ -2,7 +2,7 @@
  * Copyright © Wynntils 2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
-package com.wynntils.models.worlds.actionbar.segments;
+package com.wynntils.models.character.actionbar.segments;
 
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 

--- a/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterSelectionClassSegment.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterSelectionClassSegment.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.character.actionbar.segments;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+import com.wynntils.models.character.type.ClassType;
+
+public class CharacterSelectionClassSegment extends ActionBarSegment {
+    private final ClassType classType;
+    private final boolean isReskinned;
+
+    public CharacterSelectionClassSegment(String segmentText, ClassType classType, boolean isReskinned) {
+        super(segmentText);
+
+        this.classType = classType;
+        this.isReskinned = isReskinned;
+    }
+
+    public ClassType getClassType() {
+        return classType;
+    }
+
+    public boolean isReskinned() {
+        return isReskinned;
+    }
+
+    @Override
+    public String toString() {
+        return "CharacterSelectionClassSegment{" + "classType="
+                + classType + ", isReskinned="
+                + isReskinned + ", segmentText='"
+                + segmentText + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterSelectionLevelSegment.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterSelectionLevelSegment.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.character.actionbar.segments;
+
+import com.wynntils.handlers.actionbar.ActionBarSegment;
+
+public class CharacterSelectionLevelSegment extends ActionBarSegment {
+    private final int level;
+
+    public CharacterSelectionLevelSegment(String segmentText, int level) {
+        super(segmentText);
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    @Override
+    public String toString() {
+        return "CharacterSelectionLevelSegment{" + "level=" + level + ", segmentText='" + segmentText + '\'' + '}';
+    }
+}

--- a/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterSelectionSegment.java
+++ b/common/src/main/java/com/wynntils/models/character/actionbar/segments/CharacterSelectionSegment.java
@@ -2,7 +2,7 @@
  * Copyright © Wynntils 2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
-package com.wynntils.models.worlds.actionbar.segments;
+package com.wynntils.models.character.actionbar.segments;
 
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 

--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -4,28 +4,29 @@
  */
 package com.wynntils.models.character.type;
 
-import com.wynntils.utils.type.Pair;
-
 public enum ClassType {
-    MAGE("Mage", "Dark Wizard", 1, Pair.of("\uE002", "\uE007")),
-    ARCHER("Archer", "Hunter", 2, Pair.of("\uE000", "\uE005")),
-    WARRIOR("Warrior", "Knight", 3, Pair.of("\uE004", "\uE009")),
-    ASSASSIN("Assassin", "Ninja", 4, Pair.of("\uE001", "\uE006")),
-    SHAMAN("Shaman", "Skyseer", 5, Pair.of("\uE003", "\uE008")),
+    MAGE("Mage", "Dark Wizard", 1, "\uE002", "\uE007"),
+    ARCHER("Archer", "Hunter", 2, "\uE000", "\uE005"),
+    WARRIOR("Warrior", "Knight", 3, "\uE004", "\uE009"),
+    ASSASSIN("Assassin", "Ninja", 4, "\uE001", "\uE006"),
+    SHAMAN("Shaman", "Skyseer", 5, "\uE003", "\uE008"),
 
     // This represents the class selection menu, or the generic spell
-    NONE("none", "none", 0, Pair.of("", ""));
+    NONE("none", "none", 0, "", "");
 
     private final String name;
     private final String reskinnedName;
     private final int encodingId;
-    private final Pair<String, String> cardCharactersPair;
+    // These represent the characters used to display the side card on the character selection screen
+    private final String cardCharacter;
+    private final String cardCharacterReskinned;
 
-    ClassType(String name, String reskinnedName, int encodingId, Pair<String, String> cardCharactersPair) {
+    ClassType(String name, String reskinnedName, int encodingId, String cardCharacter, String cardCharacterReskinned) {
         this.name = name;
         this.reskinnedName = reskinnedName;
         this.encodingId = encodingId;
-        this.cardCharactersPair = cardCharactersPair;
+        this.cardCharacter = cardCharacter;
+        this.cardCharacterReskinned = cardCharacterReskinned;
     }
 
     public static ClassType fromName(String className) {
@@ -47,8 +48,7 @@ public enum ClassType {
 
     public static ClassType fromCharacterSelectionCard(String character) {
         for (ClassType type : values()) {
-            if (type.cardCharactersPair.a().equals(character)
-                    || type.cardCharactersPair.b().equals(character)) {
+            if (type.cardCharacter.equals(character) || type.cardCharacterReskinned.equals(character)) {
                 return type;
             }
         }
@@ -58,7 +58,7 @@ public enum ClassType {
     public static boolean isReskinnedCharacterSelection(ClassType classType, String character) {
         // Whilst the assets are there, the character selection does not currently display the different textures for
         // reskins so this will always be false
-        return classType.cardCharactersPair.b().equals(character);
+        return classType.cardCharacterReskinned.equals(character);
     }
 
     public String getName() {

--- a/common/src/main/java/com/wynntils/models/character/type/ClassType.java
+++ b/common/src/main/java/com/wynntils/models/character/type/ClassType.java
@@ -1,27 +1,31 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.character.type;
 
+import com.wynntils.utils.type.Pair;
+
 public enum ClassType {
-    MAGE("Mage", "Dark Wizard", 1),
-    ARCHER("Archer", "Hunter", 2),
-    WARRIOR("Warrior", "Knight", 3),
-    ASSASSIN("Assassin", "Ninja", 4),
-    SHAMAN("Shaman", "Skyseer", 5),
+    MAGE("Mage", "Dark Wizard", 1, Pair.of("\uE002", "\uE007")),
+    ARCHER("Archer", "Hunter", 2, Pair.of("\uE000", "\uE005")),
+    WARRIOR("Warrior", "Knight", 3, Pair.of("\uE004", "\uE009")),
+    ASSASSIN("Assassin", "Ninja", 4, Pair.of("\uE001", "\uE006")),
+    SHAMAN("Shaman", "Skyseer", 5, Pair.of("\uE003", "\uE008")),
 
     // This represents the class selection menu, or the generic spell
-    NONE("none", "none", 0);
+    NONE("none", "none", 0, Pair.of("", ""));
 
     private final String name;
     private final String reskinnedName;
     private final int encodingId;
+    private final Pair<String, String> cardCharactersPair;
 
-    ClassType(String name, String reskinnedName, int encodingId) {
+    ClassType(String name, String reskinnedName, int encodingId, Pair<String, String> cardCharactersPair) {
         this.name = name;
         this.reskinnedName = reskinnedName;
         this.encodingId = encodingId;
+        this.cardCharactersPair = cardCharactersPair;
     }
 
     public static ClassType fromName(String className) {
@@ -39,6 +43,22 @@ public enum ClassType {
             if (className.equalsIgnoreCase(type.reskinnedName)) return true;
         }
         return false;
+    }
+
+    public static ClassType fromCharacterSelectionCard(String character) {
+        for (ClassType type : values()) {
+            if (type.cardCharactersPair.a().equals(character)
+                    || type.cardCharactersPair.b().equals(character)) {
+                return type;
+            }
+        }
+        return NONE;
+    }
+
+    public static boolean isReskinnedCharacterSelection(ClassType classType, String character) {
+        // Whilst the assets are there, the character selection does not currently display the different textures for
+        // reskins so this will always be false
+        return classType.cardCharactersPair.b().equals(character);
     }
 
     public String getName() {

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/CharacterAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/CharacterAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.annotators.gui;
@@ -15,34 +15,35 @@ import java.util.regex.Pattern;
 import net.minecraft.world.item.ItemStack;
 
 public class CharacterAnnotator implements GuiItemAnnotator {
-    // (?:§l)? is trying to account for the fact that seemingly Wynn is trying to bold the text,
-    // but Wynn adds a color after the bold, resetting the bold effect.
-    private static final Pattern CLASS_MENU_NAME_PATTERN =
-            Pattern.compile("(?:§l)?§6(?:§l)?\\[>\\] Select ((.+)|This Character)");
+    private static final Pattern CHARACTER_MENU_NAME_PATTERN =
+            Pattern.compile("[\uDB00\uDC0B-\uDB00\uDC46]§6(§o)?(?<name>[A-Za-z0-9_ ]{1,20})");
 
-    // Test in CharacterAnnotator_CLASS_MENU_CLASS_PATTERN
-    private static final Pattern CLASS_MENU_CLASS_PATTERN =
-            Pattern.compile("§e- §7Class:(?: (?<gamemodes>§.[\uE027\uE083\uE026\uE029\uE028])+§r)? §f(?<class>.+)");
-    private static final Pattern CLASS_MENU_LEVEL_PATTERN = Pattern.compile("§e- §7Level: §f(\\d+)");
+    // Test in CharacterAnnotator_CHARACTER_MENU_CLASS_PATTERN
+    private static final Pattern CHARACTER_MENU_CLASS_PATTERN =
+            Pattern.compile("§6- §7Class:(?: (?<gamemodes>§.[\uE027\uE083\uE026\uE029\uE028])+§7)? §f(?<class>.+)");
+
+    // Test in CharacterAnnotator_CHARACTER_MENU_LEVEL_PATTERN
+    private static final Pattern CHARACTER_MENU_LEVEL_PATTERN =
+            Pattern.compile("§6- §7Level: §f(?<level>\\d+)§7 §8\\(\\d+(?:\\.\\d+)?%\\)");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
-        Matcher matcher = StyledText.fromComponent(itemStack.getHoverName()).getMatcher(CLASS_MENU_NAME_PATTERN);
+        Matcher matcher = StyledText.fromComponent(itemStack.getHoverName()).getMatcher(CHARACTER_MENU_NAME_PATTERN);
         if (!matcher.matches()) return null;
 
-        String className = matcher.group(1);
+        String className = matcher.group("name");
         int level = 0;
         ClassType classType = null;
         boolean reskinned = false;
 
         for (StyledText lore : LoreUtils.getLore(itemStack)) {
-            Matcher classMatcher = lore.getMatcher(CLASS_MENU_CLASS_PATTERN);
+            Matcher classMatcher = lore.getMatcher(CHARACTER_MENU_CLASS_PATTERN);
             if (classMatcher.matches()) {
                 classType = ClassType.fromName(classMatcher.group("class"));
                 reskinned = ClassType.isReskinned(classMatcher.group("class"));
             }
 
-            Matcher levelMatcher = lore.getMatcher(CLASS_MENU_LEVEL_PATTERN);
+            Matcher levelMatcher = lore.getMatcher(CHARACTER_MENU_LEVEL_PATTERN);
             if (levelMatcher.matches()) {
                 level = Integer.parseInt(levelMatcher.group(1));
             }

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -15,11 +15,9 @@ import com.wynntils.mc.event.PlayerInfoEvent.PlayerDisplayNameChangeEvent;
 import com.wynntils.mc.event.PlayerInfoEvent.PlayerLogOutEvent;
 import com.wynntils.mc.event.PlayerInfoFooterChangedEvent;
 import com.wynntils.mc.event.PlayerTeleportEvent;
-import com.wynntils.models.worlds.actionbar.matchers.CharacterCreationSegmentMatcher;
-import com.wynntils.models.worlds.actionbar.matchers.CharacterSelectionSegmentMatcher;
+import com.wynntils.models.character.actionbar.segments.CharacterCreationSegment;
+import com.wynntils.models.character.actionbar.segments.CharacterSelectionSegment;
 import com.wynntils.models.worlds.actionbar.matchers.WynncraftVersionSegmentMatcher;
-import com.wynntils.models.worlds.actionbar.segments.CharacterCreationSegment;
-import com.wynntils.models.worlds.actionbar.segments.CharacterSelectionSegment;
 import com.wynntils.models.worlds.actionbar.segments.WynncraftVersionSegment;
 import com.wynntils.models.worlds.bossbars.SkipCutsceneBar;
 import com.wynntils.models.worlds.event.CutsceneStartedEvent;
@@ -68,8 +66,6 @@ public final class WorldStateModel extends Model {
     public WorldStateModel() {
         super(List.of());
 
-        Handlers.ActionBar.registerSegment(new CharacterCreationSegmentMatcher());
-        Handlers.ActionBar.registerSegment(new CharacterSelectionSegmentMatcher());
         Handlers.ActionBar.registerSegment(new WynncraftVersionSegmentMatcher());
         Handlers.BossBar.registerBar(skipCutsceneBar);
     }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -955,12 +955,30 @@ public class TestRegex {
     }
 
     @Test
-    public void CharacterAnnotator_CLASS_MENU_CLASS_PATTERN() {
-        PatternTester p = new PatternTester(CharacterAnnotator.class, "CLASS_MENU_CLASS_PATTERN");
+    public void CharacterAnnotator_CHARACTER_MENU_CLASS_PATTERN() {
+        PatternTester p = new PatternTester(CharacterAnnotator.class, "CHARACTER_MENU_CLASS_PATTERN");
 
-        p.shouldMatch("§e- §7Class: §6\uE029§5\uE028§r §fAssassin");
-        p.shouldMatch("§e- §7Class: §c\uE027§b\uE083§3\uE026§r §fKnight");
-        p.shouldMatch("§e- §7Class: §fWarrior");
+        p.shouldMatch("§6- §7Class: §fMage'"); // Mage
+        p.shouldMatch("§6- §7Class: §fHunter"); // Hunter
+        p.shouldMatch("§6- §7Class: §fSkyseer"); // Skyseer
+        p.shouldMatch("§6- §7Class: §fKnight"); // Knight
+        p.shouldMatch("§6- §7Class: §fNinja"); // Ninja
+        p.shouldMatch("§6- §7Class: §b\uE083§7 §fArcher"); // Ultimate Ironman Archer
+        p.shouldMatch("§6- §7Class: §5\uE028§7 §fDark Wizard"); // Hunted Dark Wizard
+        p.shouldMatch("§6- §7Class: §6\uE029§7 §fShaman"); // Ironman Shaman
+        p.shouldMatch("§6- §7Class: §c\uE027§7 §fAssassin"); // Hardcore Assassin
+        p.shouldMatch("§6- §7Class: §3\uE026§7 §fWarrior"); // Craftsman Warrior
+        p.shouldMatch("§6- §7Class: §c\uE027§b\uE083§3\uE026§5\uE028§7 §fArcher"); // HUICH Archer
+    }
+
+    @Test
+    public void CharacterAnnotator_CHARACTER_MENU_LEVEL_PATTERN() {
+        PatternTester p = new PatternTester(CharacterAnnotator.class, "CHARACTER_MENU_LEVEL_PATTERN");
+
+        p.shouldMatch("§6- §7Level: §f106§7 §8(0%)");
+        p.shouldMatch("§6- §7Level: §f105§7 §8(3.14%)");
+        p.shouldMatch("§6- §7Level: §f12§7 §8(40.54%)");
+        p.shouldMatch("§6- §7Level: §f1§7 §8(0.67%)");
     }
 
     @Test


### PR DESCRIPTION
This probably needs a fair bit more testing but from some quick initial tests it seems ok.

CharacterAnnotator has been broken since 2.1.1 meaning that quite often when the container queries failed, `hasCharacter` was never set to true, that is now fixed however it no longer posts the `CharacterUpdateEvent` as it would occur before we can actually do anything due to the animation on joining worlds. And also fixed the 1-9 for character selection parsing the character as before the `ContainerClickEvent` would just receive air as the item, not the character item.

We also now parse the action bar in the character selection, we can get class, level and should be able to get reskin if they actually used the alternate textures they have but they currently don't. So joining via the favourite or just most recent if no favourite selected character can also update the class of character to be.

And then some optimisations for the on world join container queries, this is what likely needs more testing to ensure it's still reliable. The idea is that when changing world but not character, all of the info is still the same so does not need to be rescanned, this is currently causing an issue in Wynncraft where raids now almost always change your world and when we open the content book it clears your inventory meaning you no longer have the rune entry fee.

