### PR TITLE
fix: Allow warping to world events in custom content book

### DIFF
--- a/common/src/main/java/com/wynntils/screens/activities/ContentBookHolder.java
+++ b/common/src/main/java/com/wynntils/screens/activities/ContentBookHolder.java
@@ -13,6 +13,7 @@ import com.wynntils.mc.event.ContainerSetSlotEvent;
 import com.wynntils.models.activities.type.ActivityInfo;
 import com.wynntils.models.activities.type.ActivityTrackingState;
 import com.wynntils.models.items.items.gui.ActivityItem;
+import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.wynn.ContainerUtils;
@@ -147,11 +148,19 @@ public class ContentBookHolder extends WrappedScreenHolder<WynntilsContentBookSc
         resetNextSetContent = mouseButton != GLFW.GLFW_MOUSE_BUTTON_LEFT
                 || (slot != PROGRESS_SLOTS.b() && slot != DIALOGUE_HISTORY_SLOTS.b());
 
-        ContainerUtils.clickOnSlot(
-                slot,
-                wrappedScreen.getWrappedScreenInfo().containerId(),
-                mouseButton,
-                McUtils.containerMenu().getItems());
+        if (KeyboardUtils.isShiftDown()) {
+            ContainerUtils.shiftClickOnSlot(
+                    slot,
+                    wrappedScreen.getWrappedScreenInfo().containerId(),
+                    mouseButton,
+                    McUtils.containerMenu().getItems());
+        } else {
+            ContainerUtils.clickOnSlot(
+                    slot,
+                    wrappedScreen.getWrappedScreenInfo().containerId(),
+                    mouseButton,
+                    McUtils.containerMenu().getItems());
+        }
     }
 
     private boolean handleActivityItem(ItemStack itemStack, int slot) {

--- a/common/src/main/java/com/wynntils/screens/activities/widgets/ContentBookWidget.java
+++ b/common/src/main/java/com/wynntils/screens/activities/widgets/ContentBookWidget.java
@@ -9,11 +9,13 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.models.activities.type.ActivityInfo;
 import com.wynntils.models.activities.type.ActivityStatus;
 import com.wynntils.models.activities.type.ActivityTrackingState;
+import com.wynntils.models.activities.type.ActivityType;
 import com.wynntils.screens.activities.ContentBookHolder;
 import com.wynntils.screens.activities.WynntilsContentBookScreen;
 import com.wynntils.screens.base.TooltipProvider;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.FontRenderer;
@@ -139,7 +141,14 @@ public class ContentBookWidget extends AbstractWidget implements TooltipProvider
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_MIDDLE && canOpenMap()) {
             Models.Activity.openMapOnActivity(activityInfo);
         } else if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
-            Models.Activity.openActivityOnWiki(activityInfo);
+            // Shift right clicking world events is used to fast travel to them
+            if (activityInfo.type() == ActivityType.WORLD_EVENT
+                    && activityInfo.status() == ActivityStatus.AVAILABLE
+                    && KeyboardUtils.isShiftDown()) {
+                holder.pressSlot(slot, button);
+            } else {
+                Models.Activity.openActivityOnWiki(activityInfo);
+            }
         }
 
         return true;


### PR DESCRIPTION
After beta we should updating the parsing to read the tooltip to see if the text is there but not really possible on beta atm as everyone is champion and has fast travel tokens
