### PR TITLE
fix: parse bomb bell message

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/BombBellRelayFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/BombBellRelayFeature.java
@@ -12,15 +12,9 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
-import com.wynntils.core.text.StyledText;
-import com.wynntils.core.text.StyledTextPart;
-import com.wynntils.models.worlds.event.BombEvent;
 import com.wynntils.models.worlds.type.BombInfo;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent;
-import net.neoforged.bus.api.SubscribeEvent;
 import org.lwjgl.glfw.GLFW;
 
 public class BombBellRelayFeature extends Feature {
@@ -34,33 +28,6 @@ public class BombBellRelayFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> showTime = new Config<>(true);
-
-    @Persisted
-    public final Config<Boolean> clickableMessage = new Config<>(true);
-
-    @SubscribeEvent
-    public void onBombBell(BombEvent.BombBell event) {
-        if (clickableMessage.get()) {
-            ClickEvent clickEvent = new ClickEvent(
-                    ClickEvent.Action.RUN_COMMAND,
-                    "/switch " + event.getBombInfo().server());
-            HoverEvent hoverEvent = new HoverEvent(
-                    HoverEvent.Action.SHOW_TEXT,
-                    Component.literal(
-                            "Click to switch to " + event.getBombInfo().server()));
-
-            StyledText newMessage = event.getMessage().map(part -> {
-                StyledTextPart newPart = part.withStyle(partStyle -> partStyle.withClickEvent(clickEvent));
-                // Don't overwrite the nickname hover event
-                if (part.getPartStyle().getHoverEvent() == null) {
-                    newPart = newPart.withStyle(partStyle -> partStyle.withHoverEvent(hoverEvent));
-                }
-
-                return newPart;
-            });
-            event.setMessage(newMessage);
-        }
-    }
 
     private String getAndFormatLastBomb() {
         BombInfo lastBomb = Models.Bomb.getLastBomb();

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -8,7 +8,6 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.bossbar.TrackedBar;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
@@ -33,8 +32,8 @@ import net.neoforged.bus.api.SubscribeEvent;
 public final class BombModel extends Model {
     public static final TrackedBar InfoBar = new InfoBar();
 
-    private static final Pattern BOMB_BELL_PATTERN =
-            Pattern.compile("^\\[Bomb Bell\\] (?<user>.+) has thrown an? (?<bomb>.+) Bomb on (?<server>.+)$");
+    private static final Pattern BOMB_BELL_PATTERN = Pattern.compile(
+            "^§#fddd5cff(?:\uE01E\uE002|\uE001) (?<user>.+) has thrown an? §#f3e6b2ff(?<bomb>.+) Bomb§#fddd5cff on §#f3e6b2ff§n(?<server>.+)$");
 
     // Test in BombModel_BOMB_EXPIRED_PATTERN
     private static final Pattern BOMB_EXPIRED_PATTERN = Pattern.compile(
@@ -57,8 +56,10 @@ public final class BombModel extends Model {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onChat(ChatMessageReceivedEvent event) {
         StyledText message = event.getOriginalStyledText();
+        StyledText unwrapped =
+                StyledTextUtils.unwrap(event.getOriginalStyledText()).stripAlignment();
 
-        Matcher bellMatcher = message.getMatcher(BOMB_BELL_PATTERN, PartStyle.StyleType.NONE);
+        Matcher bellMatcher = unwrapped.getMatcher(BOMB_BELL_PATTERN);
         if (bellMatcher.matches()) {
             BombInfo bombInfo =
                     addBombFromChat(bellMatcher.group("user"), bellMatcher.group("bomb"), bellMatcher.group("server"));
@@ -70,9 +71,6 @@ public final class BombModel extends Model {
 
             return;
         }
-
-        StyledText unwrapped =
-                StyledTextUtils.unwrap(event.getOriginalStyledText()).stripAlignment();
 
         Matcher localMatcher = unwrapped.getMatcher(BOMB_THROWN_PATTERN);
         if (localMatcher.matches()) {

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -152,8 +152,10 @@ public class TestRegex {
     public void BombMobel_BOMB_BELL_PATTERN() {
         PatternTester p = new PatternTester(BombModel.class, "BOMB_BELL_PATTERN");
 
-        p.shouldMatch("§#fddd5cff\uE01E\uE002 Wanytails has thrown a §#f3e6b2ffProfession Speed Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
-        p.shouldMatch("§#fddd5cff\uE001 Wanytails has thrown a §#f3e6b2ffCombat Experience Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
+        p.shouldMatch(
+                "§#fddd5cff\uE01E\uE002 Wanytails has thrown a §#f3e6b2ffProfession Speed Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
+        p.shouldMatch(
+                "§#fddd5cff\uE001 Wanytails has thrown a §#f3e6b2ffCombat Experience Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
     }
 
     @Test

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -149,6 +149,14 @@ public class TestRegex {
     }
 
     @Test
+    public void BombMobel_BOMB_BELL_PATTERN() {
+        PatternTester p = new PatternTester(BombModel.class, "BOMB_BELL_PATTERN");
+
+        p.shouldMatch("§#fddd5cff\uE01E\uE002 Wanytails has thrown a §#f3e6b2ffProfession Speed Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
+        p.shouldMatch("§#fddd5cff\uE001 Wanytails has thrown a §#f3e6b2ffCombat Experience Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
+    }
+
+    @Test
     public void BombModel_BOMB_THROWN_PATTERN() {
         PatternTester p = new PatternTester(BombModel.class, "BOMB_THROWN_PATTERN");
         p.shouldMatch("§#a0c84bff\uE014\uE002 §lProfession Speed Bomb");


### PR DESCRIPTION
Fixes #3380

Also removes the clickable message part from the bomb bell message, this is now a vanilla Wynncraft feature