### PR TITLE
fix: Fix NPC dialogue parsing messing with multi-line player chat

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -195,7 +195,9 @@ public final class ChatHandler extends Handler {
 
         long currentTicks = McUtils.mc().level.getGameTime();
 
-        List<StyledText> lines = StyledTextUtils.splitInLines(styledText);
+        // If the unwrapped text still has multiple lines, we treat it as a chat screen
+        // (otherwise it is just a multi-line player chat message)
+        List<StyledText> lines = StyledTextUtils.splitInLines(StyledTextUtils.unwrap(styledText));
 
         // It is a multi-line screen if it is parsed to be multiple lines,
         // or if it is empty and sent in the same tick (with some fuzziness) as the current screen
@@ -530,7 +532,7 @@ public final class ChatHandler extends Handler {
      * message entirely.
      */
     private StyledText postChatLine(StyledText styledText, MessageType messageType) {
-        String plainText = styledText.getStringWithoutFormatting();
+        String plainText = StyledTextUtils.unwrap(styledText).getStringWithoutFormatting();
         if (!plainText.isBlank()) {
             // We store the unformatted string version to be able to compare between
             // foreground and background versions

--- a/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
@@ -138,12 +138,6 @@ public final class StyledTextUtils {
                 // Continue with execution, a part may have a wrap before and after it
             }
 
-            // If the part ends with a newline, it may be a preparation for a wrap
-            if (partString.endsWith(NEWLINE_PREPARATION)) {
-                lastWrappedPart = part;
-                continue;
-            }
-
             // Confirm whether the last part was wrapped
             if (lastWrappedPart != null) {
                 if (NEWLINE_WRAP_PATTERN.matcher(partString).matches()) {
@@ -189,6 +183,12 @@ public final class StyledTextUtils {
                 }
 
                 lastWrappedPart = null;
+                continue;
+            }
+
+            // If the part ends with a newline, it may be a preparation for a wrap
+            if (partString.endsWith(NEWLINE_PREPARATION)) {
+                lastWrappedPart = part;
                 continue;
             }
 


### PR DESCRIPTION
Wynncraft now does not send any formatting on multi-line player chat "\n" StyledTextPart, which unwrap did not depend on, but splitInLines did.

Fixes https://github.com/Wynntils/Wynntils/issues/3377