### PR TITLE
chore: Run remove_unused_i18n.sh script in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Delete empty files
         run: find $(git ls-files -m) -size 0 -delete
 
+      - name: Run remove_unused_i18n.sh
+        run: bash utils/remove_unused_i18n.sh
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_user_name: 'WynntilsBot'


### PR DESCRIPTION
This was accidentally left out before.