### PR TITLE
chore: Remove publicProfile and vet toggles

### DIFF
--- a/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
@@ -514,11 +514,9 @@ public class AddCommandExpansionFeature extends Feature {
                         .then(literal("popups"))
                         .then(literal("pouchmsg"))
                         .then(literal("pouchpickup"))
-                        .then(literal("publicProfile"))
                         .then(literal("queststartbeacon"))
                         .then(literal("sb"))
                         .then(literal("swears"))
-                        .then(literal("vet"))
                         .then(literal("war"))
                         .build());
     }


### PR DESCRIPTION
Removed in todays hotfix