### PR TITLE
fix: Fix sharing crafted items

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.models.activities.type.Dungeon;
@@ -38,6 +39,9 @@ import com.wynntils.utils.render.type.TextShadow;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -435,7 +439,8 @@ public class ItemTextOverlayFeature extends Feature {
         public ItemTextOverlayFeature.TextOverlay getTextOverlay() {
             Skill skill = item.getSkill();
 
-            String text = skill.getSymbol();
+            StyledText text = StyledText.fromComponent(Component.literal(skill.getSymbol())
+                    .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))));
             TextRenderSetting style = TextRenderSetting.DEFAULT
                     .withCustomColor(CustomColor.fromChatFormatting(skill.getColorCode()))
                     .withTextShadow(skillIconShadow.get());
@@ -460,7 +465,8 @@ public class ItemTextOverlayFeature extends Feature {
         public TextOverlay getTextOverlay() {
             Skill skill = item.getType().getSkill();
 
-            String text = skill.getSymbol();
+            StyledText text = StyledText.fromComponent(Component.literal(skill.getSymbol())
+                    .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))));
             TextRenderSetting style = TextRenderSetting.DEFAULT
                     .withCustomColor(CustomColor.fromChatFormatting(skill.getColorCode()))
                     .withTextShadow(skillIconShadow.get());

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/components/CraftedConsumableTooltipComponent.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/components/CraftedConsumableTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.tooltip.impl.crafted.components;
@@ -28,10 +28,10 @@ public class CraftedConsumableTooltipComponent extends CraftedTooltipComponent<C
 
         // Effects
         if (!craftedItem.getNamedEffects().isEmpty()) {
-            header.add(Component.literal("Effects:").withStyle(ChatFormatting.DARK_RED));
+            header.add(Component.literal("Effect:").withStyle(ChatFormatting.GREEN));
             craftedItem.getNamedEffects().forEach(effect -> {
                 header.add(Component.literal("- ")
-                        .withStyle(ChatFormatting.DARK_RED)
+                        .withStyle(ChatFormatting.GREEN)
                         .append(Component.literal(
                                         StringUtils.capitalizeFirst(
                                                         effect.type().name().toLowerCase(Locale.ROOT)) + ": ")

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/components/CraftedGearTooltipComponent.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/components/CraftedGearTooltipComponent.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 
 public class CraftedGearTooltipComponent extends CraftedTooltipComponent<CraftedGearItem> {
     @Override
@@ -50,9 +52,12 @@ public class CraftedGearTooltipComponent extends CraftedTooltipComponent<Crafted
             for (Pair<DamageType, RangedValue> damageStat : damages) {
                 DamageType type = damageStat.key();
                 String elementSymbol =
-                        type.getElement().isPresent() ? type.getElement().get().getDisplaySymbol() : type.getSymbol();
-                MutableComponent damage = Component.literal(elementSymbol + " " + type.getDisplayName())
-                        .withStyle(type.getColorCode());
+                        type.getElement().isPresent() ? type.getElement().get().getSymbol() : type.getSymbol();
+                MutableComponent damage = Component.empty()
+                        .withStyle(type.getColorCode())
+                        .append(Component.literal(elementSymbol)
+                                .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))))
+                        .append(Component.literal(" " + type.getDisplayName()));
                 damage.append(Component.literal("Damage: " + damageStat.value().asString())
                         .withStyle(
                                 type == DamageType.NEUTRAL
@@ -77,9 +82,11 @@ public class CraftedGearTooltipComponent extends CraftedTooltipComponent<Crafted
             List<Pair<Element, Integer>> defenses = craftedItem.getDefences();
             for (Pair<Element, Integer> defenceStat : defenses) {
                 Element element = defenceStat.key();
-                MutableComponent defense = Component.literal(
-                                element.getDisplaySymbol() + " " + element.getDisplayName())
-                        .withStyle(element.getColorCode());
+                MutableComponent defense = Component.empty()
+                        .withStyle(element.getColorCode())
+                        .append(Component.literal(element.getSymbol())
+                                .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))))
+                        .append(Component.literal(" " + element.getDisplayName()));
                 defense.append(Component.literal(" Defence: " + StringUtils.toSignedString(defenceStat.value()))
                         .withStyle(ChatFormatting.GRAY));
                 header.add(defense);
@@ -141,9 +148,20 @@ public class CraftedGearTooltipComponent extends CraftedTooltipComponent<Crafted
             if (!craftedItem.getPowders().isEmpty()) {
                 MutableComponent powderList = Component.literal("[");
                 for (Powder p : craftedItem.getPowders()) {
-                    String symbol = p.getColoredSymbol().getString();
-                    if (!powderList.getSiblings().isEmpty()) symbol = " " + symbol;
-                    powderList.append(Component.literal(symbol));
+                    String symbol = String.valueOf(p.getSymbol());
+                    if (!powderList.getSiblings().isEmpty()) {
+                        powderList.append(Component.empty()
+                                .withStyle(Style.EMPTY.withColor(p.getLightColor()))
+                                .append(Component.literal(" "))
+                                .append(Component.literal(symbol)
+                                        .withStyle(Style.EMPTY.withFont(
+                                                ResourceLocation.withDefaultNamespace("common")))));
+                        continue;
+                    }
+                    powderList.append(Component.literal(symbol)
+                            .withStyle(Style.EMPTY
+                                    .withFont(ResourceLocation.withDefaultNamespace("common"))
+                                    .withColor(p.getLightColor())));
                 }
                 powderList.append(Component.literal("]"));
                 powderLine.append(powderList);

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/components/GearTooltipComponent.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/components/GearTooltipComponent.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 
 public final class GearTooltipComponent extends IdentifiableTooltipComponent<GearInfo, GearInstance> {
     private static final int PIXEL_WIDTH = 150;
@@ -68,9 +70,12 @@ public final class GearTooltipComponent extends IdentifiableTooltipComponent<Gea
             for (Pair<DamageType, RangedValue> damageStat : damages) {
                 DamageType type = damageStat.key();
                 String elementSymbol =
-                        type.getElement().isPresent() ? type.getElement().get().getDisplaySymbol() : type.getSymbol();
-                MutableComponent damage = Component.literal(elementSymbol + " " + type.getDisplayName())
-                        .withStyle(type.getColorCode());
+                        type.getElement().isPresent() ? type.getElement().get().getSymbol() : type.getSymbol();
+                MutableComponent damage = Component.empty()
+                        .withStyle(type.getColorCode())
+                        .append(Component.literal(elementSymbol)
+                                .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))))
+                        .append(Component.literal(" " + type.getDisplayName()));
                 damage.append(Component.literal("Damage: " + damageStat.value().asString())
                         .withStyle(
                                 type == DamageType.NEUTRAL
@@ -95,9 +100,11 @@ public final class GearTooltipComponent extends IdentifiableTooltipComponent<Gea
             List<Pair<Element, Integer>> defenses = gearInfo.fixedStats().defences();
             for (Pair<Element, Integer> defenceStat : defenses) {
                 Element element = defenceStat.key();
-                MutableComponent defense = Component.literal(
-                                element.getDisplaySymbol() + " " + element.getDisplayName())
-                        .withStyle(element.getColorCode());
+                MutableComponent defense = Component.empty()
+                        .withStyle(element.getColorCode())
+                        .append(Component.literal(element.getSymbol())
+                                .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))))
+                        .append(Component.literal(" " + element.getDisplayName()));
                 defense.append(Component.literal(" Defence: " + StringUtils.toSignedString(defenceStat.value()))
                         .withStyle(ChatFormatting.GRAY));
                 header.add(defense);
@@ -195,9 +202,20 @@ public final class GearTooltipComponent extends IdentifiableTooltipComponent<Gea
                 if (!gearInstance.powders().isEmpty()) {
                     MutableComponent powderList = Component.literal("[");
                     for (Powder p : gearInstance.powders()) {
-                        String symbol = p.getColoredSymbol().getString();
-                        if (!powderList.getSiblings().isEmpty()) symbol = " " + symbol;
-                        powderList.append(Component.literal(symbol));
+                        String symbol = String.valueOf(p.getSymbol());
+                        if (!powderList.getSiblings().isEmpty()) {
+                            powderList.append(Component.empty()
+                                    .withStyle(Style.EMPTY.withColor(p.getLightColor()))
+                                    .append(Component.literal(" "))
+                                    .append(Component.literal(symbol)
+                                            .withStyle(Style.EMPTY.withFont(
+                                                    ResourceLocation.withDefaultNamespace("common")))));
+                            continue;
+                        }
+                        powderList.append(Component.literal(symbol)
+                                .withStyle(Style.EMPTY
+                                        .withFont(ResourceLocation.withDefaultNamespace("common"))
+                                        .withColor(p.getLightColor())));
                     }
                     powderList.append(Component.literal("]"));
                     powderLine.append(powderList);

--- a/common/src/main/java/com/wynntils/models/elements/type/Element.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Element.java
@@ -8,21 +8,19 @@ import com.wynntils.utils.StringUtils;
 import net.minecraft.ChatFormatting;
 
 public enum Element {
-    EARTH("\uE001", "✤", ChatFormatting.DARK_GREEN, 0),
-    THUNDER("\uE003", "✦", ChatFormatting.YELLOW, 1),
-    WATER("\uE004", "❉", ChatFormatting.AQUA, 2),
-    FIRE("\uE002", "✹", ChatFormatting.RED, 3),
-    AIR("\uE000", "❋", ChatFormatting.WHITE, 4);
+    EARTH("\uE001", ChatFormatting.DARK_GREEN, 0),
+    THUNDER("\uE003", ChatFormatting.YELLOW, 1),
+    WATER("\uE004", ChatFormatting.AQUA, 2),
+    FIRE("\uE002", ChatFormatting.RED, 3),
+    AIR("\uE000", ChatFormatting.WHITE, 4);
 
-    private final String parseSymbol;
-    private final String displaySymbol;
+    private final String symbol;
     private final ChatFormatting colorCode;
     private final String displayName;
     private final int encodingId;
 
-    Element(String parseSymbol, String displaySymbol, ChatFormatting colorCode, int encodingId) {
-        this.parseSymbol = parseSymbol;
-        this.displaySymbol = displaySymbol;
+    Element(String symbol, ChatFormatting colorCode, int encodingId) {
+        this.symbol = symbol;
         this.colorCode = colorCode;
         this.encodingId = encodingId;
         this.displayName = StringUtils.capitalized(this.name());
@@ -30,7 +28,7 @@ public enum Element {
 
     public static Element fromSymbol(String symbol) {
         for (Element element : Element.values()) {
-            if (element.parseSymbol.equals(symbol)) {
+            if (element.symbol.equals(symbol)) {
                 return element;
             }
         }
@@ -50,12 +48,8 @@ public enum Element {
         return displayName;
     }
 
-    public String getParseSymbol() {
-        return parseSymbol;
-    }
-
-    public String getDisplaySymbol() {
-        return displaySymbol;
+    public String getSymbol() {
+        return symbol;
     }
 
     public ChatFormatting getColorCode() {

--- a/common/src/main/java/com/wynntils/models/elements/type/Powder.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Powder.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.models.elements.type;
 
-import com.wynntils.core.text.StyledText;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.colors.CustomColor;
 import java.util.Locale;
@@ -66,15 +65,11 @@ public enum Powder {
     }
 
     public char getSymbol() {
-        return element.getDisplaySymbol().charAt(0);
+        return element.getSymbol().charAt(0);
     }
 
     public CustomColor getColor() {
         return CustomColor.fromInt(this.lightColor.getColor()).withAlpha(255);
-    }
-
-    public StyledText getColoredSymbol() {
-        return StyledText.fromString(lightColor.toString() + getSymbol());
     }
 
     public Item getLowTierItem() {

--- a/common/src/main/java/com/wynntils/models/elements/type/Skill.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/Skill.java
@@ -74,7 +74,7 @@ public enum Skill {
     }
 
     public String getSymbol() {
-        return associatedElement.getDisplaySymbol();
+        return associatedElement.getSymbol();
     }
 
     public ChatFormatting getColorCode() {

--- a/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
+++ b/common/src/main/java/com/wynntils/models/stats/type/DamageType.java
@@ -12,7 +12,7 @@ import net.minecraft.ChatFormatting;
 
 public enum DamageType {
     ALL("", "❤", ChatFormatting.DARK_RED),
-    NEUTRAL("Neutral", "✣", ChatFormatting.GOLD, 5),
+    NEUTRAL("Neutral", "\uE005", ChatFormatting.GOLD, 5),
     FIRE(Element.FIRE),
     WATER(Element.WATER),
     AIR(Element.AIR),
@@ -65,7 +65,7 @@ public enum DamageType {
         // displayName needs padding
         this.displayName = element.getDisplayName() + " ";
         this.apiName = element.getDisplayName();
-        this.symbol = element.getParseSymbol();
+        this.symbol = element.getSymbol();
         this.colorCode = element.getColorCode();
 
         // Encoding id is the element id

--- a/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
@@ -31,6 +31,9 @@ import java.util.Optional;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 
 public class PowderSpecialBarOverlay extends Overlay {
     @Persisted
@@ -109,8 +112,11 @@ public class PowderSpecialBarOverlay extends Overlay {
             text = StyledText.fromString("Unknown");
         } else {
             color = powderSpecialType.getColor();
-            text = StyledText.fromString(
-                    powderSpecialType.getColoredSymbol().getString() + " " + (int) powderSpecialCharge + "%");
+            text = StyledText.fromComponent(Component.empty()
+                    .withStyle(powderSpecialType.getLightColor())
+                    .append(Component.literal(String.valueOf(powderSpecialType.getSymbol()))
+                            .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))))
+                    .append(Component.literal(" " + (int) powderSpecialCharge + "%")));
         }
 
         BufferedFontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/screens/guides/powder/GuidePowderItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/powder/GuidePowderItemStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.guides.powder;
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Locale;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -43,8 +45,11 @@ public final class GuidePowderItemStack extends GuideItemStack {
 
     @Override
     public Component getHoverName() {
-        return Component.literal(element.getSymbol() + " " + element.getName() + " Powder " + MathUtils.toRoman(tier))
-                .withStyle(element.getLightColor());
+        return Component.empty()
+                .withStyle(Style.EMPTY.withColor(element.getLightColor()))
+                .append(Component.literal(String.valueOf(element.getSymbol()))
+                        .withStyle(Style.EMPTY.withFont(ResourceLocation.withDefaultNamespace("common"))))
+                .append(Component.literal(" " + element.getName() + " Powder " + MathUtils.toRoman(tier)));
     }
 
     @Override
@@ -82,21 +87,45 @@ public final class GuidePowderItemStack extends GuideItemStack {
                 .append(Component.literal("]").withStyle(ChatFormatting.GRAY)));
         itemLore.add(Component.empty());
         itemLore.add(Component.literal("Effect on Weapons:").withStyle(element.getDarkColor()));
-        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+" + powderTierInfo.min()
-                + "-" + powderTierInfo.max() + " " + element.getLightColor() + element.getSymbol() + " " + name + " "
-                + ChatFormatting.GRAY + "Damage"));
-        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
-                + powderTierInfo.convertedFromNeutral() + "% " + ChatFormatting.GOLD + "✣ Neutral" + ChatFormatting.GRAY
-                + " to " + element.getLightColor() + element.getSymbol() + " " + name));
+        itemLore.add(Component.empty()
+                .append(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
+                        + powderTierInfo.min() + "-" + powderTierInfo.max() + " " + element.getLightColor()))
+                .append(Component.literal(String.valueOf(element.getSymbol()))
+                        .withStyle(Style.EMPTY
+                                .withFont(ResourceLocation.withDefaultNamespace("common"))
+                                .withColor(element.getLightColor())))
+                .append(Component.literal(
+                        element.getLightColor() + " " + name + " " + ChatFormatting.GRAY + "Damage")));
+        itemLore.add(Component.empty()
+                .append(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
+                        + powderTierInfo.convertedFromNeutral() + "% " + ChatFormatting.GOLD + "✣ Neutral"
+                        + ChatFormatting.GRAY + " to " + element.getLightColor()))
+                .append(Component.literal(String.valueOf(element.getSymbol()))
+                        .withStyle(Style.EMPTY
+                                .withFont(ResourceLocation.withDefaultNamespace("common"))
+                                .withColor(element.getLightColor())))
+                .append(Component.literal(element.getLightColor() + " " + name)));
         itemLore.add(Component.empty());
         itemLore.add(Component.literal("Effect on Armour:").withStyle(element.getDarkColor()));
-        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
-                + powderTierInfo.addedDefence() + " " + element.getLightColor() + element.getSymbol() + " " + name + " "
-                + ChatFormatting.GRAY + "Defence"));
-        itemLore.add(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "-"
-                + powderTierInfo.removedDefence() + " " + opposingElement.getLightColor() + opposingElement.getSymbol()
-                + " " + StringUtils.capitalizeFirst(opposingElement.name().toLowerCase(Locale.ROOT)) + " "
-                + ChatFormatting.GRAY + "Defence"));
+        itemLore.add(Component.empty()
+                .append(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
+                        + powderTierInfo.addedDefence() + " " + element.getLightColor()))
+                .append(Component.literal(String.valueOf(element.getSymbol()))
+                        .withStyle(Style.EMPTY
+                                .withFont(ResourceLocation.withDefaultNamespace("common"))
+                                .withColor(element.getLightColor())))
+                .append(Component.literal(
+                        element.getLightColor() + " " + name + " " + ChatFormatting.GRAY + "Defence")));
+        itemLore.add(Component.empty()
+                .append(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "-"
+                        + powderTierInfo.removedDefence() + " " + opposingElement.getLightColor()))
+                .append(Component.literal(String.valueOf(opposingElement.getSymbol()))
+                        .withStyle(Style.EMPTY
+                                .withFont(ResourceLocation.withDefaultNamespace("common"))
+                                .withColor(opposingElement.getLightColor())))
+                .append(Component.literal(opposingElement.getLightColor() + " "
+                        + StringUtils.capitalizeFirst(opposingElement.name().toLowerCase(Locale.ROOT)) + " "
+                        + ChatFormatting.GRAY + "Defence")));
         itemLore.add(Component.empty());
         itemLore.add(Component.literal(
                         "Add this powder to your items by visiting a Powder Master or use it as an ingredient when crafting.")

--- a/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/skillpointloadouts/SkillPointLoadoutsScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.skillpointloadouts;
@@ -38,6 +38,8 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
 import org.lwjgl.glfw.GLFW;
 
 public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
@@ -204,7 +206,10 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
             FontRenderer.getInstance()
                     .renderText(
                             poseStack,
-                            StyledText.fromString(Skill.values()[i].getColorCode() + Skill.values()[i].getSymbol()),
+                            StyledText.fromComponent(Component.literal(Skill.values()[i].getSymbol())
+                                    .withStyle(Style.EMPTY
+                                            .withColor(Skill.values()[i].getColorCode())
+                                            .withFont(ResourceLocation.withDefaultNamespace("common")))),
                             dividedWidth * (21 + i * 2),
                             dividedHeight * 8,
                             CommonColors.WHITE,
@@ -238,7 +243,10 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
             FontRenderer.getInstance()
                     .renderText(
                             poseStack,
-                            StyledText.fromString(Skill.values()[i].getColorCode() + Skill.values()[i].getSymbol()),
+                            StyledText.fromComponent(Component.literal(Skill.values()[i].getSymbol())
+                                    .withStyle(Style.EMPTY
+                                            .withColor(Skill.values()[i].getColorCode())
+                                            .withFont(ResourceLocation.withDefaultNamespace("common")))),
                             dividedWidth * (51 + i * 2),
                             dividedHeight * 8,
                             CommonColors.WHITE,
@@ -314,7 +322,10 @@ public final class SkillPointLoadoutsScreen extends WynntilsGridLayoutScreen {
                 FontRenderer.getInstance()
                         .renderText(
                                 poseStack,
-                                StyledText.fromString(Skill.values()[i].getColorCode() + Skill.values()[i].getSymbol()),
+                                StyledText.fromComponent(Component.literal(Skill.values()[i].getSymbol())
+                                        .withStyle(Style.EMPTY
+                                                .withColor(Skill.values()[i].getColorCode())
+                                                .withFont(ResourceLocation.withDefaultNamespace("common")))),
                                 dividedWidth * (51 + i * 2),
                                 dividedHeight * 34,
                                 CommonColors.WHITE,


### PR DESCRIPTION
All that was needed to fix sharing crafteds was changing the symbol for the neutral DamageType but that then caused the tooltip to render incorrectly as it needed to use the right font so most of this is just changing all the places we render skill/powder/element symbols to use the font.

It also changes the crafted consumable "Effects" line to green and makes it say "Effect" instead to match actual consumables.

<img width="1321" height="323" alt="image" src="https://github.com/user-attachments/assets/676fd704-ae8f-4036-8510-6f2a8a83bc48" />
<img width="695" height="377" alt="image" src="https://github.com/user-attachments/assets/8b216da6-3821-4b51-8965-2ed3749c7612" />
<img width="137" height="288" alt="image" src="https://github.com/user-attachments/assets/b3250791-13b4-488e-a0a7-2aad790884c2" />
<img width="306" height="89" alt="image" src="https://github.com/user-attachments/assets/8742e661-b02d-4064-bbff-4cc1bfb9f272" />
<img width="1733" height="138" alt="image" src="https://github.com/user-attachments/assets/0db904b6-5181-468c-b5c2-68c0e848d791" />
<img width="553" height="353" alt="image" src="https://github.com/user-attachments/assets/75ebf4bb-f045-4dfe-b9f4-ea0fb342c61c" />
