### PR TITLE
fix: Fix element font handling in abbreviate mob health and focused mob overlay

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/AbbreviateMobHealthFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/AbbreviateMobHealthFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -7,13 +7,18 @@ package com.wynntils.features.combat;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.text.PartStyle;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.mc.event.BossHealthUpdateEvent;
 import com.wynntils.mc.mixin.accessors.ClientboundBossEventPacketAccessor;
 import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.type.IterationDecision;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.AddOperation;
 import net.minecraft.network.protocol.game.ClientboundBossEventPacket.Operation;
@@ -23,7 +28,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.COMBAT)
 public class AbbreviateMobHealthFeature extends Feature {
     private static final Pattern MOB_HEALTH_PATTERN =
-            Pattern.compile("(.*§[cb])(?<current>\\d+)(§.\\/(?<max>\\d+))?(§[cb4]\\s?❤.*)");
+            Pattern.compile("(.*§[cb])(?<current>\\d+)(§.(?<max>\\/\\d+))?(§[cb4]\\s?❤.*)");
 
     @SubscribeEvent
     public void onHealthBarEvent(BossHealthUpdateEvent event) {
@@ -46,21 +51,39 @@ public class AbbreviateMobHealthFeature extends Feature {
         Matcher healthMatcher = MOB_HEALTH_PATTERN.matcher(name);
         if (!healthMatcher.matches()) return component;
 
-        int rawHealth = Integer.parseInt(healthMatcher.group("current"));
-        String formattedHealth = StringUtils.integerToShortString(rawHealth).toUpperCase(Locale.ROOT);
+        StyledText styledText = StyledText.fromComponent(component);
 
-        String maxHealthString = healthMatcher.group("max");
-        if (maxHealthString != null) {
-            int rawMaxHealth = Integer.parseInt(maxHealthString);
-            String formattedMaxHealth = healthMatcher
-                    .group(3)
-                    .replace(
-                            maxHealthString,
-                            StringUtils.integerToShortString(rawMaxHealth).toUpperCase(Locale.ROOT));
-            formattedHealth += formattedMaxHealth;
-        }
+        StyledText modified = styledText.iterate((part, changes) -> {
+            String partStr = part.getString(null, PartStyle.StyleType.NONE);
 
-        String formattedName = healthMatcher.replaceAll("$1" + formattedHealth + "$5");
-        return Component.literal(formattedName);
+            try {
+                String formattedHealth;
+                if (partStr.equals(healthMatcher.group("current"))) {
+                    int rawHealth = Integer.parseInt(partStr);
+                    formattedHealth =
+                            StringUtils.integerToShortString(rawHealth).toLowerCase(Locale.ROOT);
+                } else if (partStr.equals(healthMatcher.group("max"))) {
+                    int rawHealth = Integer.parseInt(partStr.substring(1));
+                    formattedHealth =
+                            "/" + StringUtils.integerToShortString(rawHealth).toLowerCase(Locale.ROOT);
+                } else {
+                    return IterationDecision.CONTINUE;
+                }
+
+                StyledTextPart newPart =
+                        new StyledTextPart(formattedHealth, part.getPartStyle().getStyle(), null, Style.EMPTY);
+
+                changes.remove(part);
+                changes.add(newPart);
+            } catch (NumberFormatException ignored) {
+                return IterationDecision.CONTINUE;
+            }
+
+            return IterationDecision.CONTINUE;
+        });
+
+        if (modified.equals(styledText)) return component;
+
+        return modified.getComponent();
     }
 }

--- a/common/src/main/java/com/wynntils/models/combat/CombatModel.java
+++ b/common/src/main/java/com/wynntils/models/combat/CombatModel.java
@@ -7,9 +7,9 @@ package com.wynntils.models.combat;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
-import com.wynntils.handlers.bossbar.TrackedBar;
 import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
 import com.wynntils.handlers.labels.event.LabelsRemovedEvent;
+import com.wynntils.models.combat.bossbar.DamageBar;
 import com.wynntils.models.combat.label.DamageLabelInfo;
 import com.wynntils.models.combat.label.DamageLabelParser;
 import com.wynntils.models.combat.label.KillLabelInfo;
@@ -19,7 +19,6 @@ import com.wynntils.models.combat.type.FocusedDamageEvent;
 import com.wynntils.models.combat.type.KillCreditType;
 import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.models.worlds.event.WorldStateEvent;
-import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.type.TimedSet;
 import java.util.EnumMap;
@@ -27,15 +26,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class CombatModel extends Model {
-    // Test in CombatModel_DAMAGE_BAR_PATTERN
-    private static final Pattern DAMAGE_BAR_PATTERN = Pattern.compile(
-            "^\\s*§[0-9a-f](.*) - §c(\\d+(?:\\.\\d+)?[kKmM]?)§4❤(?:§r - ( ?(§.(.+))(Dam|Weak|Def))+)?\\s*$");
-
     // Wynncraft updates the focused mob health bar by repeatedly destroying and recreating the boss bar. We don't want
     // to lose the entire focused mob state every time the boss bar is recreated, so we delay invalidation by this many
     // milliseconds and revalidate if a recreation/update event arrives during the delay
@@ -133,8 +126,20 @@ public final class CombatModel extends Model {
         return lastDamageDealtTimestamp;
     }
 
+    public void setLastDamageDealtTimestamp(long lastDamageDealtTimestamp) {
+        this.lastDamageDealtTimestamp = lastDamageDealtTimestamp;
+    }
+
     public long getLastKillTimestamp(boolean includeShared) {
         return includeShared ? Math.max(lastSelfKillTimestamp, lastSharedKillTimestamp) : lastSelfKillTimestamp;
+    }
+
+    public void updateFocusedMob(String name, String elementals, long health) {
+        focusedMobName = name;
+        focusedMobElementals = elementals;
+        focusedMobHealth = health;
+
+        WynntilsMod.postEvent(new FocusedDamageEvent.MobFocused(name, elementals, health));
     }
 
     public String getFocusedMobName() {
@@ -153,9 +158,21 @@ public final class CombatModel extends Model {
         return focusedMobHealth;
     }
 
+    public void updateFocusedMobHealth(long newHealth) {
+        long oldHealth = this.focusedMobHealth;
+        this.focusedMobHealth = newHealth;
+
+        WynntilsMod.postEvent(
+                new FocusedDamageEvent.MobDamaged(focusedMobName, focusedMobElementals, newHealth, oldHealth));
+    }
+
     public CappedValue getFocusedMobHealthPercent() {
         checkFocusedMobValidity();
         return focusedMobHealthPercent;
+    }
+
+    public void updateFocusedMobHealthPercent(CappedValue newHealthPercent) {
+        this.focusedMobHealthPercent = newHealthPercent;
     }
 
     public long getAreaDamagePerSecond() {
@@ -189,7 +206,7 @@ public final class CombatModel extends Model {
                 .size();
     }
 
-    private void checkFocusedMobValidity() {
+    public void checkFocusedMobValidity() {
         if (focusedMobExpiryTime >= 0 && System.currentTimeMillis() >= focusedMobExpiryTime) {
             focusedMobName = "";
             focusedMobElementals = "";
@@ -199,59 +216,11 @@ public final class CombatModel extends Model {
         }
     }
 
-    private void invalidateFocusedMob() {
+    public void invalidateFocusedMob() {
         focusedMobExpiryTime = System.currentTimeMillis() + FOCUSED_MOB_INVALIDATION_DELAY;
     }
 
-    private void revalidateFocusedMob() {
+    public void revalidateFocusedMob() {
         focusedMobExpiryTime = -1L;
-    }
-
-    public final class DamageBar extends TrackedBar {
-        private DamageBar() {
-            super(DAMAGE_BAR_PATTERN);
-        }
-
-        @Override
-        public void onUpdateName(Matcher match) {
-            String mobName = match.group(1);
-            long health = StringUtils.parseSuffixedInteger(match.group(2));
-            String mobElementals = match.group(3);
-            if (mobElementals == null) {
-                mobElementals = "";
-            }
-
-            checkFocusedMobValidity();
-            if (mobName.equals(focusedMobName) && mobElementals.equals(focusedMobElementals)) {
-                long oldHealth = focusedMobHealth;
-                focusedMobHealth = health;
-
-                WynntilsMod.postEvent(new FocusedDamageEvent.MobDamaged(
-                        focusedMobName, focusedMobElementals, focusedMobHealth, oldHealth));
-            } else {
-                focusedMobName = mobName;
-                focusedMobElementals = mobElementals;
-                focusedMobHealth = health;
-
-                WynntilsMod.postEvent(
-                        new FocusedDamageEvent.MobFocused(focusedMobName, focusedMobElementals, focusedMobHealth));
-            }
-            revalidateFocusedMob();
-
-            lastDamageDealtTimestamp = System.currentTimeMillis();
-        }
-
-        @Override
-        public void onUpdateProgress(float progress) {
-            focusedMobHealthPercent = new CappedValue(Math.round(progress * 100), 100);
-            revalidateFocusedMob();
-
-            lastDamageDealtTimestamp = System.currentTimeMillis();
-        }
-
-        @Override
-        protected void reset() {
-            invalidateFocusedMob();
-        }
     }
 }

--- a/common/src/main/java/com/wynntils/models/combat/CombatModel.java
+++ b/common/src/main/java/com/wynntils/models/combat/CombatModel.java
@@ -17,6 +17,7 @@ import com.wynntils.models.combat.label.KillLabelParser;
 import com.wynntils.models.combat.type.DamageDealtEvent;
 import com.wynntils.models.combat.type.FocusedDamageEvent;
 import com.wynntils.models.combat.type.KillCreditType;
+import com.wynntils.models.combat.type.MobElementals;
 import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.type.CappedValue;
@@ -42,7 +43,7 @@ public final class CombatModel extends Model {
     private final TimedSet<KillCreditType> killSet = new TimedSet<>(60, TimeUnit.SECONDS, true);
 
     private String focusedMobName = "";
-    private String focusedMobElementals = "";
+    private MobElementals focusedMobElementals = MobElementals.EMPTY;
     private long focusedMobHealth;
     private CappedValue focusedMobHealthPercent = CappedValue.EMPTY;
     private long focusedMobExpiryTime = -1L;
@@ -114,8 +115,8 @@ public final class CombatModel extends Model {
     public void onWorldStateChange(WorldStateEvent event) {
         areaDamageSet.clear();
         focusedMobName = "";
-        focusedMobElementals = "";
         focusedMobHealth = 0;
+        focusedMobElementals = MobElementals.EMPTY;
         focusedMobHealthPercent = CappedValue.EMPTY;
         focusedMobExpiryTime = -1L;
         lastDamageDealtTimestamp = 0L;
@@ -134,7 +135,7 @@ public final class CombatModel extends Model {
         return includeShared ? Math.max(lastSelfKillTimestamp, lastSharedKillTimestamp) : lastSelfKillTimestamp;
     }
 
-    public void updateFocusedMob(String name, String elementals, long health) {
+    public void updateFocusedMob(String name, MobElementals elementals, long health) {
         focusedMobName = name;
         focusedMobElementals = elementals;
         focusedMobHealth = health;
@@ -147,7 +148,7 @@ public final class CombatModel extends Model {
         return focusedMobName;
     }
 
-    public String getFocusedMobElementals() {
+    public MobElementals getFocusedMobElementals() {
         checkFocusedMobValidity();
         // TODO: Parse this into specific elements and expose as functions
         return focusedMobElementals;
@@ -209,7 +210,7 @@ public final class CombatModel extends Model {
     public void checkFocusedMobValidity() {
         if (focusedMobExpiryTime >= 0 && System.currentTimeMillis() >= focusedMobExpiryTime) {
             focusedMobName = "";
-            focusedMobElementals = "";
+            focusedMobElementals = MobElementals.EMPTY;
             focusedMobHealth = 0;
             focusedMobHealthPercent = CappedValue.EMPTY;
             focusedMobExpiryTime = -1L;

--- a/common/src/main/java/com/wynntils/models/combat/bossbar/DamageBar.java
+++ b/common/src/main/java/com/wynntils/models/combat/bossbar/DamageBar.java
@@ -6,15 +6,27 @@ package com.wynntils.models.combat.bossbar;
 
 import com.wynntils.core.components.Models;
 import com.wynntils.handlers.bossbar.TrackedBar;
+import com.wynntils.models.combat.type.MobElementals;
+import com.wynntils.models.elements.type.Element;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.type.CappedValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public final class DamageBar extends TrackedBar {
     // Test in DamageBar_DAMAGE_BAR_PATTERN
     private static final Pattern DAMAGE_BAR_PATTERN = Pattern.compile(
-            "^\\s*§[0-9a-f](.*) - §c(\\d+(?:\\.\\d+)?[kKmM]?)§4❤(?:§r - ( ?(§.(.+))(Dam|Weak|Def))+)?\\s*$");
+            "^\\s*§(?:#)?[0-9a-f]{1,8}(?:§l)?(.*?)§r - §c(\\d+(?:\\.\\d+)?[km]?)§4❤(?:§r - ((?:§.|\\S)*?Weak))?(?:.*?((?:§.|\\S)*?Dam))?(?:.*?((?:§.|\\S)*?Def))?\\s*$");
+
+    private static final Pattern ELEMENT_PATTERN = Pattern.compile("§[0-9a-f]("
+            + Arrays.stream(Element.values())
+                    .map(e -> Pattern.quote(e.getSymbol()))
+                    .collect(Collectors.joining("|"))
+            + ")");
 
     public DamageBar() {
         super(DAMAGE_BAR_PATTERN);
@@ -24,10 +36,10 @@ public final class DamageBar extends TrackedBar {
     public void onUpdateName(Matcher match) {
         String mobName = match.group(1);
         long health = StringUtils.parseSuffixedInteger(match.group(2));
-        String mobElementals = match.group(3);
-        if (mobElementals == null) {
-            mobElementals = "";
-        }
+        List<Element> weaknesses = parseElements(match.group(3));
+        List<Element> damages = parseElements(match.group(4));
+        List<Element> defenses = parseElements(match.group(5));
+        MobElementals mobElementals = new MobElementals(weaknesses, damages, defenses);
 
         Models.Combat.checkFocusedMobValidity();
         if (mobName.equals(Models.Combat.getFocusedMobName())
@@ -49,5 +61,22 @@ public final class DamageBar extends TrackedBar {
     @Override
     protected void reset() {
         Models.Combat.invalidateFocusedMob();
+    }
+
+    private List<Element> parseElements(String elementPart) {
+        List<Element> elements = new ArrayList<>();
+        if (elementPart == null || elementPart.isEmpty()) return elements;
+
+        Matcher matcher = ELEMENT_PATTERN.matcher(elementPart);
+        while (matcher.find()) {
+            String symbol = matcher.group(1);
+            Element element = Element.fromSymbol(symbol);
+
+            if (element != null && !elements.contains(element)) {
+                elements.add(element);
+            }
+        }
+
+        return elements;
     }
 }

--- a/common/src/main/java/com/wynntils/models/combat/bossbar/DamageBar.java
+++ b/common/src/main/java/com/wynntils/models/combat/bossbar/DamageBar.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.combat.bossbar;
+
+import com.wynntils.core.components.Models;
+import com.wynntils.handlers.bossbar.TrackedBar;
+import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.type.CappedValue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DamageBar extends TrackedBar {
+    // Test in DamageBar_DAMAGE_BAR_PATTERN
+    private static final Pattern DAMAGE_BAR_PATTERN = Pattern.compile(
+            "^\\s*§[0-9a-f](.*) - §c(\\d+(?:\\.\\d+)?[kKmM]?)§4❤(?:§r - ( ?(§.(.+))(Dam|Weak|Def))+)?\\s*$");
+
+    public DamageBar() {
+        super(DAMAGE_BAR_PATTERN);
+    }
+
+    @Override
+    public void onUpdateName(Matcher match) {
+        String mobName = match.group(1);
+        long health = StringUtils.parseSuffixedInteger(match.group(2));
+        String mobElementals = match.group(3);
+        if (mobElementals == null) {
+            mobElementals = "";
+        }
+
+        Models.Combat.checkFocusedMobValidity();
+        if (mobName.equals(Models.Combat.getFocusedMobName())
+                && mobElementals.equals(Models.Combat.getFocusedMobElementals())) {
+            Models.Combat.updateFocusedMobHealth(health);
+        } else {
+            Models.Combat.updateFocusedMob(mobName, mobElementals, health);
+        }
+        Models.Combat.revalidateFocusedMob();
+        Models.Combat.setLastDamageDealtTimestamp(System.currentTimeMillis());
+    }
+
+    @Override
+    public void onUpdateProgress(float progress) {
+        Models.Combat.updateFocusedMobHealthPercent(new CappedValue(Math.round(progress * 100), 100));
+        Models.Combat.revalidateFocusedMob();
+    }
+
+    @Override
+    protected void reset() {
+        Models.Combat.invalidateFocusedMob();
+    }
+}

--- a/common/src/main/java/com/wynntils/models/combat/type/FocusedDamageEvent.java
+++ b/common/src/main/java/com/wynntils/models/combat/type/FocusedDamageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.combat.type;
@@ -17,10 +17,10 @@ import net.neoforged.bus.api.Event;
  */
 public abstract class FocusedDamageEvent extends Event {
     private final String mobName;
-    private final String mobElementals;
+    private final MobElementals mobElementals;
     private final long health;
 
-    protected FocusedDamageEvent(String mobName, String mobElementals, long health) {
+    protected FocusedDamageEvent(String mobName, MobElementals mobElementals, long health) {
         this.mobName = mobName;
         this.mobElementals = mobElementals;
         this.health = health;
@@ -30,7 +30,7 @@ public abstract class FocusedDamageEvent extends Event {
         return mobName;
     }
 
-    public String getMobElementals() {
+    public MobElementals getMobElementals() {
         return mobElementals;
     }
 
@@ -39,7 +39,7 @@ public abstract class FocusedDamageEvent extends Event {
     }
 
     public static final class MobFocused extends FocusedDamageEvent {
-        public MobFocused(String mobName, String mobElementals, long health) {
+        public MobFocused(String mobName, MobElementals mobElementals, long health) {
             super(mobName, mobElementals, health);
         }
     }
@@ -47,7 +47,7 @@ public abstract class FocusedDamageEvent extends Event {
     public static final class MobDamaged extends FocusedDamageEvent {
         private final long oldHealth;
 
-        public MobDamaged(String mobName, String mobElementals, long currentHealth, long oldHealth) {
+        public MobDamaged(String mobName, MobElementals mobElementals, long currentHealth, long oldHealth) {
             super(mobName, mobElementals, currentHealth);
             this.oldHealth = oldHealth;
         }

--- a/common/src/main/java/com/wynntils/models/combat/type/MobElementals.java
+++ b/common/src/main/java/com/wynntils/models/combat/type/MobElementals.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.combat.type;
+
+import com.wynntils.models.elements.type.Element;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
+
+public record MobElementals(List<Element> weaknesses, List<Element> damages, List<Element> defenses) {
+    public static final MobElementals EMPTY = new MobElementals(List.of(), List.of(), List.of());
+
+    public Component getFormatted() {
+        MutableComponent text = Component.empty();
+
+        appendElementGroup(text, weaknesses, "Weak", !damages.isEmpty() || !defenses.isEmpty());
+        appendElementGroup(text, damages, "Dam", !defenses.isEmpty());
+        appendElementGroup(text, defenses, "Def", false);
+
+        return text;
+    }
+
+    private void appendElementGroup(MutableComponent text, List<Element> elements, String label, boolean addSpace) {
+        if (elements.isEmpty()) return;
+
+        for (Element element : elements) {
+            text.append(Component.literal(element.getSymbol())
+                    .withStyle(Style.EMPTY
+                            .withFont(ResourceLocation.withDefaultNamespace("common"))
+                            .withColor(element.getColorCode())));
+        }
+
+        // The label uses the colour of the last element in the group, can't use the same style as the symbol uses
+        // a different font
+        ChatFormatting lastColor = elements.getLast().getColorCode();
+        text.append(Component.literal(label + (addSpace ? " " : "")).withStyle(Style.EMPTY.withColor(lastColor)));
+    }
+}

--- a/common/src/main/java/com/wynntils/overlays/gamebars/FocusedMobHealthBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/FocusedMobHealthBarOverlay.java
@@ -4,28 +4,36 @@
  */
 package com.wynntils.overlays.gamebars;
 
-import com.wynntils.core.components.Managers;
+import com.mojang.blaze3d.vertex.PoseStack;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.overlays.OverlayPosition;
 import com.wynntils.core.consumers.overlays.OverlaySize;
-import com.wynntils.features.combat.AbbreviateMobHealthFeature;
+import com.wynntils.core.persisted.Persisted;
+import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.bossbar.TrackedBar;
 import com.wynntils.handlers.bossbar.type.BossBarProgress;
 import com.wynntils.models.combat.bossbar.DamageBar;
 import com.wynntils.models.combat.type.FocusedDamageEvent;
+import com.wynntils.models.combat.type.MobElementals;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.render.buffered.BufferedFontRenderer;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.CappedValue;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public class FocusedMobHealthBarOverlay extends BaseBarOverlay {
-    private static final String FMT_STR_WITHOUT_ELEMS =
-            ChatFormatting.WHITE + "%s" + ChatFormatting.RED + " ❤ " + ChatFormatting.WHITE + "%s";
-    private static final String FMT_STR_WITH_ELEMS =
-            FMT_STR_WITHOUT_ELEMS + " " + ChatFormatting.GRAY + "[%s" + ChatFormatting.GRAY + "]";
+    @Persisted
+    public final Config<Boolean> abbreviateHealth = new Config<>(true);
+
+    private StyledText barText = StyledText.EMPTY;
 
     public FocusedMobHealthBarOverlay() {
         super(
@@ -52,23 +60,48 @@ public class FocusedMobHealthBarOverlay extends BaseBarOverlay {
     }
 
     @Override
-    protected String text() {
-        String healthString = Managers.Feature.getFeatureInstance(AbbreviateMobHealthFeature.class)
-                        .isEnabled()
-                ? StringUtils.integerToShortString(Models.Combat.getFocusedMobHealth())
-                : Long.toString(Models.Combat.getFocusedMobHealth());
-        String elementals = Models.Combat.getFocusedMobElementals();
-        if (elementals.isBlank()) {
-            return String.format(FMT_STR_WITHOUT_ELEMS, Models.Combat.getFocusedMobName(), healthString);
-        } else {
-            return String.format(FMT_STR_WITH_ELEMS, Models.Combat.getFocusedMobName(), healthString, elementals);
-        }
-    }
-
-    @Override
     public boolean isActive() {
         return Models.Combat.getFocusedMobHealth() > 0
                 && System.currentTimeMillis() - Models.Combat.getLastDamageDealtTimestamp() < 5000;
+    }
+
+    @Override
+    protected void renderText(PoseStack poseStack, MultiBufferSource bufferSource, float renderY, String text) {
+        BufferedFontRenderer.getInstance()
+                .renderAlignedTextInBox(
+                        poseStack,
+                        bufferSource,
+                        barText,
+                        this.getRenderX(),
+                        this.getRenderX() + this.getWidth(),
+                        renderY,
+                        0,
+                        this.textColor.get(),
+                        this.getRenderHorizontalAlignment(),
+                        this.textShadow.get());
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+
+        String healthString = abbreviateHealth.get()
+                ? StringUtils.integerToShortString(Models.Combat.getFocusedMobHealth())
+                : Long.toString(Models.Combat.getFocusedMobHealth());
+
+        MutableComponent text = Component.empty()
+                .withStyle(Style.EMPTY.withColor(ChatFormatting.WHITE))
+                .append(Component.literal(Models.Combat.getFocusedMobName()))
+                .append(Component.literal(" ❤ ").withStyle(Style.EMPTY.withColor(ChatFormatting.RED)))
+                .append(Component.literal(healthString));
+
+        if (!Models.Combat.getFocusedMobElementals().equals(MobElementals.EMPTY)) {
+            text.append(Component.literal(" [").withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)))
+                    .append(Models.Combat.getFocusedMobElementals().getFormatted())
+                    .append(Component.literal("]").withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
+        }
+
+        barText = StyledText.fromComponent(text);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/overlays/gamebars/FocusedMobHealthBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/FocusedMobHealthBarOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.overlays.gamebars;
@@ -11,7 +11,7 @@ import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.features.combat.AbbreviateMobHealthFeature;
 import com.wynntils.handlers.bossbar.TrackedBar;
 import com.wynntils.handlers.bossbar.type.BossBarProgress;
-import com.wynntils.models.combat.CombatModel;
+import com.wynntils.models.combat.bossbar.DamageBar;
 import com.wynntils.models.combat.type.FocusedDamageEvent;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.colors.CommonColors;
@@ -73,6 +73,6 @@ public class FocusedMobHealthBarOverlay extends BaseBarOverlay {
 
     @Override
     protected Class<? extends TrackedBar> getTrackedBarClass() {
-        return CombatModel.DamageBar.class;
+        return DamageBar.class;
     }
 }

--- a/common/src/main/java/com/wynntils/utils/StringUtils.java
+++ b/common/src/main/java/com/wynntils/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.utils;
@@ -77,7 +77,7 @@ public final class StringUtils {
         for (int i = 1; i < SUFFIXES.length; i++) {
             if (numStr.endsWith(SUFFIXES[i])) {
                 double baseValue = Double.parseDouble(numStr.substring(0, numStr.length() - 1));
-                return ((long) Math.ceil(baseValue)) * SUFFIX_MULTIPLIERS[i];
+                return (long) Math.ceil(baseValue * SUFFIX_MULTIPLIERS[i]);
             }
         }
         return Long.parseLong(numStr);

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -601,6 +601,8 @@
   "feature.wynntils.gameBarsOverlay.overlay.commanderBar.name": "Commander Bar",
   "feature.wynntils.gameBarsOverlay.overlay.corruptedBar.name": "Corrupted Bar",
   "feature.wynntils.gameBarsOverlay.overlay.focusBar.name": "Focus Bar",
+  "feature.wynntils.gameBarsOverlay.overlay.focusedMobHealthBar.abbreviateHealth.description": "Should the focused mobs health be abbreviated or displayed in full?",
+  "feature.wynntils.gameBarsOverlay.overlay.focusedMobHealthBar.abbreviateHealth.name": "Abbreviate Health",
   "feature.wynntils.gameBarsOverlay.overlay.focusedMobHealthBar.name": "Focused Mob Health Bar",
   "feature.wynntils.gameBarsOverlay.overlay.healthBar.name": "Health Bar",
   "feature.wynntils.gameBarsOverlay.overlay.holyPowerBar.name": "Holy Power Bar",

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -12,7 +12,6 @@ import com.wynntils.models.abilities.ShamanTotemModel;
 import com.wynntils.models.abilities.bossbars.OphanimBar;
 import com.wynntils.models.account.AccountModel;
 import com.wynntils.models.bonustotems.label.BonusTotemLabelParser;
-import com.wynntils.models.combat.CombatModel;
 import com.wynntils.models.combat.bossbar.DamageBar;
 import com.wynntils.models.combat.label.DamageLabelParser;
 import com.wynntils.models.combat.label.KillLabelParser;
@@ -223,12 +222,19 @@ public class TestRegex {
     @Test
     public void DamageBar_DAMAGE_BAR_PATTERN() {
         PatternTester p = new PatternTester(DamageBar.class, "DAMAGE_BAR_PATTERN");
-        p.shouldMatch("§aTravelling Merchant§r - §c5985§4❤");
-        p.shouldMatch("§aGrook§r - §c23§4❤");
-        p.shouldMatch("§cZombie§r - §c43§4❤");
-        p.shouldMatch("§cFeligember Frog§r - §c1553§4❤§r - §7§e✦Weak §c✹Dam §c✹Def");
-        p.shouldMatch("§cLongleg Gripper§r - §c40500§4❤§r - §2✤Dam §e✦§c✹Def");
-        p.shouldMatch("§cBlinder§r - §c6566§4❤");
+        p.shouldMatch("§cShrieking Observer§r - §c20.6k§4❤");
+        p.shouldMatch("§cLongleg Gripper§r - §c3902§4❤§r - §2\uE001Dam §e\uE003§c\uE002Def");
+        p.shouldMatch("§cBlinder§r - §c1543§4❤");
+        p.shouldMatch("§cLight of Freedom§r - §c107k§4❤§r - §b\uE004Dam \uE004§e\uE003Def");
+        p.shouldMatch("§cVoid Vassal§r - §c42.6k§4❤§r - §2\uE001§f\uE000Weak §b\uE004Dam ");
+        p.shouldMatch("§cAzure Necromancer§r - §c104k§4❤§r - §b\uE004§e\uE003Dam §b\uE004Def");
+        p.shouldMatch("§cCerulean Crustacean§r - §c7559§4❤§r - §2\uE001Weak §b\uE004Dam \uE004§c\uE002Def");
+        p.shouldMatch("§cSoul Shrub§r - §c485k§4❤§r - §b\uE004Weak §e\uE003§f\uE000Dam §e\uE003§2\uE001Def");
+        p.shouldMatch(
+                "§cShift Singularity§r - §c159k§4❤§r - §e\uE003Weak §b\uE004§2\uE001§f\uE000§c\uE002Dam §b\uE004§2\uE001§f\uE000§c\uE002Def");
+        p.shouldMatch("§cDespairing Crawler§r - §c3.4m§4❤§r - §e\uE003§c\uE002Dam §b\uE004§2\uE001Def");
+        p.shouldMatch(
+                "§9§lThe §1§k12345§9§l Anomaly§r - §c27.7m§4❤§r - §b\uE004§e\uE003§f\uE000Dam §b\uE004§e\uE003§f\uE000Def");
     }
 
     @Test

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -13,6 +13,7 @@ import com.wynntils.models.abilities.bossbars.OphanimBar;
 import com.wynntils.models.account.AccountModel;
 import com.wynntils.models.bonustotems.label.BonusTotemLabelParser;
 import com.wynntils.models.combat.CombatModel;
+import com.wynntils.models.combat.bossbar.DamageBar;
 import com.wynntils.models.combat.label.DamageLabelParser;
 import com.wynntils.models.combat.label.KillLabelParser;
 import com.wynntils.models.containers.ContainerModel;
@@ -214,20 +215,20 @@ public class TestRegex {
     }
 
     @Test
-    public void CombatModel_DAMAGE_BAR_PATTERN() {
-        PatternTester p = new PatternTester(CombatModel.class, "DAMAGE_BAR_PATTERN");
+    public void ContainerModel_ABILITY_TREE_PATTERN() {
+        PatternTester p = new PatternTester(ContainerModel.class, "ABILITY_TREE_PATTERN");
+        p.shouldMatch("\uDAFF\uDFEA\uE000");
+    }
+
+    @Test
+    public void DamageBar_DAMAGE_BAR_PATTERN() {
+        PatternTester p = new PatternTester(DamageBar.class, "DAMAGE_BAR_PATTERN");
         p.shouldMatch("§aTravelling Merchant§r - §c5985§4❤");
         p.shouldMatch("§aGrook§r - §c23§4❤");
         p.shouldMatch("§cZombie§r - §c43§4❤");
         p.shouldMatch("§cFeligember Frog§r - §c1553§4❤§r - §7§e✦Weak §c✹Dam §c✹Def");
         p.shouldMatch("§cLongleg Gripper§r - §c40500§4❤§r - §2✤Dam §e✦§c✹Def");
         p.shouldMatch("§cBlinder§r - §c6566§4❤");
-    }
-
-    @Test
-    public void ContainerModel_ABILITY_TREE_PATTERN() {
-        PatternTester p = new PatternTester(ContainerModel.class, "ABILITY_TREE_PATTERN");
-        p.shouldMatch("\uDAFF\uDFEA\uE000");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Wynntils/issues/3407

Also adds an abbreviate config to the overlay instead of relying on the feature

Fixed Overlay
<img width="725" height="192" alt="image" src="https://github.com/user-attachments/assets/c1deba4b-d807-4ad6-b5b7-c6ad87857f59" />

Abbreviate mob health was also having issues with the styling so now it only changes the necessary part. Wynn have also abbreviated mob health by default since 2.1 but they don't abbreviate for under 10k like ours does and they also don't do it for the lootrun defend and destroy challenges. Have made it use a lower case "k" or "m" to match the Wynn styling

Broken abbreviation
<img width="683" height="134" alt="image" src="https://github.com/user-attachments/assets/05e737da-4a6c-4be1-9e3a-b559f3869588" />

Fixed abbreviation
<img width="892" height="134" alt="image" src="https://github.com/user-attachments/assets/042d9944-fb48-4de2-8b67-4d4eee47604b" />

