### PR TITLE
feat: Hide attack cooldown feature

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -68,6 +68,7 @@ import com.wynntils.features.inventory.EmeraldPouchFillArcFeature;
 import com.wynntils.features.inventory.EmeraldPouchHotkeyFeature;
 import com.wynntils.features.inventory.ExtendedItemCountFeature;
 import com.wynntils.features.inventory.GuildBankHotkeyFeature;
+import com.wynntils.features.inventory.HideAttackCooldownFeature;
 import com.wynntils.features.inventory.IngredientPouchHotkeyFeature;
 import com.wynntils.features.inventory.InventoryEmeraldCountFeature;
 import com.wynntils.features.inventory.ItemFavoriteFeature;
@@ -272,6 +273,7 @@ public final class FeatureManager extends Manager {
         registerFeature(new EmeraldPouchHotkeyFeature());
         registerFeature(new ExtendedItemCountFeature());
         registerFeature(new GuildBankHotkeyFeature());
+        registerFeature(new HideAttackCooldownFeature());
         registerFeature(new IngredientPouchHotkeyFeature());
         registerFeature(new InventoryEmeraldCountFeature());
         registerFeature(new ItemFavoriteFeature());

--- a/common/src/main/java/com/wynntils/features/inventory/HideAttackCooldownFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/HideAttackCooldownFeature.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.inventory;
+
+import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.persisted.config.Category;
+import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.mc.event.ItemCooldownRenderEvent;
+import com.wynntils.utils.wynn.ItemUtils;
+import net.neoforged.bus.api.SubscribeEvent;
+
+@ConfigCategory(Category.INVENTORY)
+public class HideAttackCooldownFeature extends Feature {
+    @SubscribeEvent
+    public void onCooldownRender(ItemCooldownRenderEvent event) {
+        event.setCanceled(!ItemUtils.isWeapon(event.getItemStack()));
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/ItemCooldownRenderEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemCooldownRenderEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+public class ItemCooldownRenderEvent extends Event implements ICancellableEvent {
+    private final ItemStack itemStack;
+
+    public ItemCooldownRenderEvent(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public ItemStack getItemStack() {
+        return itemStack;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/GuiGraphicsMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/GuiGraphicsMixin.java
@@ -10,6 +10,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.ItemCooldownRenderEvent;
 import com.wynntils.mc.event.ItemCountOverlayRenderEvent;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.event.TooltipRenderEvent;
@@ -134,6 +135,23 @@ public abstract class GuiGraphicsMixin {
         wynntilsCountOverlayColor.set(event.getCountColor());
 
         return event.getCountString();
+    }
+
+    @Inject(
+            method = "renderItemCooldown(Lnet/minecraft/world/item/ItemStack;II)V",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/gui/GuiGraphics;fill(Lnet/minecraft/client/renderer/RenderType;IIIIII)V"),
+            cancellable = true)
+    private void renderItemCooldown(ItemStack stack, int x, int y, CallbackInfo ci) {
+        ItemCooldownRenderEvent event = new ItemCooldownRenderEvent(stack);
+        MixinHelper.post(event);
+
+        if (event.isCanceled()) {
+            ci.cancel();
+        }
     }
 
     @WrapOperation(

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -665,6 +665,8 @@
   "feature.wynntils.heldItemCooldownOverlay.description": "Displays the cooldown of your held item (e.g. weapon swing cooldown) as an overlay.",
   "feature.wynntils.heldItemCooldownOverlay.name": "Held Item Cooldown Overlay",
   "feature.wynntils.heldItemCooldownOverlay.overlay.heldItemCooldown.name": "Held Item Cooldown",
+  "feature.wynntils.hideAttackCooldown.description": "Hides the attack cooldown indicator on items that are not weapons.",
+  "feature.wynntils.hideAttackCooldown.name": "Hide Attack Cooldown",
   "feature.wynntils.hideDamageLabels.description": "Hides the damage labels that popup when damaging enemies",
   "feature.wynntils.hideDamageLabels.name": "Hide Damage Labels",
   "feature.wynntils.horseMount.alreadyRiding": "You are already riding a horse.",


### PR DESCRIPTION
Since most items are now potions, they all get the attack cooldown rendered on them which looks really ugly imo so this feature removes it from items that aren't weapons.

<img width="536" height="663" alt="image" src="https://github.com/user-attachments/assets/e232ec41-6d2f-413f-be37-1f0a98bc0ce7" />


Content book always has the highlight currently
<img width="631" height="87" alt="image" src="https://github.com/user-attachments/assets/68bb5ed7-8d3d-4918-96e5-e99e03c0ec31" />

Feature enabled
<img width="626" height="88" alt="image" src="https://github.com/user-attachments/assets/13c114b3-d2eb-45c7-b01a-2de3db122d48" />

