### PR TITLE
fix: Trim bomb bell server

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -62,8 +62,10 @@ public final class BombModel extends Model {
 
         Matcher bellMatcher = unwrapped.getMatcher(BOMB_BELL_PATTERN);
         if (bellMatcher.matches()) {
-            BombInfo bombInfo =
-                    addBombFromChat(bellMatcher.group("user"), bellMatcher.group("bomb"), bellMatcher.group("server"));
+            BombInfo bombInfo = addBombFromChat(
+                    bellMatcher.group("user"),
+                    bellMatcher.group("bomb"),
+                    bellMatcher.group("server").trim());
             if (bombInfo == null) return;
 
             BombEvent.BombBell bombEvent = new BombEvent.BombBell(bombInfo, message);


### PR DESCRIPTION
When only the server is put onto the 2nd line, the colour and underline styling is still put onto the end of the 1st line which means the pattern will end up matching the padding space too so just trim it.

```
§#fddd5cff\uDAFF\uDFFC\uE01E\uDAFF\uDFFF\uE002\uDAFF\uDFFE GravityLizard has thrown a §#f3e6b2ffProfession Speed Bomb§#fddd5cff on §#f3e6b2ff§n\n§#fddd5cff\uDAFF\uDFFC\uE001\uDB00\uDC06 §#f3e6b2ff§nEU18
```