### PR TITLE
feat: Inline font formatting

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -273,8 +273,8 @@ public final class FunctionManager extends Manager {
             resultBuilder.append(c);
         }
 
-        // Parse color codes before calculating the templates
-        String escapedTemplate = parseColorCodes(resultBuilder.toString());
+        // Parse formatting codes before calculating the templates
+        String escapedTemplate = parseFormattingCodes(resultBuilder.toString());
 
         String calculatedString = doFormat(escapedTemplate);
 
@@ -288,13 +288,16 @@ public final class FunctionManager extends Manager {
                 .toArray(StyledText[]::new);
     }
 
-    private String parseColorCodes(String toProcess) {
+    private String parseFormattingCodes(String toProcess) {
         // Replace &<code> with §<code> if not escaped (e.g., &a → §a, but \&\a stays unchanged)
         // doEscapeFormat preprocesses the string and replaces \& with \&\ so that it doesn't get replaced
         String processed = toProcess.replaceAll("&(?<!\\\\)([0-9a-fA-Fk-oK-OrR])", "§$1");
 
         // Replace &#AARRGGBB with §#AARRGGBB for hex colors
         processed = processed.replaceAll("&(?<!\\\\)(#[0-9A-Fa-f]{8})", "§$1");
+
+        // Replace &{<code>} with §{<code>} for fonts
+        processed = processed.replaceAll("&\\{(?<!\\\\)([0-9a-zA-Z_\\-\\/]+)\\}", "§{$1}");
 
         return processed;
     }

--- a/common/src/main/java/com/wynntils/core/consumers/functions/templates/parser/TemplateParser.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/templates/parser/TemplateParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.functions.templates.parser;
@@ -31,7 +31,8 @@ public final class TemplateParser {
         for (int i = 0; i < templateString.length(); i++) {
             char current = templateString.charAt(i);
 
-            if (current == '{') {
+            // §{} indicates font formatting instead of a template
+            if (current == '{' && (i == 0 || templateString.charAt(i - 1) != '§')) {
                 // Handle if we are already in an expression
                 if (expressionContextStart != -1) {
                     expressionNestLevel++;

--- a/common/src/main/java/com/wynntils/core/text/PartStyle.java
+++ b/common/src/main/java/com/wynntils/core/text/PartStyle.java
@@ -114,11 +114,14 @@ public final class PartStyle {
         //    A color segment is the prefix and the chatFormatting char.
         //    If this is a custom color, a hex color code is used.
         //    Example: §#FF0000 or §1
-        // 2. Formatting is converted the same way as in the Style class.
-        // 3. Click events are wrapped in square brackets, and is represented as an id.
+        // 2. Font is converted to a font segment.
+        //    A font segment is the prefix and font path between {} symbols
+        //    Example: §{banner/ribbon} or §{default}
+        // 3. Formatting is converted the same way as in the Style class.
+        // 4. Click events are wrapped in square brackets, and is represented as an id.
         //    The parent of this style's owner is responsible for keeping track of click events.
         //    Example: §[1] -> (1st click event)
-        // 4. Hover events are wrapped in angle brackets, and is represented as an id.
+        // 5. Hover events are wrapped in angle brackets, and is represented as an id.
         //    The parent of this style's owner is responsible for keeping track of hover events.
         //    Example: §<1> -> (1st hover event)
 
@@ -155,7 +158,16 @@ public final class PartStyle {
                 }
             }
 
-            // 2. Formatting
+            // 2. Font
+            if (type == StyleType.INCLUDE_FONTS || type == StyleType.INCLUDE_EVERYTHING) {
+                styleString
+                        .append(STYLE_PREFIX)
+                        .append('{')
+                        .append(previousStyle.font.toString())
+                        .append('}');
+            }
+
+            // 3. Formatting
             if (obfuscated) {
                 styleString.append(STYLE_PREFIX).append(ChatFormatting.OBFUSCATED.getChar());
             }
@@ -172,8 +184,8 @@ public final class PartStyle {
                 styleString.append(STYLE_PREFIX).append(ChatFormatting.ITALIC.getChar());
             }
 
-            if (type == StyleType.INCLUDE_EVENTS) {
-                // 3. Click event
+            if (type == StyleType.INCLUDE_EVENTS || type == StyleType.INCLUDE_EVERYTHING) {
+                // 4. Click event
                 if (clickEvent != null) {
                     styleString
                             .append(STYLE_PREFIX)
@@ -182,7 +194,7 @@ public final class PartStyle {
                             .append("]");
                 }
 
-                // 4. Hover event
+                // 5. Hover event
                 if (hoverEvent != null) {
                     styleString
                             .append(STYLE_PREFIX)
@@ -521,7 +533,9 @@ public final class PartStyle {
     }
 
     public enum StyleType {
+        INCLUDE_EVERYTHING, // Includes both events and fonts
         INCLUDE_EVENTS, // Includes click and hover events
+        INCLUDE_FONTS, // Include fonts
         DEFAULT, // The most minimal way to represent a style
         NONE // No styling
     }

--- a/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
+++ b/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
@@ -246,12 +246,16 @@ public final class StyledTextPart {
                     fontFormatting.append(current);
                     continue;
                 }
-                if (fontFormatting.isEmpty()) continue;
-                currentStyle = currentStyle.withFont(ResourceLocation.parse(fontFormatting.toString()));
-                fontFormattingPrefix = false;
-                fontFormatting = new StringBuilder();
+                if (!fontFormatting.isEmpty()) {
+                    parts.add(new StyledTextPart(currentString.toString(), currentStyle, null, parentStyle));
+                    currentString = new StringBuilder();
 
-                continue;
+                    currentStyle = currentStyle.withFont(ResourceLocation.parse(fontFormatting.toString()));
+                    fontFormattingPrefix = false;
+                    fontFormatting = new StringBuilder();
+
+                    continue;
+                }
             }
 
             if (current == ChatFormatting.PREFIX_CODE) {

--- a/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
+++ b/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
@@ -62,10 +62,14 @@ public final class StyledTextPart {
         boolean nextIsFormatting = false;
         StringBuilder hexColorFormatting = new StringBuilder();
 
+        StringBuilder fontFormatting = new StringBuilder();
         // []
         boolean clickEventPrefix = false;
         // <>
         boolean hoverEventPrefix = false;
+        // {}
+        boolean fontFormattingPrefix = false;
+
         String eventIndexString = "";
 
         for (char current : codedString.toCharArray()) {
@@ -87,6 +91,11 @@ public final class StyledTextPart {
                 // It looks like we have a hex color code
                 if (current == '#') {
                     hexColorFormatting.append(current);
+                    continue;
+                }
+
+                if (current == '{') {
+                    fontFormattingPrefix = true;
                     continue;
                 }
 
@@ -229,6 +238,18 @@ public final class StyledTextPart {
                     currentStyle = currentStyle.withColor(customColor.asInt());
                     hexColorFormatting = new StringBuilder();
                 }
+
+                continue;
+            }
+            if (fontFormattingPrefix) {
+                if (current != '}') {
+                    fontFormatting.append(current);
+                    continue;
+                }
+                if (fontFormatting.isEmpty()) continue;
+                currentStyle = currentStyle.withFont(ResourceLocation.parse(fontFormatting.toString()));
+                fontFormattingPrefix = false;
+                fontFormatting = new StringBuilder();
 
                 continue;
             }


### PR DESCRIPTION
Implements a way to specify font in coded text, similar to color codes. This allows the use of previously inaccessible Wynncraft fonts to users, not only that but current way of using these fonts is quite fragile, there is a possibility that things get broken with Wynncraft RP changes as these characters are fetching first available font, meaning if they add a new font that will get loaded before current one, and it uses same characters, suddenly every text will use that new font. And also, as adding a new font is as easy as creating a file in a resourcepack, it allows people adding their own fully custom characters via their own fonts, meaning they won't ever be affected by other RPs including Wynncraft one.

The format is similar to current formatting codes, it basically looks like this `§{<path>}` where `<path>` is the path to or an identifier of the font. Here is an example: `&{banner/ribbon}`, this will render the text using the ribbon font they use for their banners, this is how it looks in the info box:
<img width="107" height="59" alt="image" src="https://github.com/user-attachments/assets/626ca841-a9b5-4e90-9deb-432d0927c66f" />
A simple change of `ribbon` to `flag` will cause the same text to look like this as these fonts use exactly same characters
<img width="74" height="49" alt="image" src="https://github.com/user-attachments/assets/7ae3d155-c857-4acc-a1a2-aefbdc2d5509" />
