### PR TITLE
feat: Add emote command arguments

### DIFF
--- a/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
@@ -60,6 +60,7 @@ public class AddCommandExpansionFeature extends Feature {
 
         addArgumentlessCommandNodes(root);
         addChangetagCommandNode(root);
+        addEmoteCommandNode(root);
         addFriendCommandNode(root);
         addGuildCommandNode(root);
         addIgnoreCommandNode(root);
@@ -180,12 +181,6 @@ public class AddCommandExpansionFeature extends Feature {
         addAlias(root, consumablesNode, "tokens", AliasCommandLevel.ALL);
         addAlias(root, consumablesNode, "consumable", AliasCommandLevel.ALL);
 
-        // "emotes" aliases
-        CommandNode<CommandSourceStack> emotesNode = literal("emotes").build();
-        addNode(root, emotesNode);
-
-        addAlias(root, consumablesNode, "emote", AliasCommandLevel.ALL);
-
         // "use" aliases
         CommandNode<CommandSourceStack> useNode = literal("use").build();
         addNode(root, useNode);
@@ -258,6 +253,23 @@ public class AddCommandExpansionFeature extends Feature {
                         .then(literal("CHAMPION"))
                         .then(literal("RESET"))
                         .build());
+    }
+
+    private void addEmoteCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
+        // FIXME: We should only provide the emotes that the player has access to
+        CommandNode<CommandSourceStack> node = literal("emote")
+                .then(literal("cheer"))
+                .then(literal("clap"))
+                .then(literal("dance"))
+                .then(literal("flop"))
+                .then(literal("hug"))
+                .then(literal("relax"))
+                .then(literal("jump"))
+                .then(literal("wave"))
+                .build();
+        addNode(root, node);
+
+        addAlias(root, node, "emotes", AliasCommandLevel.ALL);
     }
 
     private void addFriendCommandNode(RootCommandNode<SharedSuggestionProvider> root) {


### PR DESCRIPTION
Currently the arguments will display all of the available emotes instead of just the ones the player has unlocked, we could scan the page on join but for a minor feature like this I don't think it's worthwhile.

For a few weeks now Wynncraft have had autofill for commands but only for arguments, not the root command itself so perhaps we should look into reworking this feature to only autofill the root and then get the parameters from the server