### PR TITLE
feat: Handle rerolls in lootrun pulls, fix pulls not incrementing

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -29,6 +29,7 @@ import com.wynntils.models.containers.containers.ItemIdentifierContainer;
 import com.wynntils.models.containers.containers.JukeboxContainer;
 import com.wynntils.models.containers.containers.LeaderboardRewardsContainer;
 import com.wynntils.models.containers.containers.LobbyContainer;
+import com.wynntils.models.containers.containers.LootrunRewardChestContainer;
 import com.wynntils.models.containers.containers.RaidRewardChestContainer;
 import com.wynntils.models.containers.containers.RatingRewardsContainer;
 import com.wynntils.models.containers.containers.ScrapMenuContainer;
@@ -144,6 +145,7 @@ public final class ContainerModel extends Model {
         registerContainer(new LeaderboardRewardsContainer());
         registerContainer(new LobbyContainer());
         registerContainer(new LootChestContainer());
+        registerContainer(new LootrunRewardChestContainer());
         registerContainer(new MiscBucketContainer());
         registerContainer(new ObjectiveRewardContainer());
         registerContainer(new PlayerEffectsMenuContainer());

--- a/common/src/main/java/com/wynntils/models/containers/containers/LootrunRewardChestContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/LootrunRewardChestContainer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.containers;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.models.containers.Container;
+import java.util.regex.Pattern;
+
+public class LootrunRewardChestContainer extends Container {
+    private static final Pattern TITLE_PATTERN = Pattern.compile("\uDAFF\uDFF2\uE00A");
+
+    public static final int CLOSE_CHEST_SLOT = 4;
+    public static final StyledText CLOSE_CHEST_ITEM_NAME = StyledText.fromString("§c§lClose Chest");
+    public static final Pattern REROLL_CONFIRM_PATTERN = Pattern.compile("§7Click again to confirm");
+    public static final int REROLL_REWARDS_SLOT = 5;
+
+    public LootrunRewardChestContainer() {
+        super(TITLE_PATTERN);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -180,7 +180,6 @@ public final class LootrunModel extends Model {
     private boolean foundLootrunMythic = false;
     private boolean rerollingRewards = false;
     private boolean rewardChestIsOpened = false;
-    private int expectedLootrunRewardChestId = -2;
 
     private Map<LootrunLocation, Set<TaskLocation>> taskLocations = new HashMap<>();
 

--- a/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/LootrunModel.java
@@ -102,7 +102,7 @@ public final class LootrunModel extends Model {
     //         ÀÀ§f2§7 Reward Rerolls§r                  §7Mobs Killed: §f236
     //    ÀÀÀ§f260§7 Lootrun Experience§r       ÀÀ§7Challenges Completed: §f13
 
-    private static final Pattern LOOTRUN_COMPLETED_PATTERN = Pattern.compile("\uDB00\uDC61§6§lLootrun Completed!");
+    private static final Pattern LOOTRUN_COMPLETED_PATTERN = Pattern.compile("\uDB00\uDC62§6§lLootrun Completed!");
 
     // Rewards
     private static final Pattern REWARD_PULLS_PATTERN = Pattern.compile("§.(\\d+)§7 Reward Pulls§r");

--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -231,6 +231,8 @@ public final class RaidModel extends Model {
 
     @SubscribeEvent
     public void onSlotClicked(ContainerClickEvent e) {
+        if (e.getItemStack().isEmpty()) return;
+
         if (Models.Container.getCurrentContainer() instanceof RaidRewardChestContainer raidRewardChest) {
             if (e.getSlotNum() == raidRewardChest.REROLL_REWARDS_SLOT) {
                 StyledText rerollLoreConfirm =


### PR DESCRIPTION
Rerolls are handled similarly to how we handle them in RaidModel. There's probably some overlap that we could improve at some point but not necessary for here I think.

This is also fixes the pull counter not increasing as once again they have made a tiny change to a unicode character (: