### PR TITLE
feat: Display buy amount in item name when bulk buying

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
@@ -200,7 +200,8 @@ public class BulkBuyFeature extends Feature {
 
         List<Component> tooltips = List.of(component);
 
-        event.setTooltips(LoreUtils.appendTooltip(event.getItemStack(), replacePrices(event.getTooltips()), tooltips));
+        event.setTooltips(LoreUtils.appendTooltip(
+                event.getItemStack(), replacePrices(event.getItemStack(), event.getTooltips()), tooltips));
     }
 
     private int findItemPrice(List<StyledText> lore) {
@@ -217,15 +218,19 @@ public class BulkBuyFeature extends Feature {
 
     /**
      * When shift is pressed:
+     * Adds the amount to buy to the item name.
      * Replaces the price in the lore with the bulk buy price.
      * Also replaces the "✔" with a "✖" with a if the user can't afford the bulk buy.
      * @param oldLore Lore of the item that user wants to bulk buy
      * @return New lore with the above replacements
      */
-    private List<Component> replacePrices(List<Component> oldLore) {
+    private List<Component> replacePrices(ItemStack itemStack, List<Component> oldLore) {
         if (!KeyboardUtils.isShiftDown()) return oldLore;
 
         List<Component> returnable = new ArrayList<>(oldLore);
+
+        // Add the amount to buy to the item name
+        returnable.set(0, Component.literal(bulkBuyAmount.get() + "x ").append(itemStack.getHoverName()));
 
         // iterate through lore to find the price, then replace it with the bulk buy price
         // there is no better way to do this since we cannot tell which line is the price (user may or may not have nbt


### PR DESCRIPTION
<img width="491" height="158" alt="image" src="https://github.com/user-attachments/assets/5db09a95-433c-4006-b604-301139c0bed9" />

Requested for https://github.com/Wynntils/Wynntils/pull/3371 but wasn't done in time