### PR TITLE
chore: Remove hideAdditionalInfo from TooltipVanillaHideFeature

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/TooltipVanillaHideFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/TooltipVanillaHideFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.tooltips;
@@ -18,20 +18,10 @@ public class TooltipVanillaHideFeature extends Feature {
     @Persisted
     public final Config<Boolean> hideAdvanced = new Config<>(true);
 
-    @Persisted
-    public final Config<Boolean> hideAdditionalInfo = new Config<>(true);
-
     @SubscribeEvent
-    public void onTooltipFlagsAdvanced(ItemTooltipFlagsEvent.Advanced event) {
+    public void onTooltipFlagsAdvanced(ItemTooltipFlagsEvent event) {
         if (!hideAdvanced.get()) return;
 
         event.setFlags(TooltipFlag.NORMAL);
-    }
-
-    @SubscribeEvent
-    public void onTooltipFlagsMask(ItemTooltipFlagsEvent.HideAdditionalTooltip event) {
-        if (!hideAdditionalInfo.get()) return;
-
-        event.setHideAdditionalTooltip(true);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/ItemTooltipFlagsEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/ItemTooltipFlagsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;
@@ -8,48 +8,24 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.bus.api.Event;
 
-public abstract class ItemTooltipFlagsEvent extends Event {
+public class ItemTooltipFlagsEvent extends Event {
     private final ItemStack itemStack;
+    private TooltipFlag flags;
 
-    protected ItemTooltipFlagsEvent(ItemStack itemStack) {
+    public ItemTooltipFlagsEvent(ItemStack itemStack, TooltipFlag flags) {
         this.itemStack = itemStack;
+        this.flags = flags;
     }
 
     public ItemStack getItemStack() {
         return itemStack;
     }
 
-    public static final class Advanced extends ItemTooltipFlagsEvent {
-        private TooltipFlag flags;
-
-        public Advanced(ItemStack itemStack, TooltipFlag flags) {
-            super(itemStack);
-            this.flags = flags;
-        }
-
-        public TooltipFlag getFlags() {
-            return flags;
-        }
-
-        public void setFlags(TooltipFlag flags) {
-            this.flags = flags;
-        }
+    public TooltipFlag getFlags() {
+        return flags;
     }
 
-    public static final class HideAdditionalTooltip extends ItemTooltipFlagsEvent {
-        private boolean hideTooltip;
-
-        public HideAdditionalTooltip(ItemStack itemStack, boolean hideTooltip) {
-            super(itemStack);
-            this.hideTooltip = hideTooltip;
-        }
-
-        public boolean getHideAdditionalTooltip() {
-            return hideTooltip;
-        }
-
-        public void setHideAdditionalTooltip(boolean hideTooltip) {
-            this.hideTooltip = hideTooltip;
-        }
+    public void setFlags(TooltipFlag flags) {
+        this.flags = flags;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ItemStackMixin.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.mc.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.wynntils.core.events.MixinHelper;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.ItemAnnotation;
@@ -25,27 +24,6 @@ public abstract class ItemStackMixin implements ItemStackExtension {
     @Unique
     private StyledText wynntilsOriginalName;
 
-    // Note: If this mixin method is causing compatibility issues, we have a few options:
-    // 1. Remove the mixin method. It's barely used in Wynntils.
-    // 2. Set the hide additional tooltip flag for the item itself. This is a bit more invasive.
-    @ModifyExpressionValue(
-            method =
-                    "getTooltipLines(Lnet/minecraft/world/item/Item$TooltipContext;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/TooltipFlag;)Ljava/util/List;",
-            at =
-                    @At(
-                            value = "INVOKE",
-                            target =
-                                    "Lnet/minecraft/world/item/ItemStack;has(Lnet/minecraft/core/component/DataComponentType;)Z",
-                            ordinal = 2))
-    private boolean redirectGetHideFlags(boolean original) {
-        ItemStack itemStack = (ItemStack) (Object) this;
-        ItemTooltipFlagsEvent.HideAdditionalTooltip event =
-                new ItemTooltipFlagsEvent.HideAdditionalTooltip(itemStack, original);
-        MixinHelper.post(event);
-
-        return event.getHideAdditionalTooltip();
-    }
-
     @ModifyVariable(
             method =
                     "getTooltipLines(Lnet/minecraft/world/item/Item$TooltipContext;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/item/TooltipFlag;)Ljava/util/List;",
@@ -54,7 +32,7 @@ public abstract class ItemStackMixin implements ItemStackExtension {
             argsOnly = true)
     private TooltipFlag onGetTooltipLines(TooltipFlag flags) {
         ItemStack itemStack = (ItemStack) (Object) this;
-        ItemTooltipFlagsEvent.Advanced event = new ItemTooltipFlagsEvent.Advanced(itemStack, flags);
+        ItemTooltipFlagsEvent event = new ItemTooltipFlagsEvent(itemStack, flags);
         MixinHelper.post(event);
 
         return event.getFlags();

--- a/common/src/main/resources/assets/wynntils/lang/de_de.json
+++ b/common/src/main/resources/assets/wynntils/lang/de_de.json
@@ -1185,8 +1185,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Ob Tooltips umgebrochen werden sollen, wenn sie den Bildschirmrand erreichen",
   "feature.wynntils.tooltipFitting.wrapText.name": "Textumbruch",
   "feature.wynntils.tooltipVanillaHide.description": "Verbirgt die Vanilla-Tooltips.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Dies wird zusätzliche Informationen wie 'Gefärbt' verbergen, die auf Wynncraft nicht relevant sind",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Zusätzliche Tooltip-Informationen Verbergen",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Dies wird die erweiterten Tooltips (F3+H) auf Wynncraft deaktivieren",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Erweiterte Tooltip Immer Verbergen",
   "feature.wynntils.tooltipVanillaHide.name": "Irrelevante Tooltip-Informationen Verbergen",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1398,8 +1398,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Whether tooltips should wrap when they reach the side of the screen",
   "feature.wynntils.tooltipFitting.wrapText.name": "Wrap Text",
   "feature.wynntils.tooltipVanillaHide.description": "Hides vanilla tooltips.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "This will hide additional info, such as 'Dyed', that is not relevant on Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Hide Additional Tooltip Info",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "This will turn off advanced tooltips (F3+H) on Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Always Hide Advanced Tooltip",
   "feature.wynntils.tooltipVanillaHide.name": "Hide Irrelevant Tooltip Info",

--- a/common/src/main/resources/assets/wynntils/lang/es_es.json
+++ b/common/src/main/resources/assets/wynntils/lang/es_es.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Si las descripciones deben ajustarse cuando alcanzan el lado de la pantalla",
   "feature.wynntils.tooltipFitting.wrapText.name": "Ajustar Texto",
   "feature.wynntils.tooltipVanillaHide.description": "Oculta las descripciones emergentes de vainilla.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Esto ocultará información adicional, como 'Teñido', que no es relevante en Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Ocultar Información Adicional de Descripción",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Esto desactivará las descripciones emergentes avanzadas (F3+H) en Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Ocultar Siempre Descripción Avanzada",
   "feature.wynntils.tooltipVanillaHide.name": "Ocultar Información de Descripción Irrelevante",

--- a/common/src/main/resources/assets/wynntils/lang/fr_fr.json
+++ b/common/src/main/resources/assets/wynntils/lang/fr_fr.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Si les info-bulles doivent se replier lorsqu'elles atteignent le bord de l'écran",
   "feature.wynntils.tooltipFitting.wrapText.name": "Envelopper le Texte",
   "feature.wynntils.tooltipVanillaHide.description": "Masque les info-bulles vanille.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Cela masquera des informations supplémentaires, telles que 'Teinté', qui ne sont pas pertinentes sur Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Masquer les Informations Supplémentaires de l'Info-bulle",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Cela désactivera les info-bulles avancées (F3+H) sur Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Toujours Masquer l'Info-bulle Avancée",
   "feature.wynntils.tooltipVanillaHide.name": "Masquer les Informations d'Info-bulle Non Pertinentes",

--- a/common/src/main/resources/assets/wynntils/lang/hu_hu.json
+++ b/common/src/main/resources/assets/wynntils/lang/hu_hu.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "A tooltip-ek tördelődjenek, amikor elérik a képernyő szélét?",
   "feature.wynntils.tooltipFitting.wrapText.name": "Szöveg Tördelése",
   "feature.wynntils.tooltipVanillaHide.description": "Elrejti a vanília tooltipjeit.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Ez elrejti a további információkat, mint például a 'Festett', amelyek nem relevánsak a Wynncrafton",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "További Tooltip Információk Elrejtése",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Ez kikapcsolja a fejlett tooltip-eket (F3+H) a Wynncrafton",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Mindig Rejtsd el a Fejlett Tooltipet",
   "feature.wynntils.tooltipVanillaHide.name": "Nem Releváns Tooltip Információk Elrejtése",

--- a/common/src/main/resources/assets/wynntils/lang/it_it.json
+++ b/common/src/main/resources/assets/wynntils/lang/it_it.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Se le descrizioni devono avvolgersi quando raggiungono il lato dello schermo",
   "feature.wynntils.tooltipFitting.wrapText.name": "Avvolgere il Testo",
   "feature.wynntils.tooltipVanillaHide.description": "Nasconde le descrizioni emergenti di vanilla.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Questo nasconderà informazioni aggiuntive, come 'Tinto', che non sono rilevanti su Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Nascondi Informazioni Aggiuntive della Descrizione",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Questo disattiverà le descrizioni avanzate (F3+H) su Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Nascondi Sempre la Descrizione Avanzata",
   "feature.wynntils.tooltipVanillaHide.name": "Nascondi Informazioni di Descrizione Irrilevanti",

--- a/common/src/main/resources/assets/wynntils/lang/ja_jp.json
+++ b/common/src/main/resources/assets/wynntils/lang/ja_jp.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "ツールチップが画面の端に達したときに折り返すかどうか",
   "feature.wynntils.tooltipFitting.wrapText.name": "テキストを折り返す",
   "feature.wynntils.tooltipVanillaHide.description": "バニラのツールチップを隠します。",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "これは、Wynncraftで関連性のない「染色」などの追加情報を隠します",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "追加ツールチップ情報を隠す",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "これにより、Wynncraftで高度なツールチップ（F3+H）が無効になります",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "常に高度なツールチップを隠す",
   "feature.wynntils.tooltipVanillaHide.name": "関連性のないツールチップ情報を隠す",

--- a/common/src/main/resources/assets/wynntils/lang/ko_kr.json
+++ b/common/src/main/resources/assets/wynntils/lang/ko_kr.json
@@ -1372,8 +1372,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "도구 설명이 화면 끝에 닿았을 때 글자를 자동으로 조정할까요?",
   "feature.wynntils.tooltipFitting.wrapText.name": "글자 자동 조정",
   "feature.wynntils.tooltipVanillaHide.description": "바닐라의 도구 설명을 숨깁니다.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "바닐라에서 제공되는 '염색됨'과 같은 Wynncraft와 관련 없는 추가 정보를 숨깁니다.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "도구 설명 추가 정보 숨기기",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "마인크래프트에서 제공되는 고급 도구 설명 (F3 + H) 를 Wynncraft 에서 동작하지 않도록 합니다.",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "고급 도구 설명 숨기기",
   "feature.wynntils.tooltipVanillaHide.name": "필요없는 도구 설명 숨기기",

--- a/common/src/main/resources/assets/wynntils/lang/nl_nl.json
+++ b/common/src/main/resources/assets/wynntils/lang/nl_nl.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Moeten tooltips worden afgebroken wanneer ze de rand van het scherm bereiken?",
   "feature.wynntils.tooltipFitting.wrapText.name": "Tekst Omslaan",
   "feature.wynntils.tooltipVanillaHide.description": "Verbergt vanilla tooltips.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Dit verbergt aanvullende informatie, zoals 'Geverfd', die niet relevant is op Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Verberg Aanvullende Tooltip Info",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Dit schakelt geavanceerde tooltips (F3+H) uit op Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Verberg Altijd Geavanceerde Tooltip",
   "feature.wynntils.tooltipVanillaHide.name": "Verberg Irrelevante Tooltip Info",

--- a/common/src/main/resources/assets/wynntils/lang/pl_pl.json
+++ b/common/src/main/resources/assets/wynntils/lang/pl_pl.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Czy podpowiedzi powinny się zawijać, gdy osiągną krawędź ekranu?",
   "feature.wynntils.tooltipFitting.wrapText.name": "Zawijanie Tekstu",
   "feature.wynntils.tooltipVanillaHide.description": "Ukrywa podpowiedzi waniliowe.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "To ukryje dodatkowe informacje, takie jak 'Farbowane', które nie są istotne na Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Ukryj Dodatkowe Informacje o Podpowiedziach",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "To wyłącza zaawansowane podpowiedzi (F3+H) na Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Zawsze Ukrywaj Zaawansowane Podpowiedzi",
   "feature.wynntils.tooltipVanillaHide.name": "Ukryj Nieistotne Informacje o Podpowiedziach",

--- a/common/src/main/resources/assets/wynntils/lang/pt_pt.json
+++ b/common/src/main/resources/assets/wynntils/lang/pt_pt.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Se as dicas de ferramentas devem se ajustar quando atingem o lado da tela",
   "feature.wynntils.tooltipFitting.wrapText.name": "Envolver Texto",
   "feature.wynntils.tooltipVanillaHide.description": "Oculta as dicas de ferramentas de baunilha.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Isso ocultará informações adicionais, como 'Tingido', que não são relevantes no Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Ocultar Informações Adicionais da Dica de Ferramenta",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Isso desativará as dicas de ferramentas avançadas (F3+H) no Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Sempre Ocultar Dica de Ferramenta Avançada",
   "feature.wynntils.tooltipVanillaHide.name": "Ocultar Informações de Dica de Ferramenta Irrelevantes",

--- a/common/src/main/resources/assets/wynntils/lang/ru_ru.json
+++ b/common/src/main/resources/assets/wynntils/lang/ru_ru.json
@@ -1196,8 +1196,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Должны ли подсказки переноситься, когда они достигают края экрана",
   "feature.wynntils.tooltipFitting.wrapText.name": "Перенос Текста",
   "feature.wynntils.tooltipVanillaHide.description": "Скрывает ванильные подсказки.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Это скроет дополнительную информацию, такую как 'Окрашено', которая не имеет значения в Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Скрыть Дополнительную Информацию Подсказки",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Это отключит расширенные подсказки (F3+H) на Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Всегда Скрывать Расширенную Подсказку",
   "feature.wynntils.tooltipVanillaHide.name": "Скрыть Нерелевантную Информацию Подсказки",

--- a/common/src/main/resources/assets/wynntils/lang/sv_se.json
+++ b/common/src/main/resources/assets/wynntils/lang/sv_se.json
@@ -1196,8 +1196,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "Om verktygstips ska brytas när de når skärmens kant",
   "feature.wynntils.tooltipFitting.wrapText.name": "Bryt Text",
   "feature.wynntils.tooltipVanillaHide.description": "Döljer vanliga verktygstips.",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "Detta kommer att dölja ytterligare information, såsom 'Färgad', som inte är relevant på Wynncraft",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "Dölj Ytterligare Verktygstips Info",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "Detta kommer att stänga av avancerade verktygstips (F3+H) på Wynncraft",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "Dölj Alltid Avancerade Verktygstips",
   "feature.wynntils.tooltipVanillaHide.name": "Dölj Irrelevant Verktygstips Info",

--- a/common/src/main/resources/assets/wynntils/lang/zh_cn.json
+++ b/common/src/main/resources/assets/wynntils/lang/zh_cn.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "提示是否应在到达屏幕边缘时换行",
   "feature.wynntils.tooltipFitting.wrapText.name": "换行文本",
   "feature.wynntils.tooltipVanillaHide.description": "隐藏原版提示。",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "这将隐藏在 Wynncraft 中不相关的“染色”等附加信息",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "隐藏附加提示信息",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "这将在 Wynncraft 上禁用高级提示 (F3+H)",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "始终隐藏高级提示",
   "feature.wynntils.tooltipVanillaHide.name": "隐藏不相关的提示信息",

--- a/common/src/main/resources/assets/wynntils/lang/zh_tw.json
+++ b/common/src/main/resources/assets/wynntils/lang/zh_tw.json
@@ -1182,8 +1182,6 @@
   "feature.wynntils.tooltipFitting.wrapText.description": "提示是否應在到達螢幕邊緣時換行",
   "feature.wynntils.tooltipFitting.wrapText.name": "換行文本",
   "feature.wynntils.tooltipVanillaHide.description": "隱藏原版提示。",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.description": "這將隱藏在 Wynncraft 中不相關的“染色”等附加信息",
-  "feature.wynntils.tooltipVanillaHide.hideAdditionalInfo.name": "隱藏附加提示信息",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.description": "這將在 Wynncraft 上禁用高級提示 (F3+H)",
   "feature.wynntils.tooltipVanillaHide.hideAdvanced.name": "始終隱藏高級提示",
   "feature.wynntils.tooltipVanillaHide.name": "隱藏不相關的提示信息",


### PR DESCRIPTION
The additional info such as dye, or enchantments are no longer displayed so no need for this anymore