### PR TITLE
fix: Inventory slots missing 1 slot

### DIFF
--- a/common/src/main/java/com/wynntils/models/inventory/InventoryModel.java
+++ b/common/src/main/java/com/wynntils/models/inventory/InventoryModel.java
@@ -27,7 +27,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class InventoryModel extends Model {
-    private static final int MAX_INVENTORY_SLOTS = 28;
+    private static final int MAX_INVENTORY_SLOTS = 29;
     private static final List<String> AUTO_CASTER_MAJOR_IDS = List.of("Sorcery", "Madness");
 
     private final InventoryWatcher emptySlotWatcher = new InventoryWatcher(ItemStack::isEmpty);


### PR DESCRIPTION
I guess it happened when they removed Soul Points and nobody ever noticed