### PR TITLE
fix: Fix horse mount failure not swapping back to previous item, add summon attempts config

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -42,7 +42,6 @@ public class HorseMountFeature extends Feature {
     private static final SoundEvent HORSE_WHISTLE_SOUND = SoundEvent.createVariableRangeEvent(HORSE_WHISTLE_ID);
 
     private static final int SEARCH_RADIUS = 6; // Furthest blocks away from which we can interact with a horse
-    private static final int SUMMON_ATTEMPTS = 8;
     private static final int SUMMON_DELAY_TICKS = 6;
 
     private static final List<String> HORSE_ERROR_MESSAGES = List.of(
@@ -63,6 +62,9 @@ public class HorseMountFeature extends Feature {
 
     @Persisted
     public final Config<Boolean> guaranteedMount = new Config<>(true);
+
+    @Persisted
+    public final Config<Integer> summonAttempts = new Config<>(8);
 
     @Persisted
     public final Config<Boolean> playWhistle = new Config<>(true);
@@ -101,7 +103,7 @@ public class HorseMountFeature extends Feature {
                 postHorseErrorMessage(MountHorseStatus.NO_HORSE);
                 return;
             }
-            trySummonAndMountHorse(horseInventorySlot, SUMMON_ATTEMPTS);
+            trySummonAndMountHorse(horseInventorySlot, summonAttempts.get());
         } else { // Horse already exists, mount it
             mountHorse(horse);
         }
@@ -114,7 +116,6 @@ public class HorseMountFeature extends Feature {
         }
 
         // swap to soul points to avoid right click problems
-        int prevItem = McUtils.inventory().selected;
         int nonConflictingSlot = findNonConflictingSlot();
         if (nonConflictingSlot == -1) {
             postHorseErrorMessage(MountHorseStatus.CONFLICTING_SLOTS);
@@ -149,6 +150,7 @@ public class HorseMountFeature extends Feature {
     private void trySummonAndMountHorse(int horseInventorySlot, int attempts) {
         if (attempts <= 0) {
             postHorseErrorMessage(MountHorseStatus.NO_HORSE);
+            McUtils.sendPacket(new ServerboundSetCarriedItemPacket(prevItem));
             return;
         }
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -682,6 +682,8 @@
   "feature.wynntils.horseMount.noHorse": "Your horse was unable to be found.",
   "feature.wynntils.horseMount.playWhistle.description": "Should a whistle sound play when you mount your horse?",
   "feature.wynntils.horseMount.playWhistle.name": "Play Whistle",
+  "feature.wynntils.horseMount.summonAttempts.description": "How many times should an attempt be made to mount your horse before stopping?",
+  "feature.wynntils.horseMount.summonAttempts.name": "Summon Attempts",
   "feature.wynntils.infoBox.description": "Adds the ability to add custom info boxes to the screen as overlays. Info boxes can display custom functions.",
   "feature.wynntils.infoBox.name": "Info Boxes",
   "feature.wynntils.infoBox.overlay.infoBox.content.description": "What should be displayed in the info box?",


### PR DESCRIPTION
When reaching 0 attempts we need to swap back to the previously held item.

And makes the summon attempts a config