### PR TITLE
feat: Rework Auto Attack

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/AutoAttackFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/AutoAttackFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.ArmSwingEvent;
 import com.wynntils.mc.event.ChangeCarriedItemEvent;
+import com.wynntils.mc.event.PlayerInteractEvent;
 import com.wynntils.mc.event.SetSlotEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.mc.event.UseItemEvent;
@@ -21,6 +22,7 @@ import com.wynntils.utils.mc.MouseUtils;
 import com.wynntils.utils.wynn.ItemUtils;
 import java.util.Optional;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -59,6 +61,18 @@ public class AutoAttackFeature extends Feature {
     @SubscribeEvent
     public void onUseItem(UseItemEvent event) {
         if (Models.Character.getClassType() == ClassType.ARCHER) return;
+
+        handleInput();
+    }
+
+    @SubscribeEvent
+    public void onInteract(PlayerInteractEvent.InteractAt event) {
+        if (Models.Character.getClassType() == ClassType.ARCHER) return;
+
+        if (event.getEntityHitResult() != null) {
+            EntityType<?> entityType = event.getEntityHitResult().getEntity().getType();
+            if (entityType == EntityType.INTERACTION) return;
+        }
 
         handleInput();
     }

--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -80,8 +80,9 @@ public class QuickCastFeature extends Feature {
         if (!blockAttacks.get()) return;
         if (event.getActionContext() != ArmSwingEvent.ArmSwingContext.ATTACK_OR_START_BREAKING_BLOCK) return;
         if (event.getHand() != InteractionHand.MAIN_HAND) return;
+        if (Models.Spell.isSpellQueueEmpty()) return;
 
-        event.setCanceled(!Models.Spell.isSpellQueueEmpty());
+        event.setCanceled(true);
     }
 
     @SubscribeEvent
@@ -89,8 +90,9 @@ public class QuickCastFeature extends Feature {
         lastSpellTick = McUtils.player().tickCount;
 
         if (!blockAttacks.get()) return;
+        if (Models.Spell.isSpellQueueEmpty()) return;
 
-        event.setCanceled(!Models.Spell.isSpellQueueEmpty());
+        event.setCanceled(true);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/spells/SpellModel.java
+++ b/common/src/main/java/com/wynntils/models/spells/SpellModel.java
@@ -33,7 +33,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public final class SpellModel extends Model {
     private static final Pattern SPELL_CAST =
             Pattern.compile("^§7(.*) spell cast! §3\\[§b-([0-9]+) ✺§3\\](?: §4\\[§c-([0-9]+) ❤§4\\])?$");
-    private static final int SPELL_COST_RESET_TICKS = 60;
+    public static final int SPELL_COST_RESET_TICKS = 60;
     private static final int SPELL_EXPIRE_TICKS = 40;
 
     private static final Queue<SpellDirection> SPELL_PACKET_QUEUE = new LinkedList<>();


### PR DESCRIPTION
I only did a very limited amount of testing with and without quick casts but it seemed ok, won't re-enable it by default just yet.

It now just completely ignores archer, it already has auto attacking in vanilla.

We no longer rely on spell updates from the action bar and instead fully rely on mouse input events.

I know there was some discussion before about making a Manager or something to handle the mouse inputs but I think it might just be a bit overkill for this, when every other feature can rely on the action bar updates without issue.