### PR TITLE
feat: Font function improvements

### DIFF
--- a/common/src/main/java/com/wynntils/models/wynnfont/WynnFontModel.java
+++ b/common/src/main/java/com/wynntils/models/wynnfont/WynnFontModel.java
@@ -69,6 +69,7 @@ public final class WynnFontModel extends Model {
         if (right != BackgroundEdge.NONE) {
             sb.append("§");
             sb.append(backgroundColor.toHexString());
+            sb.append(NEGATIVE_SPACE_EDGE);
             sb.append(right.getRight());
         }
         return sb.toString();

--- a/common/src/main/java/com/wynntils/models/wynnfont/WynnFontModel.java
+++ b/common/src/main/java/com/wynntils/models/wynnfont/WynnFontModel.java
@@ -82,8 +82,7 @@ public final class WynnFontModel extends Model {
                 sb.append(' ');
                 continue;
             }
-            Character fancy = normalToFancy.get(c);
-            if (fancy == null) continue;
+            Character fancy = normalToFancy.getOrDefault(c, c);
             sb.append(fancy);
         }
         return sb.toString();


### PR DESCRIPTION
<img width="1143" height="285" alt="image" src="https://github.com/user-attachments/assets/be5cb9fa-b7f5-4f8b-8fd3-41d609610b9a" />

Example
```
{to_background_text("<Invalid> Characters!";from_hex("#ffffffff");from_hex("#00ffffff");"PILL";"PILL")}\n{to_fancy_text(str(z(my_loc)))}\n{to_background_text("All valid characters";from_hex("#ffffffff");from_hex("#00ffffff");"PILL";"PILL")}
```

Adds the missing negative space to the pill background so it is no longer 1 pixel too long on the right side.

With the fancy and background font function, if no character exists in the map then the regular font is used.

For the background font, depending on where the string currently is, it will handle whether or not the text is in a background so it won't end up abruptly ending a background before resuming, it will close it properly