### PR TITLE
fix: Fix quick jumps not working with full inventory

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
@@ -11,8 +11,6 @@ import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
-import com.wynntils.mc.event.ContainerSetContentEvent;
-import com.wynntils.mc.event.ContainerSetSlotEvent;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
 import com.wynntils.mc.event.MouseScrollEvent;
 import com.wynntils.mc.event.ScreenClosedEvent;
@@ -22,6 +20,7 @@ import com.wynntils.models.containers.containers.personal.CharacterBankContainer
 import com.wynntils.models.containers.containers.personal.IslandBlockBankContainer;
 import com.wynntils.models.containers.containers.personal.PersonalBlockBankContainer;
 import com.wynntils.models.containers.containers.personal.PersonalStorageContainer;
+import com.wynntils.models.containers.event.BankPageSetEvent;
 import com.wynntils.screens.container.widgets.PersonalStorageUtilitiesWidget;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;
@@ -72,7 +71,7 @@ public class PersonalStorageUtilitiesFeature extends Feature {
     }
 
     @SubscribeEvent
-    public void onContainerSetSlot(ContainerSetSlotEvent.Pre event) {
+    public void onBankPageSet(BankPageSetEvent e) {
         if (Models.Bank.getStorageContainerType() == null) return;
         // onScreenInit is not called when changing pages so we have to update current and last page here
         currentPage = Models.Bank.getCurrentPage();
@@ -81,11 +80,7 @@ public class PersonalStorageUtilitiesFeature extends Feature {
         // Mods such as Flow still render the widget after we close the screen so name has to be
         // set here instead of being retrieved in the widgets render method
         widget.updatePageName();
-    }
 
-    @SubscribeEvent
-    public void onContainerSetContent(ContainerSetContentEvent.Pre event) {
-        if (Models.Bank.getStorageContainerType() == null) return;
         if (!quickJumping) return;
 
         // ContainerSetSlotEvent will click too early so we have to do it after content set

--- a/common/src/main/java/com/wynntils/models/containers/BankModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/BankModel.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.containers;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.persisted.Persisted;
@@ -14,6 +15,7 @@ import com.wynntils.mc.event.ContainerSetSlotEvent;
 import com.wynntils.mc.event.ScreenClosedEvent;
 import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.models.containers.containers.personal.PersonalStorageContainer;
+import com.wynntils.models.containers.event.BankPageSetEvent;
 import com.wynntils.models.containers.type.PersonalStorageType;
 import java.util.List;
 import java.util.Map;
@@ -243,6 +245,8 @@ public final class BankModel extends Model {
         if (isItemIndicatingLastBankPage(nextPageItem)) {
             updateFinalPage();
         }
+
+        WynntilsMod.postEvent(new BankPageSetEvent());
     }
 
     private boolean isItemIndicatingLastBankPage(ItemStack item) {

--- a/common/src/main/java/com/wynntils/models/containers/event/BankPageSetEvent.java
+++ b/common/src/main/java/com/wynntils/models/containers/event/BankPageSetEvent.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.event;
+
+import net.neoforged.bus.api.Event;
+
+/**
+ * Fires when a bank page has been fully loaded
+ */
+public class BankPageSetEvent extends Event {}


### PR DESCRIPTION
I swear we had fixed this issue before but here it is again. Bank model already handles updating on SetSlot and SetContent so we now just post an event from there and listen to that in the feature