### PR TITLE
fix: Connect to Hades on separate thread and broaden exception handling

### DIFF
--- a/common/src/main/java/com/wynntils/services/hades/HadesService.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesService.java
@@ -29,9 +29,10 @@ import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.services.hades.type.PlayerStatus;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.CappedValue;
+import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -67,7 +68,7 @@ public final class HadesService extends Service {
     private void login() {
         // Try to log in to Hades, if we're not already connected
         if (!isConnected()) {
-            tryCreateConnection();
+            CompletableFuture.runAsync(this::tryCreateConnection);
         }
     }
 
@@ -82,8 +83,8 @@ public final class HadesService extends Service {
 
             tickCountUntilUpdate = 0;
             lastSentStatus = null;
-        } catch (UnknownHostException e) {
-            WynntilsMod.error("Could not resolve Hades host address.", e);
+        } catch (IOException e) {
+            WynntilsMod.error("Could not connect to Hades.", e);
         }
     }
 
@@ -149,7 +150,7 @@ public final class HadesService extends Service {
     public void onWorldStateChange(WorldStateEvent event) {
         if (event.getNewState() != WorldState.NOT_CONNECTED && !isConnected()) {
             if (Services.WynntilsAccount.isLoggedIn()) {
-                tryCreateConnection();
+                CompletableFuture.runAsync(this::tryCreateConnection);
             }
         }
 
@@ -197,14 +198,14 @@ public final class HadesService extends Service {
         if (!isConnected()) return;
         if (!Models.WorldState.onWorld() || McUtils.player().hasEffect(MobEffects.NIGHT_VISION)) return;
         if (!Managers.Feature.getFeatureInstance(HadesFeature.class)
-                        .shareWithParty
-                        .get()
+                .shareWithParty
+                .get()
                 && !Managers.Feature.getFeatureInstance(HadesFeature.class)
-                        .shareWithGuild
-                        .get()
+                .shareWithGuild
+                .get()
                 && !Managers.Feature.getFeatureInstance(HadesFeature.class)
-                        .shareWithFriends
-                        .get()) return;
+                .shareWithFriends
+                .get()) return;
 
         tickCountUntilUpdate--;
 

--- a/common/src/main/java/com/wynntils/services/hades/HadesService.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesService.java
@@ -198,14 +198,14 @@ public final class HadesService extends Service {
         if (!isConnected()) return;
         if (!Models.WorldState.onWorld() || McUtils.player().hasEffect(MobEffects.NIGHT_VISION)) return;
         if (!Managers.Feature.getFeatureInstance(HadesFeature.class)
-                .shareWithParty
-                .get()
+                        .shareWithParty
+                        .get()
                 && !Managers.Feature.getFeatureInstance(HadesFeature.class)
-                .shareWithGuild
-                .get()
+                        .shareWithGuild
+                        .get()
                 && !Managers.Feature.getFeatureInstance(HadesFeature.class)
-                .shareWithFriends
-                .get()) return;
+                        .shareWithFriends
+                        .get()) return;
 
         tickCountUntilUpdate--;
 


### PR DESCRIPTION
Should handle the `[11:38:19] [Render thread/ERROR] (EventBus) Exception caught during firing event: Connection refused: getsockopt: io.wynntils.com/65.108.47.218:9000` spam better and not cause the game to hang whilst it is trying to connect (and failing)