### PR TITLE
fix: Overlay crashes

### DIFF
--- a/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
+++ b/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
@@ -23,6 +23,9 @@ public final class WynnObjective {
     private final boolean isGuildObjective;
     private final boolean hasEventBonus;
 
+    public static WynnObjective DEMO_GUILD = new WynnObjective(
+            "Guild Objective", new CappedValue(5, 15), 0, StyledText.fromString("Guild Objectives"), true, false);
+
     private WynnObjective(
             String goal,
             CappedValue score,

--- a/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
+++ b/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
@@ -24,7 +24,7 @@ public final class WynnObjective {
     private final boolean hasEventBonus;
 
     public static WynnObjective DEMO_GUILD = new WynnObjective(
-            "Guild Objective", new CappedValue(5, 15), 0, StyledText.fromString("Guild Objectives"), true, false);
+            "Guild Objective", new CappedValue(5, 15), 0, StyledText.fromString("Slay Loot Chests"), true, false);
 
     private WynnObjective(
             String goal,

--- a/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
+++ b/common/src/main/java/com/wynntils/models/objectives/WynnObjective.java
@@ -23,8 +23,8 @@ public final class WynnObjective {
     private final boolean isGuildObjective;
     private final boolean hasEventBonus;
 
-    public static WynnObjective DEMO_GUILD = new WynnObjective(
-            "Guild Objective", new CappedValue(5, 15), 0, StyledText.fromString("Slay Loot Chests"), true, false);
+    public static final WynnObjective DEMO_GUILD = new WynnObjective(
+            "Slay Loot Chests", new CappedValue(5, 15), 0, StyledText.fromString("Slay Loot Chests 5/15"), true, false);
 
     private WynnObjective(
             String goal,

--- a/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
@@ -90,6 +90,22 @@ public abstract class BaseBarOverlay extends Overlay {
     @Override
     public void render(
             GuiGraphics guiGraphics, MultiBufferSource bufferSource, DeltaTracker deltaTracker, Window window) {
+        float renderedProgress = Math.round((flip.get() ? -1 : 1) * currentProgress * 100) / 100f;
+        renderAll(guiGraphics, bufferSource, renderedProgress);
+    }
+
+    @Override
+    public void renderPreview(
+            GuiGraphics guiGraphics, MultiBufferSource bufferSource, DeltaTracker deltaTracker, Window window) {
+        if (progress() == null) {
+            renderAll(guiGraphics, bufferSource, 50);
+            return;
+        }
+        float renderedProgress = Math.round((flip.get() ? -1 : 1) * currentProgress * 100) / 100f;
+        renderAll(guiGraphics, bufferSource, renderedProgress);
+    }
+
+    private void renderAll(GuiGraphics guiGraphics, MultiBufferSource bufferSource, float renderedProgress) {
         PoseStack poseStack = guiGraphics.pose();
 
         float barHeight = textureHeight() * (this.getWidth() / 81);
@@ -97,15 +113,21 @@ public abstract class BaseBarOverlay extends Overlay {
 
         renderText(poseStack, bufferSource, renderY, text());
 
-        float renderedProgress = Math.round((flip.get() ? -1 : 1) * currentProgress * 100) / 100f;
         renderBar(poseStack, bufferSource, renderY + 10, barHeight, renderedProgress);
     }
 
     protected String text() {
         BossBarProgress barProgress = progress();
-        return String.format(
-                "%s %s %s",
-                barProgress.value().current(), icon(), barProgress.value().max());
+        int current;
+        int max;
+        if (barProgress == null) {
+            current = 1;
+            max = 2;
+        } else {
+            current = progress().value().current();
+            max = progress().value().max();
+        }
+        return String.format("%s %s %s", current, icon(), max);
     }
 
     protected String icon() {

--- a/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/gamebars/BaseBarOverlay.java
@@ -118,16 +118,12 @@ public abstract class BaseBarOverlay extends Overlay {
 
     protected String text() {
         BossBarProgress barProgress = progress();
-        int current;
-        int max;
-        if (barProgress == null) {
-            current = 1;
-            max = 2;
-        } else {
-            current = progress().value().current();
-            max = progress().value().max();
+        if (progress() == null) {
+            return icon();
         }
-        return String.format("%s %s %s", current, icon(), max);
+        return String.format(
+                "%s %s %s",
+                progress().value().current(), icon(), progress().value().max());
     }
 
     protected String icon() {

--- a/common/src/main/java/com/wynntils/overlays/objectives/GuildObjectiveOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/objectives/GuildObjectiveOverlay.java
@@ -75,7 +75,9 @@ public class GuildObjectiveOverlay extends ObjectiveOverlayBase {
     public void renderPreview(
             GuiGraphics guiGraphics, MultiBufferSource bufferSource, DeltaTracker deltaTracker, Window window) {
         WynnObjective guildObjective = Models.Objectives.getGuildObjective();
-        if (guildObjective == null) guildObjective = WynnObjective.DEMO_GUILD;
+        if (guildObjective == null) {
+            guildObjective = WynnObjective.DEMO_GUILD;
+        }
         renderObjective(guiGraphics, bufferSource, guildObjective);
     }
 

--- a/common/src/main/java/com/wynntils/overlays/objectives/GuildObjectiveOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/objectives/GuildObjectiveOverlay.java
@@ -67,7 +67,20 @@ public class GuildObjectiveOverlay extends ObjectiveOverlayBase {
     public void render(
             GuiGraphics guiGraphics, MultiBufferSource bufferSource, DeltaTracker deltaTracker, Window window) {
         WynnObjective guildObjective = Models.Objectives.getGuildObjective();
+        if (guildObjective == null) return;
+        renderObjective(guiGraphics, bufferSource, guildObjective);
+    }
 
+    @Override
+    public void renderPreview(
+            GuiGraphics guiGraphics, MultiBufferSource bufferSource, DeltaTracker deltaTracker, Window window) {
+        WynnObjective guildObjective = Models.Objectives.getGuildObjective();
+        if (guildObjective == null) guildObjective = WynnObjective.DEMO_GUILD;
+        renderObjective(guiGraphics, bufferSource, guildObjective);
+    }
+
+    private void renderObjective(
+            GuiGraphics guiGraphics, MultiBufferSource bufferSource, WynnObjective guildObjective) {
         PoseStack poseStack = guiGraphics.pose();
 
         if (this.hideOnInactivity.get()) {


### PR DESCRIPTION
My #3387 had some unforeseen consequences of rendering previews, I checked the crashes and unless I missed something, it only applies to all class specific game bars as well as guild objective specifically.
This should be fixed, but I do wonder why bars were crashing in the first place as even in my dev environment I had 2 of them set to always render, and it was fine, but then as soon as I launched main branch they crashed, was there maybe some other PR that changed something in them?