### PR TITLE
feat: Ping Release Updates role in release webhook

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -170,6 +170,7 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          content: "<@&1406607918609993748>"
           embed-color: "9498256"
           embed-title: ${{ format('Wynntils {0}', needs.set-version.outputs.tag) }}
           embed-url: https://github.com/Wynntils/Wynntils/releases/tag/${{ needs.set-version.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          content: "<@&1406607918609993748>"
           embed-color: "9498256"
           embed-title: ${{ format('Wynntils {0}', needs.set-version.outputs.tag) }}
           embed-url: https://github.com/Wynntils/Wynntils/releases/tag/${{ needs.set-version.outputs.tag }}


### PR DESCRIPTION
New release embeds in #builds will ping the Release Updates role.

Do not merge until the role has actually been made available for selection