### PR TITLE
fix: Content book fixes

### DIFF
--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -87,7 +87,7 @@ public final class ActivityModel extends Model {
     private static final Pattern DIFFICULTY_PATTERN = Pattern.compile("^\uDB00\uDC0E§7Difficulty: (\\w*)$");
     private static final Pattern REWARD_HEADER_PATTERN = Pattern.compile("^\uDB00\uDC0E§dRewards:$");
     private static final Pattern REWARD_PATTERN = Pattern.compile("^§d\uDB00\uDC04(- )?§7\\+?(?<reward>.+)$");
-    private static final Pattern TRACKING_PATTERN = Pattern.compile("^.*§(?:#.{8}|.)§lCLICK TO (UN)?TRACK$");
+    private static final Pattern TRACKING_PATTERN = Pattern.compile(".+§f\uE000 §#[a-f0-9]{8}§lClick To (Untrack|Track)");
     private static final Pattern OVERALL_PROGRESS_PATTERN = Pattern.compile("^\\S*§7(\\d+) of (\\d+) completed$");
     private static final Pattern WIKI_REDIRECT_PATTERN = Pattern.compile("#REDIRECT \\[\\[(?<redirectname>.+)\\]\\]");
 
@@ -317,7 +317,7 @@ public final class ActivityModel extends Model {
 
             Matcher trackingMatcher = line.getMatcher(TRACKING_PATTERN);
             if (trackingMatcher.matches()) {
-                trackingState = trackingMatcher.group(1) == null
+                trackingState = trackingMatcher.group(1).equals("Track")
                         ? ActivityTrackingState.TRACKABLE
                         : ActivityTrackingState.TRACKED;
                 continue;

--- a/common/src/main/java/com/wynntils/models/activities/type/ActivityInfo.java
+++ b/common/src/main/java/com/wynntils/models/activities/type/ActivityInfo.java
@@ -20,6 +20,7 @@ public record ActivityInfo(
         Optional<ActivityDistance> distance,
         Optional<String> distanceInfo,
         Optional<ActivityDifficulty> difficulty,
+        Optional<WorldEventFastTravelStatus> worldEventFastTravelStatus,
         ActivityRequirements requirements,
         Map<ActivityRewardType, List<StyledText>> rewards,
         ActivityTrackingState trackingState) {}

--- a/common/src/main/java/com/wynntils/models/activities/type/WorldEventFastTravelStatus.java
+++ b/common/src/main/java/com/wynntils/models/activities/type/WorldEventFastTravelStatus.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.activities.type;
+
+import com.wynntils.core.text.StyledText;
+import java.util.regex.Pattern;
+
+public enum WorldEventFastTravelStatus {
+    AVAILABLE(Pattern.compile(".+§f\uE004\uDB00\uDC02\uE014\uDB00\uDC02\uE001 §a§lShift Right-Click To Fast Travel")),
+    UNAVAILABLE(Pattern.compile(".+§f\uE004\uDB00\uDC02\uE014\uDB00\uDC02\uE001 §c§lShift Right-Click To Fast Travel")),
+    NOT_ALLOWED(Pattern.compile(".+§cFast Travel is not allowed right now")),
+    ON_COOLDOWN(Pattern.compile(".+§cFast Travel Available in( \\d+m)?( \\d+s)?"));
+
+    private final Pattern pattern;
+
+    WorldEventFastTravelStatus(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    public static WorldEventFastTravelStatus fromLine(StyledText statusLine) {
+        for (WorldEventFastTravelStatus status : values()) {
+            if (statusLine.matches(status.pattern)) return status;
+        }
+
+        return null;
+    }
+}

--- a/common/src/main/java/com/wynntils/screens/activities/widgets/ContentBookWidget.java
+++ b/common/src/main/java/com/wynntils/screens/activities/widgets/ContentBookWidget.java
@@ -24,6 +24,8 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.Pair;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import net.minecraft.ChatFormatting;
@@ -62,22 +64,25 @@ public class ContentBookWidget extends AbstractWidget implements TooltipProvider
         this.holder = holder;
         this.searchMatch = searchMatch;
 
-        this.tooltip = LoreUtils.getTooltipLines(itemStack);
-        this.tooltip.add(Component.empty());
+        List<Component> addons = new ArrayList<>();
+
+        addons.add(Component.empty());
 
         if (canSetCompass()) {
-            this.tooltip.add(Component.translatable("screens.wynntils.contentBook.leftClickToSetCompass")
+            addons.add(Component.translatable("screens.wynntils.contentBook.leftClickToSetCompass")
                     .withStyle(ChatFormatting.BOLD)
                     .withStyle(ChatFormatting.GREEN));
         }
         if (canOpenMap()) {
-            this.tooltip.add(Component.translatable("screens.wynntils.contentBook.middleClickToOpenOnMap")
+            addons.add(Component.translatable("screens.wynntils.contentBook.middleClickToOpenOnMap")
                     .withStyle(ChatFormatting.BOLD)
                     .withStyle(ChatFormatting.YELLOW));
         }
-        this.tooltip.add(Component.translatable("screens.wynntils.contentBook.rightClickToOpenWiki")
+        addons.add(Component.translatable("screens.wynntils.contentBook.rightClickToOpenWiki")
                 .withStyle(ChatFormatting.BOLD)
                 .withStyle(ChatFormatting.GOLD));
+
+        this.tooltip = LoreUtils.appendTooltip(itemStack, LoreUtils.getTooltipLines(itemStack), addons);
 
         if (activityInfo.trackingState() == ActivityTrackingState.TRACKED) {
             nameStyle = nameStyle.withBold(true).withUnderlined(true);

--- a/common/src/main/java/com/wynntils/screens/activities/widgets/ContentBookWidget.java
+++ b/common/src/main/java/com/wynntils/screens/activities/widgets/ContentBookWidget.java
@@ -24,7 +24,6 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.Pair;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Tracked state is now parsed again so the content description will be displayed in the custom book again.

Parses the world event fast travel status separately so that is no longer appended to the description.

<img width="1257" height="219" alt="image" src="https://github.com/user-attachments/assets/b33628b0-768e-4f99-bcbc-fb789f1a5213" />
