### PR TITLE
chore: Allow Functions to be used in tests

### DIFF
--- a/common/src/main/java/com/wynntils/core/WynntilsMod.java
+++ b/common/src/main/java/com/wynntils/core/WynntilsMod.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.core;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.wynntils.core.components.CoreComponent;
@@ -22,6 +23,11 @@ import com.wynntils.core.mod.type.CrashType;
 import com.wynntils.utils.mc.McUtils;
 import java.io.File;
 import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -30,6 +36,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import net.minecraft.SharedConstants;
+import net.minecraft.client.resources.language.ClientLanguage;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.server.Bootstrap;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.bus.api.IEventBus;
@@ -177,9 +186,6 @@ public final class WynntilsMod {
     }
 
     public static void init(ModLoader loader, String modVersion, boolean isDevelopmentEnvironment, File modFile) {
-        // When running tests the init function can be called multiple times
-        if (modJar != null) return;
-
         modJar = modFile;
 
         // Note that at this point, no resources (including I18n) are available, so we postpone features until then
@@ -215,6 +221,39 @@ public final class WynntilsMod {
         addCrashCallbacks();
 
         WynntilsMod.postEvent(new WynntilsInitEvent.ModInitFinished());
+    }
+
+    public static void setupTestEnv() {
+        if (initCompleted) return;
+
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+
+        init(null, "SNAPSHOT", true, null);
+
+        loadI18n();
+
+        Managers.Function.init();
+        Managers.Config.init();
+        Managers.Storage.initFeatures();
+        Services.Statistics.init();
+
+        initCompleted = true;
+    }
+
+    private static void loadI18n() {
+        // Assume tests are run in the fabric directory
+        Path langFile = Path.of("../common/src/main/resources/assets/wynntils/lang/en_us.json");
+        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        Map<String, String> langMap;
+
+        try (Reader reader = Files.newBufferedReader(langFile, StandardCharsets.UTF_8)) {
+            langMap = GSON.fromJson(reader, type);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load " + langFile, e);
+        }
+        ClientLanguage language = new ClientLanguage(langMap, false);
+        I18n.setLanguage(language);
     }
 
     private static void registerComponents(Class<?> registryClass, Class<? extends CoreComponent> componentClass) {

--- a/common/src/main/resources/wynntils.accessWidener
+++ b/common/src/main/resources/wynntils.accessWidener
@@ -78,3 +78,6 @@ mutable field net/minecraft/client/gui/components/ChatComponent trimmedMessages 
 mutable field net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation name Lnet/minecraft/network/chat/Component;
 mutable field net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateNameOperation name Lnet/minecraft/network/chat/Component;
 mutable field net/minecraft/world/scores/Scoreboard playerScores Ljava/util/Map;
+# For testing
+accessible method net/minecraft/client/resources/language/ClientLanguage <init> (Ljava/util/Map;Z)V
+accessible method net/minecraft/client/resources/language/I18n setLanguage (Lnet/minecraft/locale/Language;)V

--- a/fabric/src/test/java/TestCustomColor.java
+++ b/fabric/src/test/java/TestCustomColor.java
@@ -1,10 +1,9 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.utils.colors.CustomColor;
-import net.minecraft.SharedConstants;
-import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,7 @@ import org.junit.jupiter.api.Test;
 public class TestCustomColor {
     @BeforeAll
     public static void setup() {
-        SharedConstants.tryDetectVersion();
-        Bootstrap.bootStrap();
+        WynntilsMod.setupTestEnv();
     }
 
     @Test

--- a/fabric/src/test/java/TestEncodedByteBuffer.java
+++ b/fabric/src/test/java/TestEncodedByteBuffer.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.type.UnsignedByte;
-import net.minecraft.SharedConstants;
-import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,7 @@ import org.junit.jupiter.api.Test;
 public class TestEncodedByteBuffer {
     @BeforeAll
     public static void setup() {
-        SharedConstants.tryDetectVersion();
-        Bootstrap.bootStrap();
+        WynntilsMod.setupTestEnv();
     }
 
     @Test

--- a/fabric/src/test/java/TestGenericFunctions.java
+++ b/fabric/src/test/java/TestGenericFunctions.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Managers;
+import com.wynntils.core.text.StyledText;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestGenericFunctions {
+    @BeforeAll
+    public static void setup() {
+        WynntilsMod.setupTestEnv();
+    }
+
+    private static void assertTemplateResult(String template, String expected) {
+        StyledText[] result = Managers.Function.doFormatLines(template);
+
+        Assertions.assertEquals(1, result.length, "Too many lines");
+        String str = result[0].getString();
+        Assertions.assertEquals(expected, str, "Incorrect template result");
+    }
+
+    @Test
+    public void math_testAddInt() {
+        assertTemplateResult("{int(add(5;6))}", "11");
+    }
+}

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -2,6 +2,7 @@
  * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.features.chat.MessageFilterFeature;
 import com.wynntils.features.inventory.PersonalStorageUtilitiesFeature;
 import com.wynntils.features.redirects.ChatRedirectFeature;
@@ -45,8 +46,6 @@ import com.wynntils.models.wynnitem.parsing.WynnItemParser;
 import com.wynntils.utils.mc.StyledTextUtils;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
-import net.minecraft.SharedConstants;
-import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -54,8 +53,7 @@ import org.junit.jupiter.api.Test;
 public class TestRegex {
     @BeforeAll
     public static void setup() {
-        SharedConstants.tryDetectVersion();
-        Bootstrap.bootStrap();
+        WynntilsMod.setupTestEnv();
     }
 
     public static final class PatternTester {

--- a/fabric/src/test/java/TestStyledText.java
+++ b/fabric/src/test/java/TestStyledText.java
@@ -12,12 +12,10 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
-import net.minecraft.SharedConstants;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,9 +23,7 @@ import org.junit.jupiter.api.Test;
 public class TestStyledText {
     @BeforeAll
     public static void setup() {
-        SharedConstants.tryDetectVersion();
-        Bootstrap.bootStrap();
-        WynntilsMod.init(null, "SNAPSHOT", true, null);
+        WynntilsMod.setupTestEnv();
     }
 
     @Test

--- a/fabric/src/test/java/TestUnsignedByte.java
+++ b/fabric/src/test/java/TestUnsignedByte.java
@@ -1,10 +1,9 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.utils.type.UnsignedByte;
-import net.minecraft.SharedConstants;
-import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,7 @@ import org.junit.jupiter.api.Test;
 public class TestUnsignedByte {
     @BeforeAll
     public static void setup() {
-        SharedConstants.tryDetectVersion();
-        Bootstrap.bootStrap();
+        WynntilsMod.setupTestEnv();
     }
 
     @Test

--- a/fabric/src/test/java/TestUnsignedByteUtils.java
+++ b/fabric/src/test/java/TestUnsignedByteUtils.java
@@ -1,15 +1,14 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.utils.UnsignedByteUtils;
 import com.wynntils.utils.type.ArrayReader;
 import com.wynntils.utils.type.UnsignedByte;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import net.minecraft.SharedConstants;
-import net.minecraft.server.Bootstrap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -20,8 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TestUnsignedByteUtils {
     @BeforeAll
     public static void setup() {
-        SharedConstants.tryDetectVersion();
-        Bootstrap.bootStrap();
+        WynntilsMod.setupTestEnv();
     }
 
     @Test


### PR DESCRIPTION
This also introduces a simpler way to initialize a testing environment. With this, all major Wynntils functionality except Features should be present at test time. For stuff that relies on Minecraft internals, or Wynncraft server, things might still break. But in general, things that are useful to unit test should be possible.