### PR TITLE
fix: Handle status effect prefix fonts

### DIFF
--- a/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
@@ -94,7 +94,8 @@ public final class StatusEffectModel extends Model {
             String color = ChatFormatting.GRAY.toString();
 
             Style prefixStyle = effect.getFirstPart().getPartStyle().getStyle();
-            StyledText prefix = StyledText.fromComponent(Component.literal(m.group("prefix").trim()).withStyle(prefixStyle));
+            StyledText prefix = StyledText.fromComponent(
+                    Component.literal(m.group("prefix").trim()).withStyle(prefixStyle));
             StyledText name = StyledText.fromString(color + m.group("name").trim());
             StyledText minutes = StyledText.fromString(m.group("minutes")).trim();
             StyledText seconds = StyledText.fromString(m.group("seconds")).trim();

--- a/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -91,7 +93,8 @@ public final class StatusEffectModel extends Model {
 
             String color = ChatFormatting.GRAY.toString();
 
-            StyledText prefix = StyledText.fromString(m.group("prefix").trim());
+            Style prefixStyle = effect.getFirstPart().getPartStyle().getStyle();
+            StyledText prefix = StyledText.fromComponent(Component.literal(m.group("prefix").trim()).withStyle(prefixStyle));
             StyledText name = StyledText.fromString(color + m.group("name").trim());
             StyledText minutes = StyledText.fromString(m.group("minutes")).trim();
             StyledText seconds = StyledText.fromString(m.group("seconds")).trim();


### PR DESCRIPTION
Current
<img width="268" height="52" alt="image" src="https://github.com/user-attachments/assets/9d12e2ca-bd3c-43c1-b614-58f0398b903f" />

Fix
<img width="282" height="57" alt="image" src="https://github.com/user-attachments/assets/6abad5e2-ef8f-4694-bd34-b8c47912d8a7" />

I was doing a nicer fix by iterating over the parts and matching each detail of the status effect that way but ran into an issue with modifiers being the same part as the effect name and couldn't think of a clean way to handle that