### PR TITLE
fix: Allow price conversion feature to not have space before "-t"

### DIFF
--- a/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
+++ b/common/src/main/java/com/wynntils/models/emeralds/EmeraldModel.java
@@ -33,7 +33,7 @@ public final class EmeraldModel extends Model {
     private static final Pattern EB_PATTERN = Pattern.compile("(\\.?\\d+\\.?\\d*)\\s*(b|eb)");
     private static final Pattern K_PATTERN = Pattern.compile("(\\.?\\d+\\.?\\d*)\\s*(k|thousand)");
     private static final Pattern M_PATTERN = Pattern.compile("(\\.?\\d+\\.?\\d*)\\s*(m|million)");
-    private static final Pattern E_PATTERN = Pattern.compile("(\\d+)($|\\s|\\s*e|\\s*em)(?![^\\d\\s-])");
+    private static final Pattern E_PATTERN = Pattern.compile("(\\d+)($|-t|\\s|\\s*e|\\s*em)(?![^\\d\\s-])");
     private static final Pattern RAW_PRICE_PATTERN = Pattern.compile("\\d+");
     private static final double SILVERBULL_TAX_AMOUNT = 1.03;
     private static final double NORMAL_TAX_AMOUNT = 1.05;

--- a/common/src/main/java/com/wynntils/models/trademarket/TradeMarketModel.java
+++ b/common/src/main/java/com/wynntils/models/trademarket/TradeMarketModel.java
@@ -60,6 +60,7 @@ public final class TradeMarketModel extends Model {
             Pattern.compile("^§5(\uE00A\uE002|\uE001) Type the item name or type 'cancel' to cancel:$");
     private static final Pattern AMOUNT_INPUT_PATTERN = Pattern.compile(
             "^§5(\uE00A\uE002|\uE001) Type the amount you wish to (buy|sell) or type 'cancel' to cancel:$");
+    // Test in TradeMarketModel_PRICE_INPUT_PATTERN
     private static final Pattern PRICE_INPUT_PATTERN = Pattern.compile(
             "^§5(\uE00A\uE002|\uE001) Type the price in emeralds or formatted \\(e\\.g '10eb', '10stx 5eb'\\) or type 'cancel' to cancel:$");
     private static final Pattern CANCELLED_PATTERN =

--- a/fabric/src/test/java/TestModels.java
+++ b/fabric/src/test/java/TestModels.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Models;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestModels {
+    @BeforeAll
+    public static void setup() {
+        WynntilsMod.setupTestEnv();
+    }
+
+    @Test
+    public void EmeraldModel_convertEmeraldPrice() {
+        // Pure numbers will not be changed
+        String eStr = Models.Emerald.convertEmeraldPrice("105");
+        Assertions.assertEquals("", eStr);
+
+        String badStr = Models.Emerald.convertEmeraldPrice("whatisthisidonteven");
+        Assertions.assertEquals("", badStr);
+
+        String badStr2 = Models.Emerald.convertEmeraldPrice("10$");
+        Assertions.assertEquals("", badStr);
+
+        String kStr = Models.Emerald.convertEmeraldPrice("10k");
+        Assertions.assertEquals("10000", kStr);
+
+        String kmStr = Models.Emerald.convertEmeraldPrice("1 m 20k");
+        Assertions.assertEquals("1020000", kmStr);
+
+        String leStr = Models.Emerald.convertEmeraldPrice("1 le");
+        Assertions.assertEquals("4096", leStr);
+
+        String eStrTax = Models.Emerald.convertEmeraldPrice("105 -t");
+        Assertions.assertEquals("100", eStrTax);
+
+        String eStrTax2 = Models.Emerald.convertEmeraldPrice("105-t");
+        Assertions.assertEquals("100", eStrTax2);
+
+        String kStrTax = Models.Emerald.convertEmeraldPrice("10k -t");
+        Assertions.assertEquals("9524", kStrTax);
+
+        String kStrTax2 = Models.Emerald.convertEmeraldPrice("10k-t");
+        Assertions.assertEquals("9524", kStrTax2);
+    }
+}

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -1113,4 +1113,11 @@ public class TestRegex {
         p.shouldMatch("§#54fffcff§lIngenuous Mage's Gambit");
         p.shouldMatch("§#ac2c01ff§lArcane Incontinent's Gambit");
     }
+
+    @Test
+    public void TradeMarketModel_PRICE_INPUT_PATTERN() {
+        PatternTester p = new PatternTester(TradeMarketModel.class, "PRICE_INPUT_PATTERN");
+        p.shouldMatch(
+                "§5\uE00A\uE002 Type the price in emeralds or formatted (e.g '10eb', '10stx 5eb') or type 'cancel' to cancel:");
+    }
 }


### PR DESCRIPTION
I got annoyed that `105-t` did not work. It took me a while to debug where the problem lied, but I did that using tests so I think we should keep them.