### PR TITLE
chore: Remove log when editing notification

### DIFF
--- a/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
+++ b/common/src/main/java/com/wynntils/core/notifications/NotificationManager.java
@@ -85,8 +85,6 @@ public final class NotificationManager extends Manager {
         // If the message is the same, don't do anything
         if (oldMessage.equals(newMessage)) return msgContainer;
 
-        WynntilsMod.info("Message Edited: " + msgContainer.getRenderTask() + " -> " + newMessage.getString());
-
         // If we have multiple repeated messages, we want to only edit the last one.
         Component oldComponent = msgContainer.getRenderTask().getText().getComponent();
         if (msgContainer.getMessageCount() > 1) {


### PR DESCRIPTION
Should've been done with https://github.com/Wynntils/Wynntils/pull/3335 but forgot there was a separate edit log, again can cause a lot of unnecessary log spam