### PR TITLE
fix: Reset spell input text on world state change

### DIFF
--- a/common/src/main/java/com/wynntils/models/spells/SpellModel.java
+++ b/common/src/main/java/com/wynntils/models/spells/SpellModel.java
@@ -20,7 +20,6 @@ import com.wynntils.models.spells.type.SpellDirection;
 import com.wynntils.models.spells.type.SpellFailureReason;
 import com.wynntils.models.spells.type.SpellType;
 import com.wynntils.models.worlds.event.WorldStateEvent;
-import com.wynntils.utils.mc.McUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -35,7 +34,6 @@ public final class SpellModel extends Model {
     private static final Pattern SPELL_CAST =
             Pattern.compile("^§7(.*) spell cast! §3\\[§b-([0-9]+) ✺§3\\](?: §4\\[§c-([0-9]+) ❤§4\\])?$");
     public static final int SPELL_COST_RESET_TICKS = 60;
-    private static final int SPELL_EXPIRE_TICKS = 40;
 
     private static final Queue<SpellDirection> SPELL_PACKET_QUEUE = new LinkedList<>();
 
@@ -44,7 +42,6 @@ public final class SpellModel extends Model {
     private SpellDirection[] lastSpell = SpellDirection.NO_SPELL;
     private String lastBurstSpellName = "";
     private String lastSpellName = "";
-    private int lastSpellTick = 0;
     private int repeatedBurstSpellCount = 0;
     private int repeatedSpellCount = 0;
     private int ticksSinceCastBurst = 0;
@@ -137,7 +134,6 @@ public final class SpellModel extends Model {
     public void onWorldStateChange(WorldStateEvent e) {
         SPELL_PACKET_QUEUE.clear();
         lastSpell = SpellDirection.NO_SPELL;
-        lastSpellTick = 0;
         lastBurstSpellName = "";
         lastSpellName = "";
         repeatedBurstSpellCount = 0;
@@ -150,7 +146,6 @@ public final class SpellModel extends Model {
     public void onHeldItemChange(ChangeCarriedItemEvent event) {
         SPELL_PACKET_QUEUE.clear();
         lastSpell = SpellDirection.NO_SPELL;
-        lastSpellTick = 0;
     }
 
     public void addSpellToQueue(List<SpellDirection> spell) {
@@ -210,13 +205,11 @@ public final class SpellModel extends Model {
         // noop if the spell state hasn't changed
         if (Arrays.equals(spellSegment.getDirections(), lastSpell)) return;
         lastSpell = spellSegment.getDirections();
-        lastSpellTick = McUtils.player().tickCount;
 
         WynntilsMod.postEvent(new SpellEvent.Partial(lastSpell));
 
         if (lastSpell.length == 3) {
             WynntilsMod.postEvent(new SpellEvent.Completed(lastSpell, SpellType.fromSpellDirectionArray(lastSpell)));
-            lastSpellTick = 0;
         }
     }
 
@@ -225,7 +218,6 @@ public final class SpellModel extends Model {
             if (lastSpell.length != 3) {
                 lastSpell = SpellDirection.NO_SPELL;
             }
-            lastSpellTick = 0;
             WynntilsMod.postEvent(new SpellEvent.Expired());
         }
     }

--- a/common/src/main/java/com/wynntils/overlays/SpellInputsOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/SpellInputsOverlay.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.spells.event.SpellEvent;
 import com.wynntils.models.spells.type.SpellDirection;
+import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.buffered.BufferedFontRenderer;
 import com.wynntils.utils.render.type.HorizontalAlignment;
@@ -83,6 +84,11 @@ public class SpellInputsOverlay extends Overlay {
 
     @SubscribeEvent
     public void onSpellExpired(SpellEvent.Expired event) {
+        spellText = StyledText.EMPTY;
+    }
+
+    @SubscribeEvent
+    public void onWorldStateChanged(WorldStateEvent event) {
         spellText = StyledText.EMPTY;
     }
 


### PR DESCRIPTION
If you change world before the expired event fires, the text will remain the same so just reset it.

And removed some variables that are no longer used now that we handle spell expired from the action bar