### PR TITLE
feat: Color Template for Info Boxes

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/infobox/InfoBoxOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/infobox/InfoBoxOverlay.java
@@ -23,7 +23,7 @@ public class InfoBoxOverlay extends TextOverlay implements CustomNameProperty {
     private final Config<String> content = new Config<>("");
 
     @Persisted
-    final Config<String> colorTemplate = new Config<>("");
+    private final Config<String> colorTemplate = new Config<>("");
 
     private CustomColor colorCache = CommonColors.WHITE;
 

--- a/common/src/main/java/com/wynntils/overlays/infobox/InfoBoxOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/infobox/InfoBoxOverlay.java
@@ -4,11 +4,16 @@
  */
 package com.wynntils.overlays.infobox;
 
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.overlays.CustomNameProperty;
 import com.wynntils.core.consumers.overlays.TextOverlay;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.HiddenConfig;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.type.ErrorOr;
 
 public class InfoBoxOverlay extends TextOverlay implements CustomNameProperty {
     @Persisted
@@ -16,6 +21,11 @@ public class InfoBoxOverlay extends TextOverlay implements CustomNameProperty {
 
     @Persisted
     private final Config<String> content = new Config<>("");
+
+    @Persisted
+    final Config<String> colorTemplate = new Config<>("");
+
+    private CustomColor colorCache = CommonColors.WHITE;
 
     public InfoBoxOverlay(int id) {
         super(id);
@@ -33,6 +43,33 @@ public class InfoBoxOverlay extends TextOverlay implements CustomNameProperty {
         }
 
         return "&cX: {x(my_loc):0}, &9Y: {y(my_loc):0}, &aZ: {z(my_loc):0}";
+    }
+
+    @Override
+    protected CustomColor getRenderColor() {
+        return colorCache;
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (!isRendered()) return;
+
+        String template = colorTemplate.get();
+        if (template.isBlank()) {
+            colorCache = CommonColors.WHITE;
+            return;
+        }
+
+        String formattedText =
+                StyledText.join("", Managers.Function.doFormatLines(template)).getString();
+        ErrorOr<CustomColor> colorOrError = Managers.Function.tryGetRawValueOfType(formattedText, CustomColor.class);
+
+        if (colorOrError.hasError()) {
+            colorCache = CommonColors.WHITE;
+            return;
+        }
+        colorCache = colorOrError.getValue();
     }
 
     @Override

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -685,6 +685,8 @@
   "feature.wynntils.horseMount.summonAttempts.name": "Summon Attempts",
   "feature.wynntils.infoBox.description": "Adds the ability to add custom info boxes to the screen as overlays. Info boxes can display custom functions.",
   "feature.wynntils.infoBox.name": "Info Boxes",
+  "feature.wynntils.infoBox.overlay.infoBox.colorTemplate.description": "The template that determines the color of the text. Must be a CustomColor. This template should not have curly brackets.",
+  "feature.wynntils.infoBox.overlay.infoBox.colorTemplate.name": "Color Template",
   "feature.wynntils.infoBox.overlay.infoBox.content.description": "What should be displayed in the info box?",
   "feature.wynntils.infoBox.overlay.infoBox.content.name": "Info Box Content",
   "feature.wynntils.infoBox.overlay.infoBox.name": "Info Box %d",


### PR DESCRIPTION
Adds Color Template found in Custom Universal Bar into Info Boxes, this allows for much easier color manipulation across the info box
<img width="2560" height="1417" alt="image" src="https://github.com/user-attachments/assets/6c886588-3bdd-4d56-97a9-93b1fa085c01" />
