### PR TITLE
fix: Fix bomb bell overlay max config not applying to groups

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -18,7 +18,6 @@ import com.wynntils.models.worlds.type.BombInfo;
 import com.wynntils.models.worlds.type.BombSortOrder;
 import com.wynntils.models.worlds.type.BombType;
 import com.wynntils.utils.mc.StyledTextUtils;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
@@ -159,9 +158,7 @@ public final class BombModel extends Model {
 
         if (group) {
             return stream.collect(Collectors.groupingBy(BombInfo::bomb)).values().stream()
-                    .flatMap(list -> list.stream()
-                            .sorted(comparator)
-                            .limit(maxPerGroup));
+                    .flatMap(list -> list.stream().sorted(comparator).limit(maxPerGroup));
         } else {
             return stream.sorted(comparator).limit(maxPerGroup);
         }

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -148,19 +148,23 @@ public final class BombModel extends Model {
     }
 
     public Stream<BombInfo> getBombBellStream(boolean group, BombSortOrder sortOrder) {
+        return getBombBellStream(group, sortOrder, getBombBells().size());
+    }
+
+    public Stream<BombInfo> getBombBellStream(boolean group, BombSortOrder sortOrder, int maxPerGroup) {
         Stream<BombInfo> stream = getBombBells().stream();
         Comparator<BombInfo> comparator = sortOrder == BombSortOrder.NEWEST
                 ? Comparator.comparing(BombInfo::getRemainingLong).reversed()
                 : Comparator.comparing(BombInfo::getRemainingLong);
 
-        stream = stream.sorted(comparator);
-
         if (group) {
-            stream = stream.collect(Collectors.groupingBy(BombInfo::bomb)).values().stream()
-                    .flatMap(Collection::stream);
+            return stream.collect(Collectors.groupingBy(BombInfo::bomb)).values().stream()
+                    .flatMap(list -> list.stream()
+                            .sorted(comparator)
+                            .limit(maxPerGroup));
+        } else {
+            return stream.sorted(comparator).limit(maxPerGroup);
         }
-
-        return stream;
     }
 
     public BombInfo getLastBomb() {

--- a/common/src/main/java/com/wynntils/overlays/BombBellOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/BombBellOverlay.java
@@ -148,13 +148,12 @@ public class BombBellOverlay extends Overlay {
 
     @Override
     public void tick() {
-        Stream<BombInfo> bombsToRender = Models.Bomb.getBombBellStream(groupBombs.get(), sortOrder.get())
+        Stream<BombInfo> bombsToRender = Models.Bomb.getBombBellStream(groupBombs.get(), sortOrder.get(), maxBombs.get())
                 .filter(bombInfo -> {
                     BombType bombType = bombInfo.bomb();
-                    Supplier<Boolean> bombTypeSuplier = bombTypeMap.get(bombType);
-                    return bombTypeSuplier != null && bombTypeSuplier.get();
-                })
-                .limit(maxBombs.get());
+                    Supplier<Boolean> bombTypeSupplier = bombTypeMap.get(bombType);
+                    return bombTypeSupplier != null && bombTypeSupplier.get();
+                });
 
         renderTasks = bombsToRender
                 .map(bombInfo -> new TextRenderTask(bombInfo.asString(), textRenderSetting))

--- a/common/src/main/java/com/wynntils/overlays/BombBellOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/BombBellOverlay.java
@@ -148,7 +148,8 @@ public class BombBellOverlay extends Overlay {
 
     @Override
     public void tick() {
-        Stream<BombInfo> bombsToRender = Models.Bomb.getBombBellStream(groupBombs.get(), sortOrder.get(), maxBombs.get())
+        Stream<BombInfo> bombsToRender = Models.Bomb.getBombBellStream(
+                        groupBombs.get(), sortOrder.get(), maxBombs.get())
                 .filter(bombInfo -> {
                     BombType bombType = bombInfo.bomb();
                     Supplier<Boolean> bombTypeSupplier = bombTypeMap.get(bombType);


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Wynntils/issues/3527

Limit was always being applied so it would only display that amount of bombs which should only happen when grouping is disabled. With grouping enabled the limit should be per bomb