### PR TITLE
fix: Return to title menu when disconnecting after having used the Wynncraft button

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
@@ -76,6 +76,9 @@ public class WynncraftButtonFeature extends Feature {
     @Persisted
     public final Storage<Boolean> ignoreFailedDownloads = new Storage<>(false);
 
+    @Persisted
+    private final Config<Boolean> returnToTitle = new Config<>(true);
+
     @SubscribeEvent
     public void onTitleScreenInit(TitleScreenInitEvent.Post event) {
         TitleScreen titleScreen = event.getTitleScreen();
@@ -93,8 +96,10 @@ public class WynncraftButtonFeature extends Feature {
         }
         if (event.getScreen() instanceof JoinMultiplayerScreen) {
             hasUsedButton = false;
-            event.setCanceled(true);
-            McUtils.mc().setScreen(new TitleScreen());
+            if (returnToTitle.get()) {
+                event.setCanceled(true);
+                McUtils.mc().setScreen(new TitleScreen());
+            }
         }
     }
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1622,6 +1622,8 @@
   "feature.wynntils.wynncraftButton.loadResourcePack.description": "Should the Wynncraft resource pack be loaded?",
   "feature.wynntils.wynncraftButton.loadResourcePack.name": "Load Resource Pack",
   "feature.wynntils.wynncraftButton.name": "Wynncraft Button",
+  "feature.wynntils.wynncraftButton.returnToTitle.description": "Should you return to the title screen, instead of the server screen, after disconnecting when having connected using the button?",
+  "feature.wynntils.wynncraftButton.returnToTitle.name": "Return to title screen after disconnect",
   "feature.wynntils.wynncraftButton.serverRegionOverride.description": "Which server region should the button and auto-connect join? Wc will connect to your default region",
   "feature.wynntils.wynncraftButton.serverRegionOverride.name": "Server Region Override",
   "feature.wynntils.wynncraftButton.serverType.description": "Which server should the button and auto-connect join?",


### PR DESCRIPTION
This has been annoying me for some time, that you end up in the multiplayer screen after disconnect even when connecting using the button...