### PR TITLE
fix: Chat rewrites stopped working after #3549 in chat tabs

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -54,7 +54,7 @@ public class ChatTabsFeature extends Feature {
 
     // We do this here, and not in Services.ChatTab to not introduce a feature-model dependency.
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onChatReceived(ChatMessageEvent.Match event) {
+    public void onChatReceived(ChatMessageEvent.Discard event) {
         // We will send this message to every matching tab, so we can cancel it.
         event.setCanceled(true);
 

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -551,7 +551,8 @@ public final class ChatHandler extends Handler {
         ChatMessageEvent.Edit rewriteEvent = new ChatMessageEvent.Edit(styledText, messageType, recipientType);
         WynntilsMod.postEvent(rewriteEvent);
 
-        ChatMessageEvent.Discard discardEvent = new ChatMessageEvent.Discard(rewriteEvent.getMessage(), messageType, recipientType);
+        ChatMessageEvent.Discard discardEvent =
+                new ChatMessageEvent.Discard(rewriteEvent.getMessage(), messageType, recipientType);
         WynntilsMod.postEvent(discardEvent);
         if (discardEvent.isCanceled()) return null;
 

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -550,6 +550,11 @@ public final class ChatHandler extends Handler {
 
         ChatMessageEvent.Edit rewriteEvent = new ChatMessageEvent.Edit(styledText, messageType, recipientType);
         WynntilsMod.postEvent(rewriteEvent);
+
+        ChatMessageEvent.Discard discardEvent = new ChatMessageEvent.Discard(rewriteEvent.getMessage(), messageType, recipientType);
+        WynntilsMod.postEvent(discardEvent);
+        if (discardEvent.isCanceled()) return null;
+
         return rewriteEvent.getMessage();
     }
 

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageEvent.java
@@ -61,6 +61,8 @@ public abstract class ChatMessageEvent extends Event {
         }
     }
 
+    // This is a temporary measure to workaround a regression with chat tabs,
+    // while we await the proper chat overhaul.
     public static class Discard extends ChatMessageEvent implements ICancellableEvent {
         public Discard(StyledText message, MessageType messageType, RecipientType recipientType) {
             super(message, messageType, recipientType);

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageEvent.java
@@ -10,7 +10,7 @@ import com.wynntils.handlers.chat.type.RecipientType;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
-public abstract class ChatMessageEvent extends Event implements ICancellableEvent {
+public abstract class ChatMessageEvent extends Event {
     protected final StyledText message;
     private final MessageType messageType;
     private final RecipientType recipientType;
@@ -36,7 +36,7 @@ public abstract class ChatMessageEvent extends Event implements ICancellableEven
     /**
      * This event is what models and features should use to listen to chat messsages.
      */
-    public static class Match extends ChatMessageEvent {
+    public static class Match extends ChatMessageEvent implements ICancellableEvent {
         public Match(StyledText message, MessageType messageType, RecipientType recipientType) {
             super(message, messageType, recipientType);
         }
@@ -58,6 +58,12 @@ public abstract class ChatMessageEvent extends Event implements ICancellableEven
 
         public void setMessage(StyledText message) {
             this.editedMessage = message;
+        }
+    }
+
+    public static class Discard extends ChatMessageEvent implements ICancellableEvent {
+        public Discard(StyledText message, MessageType messageType, RecipientType recipientType) {
+            super(message, messageType, recipientType);
         }
     }
 }


### PR DESCRIPTION
When using chat tabs, rewriting of chats stopped working after #3549.

This is a workaround to restore functionality. The proper solution, I think, is a better implementation of chat tabs.