### PR TITLE
feat: Add crash protection for enabling a feature

### DIFF
--- a/common/src/main/java/com/wynntils/commands/FeatureCommand.java
+++ b/common/src/main/java/com/wynntils/commands/FeatureCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.commands;
@@ -181,7 +181,7 @@ public class FeatureCommand extends Command {
             return 1;
         }
 
-        Managers.Feature.disableFeature(feature);
+        Managers.Feature.disableFeature(feature, false);
 
         if (feature.isEnabled()) {
             context.getSource()

--- a/common/src/main/java/com/wynntils/core/consumers/features/Feature.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/Feature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2021-2023.
+ * Copyright © Wynntils 2021-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.features;
@@ -98,7 +98,7 @@ public abstract class Feature extends AbstractConfigurable implements Storageabl
         if (userEnabled.get()) {
             Managers.Feature.enableFeature(this);
         } else {
-            Managers.Feature.disableFeature(this);
+            Managers.Feature.disableFeature(this, false);
         }
     }
 


### PR DESCRIPTION
When enabling a feature not during init, we did not have crash protection. Note that this code is also executed if you had set a feature to be userEnabled, even if it was already enabled by default.