### PR TITLE
feat: Update FixPacketBugsFeature to hide "Ignoring player info update for unknown player ..." messages

### DIFF
--- a/common/src/main/java/com/wynntils/mc/event/PlayerInfoUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerInfoUpdateEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import java.util.List;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.neoforged.bus.api.Event;
+
+public class PlayerInfoUpdateEvent extends Event {
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> entries;
+    private final List<ClientboundPlayerInfoUpdatePacket.Entry> newEntries;
+
+    public PlayerInfoUpdateEvent(
+            List<ClientboundPlayerInfoUpdatePacket.Entry> entries,
+            List<ClientboundPlayerInfoUpdatePacket.Entry> newEntries) {
+        this.entries = entries;
+        this.newEntries = newEntries;
+    }
+
+    public List<ClientboundPlayerInfoUpdatePacket.Entry> getEntries() {
+        return entries;
+    }
+
+    public List<ClientboundPlayerInfoUpdatePacket.Entry> getNewEntries() {
+        return newEntries;
+    }
+
+    public void setEntries(List<ClientboundPlayerInfoUpdatePacket.Entry> entries) {
+        this.entries = entries;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/accessors/ClientboundPlayerInfoUpdatePacketAccessor.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/accessors/ClientboundPlayerInfoUpdatePacketAccessor.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin.accessors;
+
+import java.util.List;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientboundPlayerInfoUpdatePacket.class)
+public interface ClientboundPlayerInfoUpdatePacketAccessor {
+    @Accessor("entries")
+    @Mutable
+    void setEntries(List<ClientboundPlayerInfoUpdatePacket.Entry> entries);
+}

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -54,6 +54,7 @@
     "WingsLayerMixin",
     "accessors.ChatScreenAccessor",
     "accessors.ClientboundBossEventPacketAccessor",
+    "accessors.ClientboundPlayerInfoUpdatePacketAccessor",
     "accessors.ClientboundSetPlayerTeamPacketAccessor",
     "accessors.ItemStackInfoAccessor",
     "accessors.LerpingBossEventAccessor",


### PR DESCRIPTION
I got annoyed at the constant spamming in the logs due to misformed packets from Wynncraft.

I classified this as `feat:` since it technically adds new functionality, even though I guess most users don't care about this. You might be able to convince me it should be something else instead... (but what? Maybe `chore`?)