### PR TITLE
fix: Don't render item locks on party finder match found screen

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -31,6 +31,7 @@ import com.wynntils.models.containers.containers.JukeboxContainer;
 import com.wynntils.models.containers.containers.LeaderboardRewardsContainer;
 import com.wynntils.models.containers.containers.LobbyContainer;
 import com.wynntils.models.containers.containers.LootrunRewardChestContainer;
+import com.wynntils.models.containers.containers.PartyFinderMatchFoundContainer;
 import com.wynntils.models.containers.containers.RaidRewardChestContainer;
 import com.wynntils.models.containers.containers.RaidRewardPreviewContainer;
 import com.wynntils.models.containers.containers.RatingRewardsContainer;
@@ -148,6 +149,7 @@ public final class ContainerModel extends Model {
         registerContainer(new LootrunRewardChestContainer());
         registerContainer(new MiscBucketContainer());
         registerContainer(new ObjectiveRewardContainer());
+        registerContainer(new PartyFinderMatchFoundContainer());
         registerContainer(new PersonalBlockBankContainer());
         registerContainer(new RaidRewardChestContainer());
         registerContainer(new RaidRewardPreviewContainer());

--- a/common/src/main/java/com/wynntils/models/containers/containers/PartyFinderMatchFoundContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/PartyFinderMatchFoundContainer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.containers;
+
+import com.wynntils.models.containers.Container;
+import com.wynntils.models.containers.type.FullscreenContainerProperty;
+import java.util.regex.Pattern;
+
+public class PartyFinderMatchFoundContainer extends Container implements FullscreenContainerProperty {
+    private static final Pattern TITLE_PATTERN = Pattern.compile("\uDAFF\uDFE0[\uE041-\uE051]");
+
+    public PartyFinderMatchFoundContainer() {
+        super(TITLE_PATTERN);
+    }
+}


### PR DESCRIPTION
Current with item locks
<img width="1920" height="1009" alt="2025-10-05_14 13 24" src="https://github.com/user-attachments/assets/66924d4e-8a76-4714-b8fa-785fb25df14e" />

Fixed
<img width="1920" height="1009" alt="2025-10-05_13 06 18" src="https://github.com/user-attachments/assets/27e4e9ce-ee20-4c4d-b9a1-fe733f640168" />
