### PR TITLE
feat: Send Hades version in authentication packet

### DIFF
--- a/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Services;
 import com.wynntils.features.players.HadesFeature;
 import com.wynntils.hades.objects.HadesConnection;
+import com.wynntils.hades.protocol.enums.HadesVersion;
 import com.wynntils.hades.protocol.interfaces.adapters.IHadesClientAdapter;
 import com.wynntils.hades.protocol.packets.client.HCPacketAuthenticate;
 import com.wynntils.hades.protocol.packets.server.HSPacketAuthenticationResponse;
@@ -51,7 +52,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
                     "Tried to auth to the remote player server without being logged in on Athena.");
         }
 
-        hadesConnection.sendPacketAndFlush(new HCPacketAuthenticate(Services.WynntilsAccount.getToken()));
+        hadesConnection.sendPacketAndFlush(new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_1));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.hades;
@@ -52,7 +52,8 @@ public class HadesClientHandler implements IHadesClientAdapter {
                     "Tried to auth to the remote player server without being logged in on Athena.");
         }
 
-        hadesConnection.sendPacketAndFlush(new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_1));
+        hadesConnection.sendPacketAndFlush(
+                new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_1));
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mixinextras_version=0.5.0
 shadow_version=9.1.0
 
 # Hades
-hades_version=0.6.0
+hades_version=0.6.1
 
 # Antiope
 antiope_version=0.2.2


### PR DESCRIPTION
Depends on https://github.com/Wynntils/Hades/pull/16

Merge after https://github.com/Wynntils/HadesServer/pull/16 is merged

Should make gear sharing more stable for users on latest version as the guild check hack is no longer being used to determine if the client supports gear sharing.

Tested the following scenarios:
Client X - Hades version (Wynntils counterpart)

Client 1 - 0.5.1 (v3.2.14)
Client 2 - 0.5.1 (v3.2.14)

Client 1 - 0.5.1 (v3.2.14)
Client 2 - 0.6.0 (v3.3.0)

Client 1 - 0.5.1 (v3.2.14)
Client 2 - 0.6.1 (v3.3.1)

Client 1 - 0.6.0 (v3.3.0)
Client 2 - 0.6.0 (v3.3.0)

Client 1 - 0.6.0 (v3.3.0)
Client 2 - 0.6.1 (v3.3.1)

Client 1 - 0.6.1 (v3.3.1)
Client 2 - 0.6.1 (v3.3.1)