### PR TITLE
fix: Fix spell input overlay not always clearing inputs

### DIFF
--- a/common/src/main/java/com/wynntils/models/spells/SpellModel.java
+++ b/common/src/main/java/com/wynntils/models/spells/SpellModel.java
@@ -47,6 +47,8 @@ public final class SpellModel extends Model {
     private int ticksSinceCastBurst = 0;
     private int ticksSinceCast = 0;
 
+    private boolean expireNextClear = false;
+
     public SpellModel() {
         super(List.of());
 
@@ -145,7 +147,10 @@ public final class SpellModel extends Model {
     @SubscribeEvent
     public void onHeldItemChange(ChangeCarriedItemEvent event) {
         SPELL_PACKET_QUEUE.clear();
+        // We need to reset lastSpell here as the actual inputs are now cleared, but they are still visible
+        // so we don't post the expired event until the action bar has actually updated with the cleared inputs
         lastSpell = SpellDirection.NO_SPELL;
+        expireNextClear = true;
     }
 
     public void addSpellToQueue(List<SpellDirection> spell) {
@@ -218,6 +223,9 @@ public final class SpellModel extends Model {
             if (lastSpell.length != 3) {
                 lastSpell = SpellDirection.NO_SPELL;
             }
+            WynntilsMod.postEvent(new SpellEvent.Expired());
+        } else if (expireNextClear) {
+            expireNextClear = false;
             WynntilsMod.postEvent(new SpellEvent.Expired());
         }
     }

--- a/common/src/main/java/com/wynntils/overlays/SpellInputsOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/SpellInputsOverlay.java
@@ -13,9 +13,9 @@ import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
-import com.wynntils.models.spells.actionbar.segments.SpellSegment;
+import com.wynntils.models.spells.event.SpellEvent;
 import com.wynntils.models.spells.type.SpellDirection;
+import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.render.buffered.BufferedFontRenderer;
 import com.wynntils.utils.render.type.HorizontalAlignment;
@@ -70,8 +70,26 @@ public class SpellInputsOverlay extends Overlay {
     }
 
     @SubscribeEvent
-    public void onActionBarUpdate(ActionBarUpdatedEvent event) {
-        event.runIfPresentOrElse(SpellSegment.class, this::handleSpellInput, this::clearSpellInput);
+    public void onSpellCast(SpellEvent.Partial event) {
+        SpellDirection[] dirs = event.getSpellDirectionArray();
+        SpellInputStyle style = inputStyle.get();
+
+        spellText = switch (style) {
+            case SMALL -> buildUnicodeInputs(dirs, true);
+            case FULL -> buildUnicodeInputs(dirs, false);
+            case ORIGINAL -> buildUnicodeInputs(dirs, Models.CharacterStats.getLevel() >= SMALL_CHARACTERS_LEVEL);
+            case LEGACY -> buildLegacyInputs(dirs);
+        };
+    }
+
+    @SubscribeEvent
+    public void onSpellExpired(SpellEvent.Expired event) {
+        spellText = StyledText.EMPTY;
+    }
+
+    @SubscribeEvent
+    public void onWorldStateChanged(WorldStateEvent event) {
+        spellText = StyledText.EMPTY;
     }
 
     @Override
@@ -119,21 +137,6 @@ public class SpellInputsOverlay extends Overlay {
                         this.getRenderVerticalAlignment(),
                         textShadow.get(),
                         fontScale.get());
-    }
-
-    private void handleSpellInput(SpellSegment spellSegment) {
-        SpellDirection[] dirs = spellSegment.getDirections();
-
-        spellText = switch (inputStyle.get()) {
-            case SMALL -> buildUnicodeInputs(dirs, true);
-            case FULL -> buildUnicodeInputs(dirs, false);
-            case ORIGINAL -> buildUnicodeInputs(dirs, Models.CharacterStats.getLevel() >= SMALL_CHARACTERS_LEVEL);
-            case LEGACY -> buildLegacyInputs(dirs);
-        };
-    }
-
-    private void clearSpellInput() {
-        spellText = StyledText.EMPTY;
     }
 
     private StyledText buildUnicodeInputs(SpellDirection[] dirs, boolean small) {


### PR DESCRIPTION
The expired event from the model is not always posted (intended behaviour) so just listen to the action bar in the overlay instead to determine when it should render the inputs