### PR TITLE
feat: Individual stat weightings

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -6,6 +6,7 @@ package com.wynntils.features.tooltips;
 
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
+import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
@@ -13,19 +14,25 @@ import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
 import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.handlers.tooltip.type.TooltipWeightDecorator;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.models.gear.type.ItemWeightSource;
 import com.wynntils.models.items.WynnItem;
+import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.items.properties.NamedItemProperty;
 import com.wynntils.models.stats.StatCalculator;
 import com.wynntils.models.stats.type.StatActualValue;
 import com.wynntils.models.stats.type.StatListOrdering;
 import com.wynntils.models.stats.type.StatPossibleValues;
+import com.wynntils.models.stats.type.StatType;
+import com.wynntils.models.stats.type.StatUnit;
+import com.wynntils.services.itemweight.type.ItemWeighting;
 import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.TooltipUtils;
 import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.wynn.ColorScaleUtils;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -44,11 +51,15 @@ import org.lwjgl.glfw.GLFW;
 
 @ConfigCategory(Category.TOOLTIPS)
 public class ItemStatInfoFeature extends Feature {
-    private final Map<DecoratorType, TooltipIdentificationDecorator> decorators = Map.of(
-            DecoratorType.PERCENTAGE, new PercentageIdentificationDecorator(),
-            DecoratorType.REROLL, new RerollIdentificationDecorator(),
-            DecoratorType.RANGE, new RangeIdentificationDecorator(),
-            DecoratorType.INNER_ROLL, new InnerRollIdentificationDecorator());
+    private final Map<IdentificationDecoratorType, TooltipIdentificationDecorator> identificationDecorators = Map.of(
+            IdentificationDecoratorType.PERCENTAGE, new PercentageIdentificationDecorator(),
+            IdentificationDecoratorType.REROLL, new RerollIdentificationDecorator(),
+            IdentificationDecoratorType.RANGE, new RangeIdentificationDecorator(),
+            IdentificationDecoratorType.INNER_ROLL, new InnerRollIdentificationDecorator());
+
+    private final Map<WeightDecoratorType, TooltipWeightDecorator> weightDecorators = Map.of(
+            WeightDecoratorType.OVERALL, new SimpleWeightDecorator(),
+            WeightDecoratorType.FULL, new FullWeightDecorator());
 
     private final Set<WynnItem> brokenItems = new HashSet<>();
 
@@ -162,8 +173,12 @@ public class ItemStatInfoFeature extends Feature {
         return colorLerp.get() ? LERP_MAP : flatMap;
     }
 
-    public TooltipIdentificationDecorator getDecorator() {
-        return decorators.get(DecoratorType.getCurrentType());
+    public TooltipIdentificationDecorator getIdentificationDecorator() {
+        return identificationDecorators.get(IdentificationDecoratorType.getCurrentType());
+    }
+
+    public TooltipWeightDecorator getWeightDecorator() {
+        return weightDecorators.get(WeightDecoratorType.getCurrentType());
     }
 
     private NavigableMap<Float, TextColor> createFlatMap() {
@@ -271,7 +286,71 @@ public class ItemStatInfoFeature extends Feature {
         }
     }
 
-    private enum DecoratorType {
+    private abstract static class WeightingDecorator implements TooltipWeightDecorator {
+        @Override
+        public List<MutableComponent> getLines(ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo) {
+            return getWeightLines(weighting, itemInfo);
+        }
+
+        protected abstract List<MutableComponent> getWeightLines(
+                ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo);
+    }
+
+    private class SimpleWeightDecorator extends WeightingDecorator {
+        @Override
+        protected List<MutableComponent> getWeightLines(
+                ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo) {
+            MutableComponent weightingComponent = Component.literal(" - ")
+                    .append(Component.literal(weighting.weightName() + " Scale"))
+                    .withStyle(ChatFormatting.GRAY);
+
+            float percentage = Services.ItemWeight.calculateWeighting(weighting, itemInfo);
+            weightingComponent.append(ColorScaleUtils.getPercentageTextComponent(
+                    getColorMap(), percentage, colorLerp.get(), decimalPlaces.get()));
+
+            return List.of(weightingComponent);
+        }
+    }
+
+    private class FullWeightDecorator extends WeightingDecorator {
+        @Override
+        protected List<MutableComponent> getWeightLines(
+                ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo) {
+            List<MutableComponent> lines = new ArrayList<>();
+            MutableComponent weightingComponent = Component.literal(" - ")
+                    .append(Component.literal(weighting.weightName() + " Scale"))
+                    .withStyle(ChatFormatting.GRAY);
+
+            float percentage = Services.ItemWeight.calculateWeighting(weighting, itemInfo);
+            weightingComponent.append(ColorScaleUtils.getPercentageTextComponent(
+                    getColorMap(), percentage, colorLerp.get(), decimalPlaces.get()));
+
+            lines.add(weightingComponent);
+
+            Map<StatType, Pair<Float, Float>> statWeights = Services.ItemWeight.getStatWeights(weighting, itemInfo);
+
+            statWeights.forEach((statType, weight) -> {
+                String displayName = statType.getDisplayName() + " ";
+
+                if (statType.getUnit() == StatUnit.RAW) {
+                    displayName += "Raw ";
+                }
+
+                String weightStr = String.format(Locale.ROOT, "(%.1f%%)", weight.a());
+
+                lines.add(Component.literal("   - ")
+                        .withStyle(ChatFormatting.GRAY)
+                        .append(Component.literal(displayName))
+                        .append(Component.literal(weightStr).withStyle(ChatFormatting.WHITE))
+                        .append(ColorScaleUtils.getPercentageTextComponent(
+                                getColorMap(), weight.b(), colorLerp.get(), decimalPlaces.get())));
+            });
+
+            return lines;
+        }
+    }
+
+    private enum IdentificationDecoratorType {
         INNER_ROLL(Set.of(GLFW.GLFW_KEY_LEFT_SHIFT, GLFW.GLFW_KEY_LEFT_CONTROL)),
         REROLL(Set.of(GLFW.GLFW_KEY_LEFT_CONTROL)),
         RANGE(Set.of(GLFW.GLFW_KEY_LEFT_SHIFT)),
@@ -279,18 +358,39 @@ public class ItemStatInfoFeature extends Feature {
 
         private final Set<Integer> keyCodes;
 
-        DecoratorType(Set<Integer> keyCodes) {
+        IdentificationDecoratorType(Set<Integer> keyCodes) {
             this.keyCodes = keyCodes;
         }
 
-        public static DecoratorType getCurrentType() {
-            for (DecoratorType type : values()) {
+        public static IdentificationDecoratorType getCurrentType() {
+            for (IdentificationDecoratorType type : values()) {
                 if (type.keyCodes.stream().allMatch(KeyboardUtils::isKeyDown)) {
                     return type;
                 }
             }
 
             return PERCENTAGE;
+        }
+    }
+
+    private enum WeightDecoratorType {
+        FULL(Set.of(GLFW.GLFW_KEY_LEFT_SHIFT)),
+        OVERALL(Set.of());
+
+        private final Set<Integer> keyCodes;
+
+        WeightDecoratorType(Set<Integer> keyCodes) {
+            this.keyCodes = keyCodes;
+        }
+
+        public static WeightDecoratorType getCurrentType() {
+            for (WeightDecoratorType type : values()) {
+                if (type.keyCodes.stream().allMatch(KeyboardUtils::isKeyDown)) {
+                    return type;
+                }
+            }
+
+            return OVERALL;
         }
     }
 

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipBuilder.java
@@ -7,7 +7,9 @@ package com.wynntils.handlers.tooltip.impl.crafted;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
 import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.handlers.tooltip.type.TooltipWeightDecorator;
 import com.wynntils.models.character.type.ClassType;
+import com.wynntils.models.gear.type.ItemWeightSource;
 import com.wynntils.models.items.properties.CraftedItemProperty;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.type.Pair;
@@ -46,7 +48,11 @@ public final class CraftedTooltipBuilder extends TooltipBuilder {
     }
 
     @Override
-    protected List<Component> getWeightedHeaderLines(List<Component> originalHeader, TooltipStyle style) {
+    protected List<Component> getWeightedHeaderLines(
+            List<Component> originalHeader,
+            ItemWeightSource weightSource,
+            TooltipWeightDecorator weightDecorator,
+            TooltipStyle style) {
         // Crafted items do not have weighting
         return originalHeader;
     }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipStyle.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipStyle.java
@@ -4,7 +4,6 @@
  */
 package com.wynntils.handlers.tooltip.type;
 
-import com.wynntils.models.gear.type.ItemWeightSource;
 import com.wynntils.models.stats.type.StatListOrdering;
 
 public record TooltipStyle(
@@ -12,6 +11,5 @@ public record TooltipStyle(
         boolean useDelimiters,
         boolean showBestValueLastAlways,
         boolean showStars,
-        ItemWeightSource weightSource,
         boolean showMaxValue // this only applies to crafted items
         ) {}

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipWeightDecorator.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipWeightDecorator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.tooltip.type;
+
+import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import com.wynntils.services.itemweight.type.ItemWeighting;
+import java.util.List;
+import net.minecraft.network.chat.MutableComponent;
+
+@FunctionalInterface
+public interface TooltipWeightDecorator {
+    List<MutableComponent> getLines(ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo);
+}

--- a/common/src/main/java/com/wynntils/utils/mc/TooltipUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/TooltipUtils.java
@@ -11,6 +11,7 @@ import com.wynntils.features.tooltips.ItemStatInfoFeature;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
 import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.handlers.tooltip.type.TooltipWeightDecorator;
 import com.wynntils.models.gear.type.ItemWeightSource;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
@@ -78,18 +79,23 @@ public final class TooltipUtils {
         if (builder == null) return null;
         ItemStatInfoFeature feature = Managers.Feature.getFeatureInstance(ItemStatInfoFeature.class);
 
-        TooltipIdentificationDecorator decorator =
-                feature.identificationDecorations.get() ? feature.getDecorator() : null;
+        TooltipIdentificationDecorator identificationDecorator =
+                feature.identificationDecorations.get() ? feature.getIdentificationDecorator() : null;
+        TooltipWeightDecorator weightDecorator =
+                feature.itemWeights.get() != ItemWeightSource.NONE ? feature.getWeightDecorator() : null;
         TooltipStyle currentIdentificationStyle = new TooltipStyle(
                 feature.identificationsOrdering.get(),
                 feature.groupIdentifications.get(),
                 feature.showBestValueLastAlways.get(),
                 feature.showStars.get(),
-                feature.itemWeights.get(),
                 false // this only applies to crafted items
                 );
-        LinkedList<Component> tooltips = new LinkedList<>(
-                builder.getTooltipLines(Models.Character.getClassType(), currentIdentificationStyle, decorator));
+        LinkedList<Component> tooltips = new LinkedList<>(builder.getTooltipLines(
+                Models.Character.getClassType(),
+                currentIdentificationStyle,
+                identificationDecorator,
+                feature.itemWeights.get(),
+                weightDecorator));
 
         // Update name depending on overall percentage; this needs to be done every rendering
         // for rainbow/defective effects
@@ -113,11 +119,10 @@ public final class TooltipUtils {
                 isif.groupIdentifications.get(),
                 false, // irrelevant for crafted items
                 false, // irrelevant for crafted items
-                ItemWeightSource.NONE, // irrelevant for crafted items
                 isif.showMaxValues.get());
 
-        return new LinkedList<>(
-                builder.getTooltipLines(Models.Character.getClassType(), currentIdentificationStyle, null));
+        return new LinkedList<>(builder.getTooltipLines(
+                Models.Character.getClassType(), currentIdentificationStyle, null, isif.itemWeights.get(), null));
     }
 
     private static void updateItemName(IdentifiableItemProperty itemInfo, Deque<Component> tooltips) {


### PR DESCRIPTION
Allows you to see how much each stat is impacted by the weighting.

Shift held is what the JSMacros script uses so we're using that as it's what people have gotten used to, I'm not a particular fan as that then hides the normal %'s but that's why the script and what I've implemented will show the % next to each stat in the weighting when in this view.

<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/0acdb7db-eb5a-4a27-bc2a-10b4c2de76ef" />
