### PR TITLE
feat: Add "c" and "comp" aliases to compass command

### DIFF
--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.commands;

--- a/common/src/main/java/com/wynntils/commands/CompassCommand.java
+++ b/common/src/main/java/com/wynntils/commands/CompassCommand.java
@@ -58,6 +58,11 @@ public class CompassCommand extends Command {
     }
 
     @Override
+    public List<String> getAliases() {
+        return List.of("c", "comp");
+    }
+
+    @Override
     public LiteralArgumentBuilder<CommandSourceStack> getCommandBuilder(
             LiteralArgumentBuilder<CommandSourceStack> base, CommandBuildContext context) {
         return base.then(Commands.literal("at")


### PR DESCRIPTION
Recent suggestion for "c" alias, "comp" seemed to make sense too so added that as well