### PR TITLE
fix: Get ItemStack hover name instead of custom name

### DIFF
--- a/common/src/main/java/com/wynntils/models/inventory/InventoryModel.java
+++ b/common/src/main/java/com/wynntils/models/inventory/InventoryModel.java
@@ -136,7 +136,7 @@ public final class InventoryModel extends Model {
                     Optional<MaterialItem> materialItemOpt = Models.Item.asWynnItem(itemStack, MaterialItem.class);
                     if (materialItemOpt.isEmpty()) return false;
                     MaterialItem materialItem = materialItemOpt.get();
-                    if (!itemStack.getCustomName().getString().startsWith(name)) return false;
+                    if (!itemStack.getHoverName().getString().startsWith(name)) return false;
                     return exact ? materialItem.getQualityTier() == tier : materialItem.getQualityTier() >= tier;
                 })
                 .mapToInt(itemStack -> itemStack.count)

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -183,7 +183,7 @@ public final class WorldStateModel extends Model {
         ItemStack firstHotbarSlot = e.getItems().get(36);
 
         if (firstHotbarSlot.getItem().equals(Items.COMPASS)) {
-            StyledText name = StyledText.fromComponent(firstHotbarSlot.getCustomName());
+            StyledText name = StyledText.fromComponent(firstHotbarSlot.getHoverName());
             if (name.matches(QUICK_CONNECT_PATTERN)) {
                 setState(WorldState.HUB);
                 return;


### PR DESCRIPTION
`getCustomName` can return null and `getHoverName` calls the former anyway with a null check

```
public Component getHoverName() {
    Component component = this.getCustomName();
    return component != null ? component : this.getItemName();
}
```