### PR TITLE
 fix: Don't throw exception on failing to deserialize SavedItem

### DIFF
--- a/common/src/main/java/com/wynntils/services/itemrecord/type/SavedItem.java
+++ b/common/src/main/java/com/wynntils/services/itemrecord/type/SavedItem.java
@@ -87,7 +87,7 @@ public record SavedItem(String base64, Set<String> categories, ItemStack itemSta
                 itemStack = ItemStack.CODEC
                         .parse(JsonOps.INSTANCE, itemStackJson)
                         .result()
-                        .orElseThrow(() -> new JsonParseException("Failed to decode ItemStack"));
+                        .orElse(ItemStack.EMPTY);
             } else if (jsonObject.has("itemStackInfo")) {
                 // Old items did not use the codec so will rely on the previously stored itemstackinfo
                 ItemStackInfo info = context.deserialize(jsonObject.get("itemStackInfo"), ItemStackInfo.class);


### PR DESCRIPTION
Should've been done in #3285 but only fixed the one instance there.

Had this issue whilst working on the 1.21.10 port strangely, I thought using the codec would be version proof but seemingly something went wrong