### PR TITLE
fix: Cache Hades user held item, validate gear type

### DIFF
--- a/common/src/main/java/com/wynntils/screens/playerviewer/PlayerViewerScreen.java
+++ b/common/src/main/java/com/wynntils/screens/playerviewer/PlayerViewerScreen.java
@@ -9,14 +9,13 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.inventory.type.InventoryAccessory;
 import com.wynntils.models.inventory.type.InventoryArmor;
 import com.wynntils.models.items.FakeItemStack;
 import com.wynntils.models.items.WynnItem;
-import com.wynntils.models.items.items.game.CharmItem;
 import com.wynntils.models.items.items.game.CraftedGearItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.models.items.items.game.TomeItem;
 import com.wynntils.screens.base.WynntilsContainerScreen;
 import com.wynntils.screens.base.widgets.InfoButton;
 import com.wynntils.screens.playerviewer.widgets.FriendButton;
@@ -93,7 +92,12 @@ public final class PlayerViewerScreen extends WynntilsContainerScreen<PlayerView
         List<ItemStack> accessoryItems = new ArrayList<>();
 
         if (hadesUserOpt.isPresent()) {
-            heldItem = createDecoratedItemStack(hadesUserOpt.get().getHeldItem(), player);
+            heldItem = createDecoratedItemStack(hadesUserOpt.get().getHeldItem(), player.getMainHandItem(), player);
+
+            if (heldItem == null) {
+                noGear = true;
+                return new PlayerViewerScreen(player, PlayerViewerMenu.create(ItemStack.EMPTY, List.of(), List.of()));
+            }
 
             noGear = heldItem.isEmpty();
 
@@ -105,7 +109,13 @@ public final class PlayerViewerScreen extends WynntilsContainerScreen<PlayerView
                     continue;
                 }
 
-                ItemStack accessoryItemStack = createDecoratedItemStack(wynnItem, player);
+                ItemStack accessoryItemStack = createDecoratedItemStack(wynnItem, ItemStack.EMPTY, player);
+
+                if (accessoryItemStack == null) {
+                    noGear = true;
+                    return new PlayerViewerScreen(
+                            player, PlayerViewerMenu.create(ItemStack.EMPTY, List.of(), List.of()));
+                }
 
                 accessoryItems.add(accessoryItemStack);
                 noGear = false;
@@ -119,25 +129,53 @@ public final class PlayerViewerScreen extends WynntilsContainerScreen<PlayerView
                     continue;
                 }
 
-                ItemStack armorItemStack = createDecoratedItemStack(wynnItem, player);
+                ItemStack armorItemStack = createDecoratedItemStack(
+                        wynnItem, player.getInventory().armor.get(armor.getArmorSlot()), player);
+
+                if (armorItemStack == null) {
+                    noGear = true;
+                    return new PlayerViewerScreen(
+                            player, PlayerViewerMenu.create(ItemStack.EMPTY, List.of(), List.of()));
+                }
 
                 armorItems.add(armorItemStack);
                 noGear = false;
             }
         }
 
+        // Only show gear if no invalid gear was found
         return new PlayerViewerScreen(player, PlayerViewerMenu.create(heldItem, armorItems, accessoryItems));
     }
 
-    private static ItemStack createDecoratedItemStack(WynnItem wynnItem, Player player) {
+    /**
+     * Tries to validate that the decoded WynnItem matches the expected item using the custom model data, if it does then creates an ItemStack with the proper
+     * item and custom model data.
+     * @param wynnItem The decoded WynnItem the player has shared.
+     * @param expectedItem The ItemStack equipped by the player for this slot, or an empty ItemStack for accessories
+     * @param player The player being viewed
+     * @return null if the item shared was invalid or an ItemStack with the proper item and custom model data if valid
+     */
+    private static ItemStack createDecoratedItemStack(WynnItem wynnItem, ItemStack expectedItem, Player player) {
         ItemStack itemStack = ItemStack.EMPTY;
 
         if (wynnItem instanceof GearItem gearItem) {
             itemStack = gearItem.getItemInfo().metaInfo().material().itemStack();
-        } else if (wynnItem instanceof TomeItem tomeItem) {
-            itemStack = tomeItem.getItemInfo().metaInfo().material().itemStack();
-        } else if (wynnItem instanceof CharmItem charmItem) {
-            itemStack = charmItem.getItemInfo().metaInfo().material().itemStack();
+
+            // For gear without cosmetics we can compare the custom model data to ensure the item sent matches what the
+            // player is actually wearing
+            if (gearItem.getGearType() != GearType.HELMET
+                    && !gearItem.getGearType().isWeapon()) {
+                CustomModelData expectedModelData = expectedItem.has(DataComponents.CUSTOM_MODEL_DATA)
+                        ? expectedItem.get(DataComponents.CUSTOM_MODEL_DATA)
+                        : null;
+                CustomModelData itemModelData = itemStack.has(DataComponents.CUSTOM_MODEL_DATA)
+                        ? itemStack.get(DataComponents.CUSTOM_MODEL_DATA)
+                        : null;
+
+                if (expectedItem != ItemStack.EMPTY && !expectedModelData.equals(itemModelData)) {
+                    return null;
+                }
+            }
         } else if (wynnItem instanceof CraftedGearItem craftedGearItem) {
             // Armor and weapons are sent by Wynn so we can use those itemstacks, accessories we will have to use
             // a default texture

--- a/common/src/main/java/com/wynntils/services/hades/HadesUser.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesUser.java
@@ -11,7 +11,7 @@ import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.inventory.type.InventoryAccessory;
 import com.wynntils.models.inventory.type.InventoryArmor;
 import com.wynntils.models.items.WynnItem;
-import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.models.items.properties.GearTypeItemProperty;
 import com.wynntils.services.hades.type.PlayerRelation;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.colors.CommonColors;
@@ -142,7 +142,8 @@ public class HadesUser {
             } else {
                 WynnItem item = errorOrDecodedItem.getValue();
 
-                if (item instanceof GearItem gearItem && gearItem.getGearType().isWeapon()) {
+                if (item instanceof GearTypeItemProperty gearItemType
+                        && gearItemType.getGearType().isWeapon()) {
                     this.heldItem = item;
                     this.heldItemCache = packet.getHeldItem();
                 }
@@ -176,7 +177,8 @@ public class HadesUser {
             } else {
                 WynnItem item = errorOrDecodedItem.getValue();
 
-                if (item instanceof GearItem gearItem && gearItem.getGearType() == expectedGearType) {
+                if (item instanceof GearTypeItemProperty gearItemType
+                        && gearItemType.getGearType() == expectedGearType) {
                     this.armor.put(armor, errorOrDecodedItem.getValue());
                     this.armorCache.put(armor, armorData);
                 }
@@ -196,8 +198,9 @@ public class HadesUser {
             } else {
                 WynnItem item = errorOrDecodedItem.getValue();
 
-                if (item instanceof GearItem gearItem && gearItem.getGearType() == expectedGearType) {
-                    this.accessories.put(accessory, item);
+                if (item instanceof GearTypeItemProperty gearItemType
+                        && gearItemType.getGearType() == expectedGearType) {
+                    this.accessories.put(accessory, errorOrDecodedItem.getValue());
                     this.accessoriesCache.put(accessory, accessoryData);
                 }
             }

--- a/common/src/main/java/com/wynntils/services/hades/HadesUser.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesUser.java
@@ -7,9 +7,11 @@ package com.wynntils.services.hades;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
 import com.wynntils.hades.protocol.packets.server.HSPacketUpdateMutual;
+import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.inventory.type.InventoryAccessory;
 import com.wynntils.models.inventory.type.InventoryArmor;
 import com.wynntils.models.items.WynnItem;
+import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.services.hades.type.PlayerRelation;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.colors.CommonColors;
@@ -119,28 +121,32 @@ public class HadesUser {
         this.health = new CappedValue(packet.getHealth(), packet.getMaxHealth());
         this.mana = new CappedValue(packet.getMana(), packet.getMaxMana());
 
-        handleArmorData(InventoryArmor.HELMET, packet.getHelmet());
-        handleArmorData(InventoryArmor.CHESTPLATE, packet.getChestplate());
-        handleArmorData(InventoryArmor.LEGGINGS, packet.getLeggings());
-        handleArmorData(InventoryArmor.BOOTS, packet.getBoots());
+        handleArmorData(InventoryArmor.HELMET, GearType.HELMET, packet.getHelmet());
+        handleArmorData(InventoryArmor.CHESTPLATE, GearType.CHESTPLATE, packet.getChestplate());
+        handleArmorData(InventoryArmor.LEGGINGS, GearType.LEGGINGS, packet.getLeggings());
+        handleArmorData(InventoryArmor.BOOTS, GearType.BOOTS, packet.getBoots());
 
-        handleAccessoryData(InventoryAccessory.RING_1, packet.getRingOne());
-        handleAccessoryData(InventoryAccessory.RING_2, packet.getRingTwo());
-        handleAccessoryData(InventoryAccessory.BRACELET, packet.getBracelet());
-        handleAccessoryData(InventoryAccessory.NECKLACE, packet.getNecklace());
+        handleAccessoryData(InventoryAccessory.RING_1, GearType.RING, packet.getRingOne());
+        handleAccessoryData(InventoryAccessory.RING_2, GearType.RING, packet.getRingTwo());
+        handleAccessoryData(InventoryAccessory.BRACELET, GearType.BRACELET, packet.getBracelet());
+        handleAccessoryData(InventoryAccessory.NECKLACE, GearType.NECKLACE, packet.getNecklace());
 
-        if (!packet.getHeldItem().isEmpty()) {
+        if (packet.getHeldItem().isEmpty()) {
+            this.heldItem = null;
+            this.heldItemCache = "";
+        } else if (!this.heldItemCache.equals(packet.getHeldItem())) {
             ErrorOr<WynnItem> errorOrDecodedItem = decodeItem(packet.getHeldItem());
 
             if (errorOrDecodedItem.hasError()) {
                 WynntilsMod.warn("Failed to decode Hades user held item: " + errorOrDecodedItem.getError());
             } else if (!this.heldItemCache.equals(packet.getHeldItem())) {
-                this.heldItem = errorOrDecodedItem.getValue();
-                this.heldItemCache = packet.getHeldItem();
+                WynnItem item = errorOrDecodedItem.getValue();
+
+                if (item instanceof GearItem gearItem && gearItem.getGearType().isWeapon()) {
+                    this.heldItem = item;
+                    this.heldItemCache = packet.getHeldItem();
+                }
             }
-        } else {
-            this.heldItem = null;
-            this.heldItemCache = "";
         }
 
         this.relation = packet.isPartyMember()
@@ -158,7 +164,7 @@ public class HadesUser {
         return relation;
     }
 
-    private void handleArmorData(InventoryArmor armor, String armorData) {
+    private void handleArmorData(InventoryArmor armor, GearType expectedGearType, String armorData) {
         if (armorData.isEmpty()) {
             this.armor.remove(armor);
             this.armorCache.remove(armor);
@@ -168,13 +174,17 @@ public class HadesUser {
             if (errorOrDecodedItem.hasError()) {
                 WynntilsMod.warn("Failed to decode Hades user " + armor + ": " + errorOrDecodedItem.getError());
             } else {
-                this.armor.put(armor, errorOrDecodedItem.getValue());
-                this.armorCache.put(armor, armorData);
+                WynnItem item = errorOrDecodedItem.getValue();
+
+                if (item instanceof GearItem gearItem && gearItem.getGearType() == expectedGearType) {
+                    this.armor.put(armor, errorOrDecodedItem.getValue());
+                    this.armorCache.put(armor, armorData);
+                }
             }
         }
     }
 
-    private void handleAccessoryData(InventoryAccessory accessory, String accessoryData) {
+    private void handleAccessoryData(InventoryAccessory accessory, GearType expectedGearType, String accessoryData) {
         if (accessoryData.isEmpty()) {
             this.accessories.remove(accessory);
             this.accessoriesCache.remove(accessory);
@@ -184,8 +194,12 @@ public class HadesUser {
             if (errorOrDecodedItem.hasError()) {
                 WynntilsMod.warn("Failed to decode Hades user " + accessory + ": " + errorOrDecodedItem.getError());
             } else {
-                this.accessories.put(accessory, errorOrDecodedItem.getValue());
-                this.accessoriesCache.put(accessory, accessoryData);
+                WynnItem item = errorOrDecodedItem.getValue();
+
+                if (item instanceof GearItem gearItem && gearItem.getGearType() == expectedGearType) {
+                    this.accessories.put(accessory, item);
+                    this.accessoriesCache.put(accessory, accessoryData);
+                }
             }
         }
     }

--- a/common/src/main/java/com/wynntils/services/hades/HadesUser.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesUser.java
@@ -139,7 +139,7 @@ public class HadesUser {
 
             if (errorOrDecodedItem.hasError()) {
                 WynntilsMod.warn("Failed to decode Hades user held item: " + errorOrDecodedItem.getError());
-            } else if (!this.heldItemCache.equals(packet.getHeldItem())) {
+            } else {
                 WynnItem item = errorOrDecodedItem.getValue();
 
                 if (item instanceof GearItem gearItem && gearItem.getGearType().isWeapon()) {


### PR DESCRIPTION
This makes the held item cache the same as armour and accessories so it will only decode if the cache doesn't match, rather than comparing the cache after decoding.

It also checks that armour and accessories are the expected type and that held item is a weapon