### PR TITLE
chore: Disable custom loading screen be default

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomLoadingScreenFeature.java
@@ -7,6 +7,7 @@ package com.wynntils.features.ui;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.properties.StartDisabled;
 import com.wynntils.core.mod.TickSchedulerManager;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
@@ -32,6 +33,7 @@ import net.minecraft.network.chat.contents.TranslatableContents;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
+@StartDisabled
 @ConfigCategory(Category.UI)
 public class CustomLoadingScreenFeature extends Feature {
     private static final String IGNORED_TITLE = "\uE000\uE001\uE000";


### PR DESCRIPTION
Since it's still causing some issues I think we should disable it for now and look into reworking it to instead just replace the background rendering of the normal Minecraft loading screens and then render similarly to an overlay when in a queue