### PR TITLE
fix: Show shiny status on perfect/defective shiny items

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -245,6 +245,12 @@ public class ChatItemFeature extends Feature {
         if (wynnItem instanceof NamedItemProperty namedItemProperty) {
             nameText = StyledText.fromString(namedItemProperty.getName());
 
+            if (wynnItem instanceof ShinyItemProperty shinyItemProperty
+                    && shinyItemProperty.getShinyStat().isPresent()) {
+                parts.add(new StyledTextPart("⬡ ", Style.EMPTY.withColor(ChatFormatting.WHITE), null, Style.EMPTY));
+                nameText = StyledText.fromString("Shiny ").append(nameText);
+            }
+
             if (showPerfectOrDefective.get()) {
                 if (wynnItem instanceof IdentifiableItemProperty<?, ?> identifiableItemProperty) {
                     if (identifiableItemProperty.isPerfect()) {
@@ -256,11 +262,6 @@ public class ChatItemFeature extends Feature {
                     }
                 }
             }
-        }
-
-        if (wynnItem instanceof ShinyItemProperty shinyItemProperty
-                && shinyItemProperty.getShinyStat().isPresent()) {
-            parts.add(new StyledTextPart("⬡ ", Style.EMPTY.withColor(ChatFormatting.WHITE), null, Style.EMPTY));
         }
 
         Style style = Style.EMPTY.applyFormat(ChatFormatting.UNDERLINE).withColor(ChatFormatting.GOLD);


### PR DESCRIPTION
Not mine sadly :(

<img width="500" height="456" alt="image" src="https://github.com/user-attachments/assets/a696a9bc-062f-46b7-997a-3476224ccf65" />
<img width="833" height="53" alt="image" src="https://github.com/user-attachments/assets/2e6ce028-0766-47d7-b17a-0ea9bd773c7b" />
