### PR TITLE
refactor: Use Athena cache for territory list with API fallback

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/UrlId.java
+++ b/common/src/main/java/com/wynntils/core/net/UrlId.java
@@ -30,6 +30,7 @@ public enum UrlId {
     DATA_ATHENA_ITEM_WEIGHTS("dataAthenaItemWeights"),
     DATA_ATHENA_LEADERBOARD("dataAthenaLeaderboard"),
     DATA_ATHENA_SERVER_LIST("dataAthenaServerList"),
+    DATA_ATHENA_TERRITORY_LIST_V2("dataAthenaTerritoryListV2"),
     DATA_STATIC_ABILITIES("dataStaticAbilities"),
     DATA_STATIC_ASPECTS("dataStaticAspects"),
     DATA_STATIC_CAVE_INFO("dataStaticCaveInfo"),

--- a/common/src/main/java/com/wynntils/models/territories/profile/TerritoryProfile.java
+++ b/common/src/main/java/com/wynntils/models/territories/profile/TerritoryProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories.profile;
@@ -11,10 +11,12 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.wynntils.utils.DateFormatter;
+import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.type.PoiLocation;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Position;
 
@@ -176,7 +178,15 @@ public class TerritoryProfile {
                     || guildJson.getAsJsonObject().get("prefix").isJsonNull()) {
                 guild = GuildInfo.NONE;
             } else {
-                guild = context.deserialize(guildJson, GuildInfo.class);
+                JsonObject guildObject = guildJson.getAsJsonObject();
+                String guildName = guildObject.get("name").getAsString();
+                String guildPrefix = guildObject.get("prefix").getAsString();
+                Optional<CustomColor> guildColor = guildObject.has("color")
+                        ? Optional.of(CustomColor.fromHexString(
+                                guildObject.get("color").getAsString()))
+                        : Optional.empty();
+
+                guild = new GuildInfo(guildName, guildPrefix, guildColor);
             }
 
             Instant acquired;
@@ -191,8 +201,8 @@ public class TerritoryProfile {
         }
     }
 
-    public record GuildInfo(String name, String prefix) {
-        public static final GuildInfo NONE = new GuildInfo("No owner", "None");
+    public record GuildInfo(String name, String prefix, Optional<CustomColor> color) {
+        public static final GuildInfo NONE = new GuildInfo("No owner", "None", Optional.empty());
     }
 
     public record TerritoryLocation(int startX, int startZ, int endX, int endZ) {}

--- a/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
@@ -99,6 +99,8 @@ public class TerritoryPoi implements Poi {
                 || territoryProfile.getGuildInfo() == TerritoryProfile.GuildInfo.NONE) {
             // Uncaptured territory at season reset
             colors = List.of(CommonColors.WHITE);
+        } else if (territoryProfile.getGuildInfo().color().isPresent()) {
+            colors = List.of(territoryProfile.getGuildInfo().color().get());
         } else {
             colors = List.of(Models.Guild.getColor(
                     isTerritoryInfoUsable() ? territoryInfo.getGuildName() : territoryProfile.getGuild()));

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -96,6 +96,10 @@
     "url": "https://athena.wynntils.com/cache/get/serverList"
   },
   {
+    "id": "dataAthenaTerritoryListV2",
+    "url": "https://athena.wynntils.com/v2/cache/get/territoryList"
+  },
+  {
     "id": "dataStaticAbilities",
     "md5": "fd5e9a5b76988ae00265695ee90d622a",
     "url": "https://raw.githubusercontent.com/Wynntils/Static-Storage/main/Reference/abilities.json"


### PR DESCRIPTION
The territory lookup will now use the Athena cache instead of directly calling the API, this means that guild colours can now update in real time without needing a restart and also just reduces the calls to the API significantly however after 3 failures it will fallback to using the API