### PR TITLE
refactor: Use Athena cache for leaderboards

### DIFF
--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -347,7 +347,7 @@ public class CustomNametagRendererFeature extends Feature {
         Entity entity = ((EntityRenderStateExtension) event.getEntityRenderState()).getEntity();
         if (!(entity instanceof AbstractClientPlayer player)) return;
 
-        List<LeaderboardBadge> allBadges = Services.Leaderboard.getBadges(Models.Player.getUserUUID(player));
+        List<LeaderboardBadge> allBadges = Services.Leaderboard.getPlayerBadges(Models.Player.getUserUUID(player));
 
         if (allBadges.isEmpty()) return;
 

--- a/common/src/main/java/com/wynntils/services/leaderboard/LeaderboardService.java
+++ b/common/src/main/java/com/wynntils/services/leaderboard/LeaderboardService.java
@@ -5,6 +5,8 @@
 package com.wynntils.services.leaderboard;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Service;
 import com.wynntils.core.net.ApiResponse;
@@ -18,7 +20,8 @@ import java.util.Map;
 import java.util.UUID;
 
 public class LeaderboardService extends Service {
-    private Map<UUID, List<LeaderboardBadge>> leaderboard = new HashMap<>();
+    private Map<UUID, List<LeaderboardBadge>> playerLeaderboards = new HashMap<>();
+    private Map<String, List<LeaderboardBadge>> guildLeaderboards = new HashMap<>();
 
     public LeaderboardService() {
         super(List.of());
@@ -29,32 +32,45 @@ public class LeaderboardService extends Service {
         updateLeaderboards();
     }
 
-    public List<LeaderboardBadge> getBadges(UUID id) {
-        return leaderboard.getOrDefault(id, List.of());
+    public List<LeaderboardBadge> getPlayerBadges(UUID id) {
+        return playerLeaderboards.getOrDefault(id, List.of());
     }
 
     private void updateLeaderboards() {
-        leaderboard = new HashMap<>();
+        playerLeaderboards = new HashMap<>();
+        guildLeaderboards = new HashMap<>();
 
-        for (LeaderboardType type : LeaderboardType.values()) {
-            ApiResponse apiResponse =
-                    Managers.Net.callApi(UrlId.DATA_WYNNCRAFT_LEADERBOARD, Map.of("type", type.getKey()));
-            apiResponse.handleJsonObject(json -> {
-                for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
-                    String uuidStr =
-                            entry.getValue().getAsJsonObject().get("uuid").getAsString();
+        ApiResponse apiResponse = Managers.Net.callApi(UrlId.DATA_ATHENA_LEADERBOARD);
+        apiResponse.handleJsonObject(json -> {
+            for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
+                LeaderboardType type = LeaderboardType.fromKey(entry.getKey());
 
-                    if (uuidStr.equals("redacted")) {
-                        continue;
-                    }
-
-                    UUID uuid = UUID.fromString(uuidStr);
-                    List<LeaderboardBadge> badges = leaderboard.getOrDefault(uuid, new ArrayList<>());
-
-                    badges.add(LeaderboardBadge.from(type, Integer.parseInt(entry.getKey())));
-                    leaderboard.put(uuid, badges);
+                if (type == null) {
+                    WynntilsMod.warn("Unknown leaderboard type: " + entry.getKey());
+                    continue;
                 }
-            });
-        }
+
+                JsonObject leaderboard = entry.getValue().getAsJsonObject();
+
+                for (Map.Entry<String, JsonElement> rank : leaderboard.entrySet()) {
+                    String value = rank.getValue().getAsString();
+
+                    if (value.equals("redacted")) continue;
+
+                    if (type.isGuildLeaderboard()) {
+                        List<LeaderboardBadge> badges = guildLeaderboards.getOrDefault(value, new ArrayList<>());
+
+                        badges.add(LeaderboardBadge.from(type, Integer.parseInt(rank.getKey())));
+                        guildLeaderboards.put(value, badges);
+                    } else {
+                        UUID uuid = UUID.fromString(value);
+                        List<LeaderboardBadge> badges = playerLeaderboards.getOrDefault(uuid, new ArrayList<>());
+
+                        badges.add(LeaderboardBadge.from(type, Integer.parseInt(rank.getKey())));
+                        playerLeaderboards.put(uuid, badges);
+                    }
+                }
+            }
+        });
     }
 }

--- a/common/src/main/java/com/wynntils/services/leaderboard/type/LeaderboardType.java
+++ b/common/src/main/java/com/wynntils/services/leaderboard/type/LeaderboardType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.leaderboard.type;
@@ -52,12 +52,27 @@ public enum LeaderboardType {
     HICH("hichContent"),
     HIC("hicContent"),
     // Misc
-    WARS("warsCompletion");
+    WARS("warsCompletion"),
+    HARDCORE_LEGACY_LEVEL("hardcoreLegacyLevel"), // Should move to Solo Gamemodes when a badge is added
+    // Guild
+    GUILD_LEVEL("guildLevel", true),
+    GUILD_TERRITORIES("guildTerritories", true),
+    GUILD_WARS("guildWars", true),
+    GUILD_NOG("grootslangSrGuilds", true),
+    GUILD_NOL("orphionSrGuilds", true),
+    GUILD_TCC("colossusSrGuilds", true),
+    GUILD_TNA("namelessSrGuilds", true);
 
     private final String key;
+    private final boolean guildLeaderboard;
+
+    LeaderboardType(String key, boolean guildLeaderboard) {
+        this.key = key;
+        this.guildLeaderboard = guildLeaderboard;
+    }
 
     LeaderboardType(String key) {
-        this.key = key;
+        this(key, false);
     }
 
     public String getKey() {
@@ -72,5 +87,9 @@ public enum LeaderboardType {
         }
 
         return null;
+    }
+
+    public boolean isGuildLeaderboard() {
+        return guildLeaderboard;
     }
 }


### PR DESCRIPTION
Will technically fix https://github.com/Wynntils/Wynntils/issues/3537 though we should still properly handle API rate limiting.

We can also now add badges to members of guilds that are on the leaderboards though we should probably cache the members on Athena somewhere instead of making the calls mod side