### PR TITLE
feat: Item weighting updates

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -345,6 +345,7 @@ public class ItemStatInfoFeature extends Feature {
                         .append(ColorScaleUtils.getPercentageTextComponent(
                                 getColorMap(), weight.b(), colorLerp.get(), decimalPlaces.get())));
             });
+            lines.add(Component.empty());
 
             return lines;
         }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -103,18 +103,34 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
             weightedHeader.add(currentIndex, Services.ItemWeight.NORI_HEADER);
             currentIndex++;
             currentIndex = addWeightingLines(weightedHeader, noriWeightings, weightDecorator, currentIndex);
+
+            if (!weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
+                weightedHeader.add(currentIndex, Component.empty());
+                currentIndex++;
+            }
         }
 
         if (addWynnpool) {
             weightedHeader.add(currentIndex, Services.ItemWeight.WYNNPOOL_HEADER);
             currentIndex++;
             currentIndex = addWeightingLines(weightedHeader, wynnpoolWeightings, weightDecorator, currentIndex);
+
+            if (!weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
+                weightedHeader.add(currentIndex, Component.empty());
+                currentIndex++;
+            }
         }
 
-        // We only need to add an empty line for weapons if any weightings were added, otherwise there will be extra
-        // empty lines
-        if ((addNori || addWynnpool) && gearInfo.type().isWeapon()) {
-            weightedHeader.add(currentIndex, Component.empty());
+        if (addNori || addWynnpool) {
+            if (gearInfo.type().isWeapon() && weightedHeader.get(currentIndex).equals(Component.empty())) {
+                weightedHeader.remove(currentIndex);
+            } else if (gearInfo.type().isWeapon()
+                    && !weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
+                weightedHeader.add(currentIndex, Component.empty());
+            } else if (!gearInfo.type().isWeapon()
+                    && weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
+                weightedHeader.remove(currentIndex - 1);
+            }
         }
 
         return weightedHeader;

--- a/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
+++ b/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
@@ -166,7 +166,8 @@ public class ItemWeightService extends Service {
                 JsonObject identificationsObj = weightEntry.getValue().getAsJsonObject();
 
                 Map<String, Double> identifications = identificationsObj.entrySet().stream()
-                        .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(JsonElement::getAsDouble).reversed()))
+                        .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(JsonElement::getAsDouble)
+                                .reversed()))
                         .collect(Collectors.toMap(
                                 Map.Entry::getKey, e -> e.getValue().getAsDouble(), (a, b) -> a, LinkedHashMap::new));
 

--- a/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
+++ b/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
@@ -21,10 +21,13 @@ import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.type.Pair;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
@@ -107,7 +110,7 @@ public class ItemWeightService extends Service {
             ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo) {
         if (weighting == null || itemInfo == null) return Map.of();
 
-        Map<StatType, Pair<Float, Float>> statWeights = new HashMap<>();
+        Map<StatType, Pair<Float, Float>> statWeights = new LinkedHashMap<>();
 
         for (Map.Entry<String, Double> entry : weighting.identifications().entrySet()) {
             String statApiName = entry.getKey();
@@ -162,10 +165,10 @@ public class ItemWeightService extends Service {
                 String weightName = weightEntry.getKey();
                 JsonObject identificationsObj = weightEntry.getValue().getAsJsonObject();
 
-                Map<String, Double> identifications = new HashMap<>();
-                for (Map.Entry<String, JsonElement> statEntry : identificationsObj.entrySet()) {
-                    identifications.put(statEntry.getKey(), statEntry.getValue().getAsDouble());
-                }
+                Map<String, Double> identifications = identificationsObj.entrySet().stream()
+                        .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(JsonElement::getAsDouble)))
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey, e -> e.getValue().getAsDouble(), (a, b) -> a, LinkedHashMap::new));
 
                 itemWeights.add(new ItemWeighting(weightName, identifications));
             }

--- a/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
+++ b/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
@@ -166,7 +166,7 @@ public class ItemWeightService extends Service {
                 JsonObject identificationsObj = weightEntry.getValue().getAsJsonObject();
 
                 Map<String, Double> identifications = identificationsObj.entrySet().stream()
-                        .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(JsonElement::getAsDouble)))
+                        .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(JsonElement::getAsDouble).reversed()))
                         .collect(Collectors.toMap(
                                 Map.Entry::getKey, e -> e.getValue().getAsDouble(), (a, b) -> a, LinkedHashMap::new));
 


### PR DESCRIPTION
Scales are now sorted by their weight, least impact to most.
Improved the spacing between the scales to make it a little easier to read.
Shift + Control now shows the contribution towards the overall scale as the coloured percentage instead of the actual roll percentage