### PR TITLE
fix: Call callOnConfigUpdate for disabled overlays, only call for the single enabled overlay

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -101,14 +101,13 @@ public final class OverlayManager extends Manager {
         overlayParentMap.getOrDefault(parent, List.of()).forEach(this::enableOverlay);
     }
 
-    public void enableOverlay(Overlay enableOverlay) {
-        if (!enableOverlay.shouldBeEnabled() || isEnabled(enableOverlay)) return;
+    public void enableOverlay(Overlay enabledOverlay) {
+        if (!enabledOverlay.shouldBeEnabled() || isEnabled(enabledOverlay)) return;
 
-        enabledOverlays.add(enableOverlay);
-        WynntilsMod.registerEventListener(enableOverlay);
+        enabledOverlays.add(enabledOverlay);
+        WynntilsMod.registerEventListener(enabledOverlay);
 
-        enabledOverlays.forEach(
-                overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::callOnConfigUpdate));
+        enabledOverlay.getConfigOptionFromString("userEnabled").ifPresent(enabledOverlay::callOnConfigUpdate);
     }
 
     public void discoverOverlays(Feature feature) {

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -94,8 +94,7 @@ public final class OverlayManager extends Manager {
         enabledOverlays.remove(disabledOverlay);
         WynntilsMod.unregisterEventListener(disabledOverlay);
 
-        enabledOverlays.forEach(
-                overlay -> overlay.getConfigOptionFromString("userEnabled").ifPresent(overlay::callOnConfigUpdate));
+        disabledOverlay.getConfigOptionFromString("userEnabled").ifPresent(disabledOverlay::callOnConfigUpdate);
     }
 
     public void enableOverlays(Feature parent) {


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Wynntils/issues/3545

I've only done a limited amount of testing for the moment, so this may have some side effects.

Perhaps someone who was around when the OverlayManager was written can weigh in on whether it is intentional for all enabled overlays to have `callOnConfigUpdate` be called when an overlay is disabled and not the disabled overlay as it just seems like a mistake to me