### PR TITLE
fix: Don't lock slots in housing edit mode

### DIFF
--- a/common/src/main/java/com/wynntils/core/components/Models.java
+++ b/common/src/main/java/com/wynntils/core/components/Models.java
@@ -35,6 +35,7 @@ import com.wynntils.models.gear.GearModel;
 import com.wynntils.models.gear.SetModel;
 import com.wynntils.models.guild.GuildModel;
 import com.wynntils.models.horse.HorseModel;
+import com.wynntils.models.housing.HousingModel;
 import com.wynntils.models.ingredients.IngredientModel;
 import com.wynntils.models.inventory.IngredientPouchModel;
 import com.wynntils.models.inventory.InventoryModel;
@@ -95,6 +96,7 @@ public final class Models {
     public static final GuildModel Guild = new GuildModel();
     public static final GuildWarTowerModel GuildWarTower = new GuildWarTowerModel();
     public static final HorseModel Horse = new HorseModel();
+    public static final HousingModel Housing = new HousingModel();
     public static final IngredientModel Ingredient = new IngredientModel();
     public static final IngredientPouchModel IngredientPouch = new IngredientPouchModel();
     public static final InventoryModel Inventory = new InventoryModel();

--- a/common/src/main/java/com/wynntils/crowdsource/NpcLocationDataCollector.java
+++ b/common/src/main/java/com/wynntils/crowdsource/NpcLocationDataCollector.java
@@ -14,7 +14,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class NpcLocationDataCollector extends CrowdSourcedDataCollector<NpcLabelInfo> {
     @SubscribeEvent
     public void onLabelIdentified(LabelIdentifiedEvent event) {
-        if (Models.WorldState.onHousing()) return;
+        if (Models.Housing.isOnHousing()) return;
 
         if (event.getLabelInfo() instanceof NpcLabelInfo npcLabelInfo) {
             collect(npcLabelInfo);

--- a/common/src/main/java/com/wynntils/crowdsource/ProfessionStationLocationDataCollector.java
+++ b/common/src/main/java/com/wynntils/crowdsource/ProfessionStationLocationDataCollector.java
@@ -15,7 +15,7 @@ public class ProfessionStationLocationDataCollector
         extends CrowdSourcedDataCollector<ProfessionCraftingStationLabelInfo> {
     @SubscribeEvent
     public void onLabelIdentified(LabelIdentifiedEvent event) {
-        if (Models.WorldState.onHousing()) return;
+        if (Models.Housing.isOnHousing()) return;
 
         if (event.getLabelInfo() instanceof ProfessionCraftingStationLabelInfo labelInfo) {
             collect(labelInfo);

--- a/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
@@ -60,6 +60,7 @@ public class ItemLockFeature extends Feature {
 
         // Don't render lock on full screen containers
         if (Models.Container.getCurrentContainer() instanceof FullscreenContainerProperty) return;
+        if (Models.Housing.isInEditMode()) return;
 
         for (Integer slotId : classSlotLockMap.get().getOrDefault(Models.Character.getId(), new TreeSet<>())) {
             Optional<Slot> lockedSlot = abstractContainerScreen.getMenu().slots.stream()
@@ -80,6 +81,7 @@ public class ItemLockFeature extends Feature {
         if (!(McUtils.screen() instanceof AbstractContainerScreen<?> abstractContainerScreen)
                 || Models.Container.getCurrentContainer() instanceof FullscreenContainerProperty) return;
         if (!blockAllActionsOnLockedItems.get() && event.getClickType() != ClickType.THROW) return;
+        if (Models.Housing.isInEditMode()) return;
 
         // We have to match slot.index here, because the event slot number is an index as well
         Optional<Slot> slotOptional = abstractContainerScreen.getMenu().slots.stream()
@@ -121,6 +123,7 @@ public class ItemLockFeature extends Feature {
                 .filter(slot -> slot.getItem() == selected)
                 .findFirst();
         if (heldItemSlot.isEmpty()) return;
+        if (Models.Housing.isInEditMode()) return;
 
         if (classSlotLockMap
                 .get()

--- a/common/src/main/java/com/wynntils/models/housing/HousingModel.java
+++ b/common/src/main/java/com/wynntils/models/housing/HousingModel.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.housing;
+
+import com.wynntils.core.components.Model;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.chat.event.ChatMessageEvent;
+import com.wynntils.models.worlds.event.WorldStateEvent;
+import com.wynntils.models.worlds.type.WorldState;
+import com.wynntils.utils.mc.StyledTextUtils;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.neoforged.bus.api.SubscribeEvent;
+
+public class HousingModel extends Model {
+    private static final Pattern HOUSING_EDIT_PATTERN = Pattern.compile(
+            "§e(?:\uE008\uE002|\uE001) You (?<state>are now in|have left) housing edit mode. Type §b/housing edit§e to switch back.");
+
+    private boolean onHousing = false;
+    private boolean inEditMode = false;
+    private String currentHousingName = "";
+
+    public HousingModel() {
+        super(List.of());
+    }
+
+    @SubscribeEvent
+    public void onWorldStateChange(WorldStateEvent event) {
+        if (event.getNewState() != WorldState.WORLD) return;
+
+        updateHousingState(false, "");
+    }
+
+    @SubscribeEvent
+    public void onChatMessage(ChatMessageEvent.Match event) {
+        if (!onHousing) return;
+
+        StyledText message = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+
+        Matcher matcher = message.getMatcher(HOUSING_EDIT_PATTERN);
+        if (matcher.matches()) {
+            inEditMode = matcher.group("state").equals("are now in");
+        }
+    }
+
+    public void updateHousingState(boolean onHousing, String housingName) {
+        this.onHousing = onHousing;
+        currentHousingName = housingName;
+
+        if (!onHousing) {
+            inEditMode = false;
+        }
+    }
+
+    public boolean isOnHousing() {
+        return onHousing;
+    }
+
+    public String getCurrentHousingName() {
+        return currentHousingName;
+    }
+
+    public boolean isInEditMode() {
+        return inEditMode;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/WorldStateModel.java
@@ -7,6 +7,7 @@ package com.wynntils.models.worlds;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
@@ -53,13 +54,11 @@ public final class WorldStateModel extends Model {
     private static final StreamerModeBar streamerModeBar = new StreamerModeBar();
 
     private String currentWorldName = "";
-    private String currentHousingName = "";
     private ServerRegion currentRegion = ServerRegion.WC;
     private long serverJoinTimestamp = 0;
     private boolean onBetaServer;
     private boolean hasJoinedAnyWorld = false;
     private boolean inStream = false;
-    private boolean onHousing = false;
     private boolean inCharacterWardrobe = false;
     private WynncraftVersion worldVersion = null;
 
@@ -80,10 +79,6 @@ public final class WorldStateModel extends Model {
 
     public boolean inCharacterWardrobe() {
         return inCharacterWardrobe;
-    }
-
-    public boolean onHousing() {
-        return onHousing;
     }
 
     public boolean isInStream() {
@@ -235,8 +230,7 @@ public final class WorldStateModel extends Model {
             }
             setState(WorldState.WORLD, worldName, !hasJoinedAnyWorld);
             hasJoinedAnyWorld = true;
-            onHousing = housing;
-            currentHousingName = onHousing ? m.group(1) : "";
+            Models.Housing.updateHousingState(housing, housing ? m.group(1) : "");
             return true;
         }
         return false;
@@ -273,10 +267,6 @@ public final class WorldStateModel extends Model {
 
     public ServerRegion getCurrentServerRegion() {
         return currentRegion;
-    }
-
-    public String getCurrentHousingName() {
-        return currentHousingName;
     }
 
     public long getServerJoinTimestamp() {


### PR DESCRIPTION
Takes most of the housing info out of `WorldStateModel` and puts it into the new `HousingModel`, only the actual setting of being in housing remains in the original place.

It doesn't make sense to block slots in edit mode, especially not to keep the same ones as normal gameplay so just don't render the locks or block actions