### PR TITLE
chore: Disable NPC Dialogue Overlay by default

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/NpcDialogueOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/NpcDialogueOverlay.java
@@ -76,6 +76,7 @@ public class NpcDialogueOverlay extends Overlay {
                 HorizontalAlignment.CENTER,
                 VerticalAlignment.MIDDLE);
         updateTextRenderSettings();
+        this.userEnabled.store(false);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This will disable the overlay by default until we can fix the issues with the background text being included in the npc dialogue.

Keeping the feature itself enabled I think is fine as at least the chat will limit how much is displayed, it's not covering a huge area of the screen like the overlay