### PR TITLE
feat: Add /wynntils crowdsourcing, use in prompt

### DIFF
--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -14,6 +14,7 @@ import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.commands.Command;
 import com.wynntils.core.net.ApiResponse;
 import com.wynntils.core.net.UrlId;
+import com.wynntils.screens.crowdsourcing.WynntilsCrowdSourcingSettingsScreen;
 import com.wynntils.screens.downloads.DownloadScreen;
 import com.wynntils.screens.maps.GuildMapScreen;
 import com.wynntils.screens.maps.MainMapScreen;
@@ -76,6 +77,7 @@ public class WynntilsCommand extends Command {
         return base.then(Commands.literal("clearcaches")
                         .then(Commands.literal("run").executes(this::doClearCaches))
                         .executes(this::clearCaches))
+                .then(Commands.literal("crowdsourcing").executes(this::openCrowdsourceMenu))
                 .then(Commands.literal("debug")
                         .then(Commands.literal("profile")
                                 .then(Commands.literal("reset").executes(this::profileReset))
@@ -392,6 +394,10 @@ public class WynntilsCommand extends Command {
 
     private int secrets(CommandContext<CommandSourceStack> context) {
         return openScreen(SecretsScreen.create());
+    }
+
+    private int openCrowdsourceMenu(CommandContext<CommandSourceStack> context) {
+        return openScreen(WynntilsCrowdSourcingSettingsScreen.create());
     }
 
     private int openGuildMap(CommandContext<CommandSourceStack> context) {

--- a/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
@@ -33,7 +33,7 @@ public class DataCrowdSourcingFeature extends Feature {
 
     @SubscribeEvent
     public void onWorldChange(WorldStateEvent event) {
-        if (event.getNewState() != WorldState.WORLD) return;
+        if (!event.isFirstJoinWorld()) return;
 
         Map<CrowdSourcedDataType, ConfirmedBoolean> enabledMap = crowdSourcedDataTypeEnabledMap.get();
         List<CrowdSourcedDataType> nonConfirmedDataTypes = Arrays.stream(CrowdSourcedDataType.values())

--- a/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -19,8 +19,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.WYNNTILS)
@@ -61,9 +63,15 @@ public class DataCrowdSourcingFeature extends Feature {
             component.append(Component.literal("\n"));
         }
 
-        component.append(
-                Component.literal(
-                        "\nYou can confirm or deny the collection of each data type in the Wynntils Crowd Sourcing Screen, which you can access from the Wynntils Menu."));
+        component
+                .append(
+                        Component.literal(
+                                "\nYou can confirm or deny the collection of each data type in the Wynntils Crowd Sourcing Screen, which you can access from the Wynntils Menu or by clicking "))
+                .append(Component.literal("here.")
+                        .withStyle(ChatFormatting.GREEN)
+                        .withStyle(ChatFormatting.UNDERLINE)
+                        .withStyle(Style.EMPTY.withClickEvent(
+                                new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/wynntils crowdsourcing"))));
 
         McUtils.sendMessageToClient(component);
     }

--- a/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.models.worlds.event.WorldStateEvent;
-import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.ConfirmedBoolean;
 import java.util.Arrays;


### PR DESCRIPTION
Can go directly to the screen from the prompt and also the prompt will now only show once per session as it is quite a big wall of text to send every world switch