### PR TITLE
feat: Add /wynntils refetch to reload user info from Athena

### DIFF
--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -90,6 +90,7 @@ public class WynntilsCommand extends Command {
                 .then(Commands.literal("map").executes(this::openMap))
                 .then(Commands.literal("menu").executes(this::openMenu))
                 .then(Commands.literal("reauth").executes(this::reauth))
+                .then(Commands.literal("refetch").executes(this::refetch))
                 .then(Commands.literal("reloadcaches").executes(this::reloadCaches))
                 .then(Commands.literal("rescan").executes(this::rescan))
                 .then(Commands.literal("secrets").executes(this::secrets))
@@ -177,6 +178,17 @@ public class WynntilsCommand extends Command {
         Models.Player.reset();
         // No need to try to re-connect to Hades, we will do that automatically when we get the new token
 
+        return 1;
+    }
+
+    private int refetch(CommandContext<CommandSourceStack> context) {
+        context.getSource()
+                .sendSuccess(
+                        () -> Component.translatable("command.wynntils.refetching")
+                                .withStyle(ChatFormatting.GREEN),
+                        false);
+
+        Models.Player.loadSelf();
         return 1;
     }
 

--- a/common/src/main/java/com/wynntils/models/players/PlayerModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PlayerModel.java
@@ -145,9 +145,7 @@ public final class PlayerModel extends Model {
             clearGhostCache();
 
             // Lookup self info here as PlayerJoinedWorldEvent will only be posted for self when off world
-            Player player = McUtils.player();
-            if (player == null || player.getUUID() == null) return;
-            loadUser(player.getUUID(), player.getScoreboardName());
+            loadSelf();
         }
     }
 
@@ -182,6 +180,21 @@ public final class PlayerModel extends Model {
 
         int world = Integer.parseInt(matcher.group(2));
         ghosts.put(uuid, world);
+    }
+
+    public void loadSelf() {
+        Player player = McUtils.player();
+        if (player == null) return;
+
+        UUID uuid = player.getUUID();
+        if (uuid == null) return;
+
+        // Remove old user data
+        users.remove(uuid);
+        usersWithoutWynntilsAccount.remove(uuid);
+        userFailures.remove(uuid);
+
+        loadUser(uuid, player.getScoreboardName());
     }
 
     private void loadUser(UUID uuid, String userName) {

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -46,6 +46,7 @@
   "command.wynntils.player.lookingUp": "Looking up player stats...",
   "command.wynntils.quest.description": "List, show and track quests",
   "command.wynntils.reauth.tryReauth": "Disconnecting from Hades, and trying to reauthenticate...",
+  "command.wynntils.refetching": "Removing current data and fetching new data....",
   "command.wynntils.reloadCaches.reloading": "Reloading caches...",
   "command.wynntils.servers.description": "Show information about Wynncraft servers",
   "command.wynntils.statistics.clickHere": "Click here to confirm",


### PR DESCRIPTION
Will allow users to see their updated cape and/or donator tags without needing to restart the game