### PR TITLE
refactor: Use DataComponentGetEvent for overriding DataComponents

### DIFF
--- a/common/src/main/java/com/wynntils/features/embellishments/RemoveShinyGlintFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/RemoveShinyGlintFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.DataComponentGetEvent;
 import com.wynntils.models.items.properties.ShinyItemProperty;
 import java.util.Optional;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.DyedItemColor;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -30,12 +31,7 @@ public class RemoveShinyGlintFeature extends Feature {
     // Weapons use potion color
     @SubscribeEvent
     public void onGetPotionContents(DataComponentGetEvent.PotionContents event) {
-        Optional<ShinyItemProperty> shinyItemProperty =
-                Models.Item.asWynnItemProperty(event.getItemStack(), ShinyItemProperty.class);
-
-        if (shinyItemProperty.isEmpty()) return;
-        if (shinyItemProperty.isPresent()
-                && shinyItemProperty.get().getShinyStat().isEmpty()) return;
+        if (!hasShinyStat(event.getItemStack())) return;
 
         PotionContents itemStackPotionContents = event.getOriginalValue();
 
@@ -54,12 +50,7 @@ public class RemoveShinyGlintFeature extends Feature {
     // Armor uses dye color
     @SubscribeEvent
     public void onGetDyeColor(DataComponentGetEvent.DyedItemColor event) {
-        Optional<ShinyItemProperty> shinyItemProperty =
-                Models.Item.asWynnItemProperty(event.getItemStack(), ShinyItemProperty.class);
-
-        if (shinyItemProperty.isEmpty()) return;
-        if (shinyItemProperty.isPresent()
-                && shinyItemProperty.get().getShinyStat().isEmpty()) return;
+        if (!hasShinyStat(event.getItemStack())) return;
 
         DyedItemColor dyeColor = event.getOriginalValue();
 
@@ -71,16 +62,19 @@ public class RemoveShinyGlintFeature extends Feature {
 
     @SubscribeEvent
     public void onGetEnchantmentOverride(DataComponentGetEvent.EnchantmentGlintOverride event) {
-        Optional<ShinyItemProperty> shinyItemProperty =
-                Models.Item.asWynnItemProperty(event.getItemStack(), ShinyItemProperty.class);
-
-        if (shinyItemProperty.isEmpty()) return;
-        if (shinyItemProperty.isPresent()
-                && shinyItemProperty.get().getShinyStat().isEmpty()) return;
+        if (!hasShinyStat(event.getItemStack())) return;
 
         // Give it the enchanted effect similar to how shinies were displayed prior to the introduction of glints
         if (replaceGlint.get()) {
             event.setValue(true);
         }
+    }
+
+    private boolean hasShinyStat(ItemStack itemStack) {
+        Optional<ShinyItemProperty> shinyItemProperty =
+                Models.Item.asWynnItemProperty(itemStack, ShinyItemProperty.class);
+
+        return shinyItemProperty.isPresent()
+                && shinyItemProperty.get().getShinyStat().isPresent();
     }
 }

--- a/common/src/main/java/com/wynntils/features/embellishments/RemoveShinyGlintFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/RemoveShinyGlintFeature.java
@@ -11,12 +11,9 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.mc.event.SetSlotEvent;
+import com.wynntils.mc.event.DataComponentGetEvent;
 import com.wynntils.models.items.properties.ShinyItemProperty;
-import com.wynntils.utils.mc.McUtils;
 import java.util.Optional;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.DyedItemColor;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -30,57 +27,60 @@ public class RemoveShinyGlintFeature extends Feature {
     @Persisted
     private final Config<Boolean> replaceGlint = new Config<>(true);
 
+    // Weapons use potion color
     @SubscribeEvent
-    public void onSetSlot(SetSlotEvent.Pre event) {
-        removeOrReplaceGlint(event.getItemStack());
-    }
-
-    @Override
-    public void onEnable() {
-        if (McUtils.player() == null) return;
-
-        McUtils.inventory().items.forEach(this::removeOrReplaceGlint);
-    }
-
-    private void removeOrReplaceGlint(ItemStack itemStack) {
+    public void onGetPotionContents(DataComponentGetEvent.PotionContents event) {
         Optional<ShinyItemProperty> shinyItemProperty =
-                Models.Item.asWynnItemProperty(itemStack, ShinyItemProperty.class);
+                Models.Item.asWynnItemProperty(event.getItemStack(), ShinyItemProperty.class);
 
         if (shinyItemProperty.isEmpty()) return;
         if (shinyItemProperty.isPresent()
                 && shinyItemProperty.get().getShinyStat().isEmpty()) return;
 
-        // Weapons use the potion contents DataComponent, armor uses the dye color
-        PotionContents itemStackPotionContents = itemStack.get(DataComponents.POTION_CONTENTS);
-        if (itemStackPotionContents == null) {
-            DyedItemColor dyeColor = itemStack.get(DataComponents.DYED_COLOR);
+        PotionContents itemStackPotionContents = event.getOriginalValue();
 
-            if (dyeColor == null) return;
-            if (dyeColor.rgb() != SHINY_GLINT_COLOR) return;
+        Optional<Integer> potionColor = itemStackPotionContents.customColor();
 
-            itemStack.remove(DataComponents.DYED_COLOR);
+        if (potionColor.isEmpty()) return;
+        if (potionColor.get() != SHINY_GLINT_COLOR) return;
 
-            // Give it the enchanted effect similar to how shinies were displayed prior to the introduction of glints
-            if (replaceGlint.get()) {
-                itemStack.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true);
-            }
-        } else {
-            Optional<Integer> potionColor = itemStackPotionContents.customColor();
+        event.setNewValue(new PotionContents(
+                itemStackPotionContents.potion(),
+                Optional.empty(),
+                itemStackPotionContents.customEffects(),
+                itemStackPotionContents.customName()));
+    }
 
-            if (potionColor.isEmpty()) return;
-            if (potionColor.get() != SHINY_GLINT_COLOR) return;
+    // Armor uses dye color
+    @SubscribeEvent
+    public void onGetDyeColor(DataComponentGetEvent.DyedItemColor event) {
+        Optional<ShinyItemProperty> shinyItemProperty =
+                Models.Item.asWynnItemProperty(event.getItemStack(), ShinyItemProperty.class);
 
-            PotionContents removedContents = new PotionContents(
-                    itemStackPotionContents.potion(),
-                    Optional.empty(),
-                    itemStackPotionContents.customEffects(),
-                    itemStackPotionContents.customName());
-            itemStack.set(DataComponents.POTION_CONTENTS, removedContents);
+        if (shinyItemProperty.isEmpty()) return;
+        if (shinyItemProperty.isPresent()
+                && shinyItemProperty.get().getShinyStat().isEmpty()) return;
 
-            // Give it the enchanted effect similar to how shinies were displayed prior to the introduction of glints
-            if (replaceGlint.get()) {
-                itemStack.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true);
-            }
+        DyedItemColor dyeColor = event.getOriginalValue();
+
+        if (dyeColor == null) return;
+        if (dyeColor.rgb() != SHINY_GLINT_COLOR) return;
+
+        event.setNewValue(null);
+    }
+
+    @SubscribeEvent
+    public void onGetEnchantmentOverride(DataComponentGetEvent.EnchantmentGlintOverride event) {
+        Optional<ShinyItemProperty> shinyItemProperty =
+                Models.Item.asWynnItemProperty(event.getItemStack(), ShinyItemProperty.class);
+
+        if (shinyItemProperty.isEmpty()) return;
+        if (shinyItemProperty.isPresent()
+                && shinyItemProperty.get().getShinyStat().isEmpty()) return;
+
+        // Give it the enchanted effect similar to how shinies were displayed prior to the introduction of glints
+        if (replaceGlint.get()) {
+            event.setNewValue(true);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/embellishments/RemoveShinyGlintFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/RemoveShinyGlintFeature.java
@@ -44,7 +44,7 @@ public class RemoveShinyGlintFeature extends Feature {
         if (potionColor.isEmpty()) return;
         if (potionColor.get() != SHINY_GLINT_COLOR) return;
 
-        event.setNewValue(new PotionContents(
+        event.setValue(new PotionContents(
                 itemStackPotionContents.potion(),
                 Optional.empty(),
                 itemStackPotionContents.customEffects(),
@@ -66,7 +66,7 @@ public class RemoveShinyGlintFeature extends Feature {
         if (dyeColor == null) return;
         if (dyeColor.rgb() != SHINY_GLINT_COLOR) return;
 
-        event.setNewValue(null);
+        event.setValue(null);
     }
 
     @SubscribeEvent
@@ -80,7 +80,7 @@ public class RemoveShinyGlintFeature extends Feature {
 
         // Give it the enchanted effect similar to how shinies were displayed prior to the introduction of glints
         if (replaceGlint.get()) {
-            event.setNewValue(true);
+            event.setValue(true);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -11,8 +11,8 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.mc.event.DataComponentGetEvent;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
-import com.wynntils.mc.event.SetSlotEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
@@ -30,7 +30,6 @@ import com.wynntils.utils.render.buffered.BufferedRenderUtils;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomModelData;
 import net.neoforged.bus.api.EventPriority;
@@ -242,27 +241,17 @@ public class ItemHighlightFeature extends Feature {
     }
 
     @SubscribeEvent
-    public void onSetSlot(SetSlotEvent.Pre event) {
-        removeVanillaHighlight(event.getItemStack());
-    }
-
-    @Override
-    public void onEnable() {
-        if (McUtils.player() == null) return;
-
-        McUtils.inventory().items.forEach(this::removeVanillaHighlight);
-    }
-
-    private void removeVanillaHighlight(ItemStack itemStack) {
-        CustomModelData itemStackModelData = itemStack.get(DataComponents.CUSTOM_MODEL_DATA);
-        if (itemStackModelData == null) return;
+    public void onGetModelData(DataComponentGetEvent.CustomModelData event) {
+        CustomModelData itemStackModelData = event.getOriginalValue();
 
         List<String> newStrings = itemStackModelData.strings().stream()
                 .filter(s -> DEFAULT_HIGHLIGHT_KEYS.stream().noneMatch(s::startsWith))
                 .toList();
-        CustomModelData newModelData = new CustomModelData(
-                itemStackModelData.floats(), itemStackModelData.flags(), newStrings, itemStackModelData.colors());
-        itemStack.set(DataComponents.CUSTOM_MODEL_DATA, newModelData);
+
+        if (!newStrings.equals(itemStackModelData.strings())) {
+            event.setNewValue(new CustomModelData(
+                    itemStackModelData.floats(), itemStackModelData.flags(), newStrings, itemStackModelData.colors()));
+        }
     }
 
     private CustomColor getHighlightColor(ItemStack itemStack, boolean hotbarHighlight) {

--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -249,7 +249,7 @@ public class ItemHighlightFeature extends Feature {
                 .toList();
 
         if (!newStrings.equals(itemStackModelData.strings())) {
-            event.setNewValue(new CustomModelData(
+            event.setValue(new CustomModelData(
                     itemStackModelData.floats(), itemStackModelData.flags(), newStrings, itemStackModelData.colors()));
         }
     }

--- a/common/src/main/java/com/wynntils/mc/event/DataComponentGetEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DataComponentGetEvent.java
@@ -13,13 +13,13 @@ public abstract class DataComponentGetEvent<T> extends Event {
     private final ItemStack itemStack;
     private final DataComponentType<T> dataComponentType;
     private final T originalValue;
-    private T newValue;
+    private T value;
 
     protected DataComponentGetEvent(ItemStack itemStack, DataComponentType<T> dataComponentType, T originalValue) {
         this.itemStack = itemStack;
         this.dataComponentType = dataComponentType;
         this.originalValue = originalValue;
-        this.newValue = originalValue;
+        this.value = originalValue;
     }
 
     public ItemStack getItemStack() {
@@ -34,12 +34,12 @@ public abstract class DataComponentGetEvent<T> extends Event {
         return originalValue;
     }
 
-    public T getNewValue() {
-        return newValue;
+    public T getValue() {
+        return value;
     }
 
-    public void setNewValue(T newValue) {
-        this.newValue = newValue;
+    public void setValue(T newValue) {
+        this.value = newValue;
     }
 
     public static final class CustomModelData

--- a/common/src/main/java/com/wynntils/mc/event/DataComponentGetEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DataComponentGetEvent.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.Event;
+
+public abstract class DataComponentGetEvent<T> extends Event {
+    private final ItemStack itemStack;
+    private final DataComponentType<T> dataComponentType;
+    private final T originalValue;
+    private T newValue;
+
+    protected DataComponentGetEvent(ItemStack itemStack, DataComponentType<T> dataComponentType, T originalValue) {
+        this.itemStack = itemStack;
+        this.dataComponentType = dataComponentType;
+        this.originalValue = originalValue;
+        this.newValue = originalValue;
+    }
+
+    public ItemStack getItemStack() {
+        return itemStack;
+    }
+
+    public DataComponentType<T> getDataComponentType() {
+        return dataComponentType;
+    }
+
+    public T getOriginalValue() {
+        return originalValue;
+    }
+
+    public T getNewValue() {
+        return newValue;
+    }
+
+    public void setNewValue(T newValue) {
+        this.newValue = newValue;
+    }
+
+    public static final class CustomModelData
+            extends DataComponentGetEvent<net.minecraft.world.item.component.CustomModelData> {
+        public CustomModelData(ItemStack itemStack, net.minecraft.world.item.component.CustomModelData original) {
+            super(itemStack, DataComponents.CUSTOM_MODEL_DATA, original);
+        }
+    }
+
+    public static final class DyedItemColor
+            extends DataComponentGetEvent<net.minecraft.world.item.component.DyedItemColor> {
+        public DyedItemColor(ItemStack itemStack, net.minecraft.world.item.component.DyedItemColor original) {
+            super(itemStack, DataComponents.DYED_COLOR, original);
+        }
+    }
+
+    public static final class EnchantmentGlintOverride extends DataComponentGetEvent<Boolean> {
+        public EnchantmentGlintOverride(ItemStack itemStack, boolean original) {
+            super(itemStack, DataComponents.ENCHANTMENT_GLINT_OVERRIDE, original);
+        }
+    }
+
+    public static final class PotionContents
+            extends DataComponentGetEvent<net.minecraft.world.item.alchemy.PotionContents> {
+        public PotionContents(ItemStack itemStack, net.minecraft.world.item.alchemy.PotionContents original) {
+            super(itemStack, DataComponents.POTION_CONTENTS, original);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/DataComponentHolderMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/DataComponentHolderMixin.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.DataComponentGetEvent;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.component.CustomModelData;
+import net.minecraft.world.item.component.DyedItemColor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DataComponentHolder.class)
+public interface DataComponentHolderMixin {
+    @Inject(
+            method = "get(Lnet/minecraft/core/component/DataComponentType;)Ljava/lang/Object;",
+            at = @At("RETURN"),
+            cancellable = true)
+    private void onGetComponent(DataComponentType<?> type, CallbackInfoReturnable<Object> cir) {
+        // We are only interested in ItemStacks
+        if (!(((Object) this) instanceof ItemStack stack)) return;
+
+        Object original = cir.getReturnValue();
+
+        DataComponentGetEvent<?> event = null;
+
+        if (type == DataComponents.CUSTOM_MODEL_DATA && original instanceof CustomModelData cmd) {
+            event = new DataComponentGetEvent.CustomModelData(stack, cmd);
+        } else if (type == DataComponents.DYED_COLOR && original instanceof DyedItemColor dye) {
+            event = new DataComponentGetEvent.DyedItemColor(stack, dye);
+        } else if (type == DataComponents.ENCHANTMENT_GLINT_OVERRIDE) {
+            // Original will always be null for items that do not have an override
+            event = new DataComponentGetEvent.EnchantmentGlintOverride(stack, false);
+        } else if (type == DataComponents.POTION_CONTENTS && original instanceof PotionContents pc) {
+            event = new DataComponentGetEvent.PotionContents(stack, pc);
+        }
+
+        if (event == null) return;
+
+        MixinHelper.post(event);
+        cir.setReturnValue(event.getNewValue());
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/DataComponentHolderMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/DataComponentHolderMixin.java
@@ -46,6 +46,6 @@ public interface DataComponentHolderMixin {
         if (event == null) return;
 
         MixinHelper.post(event);
-        cir.setReturnValue(event.getNewValue());
+        cir.setReturnValue(event.getValue());
     }
 }

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -15,6 +15,7 @@
     "ConnectionMixin",
     "CrashReportMixin",
     "CustomHeadLayerMixin",
+    "DataComponentHolderMixin",
     "DimensionTypeMixin",
     "EditBoxMixin",
     "EntityLookupMixin",


### PR DESCRIPTION
Features that change any DataComponents will now update in real time instead of us overriding them when the feature is enabled and/or when a set slot event is posted