### PR TITLE
fix: Use new obtain info for item guess

### DIFF
--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -87,8 +87,7 @@ public final class GearModel extends Model {
         // If an item is pre-identified, it cannot be in a gear box
         // Also check that the item has a source that can drop boxed items
         return !gear.metaInfo().preIdentified()
-                && gear.metaInfo().obtainInfo().stream()
-                        .anyMatch(x -> ItemObtainType.BOXED_ITEMS.contains(x.sourceType()));
+                && getObtainInfo(gear).stream().anyMatch(x -> ItemObtainType.BOXED_ITEMS.contains(x.sourceType()));
     }
 
     // For "real" gear items eg. from the inventory


### PR DESCRIPTION
This now uses the same check as the guides for getting obtain info so they should be aligned and actually accurate!