### PR TITLE
feat: Core logic for config profiles (Part 1/3)

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/properties/StartDisabled.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/properties/StartDisabled.java
@@ -1,9 +1,10 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.features.properties;
 
+import com.wynntils.core.persisted.config.ConfigProfile;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,4 +15,6 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface StartDisabled {}
+public @interface StartDisabled {
+    ConfigProfile[] disabledProfiles() default {};
+}

--- a/common/src/main/java/com/wynntils/core/persisted/PersistedManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/PersistedManager.java
@@ -9,12 +9,14 @@ import com.wynntils.core.components.Manager;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.NullableConfig;
 import com.wynntils.core.persisted.type.PersistedMetadata;
 import com.wynntils.utils.type.Pair;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +111,17 @@ public final class PersistedManager extends Manager {
 
         String jsonName = getPrefix(owner) + owner.getJsonName() + "." + fieldName;
 
-        return new PersistedMetadata<>(owner, fieldName, valueType, defaultValue, i18nKeyOverride, allowNull, jsonName);
+        Map<ConfigProfile, T> profileDefaultValues = new EnumMap<>(ConfigProfile.class);
+        if (persisted instanceof Config<?> config) {
+            Config<T> typedConfig = (Config<T>) config;
+            typedConfig
+                    .getProfileDefaultValues()
+                    .forEach((profile, value) ->
+                            profileDefaultValues.put(profile, Managers.Json.deepCopy(value, valueType)));
+        }
+
+        return new PersistedMetadata<>(
+                owner, fieldName, valueType, defaultValue, profileDefaultValues, i18nKeyOverride, allowNull, jsonName);
     }
 
     private String getPrefix(PersistedOwner owner) {

--- a/common/src/main/java/com/wynntils/core/persisted/config/Config.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/Config.java
@@ -145,7 +145,7 @@ public class Config<T> extends PersistedValue<T> {
         return get().toString();
     }
 
-    public boolean wasUserEdited() {
+    public boolean userEdited() {
         return userEdited;
     }
 

--- a/common/src/main/java/com/wynntils/core/persisted/config/Config.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/Config.java
@@ -10,6 +10,8 @@ import com.wynntils.core.consumers.features.Configurable;
 import com.wynntils.core.persisted.PersistedValue;
 import com.wynntils.core.persisted.type.PersistedMetadata;
 import com.wynntils.utils.EnumUtils;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 import net.minecraft.client.resources.language.I18n;
@@ -18,9 +20,15 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class Config<T> extends PersistedValue<T> {
     private boolean userEdited = false;
+    private final Map<ConfigProfile, T> profileDefaults = new EnumMap<>(ConfigProfile.class);
 
     public Config(T value) {
         super(value);
+    }
+
+    public Config<T> withDefault(ConfigProfile profile, T value) {
+        profileDefaults.put(profile, value);
+        return this;
     }
 
     @Override
@@ -54,11 +62,7 @@ public class Config<T> extends PersistedValue<T> {
     }
 
     public void reset() {
-        T defaultValue = getMetadata().defaultValue();
-
-        // deep copy because writeField set's the field to be our default value instance when resetting, making default
-        // value change with the field's actual value
-        setValue(Managers.Json.deepCopy(defaultValue, getMetadata().valueType()));
+        setValue(getDefaultValue());
         // reset this flag so option is no longer saved to file
         this.userEdited = false;
     }
@@ -74,7 +78,7 @@ public class Config<T> extends PersistedValue<T> {
 
         // FIXME: I guess at this point the userEdited change would suffice,
         // but check this carefully before removing the old logic below.
-        T defaultValue = getMetadata().defaultValue();
+        T defaultValue = getDefaultValue();
         boolean deepEquals = Objects.deepEquals(get(), defaultValue);
 
         if (deepEquals) {
@@ -99,7 +103,18 @@ public class Config<T> extends PersistedValue<T> {
     }
 
     public T getDefaultValue() {
-        return getMetadata().defaultValue();
+        PersistedMetadata<T> metadata = getMetadata();
+        T defaultValue = metadata.defaultValue();
+
+        Map<ConfigProfile, T> defaultsForProfiles = metadata.profileDefaultValues();
+        if (!defaultsForProfiles.isEmpty()) {
+            T profileDefault = defaultsForProfiles.get(Managers.Config.getSelectedProfile());
+            if (profileDefault != null) {
+                defaultValue = profileDefault;
+            }
+        }
+
+        return Managers.Json.deepCopy(defaultValue, metadata.valueType());
     }
 
     public String getDisplayName() {
@@ -130,6 +145,10 @@ public class Config<T> extends PersistedValue<T> {
         return get().toString();
     }
 
+    public boolean wasUserEdited() {
+        return userEdited;
+    }
+
     public <E extends Enum<E>> T tryParseStringValue(String value) {
         if (isEnum()) {
             return (T) EnumUtils.fromJsonFormat((Class<E>) getType(), value);
@@ -155,5 +174,9 @@ public class Config<T> extends PersistedValue<T> {
 
     private PersistedMetadata<T> getMetadata() {
         return Managers.Persisted.getMetadata(this);
+    }
+
+    public Map<ConfigProfile, T> getProfileDefaultValues() {
+        return profileDefaults;
     }
 }

--- a/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/ConfigManager.java
@@ -264,7 +264,7 @@ public final class ConfigManager extends Manager {
 
     private void applyProfileDefaults() {
         for (Config<?> config : getConfigList()) {
-            if (!config.wasUserEdited()) {
+            if (!config.userEdited()) {
                 config.reset();
             }
         }

--- a/common/src/main/java/com/wynntils/core/persisted/config/ConfigProfile.java
+++ b/common/src/main/java/com/wynntils/core/persisted/config/ConfigProfile.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.persisted.config;
+
+public enum ConfigProfile {
+    DEFAULT,
+    NEW_PLAYER,
+    LITE,
+    LITE_FULL
+}

--- a/common/src/main/java/com/wynntils/core/persisted/type/PersistedMetadata.java
+++ b/common/src/main/java/com/wynntils/core/persisted/type/PersistedMetadata.java
@@ -1,17 +1,20 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.type;
 
 import com.wynntils.core.persisted.PersistedOwner;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 public record PersistedMetadata<T>(
         PersistedOwner owner,
         String fieldName,
         Type valueType,
         T defaultValue,
+        Map<ConfigProfile, T> profileDefaultValues,
         String i18nKeyOverride,
         boolean allowNull,
         String jsonName) {}


### PR DESCRIPTION
This is the logic side for implementing config profiles. Part 2 will be the UI for it so that users can actually select a profile and part 3 will be going through all of the features and setting their defaults from community feedback.

For features, we still use `@StartDisabled` but now we define which profile to disable it for. Providing none will disable it for all, but if say we want to disable it only for the lite profiles then we would do `@StartDisabled(disabledProfiles = {ConfigProfile.LITE, ConfigProfile.LITE_FULL})`

For configs, we add a `withDefault` when we create the config like so
```
@Persisted
private final Config<MapMaskType> maskType = new Config<>(MapMaskType.RECTANGULAR)
        .withDefault(ConfigProfile.LITE, MapMaskType.CIRCLE);
```

The default value we pass into Config is what will be used by any profile if one was not specified.

I'll get started on the UI next as that doesn't really depend on the logic here, it just needs the getter and setter for the profile