### PR TITLE
fix: Re-enable discord rich presence on connect

### DIFF
--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -104,6 +104,11 @@ public class DiscordRichPresenceFeature extends Feature {
     }
 
     @SubscribeEvent
+    public void onConnect(ConnectionEvent.ConnectedEvent e) {
+        enableRichPresence();
+    }
+
+    @SubscribeEvent
     public void onDisconnect(ConnectionEvent.DisconnectedEvent e) {
         disableRichPresence();
     }


### PR DESCRIPTION
On disconnect it is disabled, but it is never re-enabled until a config change or streamer mode is toggled