### PR TITLE
fix: Fix store item annotator to not rely on custom model data

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/StoreTierAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/StoreTierAnnotator.java
@@ -4,63 +4,61 @@
  */
 package com.wynntils.models.items.annotators.gui;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.item.GuiItemAnnotator;
 import com.wynntils.handlers.item.ItemAnnotation;
 import com.wynntils.models.items.items.gui.StoreItem;
-import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.mc.LoreUtils;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import net.minecraft.core.component.DataComponents;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.CustomModelData;
 
 public final class StoreTierAnnotator implements GuiItemAnnotator {
-    private static final Pattern TIER_PATTERN = Pattern.compile("store_tier_(.+)");
+    private static final ResourceLocation RARITY_FONT = ResourceLocation.withDefaultNamespace("banner/box");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
-        CustomModelData customModelData = itemStack.get(DataComponents.CUSTOM_MODEL_DATA);
-        if (customModelData == null) return null;
+        List<StyledText> lore = LoreUtils.getLore(itemStack);
+        if (lore.isEmpty()) return null;
 
-        List<String> strings = customModelData.strings();
-        if (strings.isEmpty()) return null;
+        StyledText firstLine = lore.getFirst();
+        if (!firstLine.getFirstPart().getPartStyle().getFont().equals(RARITY_FONT)) return null;
 
-        String tierName = strings.stream()
-                .map(TIER_PATTERN::matcher)
-                .filter(Matcher::matches)
-                .map(m -> m.group(1))
-                .findFirst()
-                .orElse(null);
-        if (tierName == null) return null;
+        StoreTier tier = StoreTier.parseTier(firstLine.getStringWithoutFormatting());
+        if (tier == null) return null;
 
-        StoreTier tier = StoreTier.parseTier(tierName);
-        if (tier == null) {
-            WynntilsMod.warn("Unknown store tier: " + tierName);
-        }
-
-        return new StoreItem(tier == null ? CommonColors.WHITE : tier.getHighlightColor());
+        return new StoreItem(tier.getHighlightColor());
     }
 
     private enum StoreTier {
-        BLACK_MARKET(CustomColor.fromInt(0x640404)),
-        GODLY(CustomColor.fromInt(0xeb2d2d)),
-        EPIC(CustomColor.fromInt(0xffbb00)),
-        RARE(CustomColor.fromInt(0xdd55ff)),
-        COMMON(CustomColor.fromInt(0xfffddd));
+        BLACK_MARKET(
+                "\uE060\uDAFF\uDFFF\uE031\uDAFF\uDFFF\uE03B\uDAFF\uDFFF\uE030\uDAFF\uDFFF\uE032\uDAFF\uDFFF\uE03A\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE03C\uDAFF\uDFFF\uE030\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE03A\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE062\uDAFF\uDFB8\uE001\uE00B\uE000\uE002\uE00A \uE00C\uE000\uE011\uE00A\uE004\uE013\uDB00\uDC02",
+                CustomColor.fromInt(0x640404)),
+        GODLY(
+                "\uE060\uDAFF\uDFFF\uE036\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE033\uDAFF\uDFFF\uE03B\uDAFF\uDFFF\uE048\uDAFF\uDFFF\uE062\uDAFF\uDFE0\uE006\uE00E\uE003\uE00B\uE018\uDB00\uDC02",
+                CustomColor.fromInt(0xeb2d2d)),
+        EPIC(
+                "\uE060\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE03F\uDAFF\uDFFF\uE038\uDAFF\uDFFF\uE032\uDAFF\uDFFF\uE062\uDAFF\uDFE8\uE004\uE00F\uE008\uE002\uDB00\uDC02",
+                CustomColor.fromInt(0xffbb00)),
+        RARE(
+                "\uE060\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE030\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE062\uDAFF\uDFE6\uE011\uE000\uE011\uE004\uDB00\uDC02",
+                CustomColor.fromInt(0xdd55ff)),
+        COMMON(
+                "\uE060\uDAFF\uDFFF\uE032\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE03C\uDAFF\uDFFF\uE03C\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE03D\uDAFF\uDFFF\uE062\uDAFF\uDFDA\uE002\uE00E\uE00C\uE00C\uE00E\uE00D\uDB00\uDC02",
+                CustomColor.fromInt(0xfffddd));
 
+        private final String rarityText;
         private final CustomColor highlightColor;
 
-        StoreTier(CustomColor highlightColor) {
+        StoreTier(String rarityText, CustomColor highlightColor) {
+            this.rarityText = rarityText;
             this.highlightColor = highlightColor;
         }
 
-        public static StoreTier parseTier(String tierName) {
+        public static StoreTier parseTier(String rarityText) {
             for (StoreTier tier : StoreTier.values()) {
-                if (tier.name().equalsIgnoreCase(tierName)) {
+                if (rarityText.startsWith(tier.rarityText)) {
                     return tier;
                 }
             }


### PR DESCRIPTION
Slight oversight from https://github.com/Wynntils/Wynntils/pull/3643, forgot this annotator was using the model data to determine the tier so when the custom item highlights feature was removing the vanilla highlight, the annotator could no longer tell what tier it was