### PR TITLE
fix: Fix items with enchantments not having glint

### DIFF
--- a/common/src/main/java/com/wynntils/mc/event/DataComponentGetEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/DataComponentGetEvent.java
@@ -57,7 +57,7 @@ public abstract class DataComponentGetEvent<T> extends Event {
     }
 
     public static final class EnchantmentGlintOverride extends DataComponentGetEvent<Boolean> {
-        public EnchantmentGlintOverride(ItemStack itemStack, boolean original) {
+        public EnchantmentGlintOverride(ItemStack itemStack, Boolean original) {
             super(itemStack, DataComponents.ENCHANTMENT_GLINT_OVERRIDE, original);
         }
     }

--- a/common/src/main/java/com/wynntils/mc/mixin/DataComponentHolderMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/DataComponentHolderMixin.java
@@ -38,7 +38,8 @@ public interface DataComponentHolderMixin {
             event = new DataComponentGetEvent.DyedItemColor(stack, dye);
         } else if (type == DataComponents.ENCHANTMENT_GLINT_OVERRIDE) {
             // Original will always be null for items that do not have an override
-            event = new DataComponentGetEvent.EnchantmentGlintOverride(stack, original != null);
+            event = new DataComponentGetEvent.EnchantmentGlintOverride(
+                    stack, original == null ? null : (Boolean) original);
         } else if (type == DataComponents.POTION_CONTENTS && original instanceof PotionContents pc) {
             event = new DataComponentGetEvent.PotionContents(stack, pc);
         }


### PR DESCRIPTION
Legacy items that actually have enchantments don't use this DataComponent for determining whether they should have the glint or not, so if the original value was null then we need to keep that instead of returning false as this takes priority over the check for enchantments