### PR TITLE
refactor: Rework AddCommandExpansionFeature, FilterAdminCommandsFeature & CommandAliasesFeature  (1.21.11 backport)

### DIFF
--- a/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
@@ -4,560 +4,234 @@
  */
 package com.wynntils.features.commands;
 
-import static net.minecraft.commands.Commands.argument;
-import static net.minecraft.commands.Commands.literal;
-
-import com.mojang.brigadier.arguments.IntegerArgumentType;
-import com.mojang.brigadier.arguments.StringArgumentType;
-import com.mojang.brigadier.suggestion.SuggestionProvider;
-import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.tree.RootCommandNode;
-import com.wynntils.core.components.Managers;
-import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.mc.event.CommandsAddedEvent;
-import com.wynntils.utils.mc.McUtils;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.SharedSuggestionProvider;
-import net.minecraft.commands.arguments.EntityArgument;
+import com.wynntils.mc.event.CommandSuggestionEvent;
+import java.util.HashSet;
+import java.util.Set;
 import net.neoforged.bus.api.SubscribeEvent;
 
 /**
- * Set up Brigadier command structure of known Wynncraft commands.
+ * Wynncraft provides suggestions for command arguments but not the roots, this feature
+ * adds those suggestions.
  *
- * The commands in this file were extracted from https://wynncraft.fandom.com/wiki/Commands,
- * https://wynncraft.com/help?guide=commands, from running the commands in-game, and from a
- * list of server commands provided by HeyZeer0.
+ * The commands in this file were extracted from https://wynncraft.wiki.gg/wiki/Commands,
+ * from running the commands in-game, and from a list of server commands provided by HeyZeer0.
  */
 @ConfigCategory(Category.COMMANDS)
 public class AddCommandExpansionFeature extends Feature {
-    private static final SuggestionProvider<CommandSourceStack> PLAYER_NAME_SUGGESTION_PROVIDER =
-            (context, builder) -> SharedSuggestionProvider.suggest(Models.Player.getAllPlayerNames(), builder);
-
-    private static final SuggestionProvider<CommandSourceStack> FRIEND_NAME_SUGGESTION_PROVIDER =
-            (context, builder) -> SharedSuggestionProvider.suggest(Models.Friends.getFriends(), builder);
-
-    private static final SuggestionProvider<CommandSourceStack> PARTY_NAME_SUGGESTION_PROVIDER =
-            (context, builder) -> SharedSuggestionProvider.suggest(
-                    Models.Party.getPartyMembers().stream().filter(p -> !p.equals(McUtils.playerName())), builder);
-
-    private static final SuggestionProvider<CommandSourceStack> SERVERS_SUGGESTION_PROVIDER =
-            (context, builder) -> SharedSuggestionProvider.suggest(Models.ServerList.getServers(), builder);
-
     @Persisted
     private final Config<Boolean> includeDeprecatedCommands = new Config<>(false);
 
     @Persisted
     private final Config<AliasCommandLevel> includeAliases = new Config<>(AliasCommandLevel.SHORT_FORMS);
 
+    private final Set<String> suggestions = new HashSet<>();
+
     @SubscribeEvent
-    public void onCommandPacket(CommandsAddedEvent event) {
-        RootCommandNode<SharedSuggestionProvider> root = event.getRoot();
-
-        addArgumentlessCommandNodes(root);
-        addChangetagCommandNode(root);
-        addEmoteCommandNode(root);
-        addFriendCommandNode(root);
-        addGuildCommandNode(root);
-        addIgnoreCommandNode(root);
-        addHousingCommandNode(root);
-        addMessagingCommandNodes(root);
-        addMiscCommandNodes(root);
-        addParticlesCommandNode(root);
-        addPartyCommandNode(root);
-        addPlayerCommandNodes(root);
-        addToggleCommandNode(root);
-
-        if (includeDeprecatedCommands.get()) {
-            addDeprecatedCommandNodes(root);
-        }
+    public void onCommandSuggestions(CommandSuggestionEvent.Add event) {
+        suggestions.stream().filter(s -> s.startsWith(event.getInput())).forEach(event::addSuggestion);
     }
 
-    private void addNode(
-            RootCommandNode<SharedSuggestionProvider> root, CommandNode<? extends SharedSuggestionProvider> node) {
-        Managers.Command.addNode(root, node);
-    }
+    @Override
+    protected void onConfigUpdate(Config<?> config) {
+        suggestions.clear();
 
-    private void addAlias(
-            RootCommandNode<SharedSuggestionProvider> root,
-            CommandNode<CommandSourceStack> originalNode,
-            String aliasName,
-            AliasCommandLevel level) {
-        if (includeAliases.get().ordinal() >= level.ordinal()) {
-            addNode(root, literal(aliasName).redirect(originalNode).build());
-        }
-    }
-
-    private void addArgumentlessCommandNodes(RootCommandNode<SharedSuggestionProvider> root) {
-        addNode(root, literal("claimingredientbomb").build());
-        addNode(root, literal("claimitembomb").build());
-        addNode(root, literal("daily").build());
-        addNode(root, literal("fixquests").build());
-        addNode(root, literal("fixstart").build());
-        addNode(root, literal("forum").build());
-        addNode(root, literal("help").build());
-        addNode(root, literal("link").build());
-        addNode(root, literal("rules").build());
-        addNode(root, literal("sign").build());
-        addNode(root, literal("skiptutorial").build());
-        addNode(root, literal("tracking").build());
+        suggestions.add("claimingredientbomb");
+        suggestions.add("claimitembomb");
+        suggestions.add("daily");
+        suggestions.add("fixquests");
+        suggestions.add("fixstart");
+        suggestions.add("forum");
+        suggestions.add("help");
+        suggestions.add("link");
+        suggestions.add("rules");
+        suggestions.add("sign");
+        suggestions.add("skiptutorial");
+        suggestions.add("tracking");
 
         // There is also a command "server" but it is reserved for those with admin permissions
         // only, so don't include it here.
         // The command "checknickname" is also available but is probably a defunct legacy command.
 
         // "hub" aliases
-        CommandNode<CommandSourceStack> hubNode = literal("hub").build();
-        addNode(root, hubNode);
-
-        addAlias(root, hubNode, "change", AliasCommandLevel.ALL);
-        addAlias(root, hubNode, "lobby", AliasCommandLevel.ALL);
-        addAlias(root, hubNode, "leave", AliasCommandLevel.ALL);
-        addAlias(root, hubNode, "port", AliasCommandLevel.ALL);
+        suggestions.add("hub");
+        addAlias("change", AliasCommandLevel.ALL);
+        addAlias("lobby", AliasCommandLevel.ALL);
+        addAlias("leave", AliasCommandLevel.ALL);
+        addAlias("port", AliasCommandLevel.ALL);
 
         // There is also an alias "servers" for "hub", but it conflicts with our command
         // so don't include it here
 
         // "class" aliases
-        CommandNode<CommandSourceStack> classNode = literal("class").build();
-        addNode(root, classNode);
-
-        addAlias(root, classNode, "classes", AliasCommandLevel.ALL);
+        suggestions.add("class");
+        addAlias("classes", AliasCommandLevel.ALL);
 
         // "characters" aliases
-        CommandNode<CommandSourceStack> charactersNode = literal("characters").build();
-        addNode(root, charactersNode);
-
-        addAlias(root, charactersNode, "char", AliasCommandLevel.ALL);
+        suggestions.add("characters");
+        addAlias("char", AliasCommandLevel.SHORT_FORMS);
 
         // "crate" aliases
-        CommandNode<CommandSourceStack> crateNode = literal("crate").build();
-        addNode(root, crateNode);
-
-        addAlias(root, crateNode, "crates", AliasCommandLevel.ALL);
+        suggestions.add("crate");
+        addAlias("crates", AliasCommandLevel.ALL);
 
         // "disguises" aliases
-        CommandNode<CommandSourceStack> disguisesNode = literal("disguises").build();
-        addNode(root, disguisesNode);
-
-        addAlias(root, disguisesNode, "disguise", AliasCommandLevel.ALL);
+        suggestions.add("disguises");
+        addAlias("disguise", AliasCommandLevel.ALL);
 
         // "effects" aliases
-        CommandNode<CommandSourceStack> effectsNode = literal("effects").build();
-        addNode(root, effectsNode);
-
-        addAlias(root, effectsNode, "effect", AliasCommandLevel.ALL);
+        suggestions.add("effects");
+        addAlias("effect", AliasCommandLevel.ALL);
 
         // "hats" aliases
-        CommandNode<CommandSourceStack> hatsNode = literal("hats").build();
-        addNode(root, hatsNode);
-
-        addAlias(root, hatsNode, "hat", AliasCommandLevel.ALL);
+        suggestions.add("hats");
+        addAlias("hat", AliasCommandLevel.ALL);
 
         // "mounts" aliases
-        CommandNode<CommandSourceStack> mountsNode = literal("mounts").build();
-        addNode(root, mountsNode);
-
-        addAlias(root, mountsNode, "mount", AliasCommandLevel.ALL);
+        suggestions.add("mounts");
+        addAlias("mount", AliasCommandLevel.ALL);
 
         // "weapons" aliases
-        CommandNode<CommandSourceStack> weaponsNode = literal("weapons").build();
-        addNode(root, weaponsNode);
-
-        addAlias(root, weaponsNode, "weapon", AliasCommandLevel.ALL);
+        suggestions.add("weapons");
+        addAlias("weapon", AliasCommandLevel.ALL);
 
         // "consumables" aliases
-        CommandNode<CommandSourceStack> consumablesNode = literal("consumables").build();
-        addNode(root, consumablesNode);
-
-        addAlias(root, consumablesNode, "bomb", AliasCommandLevel.ALL);
-        addAlias(root, consumablesNode, "bombs", AliasCommandLevel.ALL);
-        addAlias(root, consumablesNode, "token", AliasCommandLevel.ALL);
-        addAlias(root, consumablesNode, "tokens", AliasCommandLevel.ALL);
-        addAlias(root, consumablesNode, "consumable", AliasCommandLevel.ALL);
+        suggestions.add("consumables");
+        addAlias("bomb", AliasCommandLevel.ALL);
+        addAlias("bombs", AliasCommandLevel.ALL);
+        addAlias("token", AliasCommandLevel.ALL);
+        addAlias("tokens", AliasCommandLevel.ALL);
+        addAlias("consumable", AliasCommandLevel.ALL);
 
         // "use" aliases
-        CommandNode<CommandSourceStack> useNode = literal("use").build();
-        addNode(root, useNode);
-
-        addAlias(root, useNode, "rank", AliasCommandLevel.ALL);
-        addAlias(root, useNode, "shop", AliasCommandLevel.ALL);
-        addAlias(root, useNode, "store", AliasCommandLevel.ALL);
+        suggestions.add("use");
+        addAlias("rank", AliasCommandLevel.ALL);
+        addAlias("shop", AliasCommandLevel.ALL);
+        addAlias("store", AliasCommandLevel.ALL);
 
         // "kill" aliases
-        CommandNode<CommandSourceStack> killNode = literal("kill").build();
-        addNode(root, killNode);
-
-        addAlias(root, killNode, "die", AliasCommandLevel.ALL);
-        addAlias(root, killNode, "suicide", AliasCommandLevel.ALL);
+        suggestions.add("kill");
+        addAlias("die", AliasCommandLevel.ALL);
+        addAlias("suicide", AliasCommandLevel.ALL);
 
         // "itemlock" aliases
-        CommandNode<CommandSourceStack> itemlockNode = literal("itemlock").build();
-        addNode(root, itemlockNode);
-
-        addAlias(root, itemlockNode, "ilock", AliasCommandLevel.ALL);
-        addAlias(root, itemlockNode, "lock", AliasCommandLevel.ALL);
-        addAlias(root, itemlockNode, "locki", AliasCommandLevel.ALL);
-        addAlias(root, itemlockNode, "lockitem", AliasCommandLevel.ALL);
+        suggestions.add("itemlock");
+        addAlias("ilock", AliasCommandLevel.ALL);
+        addAlias("lock", AliasCommandLevel.ALL);
+        addAlias("locki", AliasCommandLevel.ALL);
+        addAlias("lockitem", AliasCommandLevel.ALL);
 
         // "pet" aliases
-        CommandNode<CommandSourceStack> petNode = literal("pet").build();
-        addNode(root, petNode);
-
-        addAlias(root, petNode, "pets", AliasCommandLevel.ALL);
+        suggestions.add("pet");
+        addAlias("pets", AliasCommandLevel.ALL);
 
         // "partyfinder" aliases
-        CommandNode<CommandSourceStack> partyfinderNode = literal("partyfinder").build();
-        addNode(root, partyfinderNode);
-
-        addAlias(root, partyfinderNode, "pfinder", AliasCommandLevel.SHORT_FORMS);
+        suggestions.add("partyfinder");
+        addAlias("pfinder", AliasCommandLevel.ALL);
 
         // "stream" aliases
-        CommandNode<CommandSourceStack> streamNode = literal("stream").build();
-        addNode(root, streamNode);
-
-        addAlias(root, streamNode, "streamer", AliasCommandLevel.ALL);
+        suggestions.add("stream");
+        addAlias("streamer", AliasCommandLevel.ALL);
 
         // "totem" aliases
-        CommandNode<CommandSourceStack> totemNode = literal("totem").build();
-        addNode(root, totemNode);
-
-        addAlias(root, totemNode, "totems", AliasCommandLevel.ALL);
+        suggestions.add("totem");
+        addAlias("totems", AliasCommandLevel.ALL);
 
         // "hunted" aliases
-        CommandNode<CommandSourceStack> huntedNode = literal("hunted").build();
-        addNode(root, huntedNode);
-
-        addAlias(root, huntedNode, "pvp", AliasCommandLevel.SHORT_FORMS);
+        suggestions.add("hunted");
+        addAlias("pvp", AliasCommandLevel.SHORT_FORMS);
 
         // "recruit" aliases
-        CommandNode<CommandSourceStack> recruitNode = literal("recruit").build();
-        addNode(root, recruitNode);
+        suggestions.add("recruit");
+        addAlias("rf", AliasCommandLevel.ALL);
 
-        addAlias(root, recruitNode, "rf", AliasCommandLevel.ALL);
+        suggestions.add("changetag");
+
+        suggestions.add("emote");
+        addAlias("emotes", AliasCommandLevel.ALL);
+
+        suggestions.add("friend");
+        addAlias("f", AliasCommandLevel.SHORT_FORMS);
+        addAlias("friends", AliasCommandLevel.ALL);
+        addAlias("buddy", AliasCommandLevel.ALL);
+        addAlias("buddies", AliasCommandLevel.ALL);
+
+        suggestions.add("guild");
+        addAlias("gu", AliasCommandLevel.SHORT_FORMS);
+        addAlias("guilds", AliasCommandLevel.ALL);
+
+        suggestions.add("ignore");
+
+        suggestions.add("housing");
+        addAlias("is", AliasCommandLevel.SHORT_FORMS);
+        addAlias("hs", AliasCommandLevel.SHORT_FORMS);
+        addAlias("home", AliasCommandLevel.ALL);
+        addAlias("house", AliasCommandLevel.ALL);
+        addAlias("island", AliasCommandLevel.ALL);
+        addAlias("plot", AliasCommandLevel.ALL);
+
+        suggestions.add("g");
+        suggestions.add("p");
+        suggestions.add("r");
+        suggestions.add("msg");
+
+        suggestions.add("report");
+        suggestions.add("switch");
+        suggestions.add("relore");
+        suggestions.add("dialogue");
+        suggestions.add("thankyou");
+
+        suggestions.add("renameitem");
+        addAlias("renameitems", AliasCommandLevel.ALL);
+
+        suggestions.add("renamepet");
+        addAlias("renamepets", AliasCommandLevel.ALL);
+
+        suggestions.add("ironman");
+
+        suggestions.add("particles");
+        addAlias("pq", AliasCommandLevel.SHORT_FORMS);
+        addAlias("particlequality", AliasCommandLevel.ALL);
+        addAlias("particlesquality", AliasCommandLevel.ALL);
+
+        suggestions.add("party");
+        addAlias("pa", AliasCommandLevel.SHORT_FORMS);
+        addAlias("group", AliasCommandLevel.ALL);
+
+        suggestions.add("duel");
+        addAlias("d", AliasCommandLevel.SHORT_FORMS);
+
+        suggestions.add("trade");
+        addAlias("tr", AliasCommandLevel.SHORT_FORMS);
+
+        suggestions.add("find");
+
+        suggestions.add("toggle");
+
+        if (includeDeprecatedCommands.get()) {
+            suggestions.add("legacystore");
+
+            addAlias("buy", AliasCommandLevel.ALL);
+            addAlias("cash", AliasCommandLevel.ALL);
+            addAlias("cashshop", AliasCommandLevel.ALL);
+            addAlias("gc", AliasCommandLevel.ALL);
+            addAlias("gold", AliasCommandLevel.ALL);
+            addAlias("goldcoins", AliasCommandLevel.ALL);
+            addAlias("goldshop", AliasCommandLevel.ALL);
+
+            suggestions.add("rename");
+            addAlias("name", AliasCommandLevel.ALL);
+        }
     }
 
-    private void addChangetagCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        addNode(
-                root,
-                literal("changetag")
-                        .then(literal("VIP"))
-                        .then(literal("VIP+"))
-                        .then(literal("HERO"))
-                        .then(literal("HERO+"))
-                        .then(literal("CHAMPION"))
-                        .then(literal("RESET"))
-                        .build());
-    }
-
-    private void addEmoteCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        // FIXME: We should only provide the emotes that the player has access to
-        CommandNode<CommandSourceStack> node = literal("emote")
-                .then(literal("cheer"))
-                .then(literal("clap"))
-                .then(literal("dance"))
-                .then(literal("explode"))
-                .then(literal("faint"))
-                .then(literal("flop"))
-                .then(literal("hug"))
-                .then(literal("relax"))
-                .then(literal("jump"))
-                .then(literal("wave"))
-                .build();
-        addNode(root, node);
-
-        addAlias(root, node, "emotes", AliasCommandLevel.ALL);
-    }
-
-    private void addFriendCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        CommandNode<CommandSourceStack> node = literal("friend")
-                .then(literal("list"))
-                .then(literal("online"))
-                .then(literal("add")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("remove")
-                        .then(argument("player", StringArgumentType.word()).suggests(FRIEND_NAME_SUGGESTION_PROVIDER)))
-                .build();
-        addNode(root, node);
-
-        addAlias(root, node, "f", AliasCommandLevel.SHORT_FORMS);
-        addAlias(root, node, "friends", AliasCommandLevel.ALL);
-        addAlias(root, node, "buddy", AliasCommandLevel.ALL);
-        addAlias(root, node, "buddies", AliasCommandLevel.ALL);
-    }
-
-    private void addGuildCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        CommandNode<CommandSourceStack> node = literal("guild")
-                .then(literal("attack"))
-                .then(literal("contribute"))
-                .then(literal("defend"))
-                .then(literal("invite")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("join").then(argument("tag", StringArgumentType.greedyString())))
-                .then(literal("kick")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("leaderboard"))
-                .then(literal("leave"))
-                .then(literal("list"))
-                .then(literal("log"))
-                .then(literal("manage"))
-                .then(literal("rank")
-                        .then(argument("player", EntityArgument.players())
-                                .suggests(PLAYER_NAME_SUGGESTION_PROVIDER)
-                                .then(argument("rank", StringArgumentType.string()))))
-                .then(literal("rewards"))
-                .then(literal("stats"))
-                .then(literal("territory"))
-                .then(literal("xp").then(argument("amount", IntegerArgumentType.integer())))
-                .build();
-        addNode(root, node);
-
-        addAlias(root, node, "gu", AliasCommandLevel.SHORT_FORMS);
-        addAlias(root, node, "guilds", AliasCommandLevel.ALL);
-    }
-
-    private void addIgnoreCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        addNode(
-                root,
-                literal("ignore")
-                        .then(literal("add")
-                                .then(argument("player", EntityArgument.players())
-                                        .suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                        .then(literal("remove")
-                                .then(argument("player", EntityArgument.players())
-                                        .suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                        .build());
-    }
-
-    private void addHousingCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        CommandNode<CommandSourceStack> node = literal("housing")
-                .then(literal("allowedit")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("ban")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("disallowedit")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("edit"))
-                .then(literal("invite")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("kick")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("kickall"))
-                .then(literal("leave"))
-                .then(literal("public"))
-                .then(literal("unban")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("visit"))
-                .build();
-        addNode(root, node);
-
-        addAlias(root, node, "is", AliasCommandLevel.SHORT_FORMS);
-        addAlias(root, node, "hs", AliasCommandLevel.SHORT_FORMS);
-        addAlias(root, node, "home", AliasCommandLevel.ALL);
-        addAlias(root, node, "house", AliasCommandLevel.ALL);
-        addAlias(root, node, "island", AliasCommandLevel.ALL);
-        addAlias(root, node, "plot", AliasCommandLevel.ALL);
-    }
-
-    private void addMessagingCommandNodes(RootCommandNode<SharedSuggestionProvider> root) {
-        addNode(
-                root,
-                literal("g")
-                        .then(argument("msg", StringArgumentType.greedyString()))
-                        .build());
-
-        addNode(
-                root,
-                literal("p")
-                        .then(argument("msg", StringArgumentType.greedyString()))
-                        .build());
-
-        addNode(
-                root,
-                literal("r")
-                        .then(argument("msg", StringArgumentType.greedyString()))
-                        .build());
-
-        CommandNode<CommandSourceStack> node = literal("msg")
-                .then(argument("player", EntityArgument.players())
-                        .suggests(PLAYER_NAME_SUGGESTION_PROVIDER)
-                        .then(argument("msg", StringArgumentType.greedyString())))
-                .build();
-        addNode(root, node);
-    }
-
-    private void addMiscCommandNodes(RootCommandNode<SharedSuggestionProvider> root) {
-        addNode(
-                root,
-                literal("report")
-                        .then(argument("player", EntityArgument.players())
-                                .suggests(PLAYER_NAME_SUGGESTION_PROVIDER)
-                                .then(argument("reason", StringArgumentType.greedyString())))
-                        .build());
-
-        addNode(
-                root,
-                literal("switch")
-                        .then(argument("world", StringArgumentType.string()).suggests(SERVERS_SUGGESTION_PROVIDER))
-                        .build());
-
-        addNode(
-                root,
-                literal("relore")
-                        .then(argument("lore", StringArgumentType.greedyString()))
-                        .build());
-
-        // first option is 0; not really supposed to be run by users
-        addNode(
-                root,
-                literal("dialogue")
-                        .then(argument("option", IntegerArgumentType.integer()))
-                        .build());
-
-        // not really supposed to be run by users
-        addNode(
-                root,
-                literal("thankyou")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER))
-                        .build());
-
-        // "renameitem" aliases
-        CommandNode<CommandSourceStack> renameitemNode = literal("renameitem")
-                .then(argument("name", StringArgumentType.greedyString()))
-                .build();
-        addNode(root, renameitemNode);
-
-        addAlias(root, renameitemNode, "renameitems", AliasCommandLevel.ALL);
-
-        // "renameitem" aliases
-        CommandNode<CommandSourceStack> renamepetNode = literal("renamepet")
-                .then(argument("name", StringArgumentType.greedyString()))
-                .build();
-        addNode(root, renamepetNode);
-
-        addAlias(root, renamepetNode, "renamepets", AliasCommandLevel.ALL);
-
-        addNode(root, literal("ironman").build());
-    }
-
-    private void addParticlesCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        CommandNode<CommandSourceStack> node = literal("particles")
-                .then(literal("off"))
-                .then(literal("low"))
-                .then(literal("medium"))
-                .then(literal("high"))
-                .then(literal("veryhigh"))
-                .then(literal("highest"))
-                .then(literal("unlimited"))
-                .then(argument("particles_per_tick", IntegerArgumentType.integer()))
-                .build();
-        addNode(root, node);
-        addAlias(root, node, "pq", AliasCommandLevel.SHORT_FORMS);
-        addAlias(root, node, "particlequality", AliasCommandLevel.ALL);
-        addAlias(root, node, "particlesquality", AliasCommandLevel.ALL);
-    }
-
-    private void addPartyCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        CommandNode<CommandSourceStack> node = literal("party")
-                .then(literal("ban")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("create"))
-                .then(literal("disband"))
-                .then(literal("finder"))
-                .then(literal("invite")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("join")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("kick")
-                        .then(argument("player", EntityArgument.players()).suggests(PARTY_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("leave"))
-                .then(literal("lobby"))
-                .then(literal("list"))
-                .then(literal("promote")
-                        .then(argument("player", EntityArgument.players()).suggests(PARTY_NAME_SUGGESTION_PROVIDER)))
-                .then(literal("unban")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER)))
-                .build();
-        addNode(root, node);
-
-        addAlias(root, node, "pa", AliasCommandLevel.SHORT_FORMS);
-        addAlias(root, node, "group", AliasCommandLevel.ALL);
-    }
-
-    private void addPlayerCommandNodes(RootCommandNode<SharedSuggestionProvider> root) {
-        CommandNode<CommandSourceStack> duelNode = literal("duel")
-                .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER))
-                .build();
-        addNode(root, duelNode);
-        addAlias(root, duelNode, "d", AliasCommandLevel.SHORT_FORMS);
-
-        CommandNode<CommandSourceStack> tradeNode = literal("trade")
-                .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER))
-                .build();
-        addNode(root, tradeNode);
-        addAlias(root, tradeNode, "tr", AliasCommandLevel.SHORT_FORMS);
-
-        addNode(
-                root,
-                literal("find")
-                        .then(argument("player", EntityArgument.players()).suggests(PLAYER_NAME_SUGGESTION_PROVIDER))
-                        .build());
-    }
-
-    private void addToggleCommandNode(RootCommandNode<SharedSuggestionProvider> root) {
-        addNode(
-                root,
-                literal("toggle")
-                        .then(literal("100"))
-                        .then(literal("autotracking"))
-                        .then(literal("beacon"))
-                        .then(literal("blood"))
-                        .then(literal("bombbell"))
-                        .then(literal("combatbar"))
-                        .then(literal("friendpopups"))
-                        .then(literal("ghosts")
-                                .then(literal("none"))
-                                .then(literal("low"))
-                                .then(literal("medium"))
-                                .then(literal("high"))
-                                .then(literal("all")))
-                        .then(literal("guildjoin"))
-                        .then(literal("guildpopups"))
-                        .then(literal("insults"))
-                        .then(literal("music"))
-                        .then(literal("outlines"))
-                        .then(literal("popups"))
-                        .then(literal("pouchmsg"))
-                        .then(literal("pouchpickup"))
-                        .then(literal("queststartbeacon"))
-                        .then(literal("sb"))
-                        .then(literal("swears"))
-                        .then(literal("war"))
-                        .build());
-    }
-
-    private void addDeprecatedCommandNodes(RootCommandNode<SharedSuggestionProvider> root) {
-        // "legacystore" aliases
-        CommandNode<CommandSourceStack> legacystoreNode = literal("legacystore").build();
-        addNode(root, legacystoreNode);
-
-        addAlias(root, legacystoreNode, "buy", AliasCommandLevel.ALL);
-        addAlias(root, legacystoreNode, "cash", AliasCommandLevel.ALL);
-        addAlias(root, legacystoreNode, "cashshop", AliasCommandLevel.ALL);
-        addAlias(root, legacystoreNode, "gc", AliasCommandLevel.ALL);
-        addAlias(root, legacystoreNode, "gold", AliasCommandLevel.ALL);
-        addAlias(root, legacystoreNode, "goldcoins", AliasCommandLevel.ALL);
-        addAlias(root, legacystoreNode, "goldshop", AliasCommandLevel.ALL);
-
-        // "rename" aliases
-        CommandNode<CommandSourceStack> renameNode = literal("rename").build();
-        addNode(root, renameNode);
-
-        addAlias(root, renameNode, "name", AliasCommandLevel.ALL);
+    private void addAlias(String alias, AliasCommandLevel level) {
+        if (includeAliases.get().ordinal() >= level.ordinal()) {
+            suggestions.add(alias);
+        }
     }
 
     public enum AliasCommandLevel {

--- a/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
@@ -33,25 +33,26 @@ public class CommandAliasesFeature extends Feature {
         String message = e.getCommand();
         String[] parts = message.split(" ");
 
-        if (parts.length < 2) return;
-
         boolean changed = false;
-
-        for (ArgumentAlias argumentAlias : argumentAliases.get()) {
-            if (!argumentAlias.roots().contains(parts[0])) continue;
-
-            for (int i = 1; i < parts.length; i++) {
-                if (argumentAlias.aliases().contains(parts[i])) {
-                    parts[i] = argumentAlias.original();
-                    changed = true;
-                }
-            }
-        }
 
         for (RootAlias rootAlias : rootAliases.get()) {
             if (rootAlias.aliases().contains(parts[0])) {
                 parts[0] = rootAlias.original();
                 changed = true;
+                break;
+            }
+        }
+
+        if (parts.length > 1) {
+            for (ArgumentAlias argumentAlias : argumentAliases.get()) {
+                if (!argumentAlias.roots().contains(parts[0])) continue;
+
+                for (int i = 1; i < parts.length; i++) {
+                    if (argumentAlias.aliases().contains(parts[i])) {
+                        parts[i] = argumentAlias.original();
+                        changed = true;
+                    }
+                }
             }
         }
 

--- a/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.CommandSentEvent;
 import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.List;
-import java.util.Objects;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 

--- a/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
@@ -31,6 +31,8 @@ public class CommandAliasesFeature extends Feature {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onCommandSent(CommandSentEvent e) {
         String message = e.getCommand();
+        if (message.isEmpty()) return;
+
         String[] parts = message.split(" ");
 
         boolean changed = false;

--- a/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
@@ -4,65 +4,96 @@
  */
 package com.wynntils.features.commands;
 
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.tree.RootCommandNode;
 import com.wynntils.core.components.Handlers;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.CommandSentEvent;
-import com.wynntils.mc.event.CommandsAddedEvent;
-import java.util.ArrayList;
+import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.List;
 import java.util.Objects;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.Commands;
-import net.minecraft.commands.SharedSuggestionProvider;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.COMMANDS)
 public class CommandAliasesFeature extends Feature {
     @Persisted
-    private final HiddenConfig<List<CommandAlias>> aliases = new HiddenConfig<>(new ArrayList<>(List.of(
-            new CommandAlias("guild attack", List.of("gu a", "guild a")),
-            new CommandAlias("guild manage", List.of("gu m", "gu man", "guild m", "guild man")),
-            new CommandAlias("guild territory", List.of("gu t", "gu terr", "guild t", "guild terr")),
-            new CommandAlias("partyfinder", List.of("pf")))));
+    private final HiddenConfig<List<RootAlias>> rootAliases =
+            new HiddenConfig<>(List.of(new RootAlias("partyfinder", List.of("pf"))));
+
+    @Persisted
+    private final HiddenConfig<List<ArgumentAlias>> argumentAliases = new HiddenConfig<>(List.of(
+            new ArgumentAlias(List.of("guild", "gu", "guilds"), "attack", List.of("a")),
+            new ArgumentAlias(List.of("guild", "gu", "guilds"), "manage", List.of("m", "man")),
+            new ArgumentAlias(List.of("guild", "gu", "guilds"), "territory", List.of("t", "terr"))));
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onCommandSent(CommandSentEvent e) {
         String message = e.getCommand();
+        String[] parts = message.split(" ");
 
-        for (CommandAlias commandAlias : aliases.get()) {
-            if (commandAlias.aliases().stream().anyMatch(alias -> Objects.equals(alias, message))) {
-                e.setCanceled(true);
-                Handlers.Command.sendCommandImmediately(commandAlias.originalCommand());
-                break;
+        if (parts.length < 2) return;
+
+        boolean changed = false;
+
+        for (ArgumentAlias argumentAlias : argumentAliases.get()) {
+            if (!argumentAlias.roots().contains(parts[0])) continue;
+
+            for (int i = 1; i < parts.length; i++) {
+                if (argumentAlias.aliases().contains(parts[i])) {
+                    parts[i] = argumentAlias.original();
+                    changed = true;
+                }
             }
+        }
+
+        for (RootAlias rootAlias : rootAliases.get()) {
+            if (rootAlias.aliases().contains(parts[0])) {
+                parts[0] = rootAlias.original();
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            e.setCanceled(true);
+            Handlers.Command.sendCommandImmediately(String.join(" ", parts));
         }
     }
 
     @SubscribeEvent
-    public void onCommandsAdded(CommandsAddedEvent event) {
-        RootCommandNode<SharedSuggestionProvider> root = event.getRoot();
+    public void onCommandSuggestions(CommandSuggestionEvent.Modify event) {
+        String input = event.getInput();
 
-        for (CommandAlias commandAlias : aliases.get()) {
-            for (String alias : commandAlias.aliases()) {
-                String[] parts = alias.split(" ");
-                LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal(parts[0]);
-
-                for (int i = 1; i < parts.length; i++) {
-                    builder.then(Commands.literal(parts[i]));
+        if (!event.getInput().contains(" ")) {
+            for (RootAlias rootAlias : rootAliases.get()) {
+                for (String alias : rootAlias.aliases()) {
+                    if (alias.startsWith(event.getInput())) {
+                        event.addSuggestion(alias);
+                    }
                 }
+            }
 
-                Managers.Command.addNode(root, builder.build());
+            return;
+        }
+
+        int lastSpace = input.lastIndexOf(' ');
+        String root = input.substring(0, lastSpace);
+        String currentArg = input.substring(lastSpace + 1);
+
+        for (ArgumentAlias argumentAlias : argumentAliases.get()) {
+            if (!argumentAlias.roots().contains(root)) continue;
+
+            for (String alias : argumentAlias.aliases()) {
+                if (currentArg.isEmpty() || alias.startsWith(currentArg)) {
+                    event.addSuggestion(alias);
+                }
             }
         }
     }
 
-    private record CommandAlias(String originalCommand, List<String> aliases) {}
+    private record RootAlias(String original, List<String> aliases) {}
+
+    private record ArgumentAlias(List<String> roots, String original, List<String> aliases) {}
 }

--- a/common/src/main/java/com/wynntils/features/commands/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/FilterAdminCommandsFeature.java
@@ -1,19 +1,14 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.commands;
 
-import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.tree.LiteralCommandNode;
-import com.mojang.brigadier.tree.RootCommandNode;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.mc.event.CommandsAddedEvent;
+import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.Set;
-import net.minecraft.commands.SharedSuggestionProvider;
-import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.COMMANDS)
@@ -38,20 +33,8 @@ public class FilterAdminCommandsFeature extends Feature {
             "wcl",
             "wynnproxy");
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    public void onCommandPacket(CommandsAddedEvent event) {
-        RootCommandNode<SharedSuggestionProvider> root = event.getRoot();
-
-        RootCommandNode<SharedSuggestionProvider> newRoot = new RootCommandNode<>();
-        for (CommandNode<SharedSuggestionProvider> child : root.getChildren()) {
-            // Only add literal nodes, not argument nodes
-            if (child instanceof LiteralCommandNode<SharedSuggestionProvider> literalChild) {
-                if (!FILTERED_COMMANDS.contains(literalChild.getName())) {
-                    newRoot.addChild(literalChild);
-                }
-            }
-        }
-
-        event.setRoot(newRoot);
+    @SubscribeEvent
+    public void onModifySuggestions(CommandSuggestionEvent.Modify event) {
+        FILTERED_COMMANDS.forEach(event::removeSuggestion);
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/CommandSuggestionEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandSuggestionEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.neoforged.bus.api.Event;
+
+public abstract class CommandSuggestionEvent extends Event {
+    private final List<String> suggestions;
+
+    protected CommandSuggestionEvent(List<String> suggestions) {
+        this.suggestions = suggestions;
+    }
+
+    public void addSuggestion(String suggestion) {
+        suggestions.add(suggestion);
+    }
+
+    public void removeSuggestion(String suggestion) {
+        suggestions.remove(suggestion);
+    }
+
+    public List<String> getSuggestions() {
+        return Collections.unmodifiableList(suggestions);
+    }
+
+    public static final class Add extends CommandSuggestionEvent {
+        private final String input;
+
+        public Add(String input) {
+            super(new ArrayList<>());
+
+            this.input = input;
+        }
+
+        public String getInput() {
+            return input;
+        }
+    }
+
+    public static final class Modify extends CommandSuggestionEvent {
+        public Modify(List<String> suggestions) {
+            super(suggestions);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/CommandSuggestionEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandSuggestionEvent.java
@@ -10,10 +10,16 @@ import java.util.List;
 import net.neoforged.bus.api.Event;
 
 public abstract class CommandSuggestionEvent extends Event {
+    private final String input;
     private final List<String> suggestions;
 
-    protected CommandSuggestionEvent(List<String> suggestions) {
+    protected CommandSuggestionEvent(String input, List<String> suggestions) {
+        this.input = input;
         this.suggestions = suggestions;
+    }
+
+    public String getInput() {
+        return input;
     }
 
     public void addSuggestion(String suggestion) {
@@ -28,23 +34,15 @@ public abstract class CommandSuggestionEvent extends Event {
         return Collections.unmodifiableList(suggestions);
     }
 
-    public static final class Add extends CommandSuggestionEvent {
-        private final String input;
-
+    public static class Add extends CommandSuggestionEvent {
         public Add(String input) {
-            super(new ArrayList<>());
-
-            this.input = input;
-        }
-
-        public String getInput() {
-            return input;
+            super(input, new ArrayList<>());
         }
     }
 
-    public static final class Modify extends CommandSuggestionEvent {
-        public Modify(List<String> suggestions) {
-            super(suggestions);
+    public static class Modify extends CommandSuggestionEvent {
+        public Modify(String input, List<String> suggestions) {
+            super(input, suggestions);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/mc/event/CommandsAddedEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/CommandsAddedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2025.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;
@@ -11,8 +11,7 @@ import net.neoforged.bus.api.Event;
 
 public class CommandsAddedEvent extends Event {
     private final CommandBuildContext context;
-
-    private RootCommandNode<SharedSuggestionProvider> root;
+    private final RootCommandNode<SharedSuggestionProvider> root;
 
     public CommandsAddedEvent(RootCommandNode<SharedSuggestionProvider> root, CommandBuildContext context) {
         this.root = root;
@@ -25,9 +24,5 @@ public class CommandsAddedEvent extends Event {
 
     public CommandBuildContext getContext() {
         return context;
-    }
-
-    public void setRoot(RootCommandNode<SharedSuggestionProvider> root) {
-        this.root = root;
     }
 }

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -163,11 +163,6 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
         CommandsAddedEvent event =
                 new CommandsAddedEvent(root, CommandBuildContext.simple(this.registryAccess, this.enabledFeatures));
         MixinHelper.post(event);
-
-        if (event.getRoot() != root) {
-            // If we changed the root, replace the CommandDispatcher
-            this.commands = new CommandDispatcher<>(event.getRoot());
-        }
     }
 
     @Inject(

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientSuggestionProviderMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientSuggestionProviderMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.CommandSuggestionEvent;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientSuggestionProvider.class)
+public class ClientSuggestionProviderMixin {
+    @Inject(
+            method =
+                    "customSuggestion(Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/concurrent/CompletableFuture;",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void onCustomSuggestion(
+            CommandContext<?> context, CallbackInfoReturnable<CompletableFuture<Suggestions>> cir) {
+        String input = context.getInput();
+
+        // Ensure it is a command with no spaces, we only want to set suggestions for the root
+        if (input.startsWith("/") && !input.contains(" ")) {
+            SuggestionsBuilder builder = new SuggestionsBuilder(input, 1);
+
+            CommandSuggestionEvent event = new CommandSuggestionEvent.Add(input.substring(1));
+            MixinHelper.post(event);
+
+            for (String root : event.getSuggestions()) {
+                builder.suggest(root);
+            }
+
+            cir.setReturnValue(builder.buildFuture());
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © Wynntils 2025.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.wynntils.core.events.MixinHelper;
+import com.wynntils.mc.event.CommandSuggestionEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import net.minecraft.client.gui.components.CommandSuggestions;
+import net.minecraft.client.gui.components.EditBox;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CommandSuggestions.class)
+public class CommandSuggestionsMixin {
+    @Shadow
+    private CompletableFuture<Suggestions> pendingSuggestions;
+
+    @Shadow
+    @Final
+    private EditBox input;
+
+    @Inject(
+            method = "updateCommandInfo()V",
+            at =
+                    @At(
+                            value = "FIELD",
+                            target =
+                                    "Lnet/minecraft/client/gui/components/CommandSuggestions;pendingSuggestions:Ljava/util/concurrent/CompletableFuture;",
+                            opcode = Opcodes.PUTFIELD,
+                            shift = At.Shift.AFTER))
+    private void onUpdateCommandInfo(CallbackInfo ci) {
+        if (pendingSuggestions == null) return;
+
+        pendingSuggestions = pendingSuggestions.thenApply(originalSuggestions -> {
+            List<String> list = originalSuggestions.getList().stream()
+                    .map(Suggestion::getText)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            CommandSuggestionEvent.Modify event = new CommandSuggestionEvent.Modify(list);
+            MixinHelper.post(event);
+
+            String fullInput = input.getValue();
+            int start = originalSuggestions.getRange().getStart();
+
+            SuggestionsBuilder suggestionsBuilder = new SuggestionsBuilder(fullInput, start);
+            for (String suggestion : event.getSuggestions()) {
+                suggestionsBuilder.suggest(suggestion);
+            }
+
+            return suggestionsBuilder.build();
+        });
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/CommandSuggestionsMixin.java
@@ -44,23 +44,26 @@ public class CommandSuggestionsMixin {
     private void onUpdateCommandInfo(CallbackInfo ci) {
         if (pendingSuggestions == null) return;
 
-        pendingSuggestions = pendingSuggestions.thenApply(originalSuggestions -> {
-            List<String> list = originalSuggestions.getList().stream()
-                    .map(Suggestion::getText)
-                    .collect(Collectors.toCollection(ArrayList::new));
+        String fullInput = input.getValue();
 
-            CommandSuggestionEvent.Modify event = new CommandSuggestionEvent.Modify(list);
-            MixinHelper.post(event);
+        if (fullInput.startsWith("/")) {
+            pendingSuggestions = pendingSuggestions.thenApply(originalSuggestions -> {
+                List<String> list = originalSuggestions.getList().stream()
+                        .map(Suggestion::getText)
+                        .collect(Collectors.toCollection(ArrayList::new));
 
-            String fullInput = input.getValue();
-            int start = originalSuggestions.getRange().getStart();
+                CommandSuggestionEvent event = new CommandSuggestionEvent.Modify(fullInput.substring(1), list);
+                MixinHelper.post(event);
 
-            SuggestionsBuilder suggestionsBuilder = new SuggestionsBuilder(fullInput, start);
-            for (String suggestion : event.getSuggestions()) {
-                suggestionsBuilder.suggest(suggestion);
-            }
+                int start = originalSuggestions.getRange().getStart();
 
-            return suggestionsBuilder.build();
-        });
+                SuggestionsBuilder suggestionsBuilder = new SuggestionsBuilder(fullInput, start);
+                for (String suggestion : event.getSuggestions()) {
+                    suggestionsBuilder.suggest(suggestion);
+                }
+
+                return suggestionsBuilder.build();
+            });
+        }
     }
 }

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -11,6 +11,8 @@
     "ClientCommonPacketListenerImplMixin",
     "ClientLevelMixin",
     "ClientPacketListenerMixin",
+    "ClientSuggestionProviderMixin",
+    "CommandSuggestionsMixin",
     "ConnectScreenMixin",
     "ConnectionMixin",
     "CrashReportMixin",


### PR DESCRIPTION
Wynncraft have provided suggestions for arguments for a few months now, but not the roots so our feature was still necessary but no longer as "clean" as vanilla when it came to arguments as we would always suggest arguments, while vanilla provides them based on criteria (Only suggesting "invite" for /party when you are actually in a party, or only suggesting emotes you have unlocked)

This is also necessary for 1.21.11 as our previous approach caused commands to not be verified by the client and would prompt a "Are you sure you want to run this command" for chat click events.

The changes here also work perfectly on 1.21.11, so we won't need to port this