### PR TITLE
feat: Add tick delay config to auto attack

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/AutoAttackFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/AutoAttackFeature.java
@@ -7,7 +7,9 @@ package com.wynntils.features.combat;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.properties.StartDisabled;
+import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
+import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.ArmSwingEvent;
 import com.wynntils.mc.event.ChangeCarriedItemEvent;
@@ -29,7 +31,8 @@ import net.neoforged.bus.api.SubscribeEvent;
 @StartDisabled
 @ConfigCategory(Category.COMBAT)
 public class AutoAttackFeature extends Feature {
-    private static final int TICKS_PER_ATTACK = 2;
+    @Persisted
+    private final Config<Integer> attackTickDelay = new Config<>(2);
 
     private long lastSpellInput = -1L;
     private int spellInputs = 0;
@@ -89,7 +92,7 @@ public class AutoAttackFeature extends Feature {
         }
 
         if (Models.Raid.isParasiteOvertaken()) return;
-        if (tickCount % TICKS_PER_ATTACK != 0) return;
+        if (tickCount % Math.max(attackTickDelay.get(), 1) != 0) return;
         if (lastSpellInput + Models.Spell.SPELL_COST_RESET_TICKS > McUtils.player().tickCount) return;
 
         if (weaponStatus == WeaponStatus.UNKNOWN) {

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -106,6 +106,8 @@
   "feature.wynntils.arrowShieldTrackerOverlay.overlay.arrowShieldTracker.textShadow.name": "Text Shadow",
   "feature.wynntils.autoApplyResourcePack.description": "Adds the ability to automatically apply the Wynntils resource pack on startup.",
   "feature.wynntils.autoApplyResourcePack.name": "Auto Apply Resource Pack",
+  "feature.wynntils.autoAttack.attackTickDelay.description": "How many ticks delay should there be before a new attack is sent. Setting this value below 1 will treat the delay as 1.",
+  "feature.wynntils.autoAttack.attackTickDelay.name": "Attack Tick Delay",
   "feature.wynntils.autoAttack.description": "Automatically continues attacking while holding down the attack key.",
   "feature.wynntils.autoAttack.name": "Auto Attack",
   "feature.wynntils.autoJoinParty.description": "Adds the ability to automatically join a party when a friend invites you.",


### PR DESCRIPTION
Manual attacks are still faster with some builds, so this will allow you to lower it to attack every tick