### PR TITLE
fix: Fix bomb bell parsing with extra space

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -36,7 +36,7 @@ public final class BombModel extends Model {
 
     // Test in BombModel_BOMB_BELL_PATTERN
     private static final Pattern BOMB_BELL_PATTERN = Pattern.compile(
-            "^§#fddd5cff(?:\uE01E\uE002|\uE001) (?<user>.+) has thrown an? §#f3e6b2ff(?<bomb>.+) Bomb§#fddd5cff on §#f3e6b2ff§n(?<server>.+)$");
+            "^§#fddd5cff(?:\uE01E\uE002|\uE001) (?<user>.+) has thrown an? §#f3e6b2ff(?<bomb>.+) Bomb§#fddd5cff ( ?)on §#f3e6b2ff§n(?<server>.+)$");
 
     // Test in BombModel_BOMB_EXPIRED_PATTERN
     private static final Pattern BOMB_EXPIRED_PATTERN = Pattern.compile(

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -157,6 +157,8 @@ public class TestRegex {
                 "§#fddd5cff\uE01E\uE002 Wanytails has thrown a §#f3e6b2ffProfession Speed Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
         p.shouldMatch(
                 "§#fddd5cff\uE001 Wanytails has thrown a §#f3e6b2ffCombat Experience Bomb§#fddd5cff on §#f3e6b2ff§nNA3");
+        p.shouldMatch(
+                "§#fddd5cff\uE001 xX_NoScope_Xx has thrown a §#f3e6b2ffProfession Experience Bomb§#fddd5cff  on §#f3e6b2ff§nEU5");
     }
 
     @Test


### PR DESCRIPTION
Sometimes there's an extra space on the new line. It's been like this for months and thought they might have fixed it but doesn't seem like they will so I've just made the pattern handle the optional extra space.
<img width="1520" height="166" alt="image" src="https://github.com/user-attachments/assets/ffe75ac9-6962-45d4-ab03-db46e7bd0fb3" />
