### PR TITLE
feat: Setup config profiles (Part 3/3)

### DIFF
--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.type.StyleType;
 import com.wynntils.mc.event.ConnectionEvent;
@@ -45,7 +46,9 @@ public class DiscordRichPresenceFeature extends Feature {
     private TerritoryProfile lastTerritoryProfile = null;
 
     public DiscordRichPresenceFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ExtendedSeasonLeaderboardFeature.java
+++ b/common/src/main/java/com/wynntils/features/ExtendedSeasonLeaderboardFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.labels.event.LabelIdentifiedEvent;
 import com.wynntils.handlers.labels.event.TextDisplayChangedEvent;
@@ -39,7 +40,9 @@ public class ExtendedSeasonLeaderboardFeature extends Feature {
     private final Config<ColorChatFormatting> guildHighlightColor = new Config<>(ColorChatFormatting.GREEN);
 
     public ExtendedSeasonLeaderboardFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/LootrunFeature.java
+++ b/common/src/main/java/com/wynntils/features/LootrunFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 
@@ -32,7 +33,10 @@ public class LootrunFeature extends Feature {
     public final Config<Boolean> showNotes = new Config<>(true);
 
     public LootrunFeature() {
-        super(ProfileDefault.ENABLED);
+        // Enabled status for this doesn't really matter, but just for settings filters we disable it
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/TerritoryDefenseMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/TerritoryDefenseMessageFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.type.StyleType;
 import com.wynntils.mc.event.InventoryMouseClickedEvent;
@@ -38,7 +39,9 @@ public class TerritoryDefenseMessageFeature extends Feature {
     private final Queue<QueuedTerritory> queuedTerritories = new LinkedList<>();
 
     public TerritoryDefenseMessageFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.containers.event.ValuableFoundEvent;
 import com.wynntils.models.gear.type.GearType;
@@ -81,7 +82,7 @@ public class ValuableFoundFeature extends Feature {
     private final Config<Float> soundPitch = new Config<>(1.0f);
 
     public ValuableFoundFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/BombBellRelayFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/BombBellRelayFeature.java
@@ -12,12 +12,16 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.Persisted;
+import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
+import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.type.BombInfo;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
+@ConfigCategory(Category.CHAT)
 public class BombBellRelayFeature extends Feature {
     @RegisterKeyBind
     private final KeyBind relayPartyKeybind =
@@ -31,7 +35,9 @@ public class BombBellRelayFeature extends Feature {
     private final Config<Boolean> showTime = new Config<>(true);
 
     public BombBellRelayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private String getAndFormatLastBomb() {

--- a/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
@@ -30,7 +31,9 @@ public class ChatCoordinatesFeature extends Feature {
     private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s?");
 
     public ChatCoordinatesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
@@ -83,7 +84,7 @@ public class ChatItemFeature extends Feature {
     private final Map<String, String> chatItems = new HashMap<>();
 
     public ChatItemFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
@@ -53,7 +54,10 @@ public class ChatMentionFeature extends Feature {
     private List<Pattern> mentionPatterns;
 
     public ChatMentionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
 
         mentionPatterns = buildPattern();
     }

--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.handlers.chat.type.RecipientType;
 import com.wynntils.mc.event.ChatScreenCreateEvent;
@@ -46,7 +47,9 @@ public class ChatTabsFeature extends Feature {
     private final Config<Boolean> oldTabHotkey = new Config<>(false);
 
     public ChatTabsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/DeathCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/DeathCoordinatesFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.character.event.CharacterDeathEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -19,7 +20,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.CHAT)
 public class DeathCoordinatesFeature extends Feature {
     public DeathCoordinatesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/DialogueOptionOverrideFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/DialogueOptionOverrideFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.KeyInputEvent;
 import com.wynntils.utils.mc.McUtils;
 import net.minecraft.client.player.LocalPlayer;
@@ -18,7 +19,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.CHAT)
 public class DialogueOptionOverrideFeature extends Feature {
     public DialogueOptionOverrideFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/InputTranscriptionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/InputTranscriptionFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ChatScreenKeyTypedEvent;
 import com.wynntils.mc.event.ChatScreenSendEvent;
 import com.wynntils.mc.event.CommandSentEvent;
@@ -42,7 +43,10 @@ public class InputTranscriptionFeature extends Feature {
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
     public InputTranscriptionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.handlers.chat.type.MessageType;
@@ -74,7 +75,10 @@ public class MessageFilterFeature extends Feature {
     private final Config<Boolean> hidePartyFinder = new Config<>(false);
 
     public MessageFilterFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/AbbreviateMobHealthFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/AbbreviateMobHealthFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.core.text.type.StyleType;
@@ -32,7 +33,9 @@ public class AbbreviateMobHealthFeature extends Feature {
             Pattern.compile("(.*§[cb])(?<current>\\d+)(§.(?<max>\\/\\d+))?(§[cb4]\\s?❤.*)");
 
     public AbbreviateMobHealthFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/ChestBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/ChestBlockerFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerCloseEvent;
 import com.wynntils.models.containers.containers.reward.RewardContainer;
@@ -39,7 +40,7 @@ public class ChestBlockerFeature extends Feature {
     private final Config<EmeraldPouchTier> emeraldPouchTier = new Config<>(EmeraldPouchTier.EIGHT);
 
     public ChestBlockerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/ContentTrackerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/ContentTrackerFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.activities.event.ActivityTrackerUpdatedEvent;
 import com.wynntils.models.activities.type.ActivityType;
 import com.wynntils.utils.mc.McUtils;
@@ -36,7 +37,9 @@ public class ContentTrackerFeature extends Feature {
     public final Config<Boolean> hideOriginalMarker = new Config<>(true);
 
     public ContentTrackerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 
 @ConfigCategory(Category.COMBAT)
 public class CustomLootrunBeaconsFeature extends Feature {
@@ -21,7 +22,7 @@ public class CustomLootrunBeaconsFeature extends Feature {
     public final Config<Boolean> showAdditionalTextInWorld = new Config<>(true);
 
     public CustomLootrunBeaconsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/combat/FixCastingSpellsFromInventoryFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/FixCastingSpellsFromInventoryFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ArmSwingEvent;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -19,7 +20,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.COMBAT)
 public class FixCastingSpellsFromInventoryFeature extends Feature {
     public FixCastingSpellsFromInventoryFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerInteractEvent;
 import com.wynntils.mc.event.UseItemEvent;
 import com.wynntils.models.elements.type.PotionType;
@@ -34,7 +35,10 @@ public class HealthPotionBlockerFeature extends Feature {
     private final Config<Integer> threshold = new Config<>(95);
 
     public HealthPotionBlockerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.mc.event.UseItemEvent;
 import com.wynntils.models.items.items.game.HorseItem;
@@ -70,7 +71,9 @@ public class HorseMountFeature extends Feature {
     private final Config<Boolean> playWhistle = new Config<>(true);
 
     public HorseMountFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/LowHealthVignetteFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/LowHealthVignetteFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.utils.MathUtils;
@@ -42,7 +43,9 @@ public class LowHealthVignetteFeature extends Feature {
     private boolean shouldRender = false;
 
     public LowHealthVignetteFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)

--- a/common/src/main/java/com/wynntils/features/combat/MythicBoxScalerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/MythicBoxScalerFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.GroundItemEntityTransformEvent;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.ItemStack;
@@ -26,7 +27,7 @@ public class MythicBoxScalerFeature extends Feature {
     private final Config<Float> scale = new Config<>(1.5f);
 
     public MythicBoxScalerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/PreventTradesDuelsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/PreventTradesDuelsFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.PlayerAttackEvent;
 import com.wynntils.mc.event.PlayerInteractEvent;
@@ -35,7 +36,9 @@ public class PreventTradesDuelsFeature extends Feature {
     private final Config<Boolean> whenHoldingGatheringTool = new Config<>(false);
 
     public PreventTradesDuelsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ArmSwingEvent;
 import com.wynntils.mc.event.ChangeCarriedItemEvent;
 import com.wynntils.mc.event.TickEvent;
@@ -75,7 +76,7 @@ public class QuickCastFeature extends Feature {
     private int packetCountdown = 0;
 
     public QuickCastFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/RangeVisualizerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/RangeVisualizerFeature.java
@@ -16,6 +16,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerRenderEvent;
 import com.wynntils.mc.event.RenderTileLevelLastEvent;
 import com.wynntils.mc.event.TickEvent;
@@ -72,7 +73,9 @@ public class RangeVisualizerFeature extends Feature {
     private final Config<Boolean> showMajorIDCircles = new Config<>(true);
 
     public RangeVisualizerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     // Handles rendering for other players and ourselves in third person

--- a/common/src/main/java/com/wynntils/features/combat/ShamanTotemTrackingFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/ShamanTotemTrackingFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.extension.EntityExtension;
 import com.wynntils.models.abilities.event.TotemEvent;
 import com.wynntils.utils.colors.CommonColors;
@@ -37,7 +38,7 @@ public class ShamanTotemTrackingFeature extends Feature {
     private final Config<CustomColor> fourthTotemColor = new Config<>(CommonColors.GREEN);
 
     public ShamanTotemTrackingFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/SpellCastVignetteFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/SpellCastVignetteFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.spells.event.SpellEvent;
@@ -44,7 +45,10 @@ public class SpellCastVignetteFeature extends Feature {
     private float intensity;
 
     public SpellCastVignetteFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/TokenTrackerBellFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/TokenTrackerBellFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.token.event.TokenGatekeeperEvent;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.CappedValue;
@@ -24,7 +25,10 @@ public class TokenTrackerBellFeature extends Feature {
     private final Config<Boolean> playSound = new Config<>(true);
 
     public TokenTrackerBellFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.HashSet;
 import java.util.Set;
@@ -33,7 +34,7 @@ public class AddCommandExpansionFeature extends Feature {
     private final Set<String> suggestions = new HashSet<>();
 
     public AddCommandExpansionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.CommandSentEvent;
 import com.wynntils.mc.event.CommandSuggestionEvent;
@@ -30,7 +31,7 @@ public class CommandAliasesFeature extends Feature {
             new ArgumentAlias(List.of("guild", "gu", "guilds"), "territory", List.of("t", "terr"))));
 
     public CommandAliasesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)

--- a/common/src/main/java/com/wynntils/features/commands/CustomCommandKeybindsFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CustomCommandKeybindsFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.utils.mc.McUtils;
 import org.lwjgl.glfw.GLFW;
 
@@ -97,7 +98,9 @@ public class CustomCommandKeybindsFeature extends Feature {
             () -> this.executeKeybind(keybindCommand6.get(), commandType6.get()));
 
     public CustomCommandKeybindsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private void executeKeybind(String keybindCommand, CommandType commandType) {

--- a/common/src/main/java/com/wynntils/features/commands/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/FilterAdminCommandsFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.Set;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -35,7 +36,7 @@ public class FilterAdminCommandsFeature extends Feature {
             "wynnproxy");
 
     public FilterAdminCommandsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/embellishments/WarHornFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/WarHornFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.territories.event.GuildWarQueuedEvent;
 import com.wynntils.utils.mc.McUtils;
 import net.minecraft.resources.ResourceLocation;
@@ -28,7 +29,10 @@ public class WarHornFeature extends Feature {
     private final Config<Float> soundPitch = new Config<>(1.0f);
 
     public WarHornFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/embellishments/WybelSoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/WybelSoundFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.handlers.chat.type.RecipientType;
@@ -32,7 +33,10 @@ public class WybelSoundFeature extends Feature {
     private final Config<Boolean> hideText = new Config<>(false);
 
     public WybelSoundFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/embellishments/WynntilsCosmeticsFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/WynntilsCosmeticsFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerRenderLayerEvent;
 import com.wynntils.mc.extension.EntityRenderStateExtension;
 import com.wynntils.utils.mc.McUtils;
@@ -25,7 +26,7 @@ public class WynntilsCosmeticsFeature extends Feature {
     public final Config<Boolean> renderOwnCape = new Config<>(true);
 
     public WynntilsCosmeticsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerCloseEvent;
@@ -144,7 +145,9 @@ public class ContainerSearchFeature extends Feature {
     private ItemSearchQuery lastSearchQuery;
 
     public ContainerSearchFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/DisableRecipeBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/DisableRecipeBookFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RecipeBookButtonCreateEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -17,7 +18,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.INVENTORY)
 public class DisableRecipeBookFeature extends Feature {
     public DisableRecipeBookFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/DurabilityOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/DurabilityOverlayFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -42,7 +43,9 @@ public class DurabilityOverlayFeature extends Feature {
     private final Config<DurabilityRenderMode> durabilityRenderMode = new Config<>(DurabilityRenderMode.ARC);
 
     public DurabilityOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
 import com.wynntils.models.items.items.game.EmeraldPouchItem;
@@ -33,7 +34,9 @@ public class EmeraldPouchFillArcFeature extends Feature {
     private final Config<Boolean> renderFillArcInventory = new Config<>(true);
 
     public EmeraldPouchFillArcFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchHotkeyFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.items.items.game.EmeraldPouchItem;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.McUtils;
@@ -35,7 +36,10 @@ public class EmeraldPouchHotkeyFeature extends Feature {
             new KeyBind("Open Emerald Pouch", GLFW.GLFW_KEY_UNKNOWN, true, this::onOpenPouchKeyPress);
 
     public EmeraldPouchHotkeyFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private void onOpenPouchKeyPress() {

--- a/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.ItemCountOverlayRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -34,7 +35,7 @@ public class ExtendedItemCountFeature extends Feature {
     private boolean isInventory;
 
     public ExtendedItemCountFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/GuildBankHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/GuildBankHotkeyFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.MenuEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -32,7 +33,10 @@ public class GuildBankHotkeyFeature extends Feature {
     private boolean openGuildBank = false;
 
     public GuildBankHotkeyFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/HideAttackCooldownFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/HideAttackCooldownFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ItemCooldownRenderEvent;
 import com.wynntils.utils.wynn.ItemUtils;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -15,11 +16,13 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.INVENTORY)
 public class HideAttackCooldownFeature extends Feature {
     public HideAttackCooldownFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent
     public void onCooldownRender(ItemCooldownRenderEvent event) {
-        event.setCanceled(!ItemUtils.isWeapon(event.getItemStack()));
+        if (ItemUtils.isWeapon(event.getItemStack())) return;
+
+        event.setCanceled(true);
     }
 }

--- a/common/src/main/java/com/wynntils/features/inventory/IngredientPouchHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/IngredientPouchHotkeyFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.utils.wynn.InventoryUtils;
 import org.lwjgl.glfw.GLFW;
 
@@ -21,7 +22,10 @@ public class IngredientPouchHotkeyFeature extends Feature {
             new KeyBind("Open Ingredient Pouch", GLFW.GLFW_KEY_UNKNOWN, true, this::onOpenIngredientPouchKeyPress);
 
     public IngredientPouchHotkeyFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private void onOpenIngredientPouchKeyPress() {

--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.models.containers.containers.CharacterInfoContainer;
@@ -62,7 +63,10 @@ public class InventoryEmeraldCountFeature extends Feature {
     private final Config<Boolean> combineInventoryAndContainer = new Config<>(false);
 
     public InventoryEmeraldCountFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ItemFavoriteFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemFavoriteFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerCloseEvent;
@@ -59,7 +60,7 @@ public class ItemFavoriteFeature extends Feature {
     private int lootChestCloseOverrideCounter = 0;
 
     public ItemFavoriteFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.DataComponentGetEvent;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -160,7 +161,9 @@ public class ItemHighlightFeature extends Feature {
     private final Config<Boolean> selectedItemHighlight = new Config<>(true);
 
     public ItemHighlightFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerRenderEvent;
@@ -56,7 +57,7 @@ public class ItemLockFeature extends Feature {
     private final Config<Boolean> allowClickOnMultiHealthPotionsInBlockingMode = new Config<>(true);
 
     public ItemLockFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
@@ -18,6 +18,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.type.StyleType;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
@@ -70,7 +71,7 @@ public class ItemScreenshotFeature extends Feature {
     private Slot screenshotSlot = null;
 
     public ItemScreenshotFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     private void onInventoryPress(Slot hoveredSlot) {

--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -141,7 +142,9 @@ public class ItemTextOverlayFeature extends Feature {
     private final Config<TextShadow> tradeMarketFilterShadow = new Config<>(TextShadow.OUTLINE);
 
     public ItemTextOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/LootchestTextFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/LootchestTextFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.models.containers.containers.reward.LootChestContainer;
@@ -34,7 +35,10 @@ public class LootchestTextFeature extends Feature {
     private final Config<String> inventoryTextTemplate = new Config<>("§8Dry: {dry_streak}");
 
     public LootchestTextFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
@@ -56,7 +57,7 @@ public class PersonalStorageUtilitiesFeature extends Feature {
     private PersonalStorageUtilitiesWidget widget;
 
     public PersonalStorageUtilitiesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/UnidentifiedItemIconFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/UnidentifiedItemIconFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -74,7 +75,9 @@ public class UnidentifiedItemIconFeature extends Feature {
     private static final StyledText QUESTION_MARK_TEXT = StyledText.fromComponent(Component.literal("?"));
 
     public UnidentifiedItemIconFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderTileLevelLastEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.marker.type.MarkerInfo;
@@ -39,7 +40,7 @@ public class BeaconBeamFeature extends Feature {
     private CustomColor currentRainbowColor = CommonColors.RED;
 
     public BeaconBeamFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/map/GuildMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/GuildMapFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.screens.maps.GuildMapScreen;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
@@ -31,7 +32,9 @@ public class GuildMapFeature extends Feature {
             new KeyBind("Open Guild Map", GLFW.GLFW_KEY_J, false, this::openGuildMap);
 
     public GuildMapFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private void openGuildMap() {

--- a/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.PlayerAttackEvent;
 import com.wynntils.mc.event.PlayerInteractEvent;
@@ -127,7 +128,7 @@ public class MainMapFeature extends Feature {
             new KeyBind("New Waypoint", GLFW.GLFW_KEY_B, true, this::openWaypointSetup);
 
     public MainMapFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     private void openMainMap() {

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.minimap.CoordinateOverlay;
 import com.wynntils.overlays.minimap.MinimapOverlay;
@@ -39,6 +40,8 @@ public class MinimapFeature extends Feature {
             new KeyBind("Decrease Minimap Zoom", GLFW.GLFW_KEY_MINUS, false, () -> minimapOverlay.adjustZoomLevel(-2));
 
     public MinimapFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.event.RenderLevelEvent;
@@ -79,7 +80,7 @@ public class WorldWaypointDistanceFeature extends Feature {
     private final List<RenderedMarkerInfo> renderedMarkers = new ArrayList<>();
 
     public WorldWaypointDistanceFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/overlays/AnnihilationSunOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/AnnihilationSunOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.AnnihilationSunOverlay;
 
@@ -19,6 +20,9 @@ public class AnnihilationSunOverlayFeature extends Feature {
     private final Overlay sunOverlay = new AnnihilationSunOverlay();
 
     public AnnihilationSunOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ArrowShieldTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ArrowShieldTrackerOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ArrowShieldTrackerOverlay;
 
@@ -19,6 +20,9 @@ public class ArrowShieldTrackerOverlayFeature extends Feature {
     private final Overlay arrowShieldTrackerOverlay = new ArrowShieldTrackerOverlay();
 
     public ArrowShieldTrackerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/BombBellOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/BombBellOverlayFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.BombBellOverlay;
 
@@ -18,6 +19,8 @@ public class BombBellOverlayFeature extends Feature {
     public final BombBellOverlay bombBellOverlay = new BombBellOverlay();
 
     public BombBellOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/BonusTotemTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/BonusTotemTimerOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.GatheringTotemTimerOverlay;
 import com.wynntils.overlays.MobTotemTimerOverlay;
@@ -23,6 +24,9 @@ public class BonusTotemTimerOverlayFeature extends Feature {
     private final Overlay gatheringTotemTimerOverlay = new GatheringTotemTimerOverlay();
 
     public BonusTotemTimerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/CombatExperienceOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CombatExperienceOverlayFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.CombatExperienceOverlay;
 
@@ -20,6 +21,8 @@ public class CombatExperienceOverlayFeature extends Feature {
     private final Overlay combatExperienceOverlay = new CombatExperienceOverlay();
 
     public CombatExperienceOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ContentTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ContentTrackerOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ContentTrackerOverlay;
 
@@ -19,6 +20,8 @@ public class ContentTrackerOverlayFeature extends Feature {
     private final Overlay trackerOverlay = new ContentTrackerOverlay();
 
     public ContentTrackerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/CustomBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CustomBarsOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayGroup;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.custombars.BubbleTexturedCustomBarOverlay;
 import com.wynntils.overlays.custombars.ExperienceTexturedCustomBarOverlay;
@@ -38,6 +39,6 @@ public class CustomBarsOverlayFeature extends Feature {
     private final List<BubbleTexturedCustomBarOverlay> customBubbleBarOverlays = new ArrayList<>();
 
     public CustomBarsOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/CustomPlayerListOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CustomPlayerListOverlayFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.CustomPlayerListOverlay;
 
@@ -22,6 +23,9 @@ public class CustomPlayerListOverlayFeature extends Feature {
     private final Overlay customPlayerListOverlay = new CustomPlayerListOverlay();
 
     public CustomPlayerListOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.gamebars.AwakenedProgressBarOverlay;
 import com.wynntils.overlays.gamebars.BloodPoolBarOverlay;
@@ -63,6 +64,9 @@ public class GameBarsOverlayFeature extends Feature {
     private final MomentumBarOverlay momentumBarOverlay = new MomentumBarOverlay();
 
     public GameBarsOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.GameNotificationOverlay;
 
@@ -19,6 +20,8 @@ public class GameNotificationOverlayFeature extends Feature {
     private final Overlay gameNotificationOverlay = new GameNotificationOverlay();
 
     public GameNotificationOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/GuardianAngelsTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GuardianAngelsTrackerOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.GuardianAngelsTrackerOverlay;
 
@@ -19,6 +20,9 @@ public class GuardianAngelsTrackerOverlayFeature extends Feature {
     private final Overlay guardianAngelsTrackerOverlay = new GuardianAngelsTrackerOverlay();
 
     public GuardianAngelsTrackerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/HeldItemCooldownOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/HeldItemCooldownOverlayFeature.java
@@ -19,6 +19,6 @@ public class HeldItemCooldownOverlayFeature extends Feature {
     private final Overlay heldItemCooldownOverlay = new HeldItemCooldownOverlay();
 
     public HeldItemCooldownOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(ProfileDefault.DISABLED);
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/HeldItemNameOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/HeldItemNameOverlayFeature.java
@@ -5,10 +5,12 @@
 package com.wynntils.features.overlays;
 
 import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.HeldItemNameOverlay;
 
@@ -16,4 +18,11 @@ import com.wynntils.overlays.HeldItemNameOverlay;
 public class HeldItemNameOverlayFeature extends Feature {
     @OverlayInfo(renderType = RenderEvent.ElementType.GUI)
     private final Overlay heldItemNameOverlay = new HeldItemNameOverlay();
+
+    public HeldItemNameOverlayFeature() {
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
+    }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/InfoBoxFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/InfoBoxFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayGroup;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.infobox.InfoBoxOverlay;
 import java.util.ArrayList;
@@ -21,6 +22,6 @@ public class InfoBoxFeature extends Feature {
     private final List<InfoBoxOverlay> infoBoxOverlays = new ArrayList<>();
 
     public InfoBoxFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/LootrunOverlaysFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/LootrunOverlaysFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.lootrun.LootrunBeaconCountOverlay;
 import com.wynntils.overlays.lootrun.LootrunMissionsOverlay;
@@ -31,6 +32,8 @@ public class LootrunOverlaysFeature extends Feature {
     private final Overlay lootrunTrialOverlay = new LootrunTrialsOverlay();
 
     public LootrunOverlaysFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/MantleShieldTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/MantleShieldTrackerOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.MantleShieldTrackerOverlay;
 
@@ -19,6 +20,9 @@ public class MantleShieldTrackerOverlayFeature extends Feature {
     private final Overlay mantleShieldTrackerOverlay = new MantleShieldTrackerOverlay();
 
     public MantleShieldTrackerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/NpcDialogueFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/NpcDialogueFeature.java
@@ -16,6 +16,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.type.NpcDialogueType;
 import com.wynntils.mc.event.KeyInputEvent;
@@ -104,7 +105,7 @@ public class NpcDialogueFeature extends Feature {
     private StyledText displayedHelperMessage = null;
 
     public NpcDialogueFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
 
         // Add this feature as a dependent of the NpcDialogueModel
         Models.NpcDialogue.addNpcDialogExtractionDependent(this);

--- a/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.objectives.DailyObjectiveOverlay;
 import com.wynntils.overlays.objectives.GuildObjectiveOverlay;
@@ -23,6 +24,9 @@ public class ObjectivesOverlayFeature extends Feature {
     public final Overlay dailyObjectiveOverlay = new DailyObjectiveOverlay();
 
     public ObjectivesOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/PartyMembersOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/PartyMembersOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.PartyMembersOverlay;
 
@@ -19,6 +20,8 @@ public class PartyMembersOverlayFeature extends Feature {
     private final Overlay partyMembersOverlay = new PartyMembersOverlay();
 
     public PartyMembersOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/PowderSpecialBarOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/PowderSpecialBarOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.PowderSpecialBarOverlay;
 
@@ -19,6 +20,9 @@ public class PowderSpecialBarOverlayFeature extends Feature {
     private final Overlay powderSpecialBarOverlay = new PowderSpecialBarOverlay();
 
     public PowderSpecialBarOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/RaidProgressFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/RaidProgressFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.raid.event.RaidEndedEvent;
 import com.wynntils.models.raid.event.RaidNewBestTimeEvent;
@@ -39,7 +40,10 @@ public class RaidProgressFeature extends Feature {
     private final Config<Boolean> playSoundOnBest = new Config<>(true);
 
     public RaidProgressFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/overlays/ScoreboardOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ScoreboardOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ScoreboardOverlay;
 
@@ -19,6 +20,9 @@ public class ScoreboardOverlayFeature extends Feature {
     private final Overlay scoreboardOverlay = new ScoreboardOverlay();
 
     public ScoreboardOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ServerUptimeInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ServerUptimeInfoOverlayFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ServerUptimeInfoOverlay;
 
@@ -20,6 +21,9 @@ public class ServerUptimeInfoOverlayFeature extends Feature {
     private final Overlay ServerUptimeInfoOverlay = new ServerUptimeInfoOverlay();
 
     public ServerUptimeInfoOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ShamanMaskOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ShamanMaskOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ShamanMaskOverlay;
 
@@ -19,6 +20,9 @@ public class ShamanMaskOverlayFeature extends Feature {
     private final Overlay shamanMaskOverlay = new ShamanMaskOverlay();
 
     public ShamanMaskOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ShamanTotemTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ShamanTotemTimerOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ShamanTotemTimerOverlay;
 
@@ -19,6 +20,9 @@ public class ShamanTotemTimerOverlayFeature extends Feature {
     private final Overlay shamanTotemTimerOverlay = new ShamanTotemTimerOverlay();
 
     public ShamanTotemTimerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/SpellCastMessageOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/SpellCastMessageOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.SpellCastMessageOverlay;
 import com.wynntils.overlays.SpellInputsOverlay;
@@ -23,6 +24,9 @@ public class SpellCastMessageOverlayFeature extends Feature {
     private final Overlay spellInputsOverlay = new SpellInputsOverlay();
 
     public SpellCastMessageOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/StatusEffectsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/StatusEffectsOverlayFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.StatusEffectsOverlay;
 
@@ -18,6 +19,9 @@ public class StatusEffectsOverlayFeature extends Feature {
     public final StatusEffectsOverlay statusEffectsOverlay = new StatusEffectsOverlay();
 
     public StatusEffectsOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/StopwatchFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/StopwatchFeature.java
@@ -16,6 +16,7 @@ import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.stopwatch.StopwatchOverlay;
 import net.minecraft.commands.CommandSourceStack;
@@ -62,7 +63,10 @@ public class StopwatchFeature extends Feature {
     private final Overlay stopwatchOverlay = new StopwatchOverlay();
 
     public StopwatchFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private void toggleStopwatch() {

--- a/common/src/main/java/com/wynntils/features/overlays/TerritoryAttackTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TerritoryAttackTimerOverlayFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.TerritoryAttackTimerOverlay;
 
@@ -24,6 +25,9 @@ public class TerritoryAttackTimerOverlayFeature extends Feature {
     public final Config<Boolean> displayBeaconBeam = new Config<>(true);
 
     public TerritoryAttackTimerOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/TokenBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TokenBarsOverlayFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.TokenBarsOverlay;
 
@@ -19,6 +20,9 @@ public class TokenBarsOverlayFeature extends Feature {
     private final Overlay tokenBarsOverlay = new TokenBarsOverlay();
 
     public TokenBarsOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/TowerEffectOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TowerEffectOverlayFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.war.event.GuildWarTowerEffectEvent;
 import com.wynntils.overlays.TowerAuraTimerOverlay;
@@ -72,7 +73,10 @@ public class TowerEffectOverlayFeature extends Feature {
     private final Config<Float> volleyVignetteIntensity = new Config<>(0.4f);
 
     public TowerEffectOverlayFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/overlays/TowerStatsFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TowerStatsFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.war.event.GuildWarEvent;
@@ -38,7 +39,10 @@ public class TowerStatsFeature extends Feature {
     private final Config<Boolean> printTowerStatsOnEnd = new Config<>(true);
 
     public TowerStatsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/AutoJoinPartyFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/AutoJoinPartyFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.players.event.PartyEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -27,7 +28,10 @@ public class AutoJoinPartyFeature extends Feature {
     private final Config<Boolean> onlySameWorld = new Config<>(true);
 
     public AutoJoinPartyFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.features.tooltips.ItemStatInfoFeature;
 import com.wynntils.mc.event.EntityNameTagRenderEvent;
 import com.wynntils.mc.event.GetCameraEntityEvent;
@@ -93,7 +94,9 @@ public class CustomNametagRendererFeature extends Feature {
     private Player hitPlayerCache = null;
 
     public CustomNametagRendererFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/HadesFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/HadesFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.hades.protocol.enums.SocialType;
 
 @ConfigCategory(Category.PLAYERS)
@@ -29,7 +30,9 @@ public class HadesFeature extends Feature {
     public final Config<Boolean> shareWithGuild = new Config<>(true);
 
     public HadesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/players/PartyManagementScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PartyManagementScreenFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ScreenClosedEvent;
 import com.wynntils.models.players.event.FriendsEvent;
 import com.wynntils.models.players.event.PartyEvent;
@@ -31,7 +32,9 @@ public class PartyManagementScreenFeature extends Feature {
             });
 
     public PartyManagementScreenFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/PlayerGhostTransparencyFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PlayerGhostTransparencyFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerRenderLayerEvent;
 import com.wynntils.mc.event.RenderTranslucentCheckEvent;
 import com.wynntils.mc.extension.EntityRenderStateExtension;
@@ -27,7 +28,9 @@ public class PlayerGhostTransparencyFeature extends Feature {
     private final Config<Boolean> transparentPlayerGhostArmor = new Config<>(true);
 
     public PlayerGhostTransparencyFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/PlayerViewerFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PlayerViewerFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.players.event.FriendsEvent;
 import com.wynntils.models.players.event.PartyEvent;
 import com.wynntils.screens.playerviewer.PlayerViewerScreen;
@@ -35,7 +36,9 @@ public class PlayerViewerFeature extends Feature {
     private PlayerViewerScreen playerViewerScreen = null;
 
     public PlayerViewerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private void tryOpenPlayerViewer() {

--- a/common/src/main/java/com/wynntils/features/redirects/AbilityRefreshRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/AbilityRefreshRedirectFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.type.StyleType;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import java.util.regex.Pattern;
@@ -19,7 +20,9 @@ public class AbilityRefreshRedirectFeature extends Feature {
     private static final Pattern REFRESH_PATTERN = Pattern.compile("\\[⬤\\] (.+) has been refreshed!");
 
     public AbilityRefreshRedirectFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.handlers.chat.type.MessageType;
@@ -101,7 +102,9 @@ public class ChatRedirectFeature extends Feature {
     private final List<Redirector> redirectors = new ArrayList<>();
 
     public ChatRedirectFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
 
         register(new BlacksmithRedirector());
         register(new BloodPactHealthDeficitRedirector());

--- a/common/src/main/java/com/wynntils/features/redirects/InventoryRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/InventoryRedirectFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
@@ -39,7 +40,9 @@ public class InventoryRedirectFeature extends Feature {
     private final Config<Boolean> redirectPotionStack = new Config<>(true);
 
     public InventoryRedirectFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/redirects/TerritoryMessageRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/TerritoryMessageRedirectFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.mc.event.SubtitleSetTextEvent;
@@ -22,7 +23,9 @@ public class TerritoryMessageRedirectFeature extends Feature {
     private static final Pattern TERRITORY_MESSAGE_PATTERN = Pattern.compile("§7\\[You are now (\\S+) (.+)\\]");
 
     public TerritoryMessageRedirectFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     // Handles the subtitle text event.

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemCompareFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemCompareFeature.java
@@ -16,6 +16,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerCloseEvent;
@@ -102,7 +103,9 @@ public class ItemCompareFeature extends Feature {
     private boolean changePositioner = false;
 
     public ItemCompareFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.models.emeralds.type.EmeraldUnits;
@@ -36,7 +37,9 @@ public class ItemGuessFeature extends Feature {
     private final Config<Boolean> showGuessesPrice = new Config<>(true);
 
     public ItemGuessFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
 import com.wynntils.handlers.tooltip.type.TooltipStyle;
 import com.wynntils.handlers.tooltip.type.TooltipWeightDecorator;
@@ -128,7 +129,9 @@ public class ItemStatInfoFeature extends Feature {
     private NavigableMap<Float, TextColor> flatMap = createFlatMap();
 
     public ItemStatInfoFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/tooltips/TooltipFittingFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/TooltipFittingFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.event.TooltipRenderEvent;
 import com.wynntils.utils.mc.ComponentUtils;
@@ -41,7 +42,7 @@ public class TooltipFittingFeature extends Feature {
     private float lastScaleFactor = 1f;
 
     public TooltipFittingFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     // scaling should only happen after every other feature has updated tooltip

--- a/common/src/main/java/com/wynntils/features/tooltips/TooltipVanillaHideFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/TooltipVanillaHideFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ItemTooltipFlagsEvent;
 import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -20,7 +21,9 @@ public class TooltipVanillaHideFeature extends Feature {
     private final Config<Boolean> hideAdvanced = new Config<>(true);
 
     public TooltipVanillaHideFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketBulkSellFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketBulkSellFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.containers.containers.trademarket.TradeMarketSellContainer;
 import com.wynntils.models.trademarket.event.TradeMarketChatInputEvent;
 import com.wynntils.models.trademarket.event.TradeMarketSellDialogueUpdatedEvent;
@@ -41,7 +42,10 @@ public class TradeMarketBulkSellFeature extends Feature {
     private int amountToSend = 0;
 
     public TradeMarketBulkSellFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceConversionFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceConversionFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ChatSentEvent;
 import com.wynntils.models.trademarket.type.TradeMarketState;
 import com.wynntils.utils.mc.McUtils;
@@ -17,7 +18,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.TRADEMARKET)
 public class TradeMarketPriceConversionFeature extends Feature {
     public TradeMarketPriceConversionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceMatchFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceMatchFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.account.AccountModel;
 import com.wynntils.models.containers.containers.trademarket.TradeMarketSellContainer;
 import com.wynntils.models.trademarket.TradeMarketModel;
@@ -38,7 +39,10 @@ public class TradeMarketPriceMatchFeature extends Feature {
     private long priceToSend = 0;
 
     public TradeMarketPriceMatchFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketQuickSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketQuickSearchFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.MenuEvent.MenuClosedEvent;
 import com.wynntils.mc.event.ScreenClosedEvent;
@@ -86,7 +87,9 @@ public class TradeMarketQuickSearchFeature extends Feature {
     private boolean instantSearchingCloseMenu = false;
 
     public TradeMarketQuickSearchFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.core.text.type.StyleType;
@@ -74,7 +75,10 @@ public class BulkBuyFeature extends Feature {
     private int bulkBoughtPrice = 0; // Price of a single item
 
     public BulkBuyFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/ContainerScrollFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/ContainerScrollFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.MouseScrollEvent;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
 import com.wynntils.utils.mc.McUtils;
@@ -27,7 +28,7 @@ public class ContainerScrollFeature extends Feature {
     private final Config<Boolean> invertScroll = new Config<>(false);
 
     public ContainerScrollFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CraftingProfessionLevelProgressBarFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CraftingProfessionLevelProgressBarFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.models.containers.containers.CraftingStationContainer;
@@ -33,7 +34,9 @@ public class CraftingProfessionLevelProgressBarFeature extends Feature {
     private final Config<ObjectivesTextures> texture = new Config<>(ObjectivesTextures.WYNN);
 
     public CraftingProfessionLevelProgressBarFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CustomGuildLogScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomGuildLogScreenFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.wrappedscreen.event.WrappedScreenOpenEvent;
 import com.wynntils.mc.event.ContainerClickEvent;
@@ -31,7 +32,9 @@ public class CustomGuildLogScreenFeature extends Feature {
     private boolean shiftClickedLogItem = false;
 
     public CustomGuildLogScreenFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CustomSeaskipperScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomSeaskipperScreenFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ScreenOpenedEvent;
 import com.wynntils.models.containers.containers.SeaskipperContainer;
 import com.wynntils.screens.maps.CustomSeaskipperScreen;
@@ -29,7 +30,9 @@ public class CustomSeaskipperScreenFeature extends Feature {
     public final Config<CustomColor> pointerColor = new Config<>(new CustomColor(1f, 1f, 1f, 1f));
 
     public CustomSeaskipperScreenFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
@@ -14,6 +14,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.wrappedscreen.event.WrappedScreenOpenEvent;
@@ -62,7 +63,9 @@ public class CustomTerritoryManagementScreenFeature extends Feature {
     private boolean openTerritoryManagement = false;
 
     public CustomTerritoryManagementScreenFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CustomTradeMarketResultScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomTradeMarketResultScreenFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.wrappedscreen.event.WrappedScreenOpenEvent;
 import com.wynntils.mc.event.ContainerClickEvent;
@@ -37,7 +38,9 @@ public class CustomTradeMarketResultScreenFeature extends Feature {
     private boolean shiftClickedSearchItem = false;
 
     public CustomTradeMarketResultScreenFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/LobbyUptimeFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/LobbyUptimeFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.models.items.items.gui.ServerItem;
 import com.wynntils.models.worlds.profile.ServerProfile;
@@ -23,7 +24,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.UI)
 public class LobbyUptimeFeature extends Feature {
     public LobbyUptimeFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/ProfessionHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/ProfessionHighlightFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -53,7 +54,10 @@ public class ProfessionHighlightFeature extends Feature {
     private final Storage<Map<String, ProfessionType>> selectionPerContainer = new Storage<>(new TreeMap<>());
 
     public ProfessionHighlightFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
@@ -17,6 +17,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ScreenInitEvent;
@@ -81,7 +82,7 @@ public class WynncraftButtonFeature extends Feature {
     private final Config<Boolean> returnToTitle = new Config<>(true);
 
     public WynncraftButtonFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.wrappedscreen.event.WrappedScreenOpenEvent;
 import com.wynntils.mc.event.ArmSwingEvent;
@@ -136,7 +137,9 @@ public class WynntilsContentBookFeature extends Feature {
     private boolean shiftClickedBookItem = false;
 
     public WynntilsContentBookFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/AutoApplyResourcePackFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/AutoApplyResourcePackFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ServerResourcePackEvent;
 import java.util.UUID;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -17,7 +18,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.UTILITIES)
 public class AutoApplyResourcePackFeature extends Feature {
     public AutoApplyResourcePackFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/utilities/CharacterSelectionUtilitiesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/CharacterSelectionUtilitiesFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
 import com.wynntils.mc.event.KeyInputEvent;
 import com.wynntils.mc.event.RenderEvent;
@@ -32,7 +33,7 @@ public class CharacterSelectionUtilitiesFeature extends Feature {
     private final Config<Boolean> hideCrosshair = new Config<>(true);
 
     public CharacterSelectionUtilitiesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/FixCrosshairPositionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/FixCrosshairPositionFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.consumers.overlays.OverlayPosition;
 import com.wynntils.core.consumers.overlays.SectionCoordinates;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.utils.mc.McUtils;
 import net.minecraft.client.Minecraft;
@@ -24,7 +25,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.UTILITIES)
 public class FixCrosshairPositionFeature extends Feature {
     public FixCrosshairPositionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     private static boolean shouldOverrideCrosshair() {

--- a/common/src/main/java/com/wynntils/features/utilities/GammabrightFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/GammabrightFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.DimensionAmbientLightEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 import org.lwjgl.glfw.GLFW;
@@ -26,7 +27,7 @@ public class GammabrightFeature extends Feature {
             new KeyBind("Gammabright", GLFW.GLFW_KEY_G, true, this::toggleGammaBright);
 
     public GammabrightFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/PerCharacterGuildContributionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/PerCharacterGuildContributionFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
@@ -41,7 +42,9 @@ public class PerCharacterGuildContributionFeature extends Feature {
     private boolean waitingForCommandResponse = false;
 
     public PerCharacterGuildContributionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/SilencerFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/SilencerFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -50,7 +51,10 @@ public class SilencerFeature extends Feature {
     private boolean firstTitleScreenInit = true;
 
     public SilencerFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/SkillPointLoadoutsFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/SkillPointLoadoutsFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ScreenOpenedEvent;
 import com.wynntils.models.containers.containers.CharacterInfoContainer;
 import com.wynntils.screens.base.widgets.WynntilsButton;
@@ -21,7 +22,9 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.UTILITIES)
 public class SkillPointLoadoutsFeature extends Feature {
     public SkillPointLoadoutsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.core.text.type.StyleType;
@@ -55,7 +56,10 @@ public class TranscribeMessagesFeature extends Feature {
     private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s?");
 
     public TranscribeMessagesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/utilities/ValuablesProtectionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/ValuablesProtectionFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerCloseEvent;
@@ -98,7 +99,9 @@ public class ValuablesProtectionFeature extends Feature {
     private int emphasizeDirection = 1; // 1 for forward, -1 for reverse
 
     public ValuablesProtectionFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/utilities/XpGainMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/XpGainMessageFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.characterstats.event.CombatXpGainEvent;
 import com.wynntils.models.profession.event.ProfessionXpGainEvent;
@@ -47,7 +48,10 @@ public class XpGainMessageFeature extends Feature {
     private final Map<ProfessionType, Float> lastRawProfessionXpGains = new EnumMap<>(ProfessionType.class);
 
     public XpGainMessageFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerInfoEvent;
 import com.wynntils.utils.mc.McUtils;
 import java.util.function.Supplier;
@@ -23,7 +24,7 @@ public class BetaWarningFeature extends Feature {
     private WarnType warnType = WarnType.NONE;
 
     public BetaWarningFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/ChangelogFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/ChangelogFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.screens.changelog.ChangelogScreen;
@@ -20,7 +21,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.WYNNTILS)
 public class ChangelogFeature extends Feature {
     public ChangelogFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
@@ -10,6 +10,7 @@ import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -32,7 +33,10 @@ public class DataCrowdSourcingFeature extends Feature {
             new HiddenConfig<>(new TreeMap<>());
 
     public DataCrowdSourcingFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/DownloadProgressFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DownloadProgressFeature.java
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.net.event.DownloadEvent;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.utils.mc.McUtils;
 import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.network.chat.Component;
@@ -17,7 +18,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.WYNNTILS)
 public class DownloadProgressFeature extends Feature {
     public DownloadProgressFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/FixPacketBugsFeature.java
@@ -8,6 +8,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.AddEntityLookupEvent;
 import com.wynntils.mc.event.PlayerInfoUpdateEvent;
 import com.wynntils.mc.event.PlayerTeamEvent;
@@ -27,7 +28,7 @@ public class FixPacketBugsFeature extends Feature {
     private static final int METHOD_ADD = 0;
 
     public FixPacketBugsFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/wynntils/TelemetryFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/TelemetryFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.utils.JsonUtils;
@@ -35,7 +36,10 @@ public class TelemetryFeature extends Feature {
     private final Config<ConfirmedBoolean> crashReports = new Config<>(ConfirmedBoolean.UNCONFIRMED);
 
     public TelemetryFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(
+                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
@@ -13,6 +13,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.services.athena.type.UpdateResult;
 import com.wynntils.utils.mc.McUtils;
@@ -32,7 +33,7 @@ public class UpdatesFeature extends Feature {
     private final Config<Boolean> autoUpdate = new Config<>(false);
 
     public UpdatesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/WeeklyConfigBackupFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/WeeklyConfigBackupFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.utils.FileUtils;
@@ -28,7 +29,7 @@ public class WeeklyConfigBackupFeature extends Feature {
     private final Storage<Long> lastBackup = new Storage<>(0L);
 
     public WeeklyConfigBackupFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/WynntilsHintMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/WynntilsHintMessagesFeature.java
@@ -11,6 +11,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -21,7 +22,9 @@ public class WynntilsHintMessagesFeature extends Feature {
     private final Config<Boolean> firstJoinOnly = new Config<>(true);
 
     public WynntilsHintMessagesFeature() {
-        super(ProfileDefault.ENABLED);
+        super(new ProfileDefault.Builder()
+                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/overlays/HeldItemCooldownOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/HeldItemCooldownOverlay.java
@@ -31,7 +31,6 @@ public class HeldItemCooldownOverlay extends Overlay {
                         HorizontalAlignment.CENTER,
                         OverlayPosition.AnchorSection.MIDDLE),
                 new OverlaySize(80, 14));
-        this.userEnabled.store(false);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/overlays/NpcDialogueOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/NpcDialogueOverlay.java
@@ -76,6 +76,7 @@ public class NpcDialogueOverlay extends Overlay {
                 HorizontalAlignment.CENTER,
                 VerticalAlignment.MIDDLE);
         updateTextRenderSettings();
+        // TODO: When issues with NPC Dialogue solved, only disable this for the MINIMAL and BLANK_SLATE profiles
         this.userEnabled.store(false);
     }
 


### PR DESCRIPTION
This is the final bit, just setting all the feature defaults. Once this is merged I'll pr the config-profiles branch into main so we can look over the whole system one final time to check it's all good

2 other changes were made here that I noticed whilst setting these, 1st was bomb bell relay was missing the config category and 2nd was changing hide attack cooldown to return early if the item is not a weapon instead of setting the event as cancelled based on that.