### PR TITLE
fix: Always mark scoreboard as outdated on reset score

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/scoreboard/ScoreboardHandler.java
@@ -77,8 +77,6 @@ public final class ScoreboardHandler extends Handler {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onSetScore(ScoreboardEvent.Reset event) {
-        if (!currentScoreboardName.equals(event.getObjectiveName())) return;
-
         updateNextTick();
     }
 


### PR DESCRIPTION
When the Upcoming Attacks segment disappears, the objective name is null, so that wouldn't mark the scoreboard as outdated and would leave the timer on there.

Could check that it is null or equal to `currentScoreboardName` but I think it makes sense to always mark for update when a reset is sent