### PR TITLE
fix: guard hotkey index

### DIFF
--- a/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
+++ b/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
@@ -54,9 +54,7 @@ public final class ChatTabService extends Service {
     }
 
     public ChatTab getTab(int index) {
-        if (index < 0 || index >= getChatTabs().size()) {
-            return null;
-        }
+        if (index < 0 || index >= getChatTabs().size()) return null;
         return getChatTabs().get(index);
     }
 

--- a/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
+++ b/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
@@ -113,9 +113,7 @@ public final class ChatTabService extends Service {
 
     public void setFocusedTab(int index) {
         ChatTab tab = getTab(index);
-        if (tab == null) {
-            return;
-        }
+        if (tab == null) return;
         setFocusedTab(tab);
     }
 

--- a/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
+++ b/common/src/main/java/com/wynntils/services/chat/ChatTabService.java
@@ -54,6 +54,9 @@ public final class ChatTabService extends Service {
     }
 
     public ChatTab getTab(int index) {
+        if (index < 0 || index >= getChatTabs().size()) {
+            return null;
+        }
         return getChatTabs().get(index);
     }
 
@@ -111,7 +114,11 @@ public final class ChatTabService extends Service {
     }
 
     public void setFocusedTab(int index) {
-        setFocusedTab(getTab(index));
+        ChatTab tab = getTab(index);
+        if (tab == null) {
+            return;
+        }
+        setFocusedTab(tab);
     }
 
     public void setFocusedTab(ChatTab focused) {


### PR DESCRIPTION
prevents crash when pressing ctrl+1..9 if the tab index is out of range.