### PR TITLE
feat: Per character gear sharing settings

### DIFF
--- a/common/src/main/java/com/wynntils/screens/playerviewer/GearSharingSettingsScreen.java
+++ b/common/src/main/java/com/wynntils/screens/playerviewer/GearSharingSettingsScreen.java
@@ -10,6 +10,7 @@ import com.wynntils.models.inventory.type.InventoryAccessory;
 import com.wynntils.models.inventory.type.InventoryArmor;
 import com.wynntils.screens.base.widgets.WynntilsCheckbox;
 import com.wynntils.utils.EnumUtils;
+import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
@@ -41,11 +42,57 @@ public class GearSharingSettingsScreen extends WynntilsScreen {
         offsetX = (this.width - Texture.PLAYER_VIEWER_BACKGROUND.width()) / 2;
         offsetY = (this.height - Texture.PLAYER_VIEWER_BACKGROUND.height()) / 2;
 
+        buildWidgets();
+    }
+
+    @Override
+    public void onClose() {
+        Services.Hades.saveGearShareOptions();
+        McUtils.setScreen(previousScreen);
+    }
+
+    @Override
+    public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+
+        RenderUtils.drawTexturedRect(guiGraphics.pose(), Texture.PLAYER_VIEWER_BACKGROUND, offsetX, offsetY);
+
+        InventoryScreen.renderEntityInInventoryFollowsMouse(
+                guiGraphics,
+                offsetX + 13,
+                offsetY - 4,
+                offsetX + 13 + Texture.PLAYER_VIEWER_BACKGROUND.width(),
+                offsetY - 4 + Texture.PLAYER_VIEWER_BACKGROUND.height(),
+                30,
+                0.2f,
+                mouseX,
+                mouseY,
+                McUtils.player());
+    }
+
+    private void buildWidgets() {
+        this.clearWidgets();
+
         this.addRenderableWidget(new Button.Builder(
                         Component.translatable("screens.wynntils.gearSharingSettings.back"), (button -> onClose()))
                 .pos(offsetX + 1, offsetY - 21)
                 .size(Texture.PLAYER_VIEWER_BACKGROUND.width() - 2, 20)
                 .build());
+
+        this.addRenderableWidget(new WynntilsCheckbox(
+                offsetX,
+                offsetY + Texture.PLAYER_VIEWER_BACKGROUND.height() + 2,
+                16,
+                Component.translatable("screens.wynntils.gearSharingSettings.globalShareSettings"),
+                !Services.Hades.isCharacterGearShareEnabled(),
+                Texture.PLAYER_VIEWER_BACKGROUND.width() - 16,
+                (checkbox, bl) -> {
+                    Services.Hades.toggleCharacterGearShareEnabled();
+                    buildWidgets();
+                },
+                ComponentUtils.wrapTooltips(
+                        List.of(Component.translatable("screens.wynntils.gearSharingSettings.globalOrCharacter")),
+                        150)));
 
         this.addRenderableWidget(new WynntilsCheckbox(
                 offsetX + 100,
@@ -122,30 +169,5 @@ public class GearSharingSettingsScreen extends WynntilsScreen {
                     Services.Hades.getGearShareOptions().setShareCraftedNames(bl);
                 },
                 List.of(Component.translatable("screens.wynntils.gearSharingSettings.shareItemNamesTooltip"))));
-    }
-
-    @Override
-    public void onClose() {
-        Services.Hades.saveGearShareOptions();
-        McUtils.setScreen(previousScreen);
-    }
-
-    @Override
-    public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        super.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
-
-        RenderUtils.drawTexturedRect(guiGraphics.pose(), Texture.PLAYER_VIEWER_BACKGROUND, offsetX, offsetY);
-
-        InventoryScreen.renderEntityInInventoryFollowsMouse(
-                guiGraphics,
-                offsetX + 13,
-                offsetY - 4,
-                offsetX + 13 + Texture.PLAYER_VIEWER_BACKGROUND.width(),
-                offsetY - 4 + Texture.PLAYER_VIEWER_BACKGROUND.height(),
-                30,
-                0.2f,
-                mouseX,
-                mouseY,
-                McUtils.player());
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2867,6 +2867,8 @@
   "screens.wynntils.downloads.name": "Downloads",
   "screens.wynntils.downloads.tryRedownload": "Click to try and redownload data",
   "screens.wynntils.gearSharingSettings.back": "Back",
+  "screens.wynntils.gearSharingSettings.globalOrCharacter": "Use global or per character sharing settings for this character?",
+  "screens.wynntils.gearSharingSettings.globalShareSettings": "Global Share Settings",
   "screens.wynntils.gearSharingSettings.shareCraftedGear": "Share Crafted Gear",
   "screens.wynntils.gearSharingSettings.shareCraftedGearTooltip": "Should gear be sent if it is crafted?",
   "screens.wynntils.gearSharingSettings.shareHeldItem": "Share Held Item",


### PR DESCRIPTION
Adds a new checkbox to the gear sharing settings screen for whether to use the global settings (Settings that have existed since the feature was reworked) or to use sharing settings specific to your current character