### PR TITLE
fix: Fix item highlights changing order of string model data

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -244,8 +244,9 @@ public class ItemHighlightFeature extends Feature {
     public void onGetModelData(DataComponentGetEvent.CustomModelData event) {
         CustomModelData itemStackModelData = event.getOriginalValue();
 
+        // The index of model data matters, so instead of removing the tier string, just replace it with an empty string
         List<String> newStrings = itemStackModelData.strings().stream()
-                .filter(s -> DEFAULT_HIGHLIGHT_KEYS.stream().noneMatch(s::startsWith))
+                .map(s -> DEFAULT_HIGHLIGHT_KEYS.stream().anyMatch(s::startsWith) ? "" : s)
                 .toList();
 
         if (!newStrings.equals(itemStackModelData.strings())) {


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Wynntils/issues/3672

<img width="522" height="139" alt="image" src="https://github.com/user-attachments/assets/b05b7ce3-e610-448c-9ce5-accc0dd7af43" />

Sneaky 1.21.11 highlight texture as forgot I was on that branch when fixing