### PR TITLE
chore: Cache gradle shared data for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,12 @@ jobs:
           path: .gradle
           key: ${{ runner.os }}-gradle--${{ hashFiles('**/settings.gradle', '**/gradle.properties') }}
 
+      - name: Cache Gradle shared data
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.home }}/.gradle/caches
+          key: ${{ runner.os }}-gradle-shared--${{ hashFiles('**/settings.gradle', '**/gradle.properties') }}
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 


### PR DESCRIPTION
I noticed the GHA build still took several minutes. It turns out we only save half of the relevant caches.