### PR TITLE
refactor: Specify enabled in ProfileDefault instead of disabled

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/ProfileDefault.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/ProfileDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.features;
@@ -13,7 +13,15 @@ public record ProfileDefault(Map<ConfigProfile, Boolean> defaults) {
     public static final ProfileDefault DISABLED = new Builder().setAll(false).build();
 
     public boolean getDefault(ConfigProfile profile) {
-        return defaults.getOrDefault(profile, true);
+        return defaults.getOrDefault(profile, false);
+    }
+
+    public static ProfileDefault onlyDefault() {
+        ProfileDefault.Builder builder = new ProfileDefault.Builder();
+
+        builder.enabledFor(ConfigProfile.DEFAULT);
+
+        return builder.build();
     }
 
     public static class Builder {
@@ -21,14 +29,17 @@ public record ProfileDefault(Map<ConfigProfile, Boolean> defaults) {
 
         private Builder setAll(boolean value) {
             for (ConfigProfile profile : ConfigProfile.values()) {
+                // Blank slate is always disabled unless explicitly enabled in enabledFor
+                if (profile == ConfigProfile.BLANK_SLATE) continue;
+
                 defaults.put(profile, value);
             }
             return this;
         }
 
-        public Builder disableFor(ConfigProfile... profiles) {
+        public Builder enabledFor(ConfigProfile... profiles) {
             for (ConfigProfile profile : profiles) {
-                defaults.put(profile, false);
+                defaults.put(profile, true);
             }
 
             return this;

--- a/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
+++ b/common/src/main/java/com/wynntils/features/DiscordRichPresenceFeature.java
@@ -47,7 +47,7 @@ public class DiscordRichPresenceFeature extends Feature {
 
     public DiscordRichPresenceFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ExtendedSeasonLeaderboardFeature.java
+++ b/common/src/main/java/com/wynntils/features/ExtendedSeasonLeaderboardFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features;
@@ -41,7 +41,7 @@ public class ExtendedSeasonLeaderboardFeature extends Feature {
 
     public ExtendedSeasonLeaderboardFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/LootrunFeature.java
+++ b/common/src/main/java/com/wynntils/features/LootrunFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features;
@@ -33,9 +33,9 @@ public class LootrunFeature extends Feature {
     public final Config<Boolean> showNotes = new Config<>(true);
 
     public LootrunFeature() {
-        // Enabled status for this doesn't really matter, but just for settings filters we disable it
+        // Enabled status for this doesn't really matter, but just for settings filters we enable it
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/TerritoryDefenseMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/TerritoryDefenseMessageFeature.java
@@ -40,7 +40,7 @@ public class TerritoryDefenseMessageFeature extends Feature {
 
     public TerritoryDefenseMessageFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
@@ -9,7 +9,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.containers.event.ValuableFoundEvent;
 import com.wynntils.models.gear.type.GearType;
@@ -81,7 +80,7 @@ public class ValuableFoundFeature extends Feature {
     private final Config<Float> soundPitch = new Config<>(1.0f);
 
     public ValuableFoundFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/BombBellRelayFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/BombBellRelayFeature.java
@@ -34,7 +34,7 @@ public class BombBellRelayFeature extends Feature {
 
     public BombBellRelayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatCoordinatesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -32,7 +32,7 @@ public class ChatCoordinatesFeature extends Feature {
 
     public ChatCoordinatesFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
@@ -83,7 +82,7 @@ public class ChatItemFeature extends Feature {
     private final Map<String, String> chatItems = new HashMap<>();
 
     public ChatItemFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatMentionFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -10,7 +10,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.PartStyle;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
@@ -54,10 +53,7 @@ public class ChatMentionFeature extends Feature {
     private List<Pattern> mentionPatterns;
 
     public ChatMentionFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
 
         mentionPatterns = buildPattern();
     }

--- a/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatTabsFeature.java
@@ -48,7 +48,7 @@ public class ChatTabsFeature extends Feature {
 
     public ChatTabsFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/chat/DeathCoordinatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/DeathCoordinatesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -21,7 +21,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class DeathCoordinatesFeature extends Feature {
     public DeathCoordinatesFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/chat/DialogueOptionOverrideFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/DialogueOptionOverrideFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -20,7 +20,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class DialogueOptionOverrideFeature extends Feature {
     public DialogueOptionOverrideFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/chat/InputTranscriptionFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/InputTranscriptionFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ChatScreenKeyTypedEvent;
 import com.wynntils.mc.event.ChatScreenSendEvent;
 import com.wynntils.mc.event.CommandSentEvent;
@@ -43,10 +42,7 @@ public class InputTranscriptionFeature extends Feature {
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
     public InputTranscriptionFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;
@@ -10,7 +10,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.handlers.chat.type.MessageType;
@@ -75,10 +74,7 @@ public class MessageFilterFeature extends Feature {
     private final Config<Boolean> hidePartyFinder = new Config<>(false);
 
     public MessageFilterFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/AbbreviateMobHealthFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/AbbreviateMobHealthFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -34,7 +34,7 @@ public class AbbreviateMobHealthFeature extends Feature {
 
     public AbbreviateMobHealthFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/combat/ChestBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/ChestBlockerFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerCloseEvent;
 import com.wynntils.models.containers.containers.reward.RewardContainer;
@@ -40,7 +39,7 @@ public class ChestBlockerFeature extends Feature {
     private final Config<EmeraldPouchTier> emeraldPouchTier = new Config<>(EmeraldPouchTier.EIGHT);
 
     public ChestBlockerFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/ContentTrackerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/ContentTrackerFeature.java
@@ -38,7 +38,7 @@ public class ContentTrackerFeature extends Feature {
 
     public ContentTrackerFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/CustomLootrunBeaconsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 
 @ConfigCategory(Category.COMBAT)
 public class CustomLootrunBeaconsFeature extends Feature {
@@ -22,7 +21,7 @@ public class CustomLootrunBeaconsFeature extends Feature {
     public final Config<Boolean> showAdditionalTextInWorld = new Config<>(true);
 
     public CustomLootrunBeaconsFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/combat/FixCastingSpellsFromInventoryFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/FixCastingSpellsFromInventoryFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -8,7 +8,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ArmSwingEvent;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -20,7 +19,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.COMBAT)
 public class FixCastingSpellsFromInventoryFeature extends Feature {
     public FixCastingSpellsFromInventoryFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerInteractEvent;
 import com.wynntils.mc.event.UseItemEvent;
 import com.wynntils.models.elements.type.PotionType;
@@ -35,10 +34,7 @@ public class HealthPotionBlockerFeature extends Feature {
     private final Config<Integer> threshold = new Config<>(95);
 
     public HealthPotionBlockerFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
@@ -71,7 +71,7 @@ public class HorseMountFeature extends Feature {
 
     public HorseMountFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/combat/LowHealthVignetteFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/LowHealthVignetteFeature.java
@@ -44,7 +44,7 @@ public class LowHealthVignetteFeature extends Feature {
 
     public LowHealthVignetteFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/combat/MythicBoxScalerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/MythicBoxScalerFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.GroundItemEntityTransformEvent;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.ItemStack;
@@ -27,7 +26,7 @@ public class MythicBoxScalerFeature extends Feature {
     private final Config<Float> scale = new Config<>(1.5f);
 
     public MythicBoxScalerFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/PreventTradesDuelsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/PreventTradesDuelsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -37,7 +37,7 @@ public class PreventTradesDuelsFeature extends Feature {
 
     public PreventTradesDuelsFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -15,7 +15,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ArmSwingEvent;
 import com.wynntils.mc.event.ChangeCarriedItemEvent;
 import com.wynntils.mc.event.TickEvent;
@@ -74,7 +73,7 @@ public class QuickCastFeature extends Feature {
     private int packetCountdown = 0;
 
     public QuickCastFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/RangeVisualizerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/RangeVisualizerFeature.java
@@ -67,7 +67,7 @@ public class RangeVisualizerFeature extends Feature {
 
     public RangeVisualizerFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/combat/ShamanTotemTrackingFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/ShamanTotemTrackingFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -10,7 +10,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.extension.EntityExtension;
 import com.wynntils.models.abilities.event.TotemEvent;
 import com.wynntils.utils.colors.CommonColors;
@@ -38,7 +37,7 @@ public class ShamanTotemTrackingFeature extends Feature {
     private final Config<CustomColor> fourthTotemColor = new Config<>(CommonColors.GREEN);
 
     public ShamanTotemTrackingFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/SpellCastVignetteFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/SpellCastVignetteFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.spells.event.SpellEvent;
@@ -45,10 +44,7 @@ public class SpellCastVignetteFeature extends Feature {
     private float intensity;
 
     public SpellCastVignetteFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/combat/TokenTrackerBellFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/TokenTrackerBellFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.token.event.TokenGatekeeperEvent;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.CappedValue;
@@ -25,10 +24,7 @@ public class TokenTrackerBellFeature extends Feature {
     private final Config<Boolean> playSound = new Config<>(true);
 
     public TokenTrackerBellFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/AddCommandExpansionFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.commands;
@@ -10,7 +10,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.HashSet;
 import java.util.Set;
@@ -34,7 +33,7 @@ public class AddCommandExpansionFeature extends Feature {
     private final Set<String> suggestions = new HashSet<>();
 
     public AddCommandExpansionFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CommandAliasesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.commands;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.CommandSentEvent;
 import com.wynntils.mc.event.CommandSuggestionEvent;
@@ -31,7 +30,7 @@ public class CommandAliasesFeature extends Feature {
             new ArgumentAlias(List.of("guild", "gu", "guilds"), "territory", List.of("t", "terr"))));
 
     public CommandAliasesFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)

--- a/common/src/main/java/com/wynntils/features/commands/CustomCommandKeybindsFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/CustomCommandKeybindsFeature.java
@@ -81,7 +81,7 @@ public class CustomCommandKeybindsFeature extends Feature {
 
     public CustomCommandKeybindsFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/commands/FilterAdminCommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/commands/FilterAdminCommandsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.commands;
@@ -8,7 +8,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.CommandSuggestionEvent;
 import java.util.Set;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -36,7 +35,7 @@ public class FilterAdminCommandsFeature extends Feature {
             "wynnproxy");
 
     public FilterAdminCommandsFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/embellishments/WarHornFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/WarHornFeature.java
@@ -10,7 +10,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.territories.event.GuildWarQueuedEvent;
 import com.wynntils.utils.mc.McUtils;
 import net.minecraft.resources.Identifier;
@@ -29,10 +28,7 @@ public class WarHornFeature extends Feature {
     private final Config<Float> soundPitch = new Config<>(1.0f);
 
     public WarHornFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/embellishments/WybelSoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/WybelSoundFeature.java
@@ -10,7 +10,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.handlers.chat.type.RecipientType;
@@ -31,10 +30,7 @@ public class WybelSoundFeature extends Feature {
     private final Config<Boolean> hideText = new Config<>(false);
 
     public WybelSoundFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/embellishments/WynntilsCosmeticsFeature.java
+++ b/common/src/main/java/com/wynntils/features/embellishments/WynntilsCosmeticsFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerRenderLayerEvent;
 import com.wynntils.mc.extension.EntityRenderStateExtension;
 import com.wynntils.utils.mc.McUtils;
@@ -26,7 +25,7 @@ public class WynntilsCosmeticsFeature extends Feature {
     public final Config<Boolean> renderOwnCape = new Config<>(true);
 
     public WynntilsCosmeticsFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -145,7 +145,7 @@ public class ContainerSearchFeature extends Feature {
 
     public ContainerSearchFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/inventory/DisableRecipeBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/DisableRecipeBookFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -8,7 +8,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RecipeBookButtonCreateEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -18,7 +17,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.INVENTORY)
 public class DisableRecipeBookFeature extends Feature {
     public DisableRecipeBookFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/DurabilityOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/DurabilityOverlayFeature.java
@@ -42,7 +42,7 @@ public class DurabilityOverlayFeature extends Feature {
 
     public DurabilityOverlayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchFillArcFeature.java
@@ -34,7 +34,7 @@ public class EmeraldPouchFillArcFeature extends Feature {
 
     public EmeraldPouchFillArcFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/EmeraldPouchHotkeyFeature.java
@@ -13,7 +13,6 @@ import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.keybinds.KeyBindDefinition;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.items.items.game.EmeraldPouchItem;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.mc.McUtils;
@@ -35,10 +34,7 @@ public class EmeraldPouchHotkeyFeature extends Feature {
     private final KeyBind emeraldPouchKeyBind = KeyBindDefinition.OPEN_EMERALD_POUCH.create(this::onOpenPouchKeyPress);
 
     public EmeraldPouchHotkeyFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     private void onOpenPouchKeyPress() {

--- a/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.ItemCountOverlayRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -35,7 +34,7 @@ public class ExtendedItemCountFeature extends Feature {
     private boolean isInventory;
 
     public ExtendedItemCountFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/GuildBankHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/GuildBankHotkeyFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.keybinds.KeyBindDefinition;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.MenuEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -32,10 +31,7 @@ public class GuildBankHotkeyFeature extends Feature {
     private boolean openGuildBank = false;
 
     public GuildBankHotkeyFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/HideAttackCooldownFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/HideAttackCooldownFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -8,7 +8,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ItemCooldownRenderEvent;
 import com.wynntils.utils.wynn.ItemUtils;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -16,7 +15,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.INVENTORY)
 public class HideAttackCooldownFeature extends Feature {
     public HideAttackCooldownFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/IngredientPouchHotkeyFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/IngredientPouchHotkeyFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.keybinds.KeyBindDefinition;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.utils.wynn.InventoryUtils;
 
 @ConfigCategory(Category.INVENTORY)
@@ -22,10 +21,7 @@ public class IngredientPouchHotkeyFeature extends Feature {
             KeyBindDefinition.OPEN_INGREDIENT_POUCH.create(this::onOpenIngredientPouchKeyPress);
 
     public IngredientPouchHotkeyFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     private void onOpenIngredientPouchKeyPress() {

--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.models.containers.containers.CharacterInfoContainer;
@@ -62,10 +61,7 @@ public class InventoryEmeraldCountFeature extends Feature {
     private final Config<Boolean> combineInventoryAndContainer = new Config<>(false);
 
     public InventoryEmeraldCountFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ItemFavoriteFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemFavoriteFeature.java
@@ -15,7 +15,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerCloseEvent;
@@ -59,7 +58,7 @@ public class ItemFavoriteFeature extends Feature {
     private int lootChestCloseOverrideCounter = 0;
 
     public ItemFavoriteFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemHighlightFeature.java
@@ -159,7 +159,7 @@ public class ItemHighlightFeature extends Feature {
 
     public ItemHighlightFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemLockFeature.java
@@ -14,7 +14,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.ContainerRenderEvent;
@@ -57,7 +56,7 @@ public class ItemLockFeature extends Feature {
     private final Config<Boolean> allowClickOnMultiHealthPotionsInBlockingMode = new Config<>(true);
 
     public ItemLockFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemScreenshotFeature.java
@@ -22,7 +22,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.type.StyleType;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
@@ -79,7 +78,7 @@ public class ItemScreenshotFeature extends Feature {
     private Slot screenshotSlot = null;
 
     public ItemScreenshotFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     private void onInventoryPress(Slot hoveredSlot) {

--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.HotbarSlotRenderEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -142,9 +141,7 @@ public class ItemTextOverlayFeature extends Feature {
     private final Config<TextShadow> tradeMarketFilterShadow = new Config<>(TextShadow.OUTLINE);
 
     public ItemTextOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/LootchestTextFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/LootchestTextFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.models.containers.containers.reward.LootChestContainer;
@@ -36,10 +35,7 @@ public class LootchestTextFeature extends Feature {
     private final Config<String> inventoryTextTemplate = new Config<>("§8Dry: {dry_streak}");
 
     public LootchestTextFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/PersonalStorageUtilitiesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.inventory;
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerClickEvent;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
@@ -57,7 +56,7 @@ public class PersonalStorageUtilitiesFeature extends Feature {
     private PersonalStorageUtilitiesWidget widget;
 
     public PersonalStorageUtilitiesFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/inventory/UnidentifiedItemIconFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/UnidentifiedItemIconFeature.java
@@ -76,7 +76,7 @@ public class UnidentifiedItemIconFeature extends Feature {
 
     public UnidentifiedItemIconFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/BeaconBeamFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderTileLevelLastEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.marker.type.MarkerInfo;
@@ -35,7 +34,7 @@ public class BeaconBeamFeature extends Feature {
     private CustomColor currentRainbowColor = CommonColors.RED;
 
     public BeaconBeamFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/map/GuildMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/GuildMapFeature.java
@@ -32,7 +32,7 @@ public class GuildMapFeature extends Feature {
 
     public GuildMapFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MainMapFeature.java
@@ -15,7 +15,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.mc.event.PlayerAttackEvent;
 import com.wynntils.mc.event.PlayerInteractEvent;
@@ -127,7 +126,7 @@ public class MainMapFeature extends Feature {
     public final KeyBind newWaypointKeybind = KeyBindDefinition.NEW_WAYPOINT.create(this::openWaypointSetup);
 
     public MainMapFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     private void openMainMap() {

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -39,7 +39,7 @@ public class MinimapFeature extends Feature {
 
     public MinimapFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.mc.event.RenderLevelEvent;
@@ -76,7 +75,7 @@ public class WorldWaypointDistanceFeature extends Feature {
     private final List<RenderedMarkerInfo> renderedMarkers = new ArrayList<>();
 
     public WorldWaypointDistanceFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/overlays/AnnihilationSunOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/AnnihilationSunOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.AnnihilationSunOverlay;
 
@@ -20,9 +19,6 @@ public class AnnihilationSunOverlayFeature extends Feature {
     private final Overlay sunOverlay = new AnnihilationSunOverlay();
 
     public AnnihilationSunOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ArrowShieldTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ArrowShieldTrackerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ArrowShieldTrackerOverlay;
 
@@ -20,9 +19,6 @@ public class ArrowShieldTrackerOverlayFeature extends Feature {
     private final Overlay arrowShieldTrackerOverlay = new ArrowShieldTrackerOverlay();
 
     public ArrowShieldTrackerOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/BombBellOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/BombBellOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -20,7 +20,7 @@ public class BombBellOverlayFeature extends Feature {
 
     public BombBellOverlayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/BonusTotemTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/BonusTotemTimerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.GatheringTotemTimerOverlay;
 import com.wynntils.overlays.MobTotemTimerOverlay;
@@ -24,9 +23,6 @@ public class BonusTotemTimerOverlayFeature extends Feature {
     private final Overlay gatheringTotemTimerOverlay = new GatheringTotemTimerOverlay();
 
     public BonusTotemTimerOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/CombatExperienceOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CombatExperienceOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -22,7 +22,7 @@ public class CombatExperienceOverlayFeature extends Feature {
 
     public CombatExperienceOverlayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ContentTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ContentTrackerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -21,7 +21,7 @@ public class ContentTrackerOverlayFeature extends Feature {
 
     public ContentTrackerOverlayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/CustomBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CustomBarsOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayGroup;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.custombars.BubbleTexturedCustomBarOverlay;
 import com.wynntils.overlays.custombars.ExperienceTexturedCustomBarOverlay;
@@ -39,6 +38,6 @@ public class CustomBarsOverlayFeature extends Feature {
     private final List<BubbleTexturedCustomBarOverlay> customBubbleBarOverlays = new ArrayList<>();
 
     public CustomBarsOverlayFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/CustomPlayerListOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/CustomPlayerListOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -11,7 +11,6 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.CustomPlayerListOverlay;
 
@@ -23,9 +22,6 @@ public class CustomPlayerListOverlayFeature extends Feature {
     private final Overlay customPlayerListOverlay = new CustomPlayerListOverlay();
 
     public CustomPlayerListOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameBarsOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.gamebars.AwakenedProgressBarOverlay;
 import com.wynntils.overlays.gamebars.BloodPoolBarOverlay;
@@ -64,9 +63,6 @@ public class GameBarsOverlayFeature extends Feature {
     private final MomentumBarOverlay momentumBarOverlay = new MomentumBarOverlay();
 
     public GameBarsOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GameNotificationOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -21,7 +21,7 @@ public class GameNotificationOverlayFeature extends Feature {
 
     public GameNotificationOverlayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/GuardianAngelsTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/GuardianAngelsTrackerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.GuardianAngelsTrackerOverlay;
 
@@ -20,9 +19,6 @@ public class GuardianAngelsTrackerOverlayFeature extends Feature {
     private final Overlay guardianAngelsTrackerOverlay = new GuardianAngelsTrackerOverlay();
 
     public GuardianAngelsTrackerOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/HeldItemNameOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/HeldItemNameOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.HeldItemNameOverlay;
 
@@ -20,9 +19,6 @@ public class HeldItemNameOverlayFeature extends Feature {
     private final Overlay heldItemNameOverlay = new HeldItemNameOverlay();
 
     public HeldItemNameOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/InfoBoxFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/InfoBoxFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayGroup;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.infobox.InfoBoxOverlay;
 import java.util.ArrayList;
@@ -22,6 +21,6 @@ public class InfoBoxFeature extends Feature {
     private final List<InfoBoxOverlay> infoBoxOverlays = new ArrayList<>();
 
     public InfoBoxFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/LootrunOverlaysFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/LootrunOverlaysFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -33,7 +33,7 @@ public class LootrunOverlaysFeature extends Feature {
 
     public LootrunOverlaysFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/MantleShieldTrackerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/MantleShieldTrackerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.MantleShieldTrackerOverlay;
 
@@ -20,9 +19,6 @@ public class MantleShieldTrackerOverlayFeature extends Feature {
     private final Overlay mantleShieldTrackerOverlay = new MantleShieldTrackerOverlay();
 
     public MantleShieldTrackerOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/NpcDialogueFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/NpcDialogueFeature.java
@@ -17,7 +17,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.type.NpcDialogueType;
 import com.wynntils.mc.event.KeyInputEvent;
@@ -106,7 +105,7 @@ public class NpcDialogueFeature extends Feature {
     private StyledText displayedHelperMessage = null;
 
     public NpcDialogueFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
 
         // Add this feature as a dependent of the NpcDialogueModel
         Models.NpcDialogue.addNpcDialogExtractionDependent(this);

--- a/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ObjectivesOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.objectives.DailyObjectiveOverlay;
 import com.wynntils.overlays.objectives.GuildObjectiveOverlay;
@@ -24,9 +23,6 @@ public class ObjectivesOverlayFeature extends Feature {
     public final Overlay dailyObjectiveOverlay = new DailyObjectiveOverlay();
 
     public ObjectivesOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/PartyMembersOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/PartyMembersOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -21,7 +21,7 @@ public class PartyMembersOverlayFeature extends Feature {
 
     public PartyMembersOverlayFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/PowderSpecialBarOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/PowderSpecialBarOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.PowderSpecialBarOverlay;
 
@@ -20,9 +19,6 @@ public class PowderSpecialBarOverlayFeature extends Feature {
     private final Overlay powderSpecialBarOverlay = new PowderSpecialBarOverlay();
 
     public PowderSpecialBarOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/RaidProgressFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/RaidProgressFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.raid.event.RaidEndedEvent;
 import com.wynntils.models.raid.event.RaidNewBestTimeEvent;
@@ -40,10 +39,7 @@ public class RaidProgressFeature extends Feature {
     private final Config<Boolean> playSoundOnBest = new Config<>(true);
 
     public RaidProgressFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/overlays/ScoreboardOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ScoreboardOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ScoreboardOverlay;
 
@@ -20,9 +19,6 @@ public class ScoreboardOverlayFeature extends Feature {
     private final Overlay scoreboardOverlay = new ScoreboardOverlay();
 
     public ScoreboardOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ServerUptimeInfoOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ServerUptimeInfoOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -11,7 +11,6 @@ import com.wynntils.core.consumers.overlays.RenderState;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ServerUptimeInfoOverlay;
 
@@ -21,9 +20,6 @@ public class ServerUptimeInfoOverlayFeature extends Feature {
     private final Overlay ServerUptimeInfoOverlay = new ServerUptimeInfoOverlay();
 
     public ServerUptimeInfoOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ShamanMaskOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ShamanMaskOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ShamanMaskOverlay;
 
@@ -20,9 +19,6 @@ public class ShamanMaskOverlayFeature extends Feature {
     private final Overlay shamanMaskOverlay = new ShamanMaskOverlay();
 
     public ShamanMaskOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/ShamanTotemTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/ShamanTotemTimerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.ShamanTotemTimerOverlay;
 
@@ -20,9 +19,6 @@ public class ShamanTotemTimerOverlayFeature extends Feature {
     private final Overlay shamanTotemTimerOverlay = new ShamanTotemTimerOverlay();
 
     public ShamanTotemTimerOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/SpellCastMessageOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/SpellCastMessageOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.SpellCastMessageOverlay;
 import com.wynntils.overlays.SpellInputsOverlay;
@@ -24,9 +23,6 @@ public class SpellCastMessageOverlayFeature extends Feature {
     private final Overlay spellInputsOverlay = new SpellInputsOverlay();
 
     public SpellCastMessageOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/StatusEffectsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/StatusEffectsOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -9,7 +9,6 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.StatusEffectsOverlay;
 
@@ -19,9 +18,6 @@ public class StatusEffectsOverlayFeature extends Feature {
     public final StatusEffectsOverlay statusEffectsOverlay = new StatusEffectsOverlay();
 
     public StatusEffectsOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/StopwatchFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/StopwatchFeature.java
@@ -17,7 +17,6 @@ import com.wynntils.core.keybinds.KeyBind;
 import com.wynntils.core.keybinds.KeyBindDefinition;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.stopwatch.StopwatchOverlay;
 import net.minecraft.commands.CommandSourceStack;
@@ -61,10 +60,7 @@ public class StopwatchFeature extends Feature {
     private final Overlay stopwatchOverlay = new StopwatchOverlay();
 
     public StopwatchFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     private void toggleStopwatch() {

--- a/common/src/main/java/com/wynntils/features/overlays/TerritoryAttackTimerOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TerritoryAttackTimerOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.TerritoryAttackTimerOverlay;
 
@@ -25,9 +24,6 @@ public class TerritoryAttackTimerOverlayFeature extends Feature {
     public final Config<Boolean> displayBeaconBeam = new Config<>(true);
 
     public TerritoryAttackTimerOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/TokenBarsOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TokenBarsOverlayFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.overlays;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.annotations.OverlayInfo;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.overlays.TokenBarsOverlay;
 
@@ -20,9 +19,6 @@ public class TokenBarsOverlayFeature extends Feature {
     private final Overlay tokenBarsOverlay = new TokenBarsOverlay();
 
     public TokenBarsOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 }

--- a/common/src/main/java/com/wynntils/features/overlays/TowerEffectOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TowerEffectOverlayFeature.java
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.war.event.GuildWarTowerEffectEvent;
 import com.wynntils.overlays.TowerAuraTimerOverlay;
@@ -73,10 +72,7 @@ public class TowerEffectOverlayFeature extends Feature {
     private final Config<Float> volleyVignetteIntensity = new Config<>(0.4f);
 
     public TowerEffectOverlayFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/overlays/TowerStatsFeature.java
+++ b/common/src/main/java/com/wynntils/features/overlays/TowerStatsFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.RenderEvent;
 import com.wynntils.models.war.event.GuildWarEvent;
@@ -39,10 +38,7 @@ public class TowerStatsFeature extends Feature {
     private final Config<Boolean> printTowerStatsOnEnd = new Config<>(true);
 
     public TowerStatsFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/AutoJoinPartyFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/AutoJoinPartyFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.players;
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.players.event.PartyEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -28,10 +27,7 @@ public class AutoJoinPartyFeature extends Feature {
     private final Config<Boolean> onlySameWorld = new Config<>(true);
 
     public AutoJoinPartyFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/CustomNametagRendererFeature.java
@@ -96,7 +96,7 @@ public class CustomNametagRendererFeature extends Feature {
 
     public CustomNametagRendererFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/players/HadesFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/HadesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.players;
@@ -31,7 +31,7 @@ public class HadesFeature extends Feature {
 
     public HadesFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/players/PartyManagementScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PartyManagementScreenFeature.java
@@ -32,7 +32,7 @@ public class PartyManagementScreenFeature extends Feature {
 
     public PartyManagementScreenFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/players/PlayerGhostTransparencyFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PlayerGhostTransparencyFeature.java
@@ -29,7 +29,7 @@ public class PlayerGhostTransparencyFeature extends Feature {
 
     public PlayerGhostTransparencyFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/players/PlayerViewerFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PlayerViewerFeature.java
@@ -31,7 +31,7 @@ public class PlayerViewerFeature extends Feature {
 
     public PlayerViewerFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/redirects/AbilityRefreshRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/AbilityRefreshRedirectFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.redirects;
@@ -21,7 +21,7 @@ public class AbilityRefreshRedirectFeature extends Feature {
 
     public AbilityRefreshRedirectFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.redirects;
@@ -103,7 +103,7 @@ public class ChatRedirectFeature extends Feature {
 
     public ChatRedirectFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
 
         register(new BlacksmithRedirector());

--- a/common/src/main/java/com/wynntils/features/redirects/InventoryRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/InventoryRedirectFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.redirects;
@@ -41,7 +41,7 @@ public class InventoryRedirectFeature extends Feature {
 
     public InventoryRedirectFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/redirects/TerritoryMessageRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/TerritoryMessageRedirectFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.redirects;
@@ -24,7 +24,7 @@ public class TerritoryMessageRedirectFeature extends Feature {
 
     public TerritoryMessageRedirectFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemCompareFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemCompareFeature.java
@@ -101,7 +101,7 @@ public class ItemCompareFeature extends Feature {
 
     public ItemCompareFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemGuessFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.tooltips;
@@ -38,7 +38,7 @@ public class ItemGuessFeature extends Feature {
 
     public ItemGuessFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.tooltips;
@@ -130,7 +130,7 @@ public class ItemStatInfoFeature extends Feature {
 
     public ItemStatInfoFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/tooltips/TooltipFittingFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/TooltipFittingFeature.java
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.mc.event.TooltipRenderEvent;
 import com.wynntils.utils.mc.ComponentUtils;
@@ -42,7 +41,7 @@ public class TooltipFittingFeature extends Feature {
     private float lastScaleFactor = 1f;
 
     public TooltipFittingFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     // scaling should only happen after every other feature has updated tooltip

--- a/common/src/main/java/com/wynntils/features/tooltips/TooltipVanillaHideFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/TooltipVanillaHideFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.tooltips;
@@ -22,7 +22,7 @@ public class TooltipVanillaHideFeature extends Feature {
 
     public TooltipVanillaHideFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketBulkSellFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketBulkSellFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.containers.containers.trademarket.TradeMarketSellContainer;
 import com.wynntils.models.trademarket.event.TradeMarketChatInputEvent;
 import com.wynntils.models.trademarket.event.TradeMarketSellDialogueUpdatedEvent;
@@ -43,10 +42,7 @@ public class TradeMarketBulkSellFeature extends Feature {
     private int amountToSend = 0;
 
     public TradeMarketBulkSellFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceConversionFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceConversionFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.trademarket;
@@ -19,7 +19,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class TradeMarketPriceConversionFeature extends Feature {
     public TradeMarketPriceConversionFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceMatchFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketPriceMatchFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.account.AccountModel;
 import com.wynntils.models.containers.containers.trademarket.TradeMarketSellContainer;
 import com.wynntils.models.trademarket.TradeMarketModel;
@@ -40,10 +39,7 @@ public class TradeMarketPriceMatchFeature extends Feature {
     private long priceToSend = 0;
 
     public TradeMarketPriceMatchFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketQuickSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketQuickSearchFeature.java
@@ -82,7 +82,7 @@ public class TradeMarketQuickSearchFeature extends Feature {
 
     public TradeMarketQuickSearchFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/BulkBuyFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.core.text.type.StyleType;
@@ -76,10 +75,7 @@ public class BulkBuyFeature extends Feature {
     private int bulkBoughtPrice = 0; // Price of a single item
 
     public BulkBuyFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/ContainerScrollFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/ContainerScrollFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.MouseScrollEvent;
 import com.wynntils.models.containers.type.ScrollableContainerProperty;
 import com.wynntils.utils.mc.McUtils;
@@ -28,7 +27,7 @@ public class ContainerScrollFeature extends Feature {
     private final Config<Boolean> invertScroll = new Config<>(false);
 
     public ContainerScrollFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/CraftingProfessionLevelProgressBarFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CraftingProfessionLevelProgressBarFeature.java
@@ -34,7 +34,7 @@ public class CraftingProfessionLevelProgressBarFeature extends Feature {
 
     public CraftingProfessionLevelProgressBarFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/CustomGuildLogScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomGuildLogScreenFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -33,7 +33,7 @@ public class CustomGuildLogScreenFeature extends Feature {
 
     public CustomGuildLogScreenFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/CustomSeaskipperScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomSeaskipperScreenFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -31,7 +31,7 @@ public class CustomSeaskipperScreenFeature extends Feature {
 
     public CustomSeaskipperScreenFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
@@ -63,7 +63,7 @@ public class CustomTerritoryManagementScreenFeature extends Feature {
 
     public CustomTerritoryManagementScreenFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/CustomTradeMarketResultScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomTradeMarketResultScreenFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -39,7 +39,7 @@ public class CustomTradeMarketResultScreenFeature extends Feature {
 
     public CustomTradeMarketResultScreenFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/LobbyUptimeFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/LobbyUptimeFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -25,7 +25,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class LobbyUptimeFeature extends Feature {
     public LobbyUptimeFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/ui/ProfessionHighlightFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/ProfessionHighlightFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.mc.event.SlotRenderEvent;
@@ -55,10 +54,7 @@ public class ProfessionHighlightFeature extends Feature {
     private final Storage<Map<String, ProfessionType>> selectionPerContainer = new Storage<>(new TreeMap<>());
 
     public ProfessionHighlightFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynncraftButtonFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ScreenInitEvent;
@@ -82,7 +81,7 @@ public class WynncraftButtonFeature extends Feature {
     private final Config<Boolean> returnToTitle = new Config<>(true);
 
     public WynncraftButtonFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/WynncraftPauseScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynncraftPauseScreenFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PauseMenuInitEvent;
 import com.wynntils.screens.base.WynntilsMenuScreenBase;
 import com.wynntils.screens.maps.GuildMapScreen;
@@ -34,7 +35,16 @@ public class WynncraftPauseScreenFeature extends Feature {
     private static final String REPORT_BUGS = "menu.reportBugs";
 
     public WynncraftPauseScreenFeature() {
-        super(ProfileDefault.ENABLED);
+        // We don't use ProfileDefault.ENABLED for this as it is one method of accessing the Wynntils menu that
+        // has minimal impact on gameplay so we want it enabled for BLANK_SLATE
+        super(new ProfileDefault.Builder()
+                .enabledFor(
+                        ConfigProfile.DEFAULT,
+                        ConfigProfile.NEW_PLAYER,
+                        ConfigProfile.LITE,
+                        ConfigProfile.MINIMAL,
+                        ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
@@ -106,7 +106,7 @@ public class WynntilsContentBookFeature extends Feature {
 
     public WynntilsContentBookFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/utilities/AutoApplyResourcePackFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/AutoApplyResourcePackFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.utilities;
@@ -10,7 +10,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.ServerResourcePackEvent;
 import java.util.UUID;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -18,7 +17,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.UTILITIES)
 public class AutoApplyResourcePackFeature extends Feature {
     public AutoApplyResourcePackFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/features/utilities/CharacterSelectionUtilitiesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/CharacterSelectionUtilitiesFeature.java
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
 import com.wynntils.mc.event.KeyInputEvent;
 import com.wynntils.mc.event.RenderEvent;
@@ -33,7 +32,7 @@ public class CharacterSelectionUtilitiesFeature extends Feature {
     private final Config<Boolean> hideCrosshair = new Config<>(true);
 
     public CharacterSelectionUtilitiesFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/FixCrosshairPositionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/FixCrosshairPositionFeature.java
@@ -24,7 +24,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class FixCrosshairPositionFeature extends Feature {
     public FixCrosshairPositionFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/utilities/GammabrightFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/GammabrightFeature.java
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.DimensionAmbientLightEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -26,7 +25,7 @@ public class GammabrightFeature extends Feature {
     private final KeyBind gammabrightKeyBind = KeyBindDefinition.TOGGLE_GAMMABRIGHT.create(this::toggleGammaBright);
 
     public GammabrightFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/PerCharacterGuildContributionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/PerCharacterGuildContributionFeature.java
@@ -43,7 +43,7 @@ public class PerCharacterGuildContributionFeature extends Feature {
 
     public PerCharacterGuildContributionFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/utilities/SilencerFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/SilencerFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -50,10 +49,7 @@ public class SilencerFeature extends Feature {
     private boolean firstTitleScreenInit = true;
 
     public SilencerFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/utilities/SkillPointLoadoutsFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/SkillPointLoadoutsFeature.java
@@ -24,7 +24,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 public class SkillPointLoadoutsFeature extends Feature {
     public SkillPointLoadoutsFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE, ConfigProfile.MINIMAL)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/TranscribeMessagesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.utilities;
@@ -11,7 +11,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.core.text.type.StyleType;
@@ -56,10 +55,7 @@ public class TranscribeMessagesFeature extends Feature {
     private static final Pattern END_OF_HEADER_PATTERN = Pattern.compile(".*:\\s?");
 
     public TranscribeMessagesFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/utilities/ValuablesProtectionFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/ValuablesProtectionFeature.java
@@ -97,7 +97,7 @@ public class ValuablesProtectionFeature extends Feature {
 
     public ValuablesProtectionFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.NEW_PLAYER, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.LITE)
                 .build());
     }
 

--- a/common/src/main/java/com/wynntils/features/utilities/XpGainMessageFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/XpGainMessageFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.utilities;
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.models.characterstats.event.CombatXpGainEvent;
 import com.wynntils.models.profession.event.ProfessionXpGainEvent;
@@ -48,10 +47,7 @@ public class XpGainMessageFeature extends Feature {
     private final Map<ProfessionType, Float> lastRawProfessionXpGains = new EnumMap<>(ProfessionType.class);
 
     public XpGainMessageFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/BetaWarningFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -12,7 +12,6 @@ import com.wynntils.core.mod.event.WynncraftConnectionEvent;
 import com.wynntils.core.net.UrlId;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerInfoEvent;
 import com.wynntils.utils.mc.McUtils;
 import java.util.function.Supplier;
@@ -24,7 +23,7 @@ public class BetaWarningFeature extends Feature {
     private WarnType warnType = WarnType.NONE;
 
     public BetaWarningFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/ChangelogFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/ChangelogFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -11,7 +11,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.screens.changelog.ChangelogScreen;
@@ -21,7 +20,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.WYNNTILS)
 public class ChangelogFeature extends Feature {
     public ChangelogFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/CommandsFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/CommandsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -9,6 +9,7 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.CommandSentEvent;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -16,7 +17,16 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.WYNNTILS)
 public class CommandsFeature extends Feature {
     public CommandsFeature() {
-        super(ProfileDefault.ENABLED);
+        // We don't use ProfileDefault.ENABLED for this as it is one method of accessing the Wynntils menu that
+        // has minimal impact on gameplay so we want it enabled for BLANK_SLATE
+        super(new ProfileDefault.Builder()
+                .enabledFor(
+                        ConfigProfile.DEFAULT,
+                        ConfigProfile.NEW_PLAYER,
+                        ConfigProfile.LITE,
+                        ConfigProfile.MINIMAL,
+                        ConfigProfile.BLANK_SLATE)
+                .build());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DataCrowdSourcingFeature.java
@@ -10,7 +10,6 @@ import com.wynntils.core.crowdsource.type.CrowdSourcedDataType;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.config.HiddenConfig;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.McUtils;
@@ -33,10 +32,7 @@ public class DataCrowdSourcingFeature extends Feature {
             new HiddenConfig<>(new TreeMap<>());
 
     public DataCrowdSourcingFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/DownloadProgressFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/DownloadProgressFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -9,7 +9,6 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.net.event.DownloadEvent;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.utils.mc.McUtils;
 import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.network.chat.Component;
@@ -18,7 +17,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 @ConfigCategory(Category.WYNNTILS)
 public class DownloadProgressFeature extends Feature {
     public DownloadProgressFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/FixPacketBugsFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/FixPacketBugsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -8,7 +8,6 @@ import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.AddEntityLookupEvent;
 import com.wynntils.mc.event.PlayerInfoUpdateEvent;
 import com.wynntils.mc.event.PlayerTeamEvent;
@@ -28,7 +27,7 @@ public class FixPacketBugsFeature extends Feature {
     private static final int METHOD_ADD = 0;
 
     public FixPacketBugsFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/common/src/main/java/com/wynntils/features/wynntils/TelemetryFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/TelemetryFeature.java
@@ -15,7 +15,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.utils.JsonUtils;
@@ -36,10 +35,7 @@ public class TelemetryFeature extends Feature {
     private final Config<ConfirmedBoolean> crashReports = new Config<>(ConfirmedBoolean.UNCONFIRMED);
 
     public TelemetryFeature() {
-        super(new ProfileDefault.Builder()
-                .disableFor(
-                        ConfigProfile.NEW_PLAYER, ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
-                .build());
+        super(ProfileDefault.onlyDefault());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/UpdatesFeature.java
@@ -13,7 +13,6 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.services.athena.type.UpdateResult;
 import com.wynntils.utils.mc.McUtils;
@@ -33,7 +32,7 @@ public class UpdatesFeature extends Feature {
     private final Config<Boolean> autoUpdate = new Config<>(false);
 
     public UpdatesFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/WeeklyConfigBackupFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/WeeklyConfigBackupFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -11,7 +11,6 @@ import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
-import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.TitleScreenInitEvent;
 import com.wynntils.utils.FileUtils;
@@ -29,7 +28,7 @@ public class WeeklyConfigBackupFeature extends Feature {
     private final Storage<Long> lastBackup = new Storage<>(0L);
 
     public WeeklyConfigBackupFeature() {
-        super(new ProfileDefault.Builder().disableFor(ConfigProfile.BLANK_SLATE).build());
+        super(ProfileDefault.ENABLED);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/features/wynntils/WynntilsHintMessagesFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/WynntilsHintMessagesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.wynntils;
@@ -23,7 +23,7 @@ public class WynntilsHintMessagesFeature extends Feature {
 
     public WynntilsHintMessagesFeature() {
         super(new ProfileDefault.Builder()
-                .disableFor(ConfigProfile.LITE, ConfigProfile.MINIMAL, ConfigProfile.BLANK_SLATE)
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER)
                 .build());
     }
 


### PR DESCRIPTION
Feedback from https://github.com/Wynntils/Wynntils/pull/3663#discussion_r2679462130

Now instead of specifying what profile we disable the feature for, we specify which profile to enable it for.
`ProfileDefault.ENABLED` will not set the `Blank Slate` profile to enabled so we no longer need to specify that anywhere besides the 2 features that are enabled in that profile.

There is now a `ProfileDefault.onlyDefault()` for features only enabled in the default profile.

This could be done on main but I'll target development so that mods which will break from this change will only have to update for 1.21.11