### PR TITLE
fix: Cape rendering fixes

### DIFF
--- a/common/src/main/java/com/wynntils/features/players/PlayerArmorHidingFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PlayerArmorHidingFeature.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.mc.event.PlayerRenderLayerEvent;
 import com.wynntils.mc.extension.EntityRenderStateExtension;
+import com.wynntils.services.cosmetics.event.PlayerArmorVisibilityEvent;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
@@ -71,6 +72,43 @@ public class PlayerArmorHidingFeature extends Feature {
             case FEET -> {
                 if (hideBoots.get()) {
                     event.setCanceled(true);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onPlayerArmorVisibilityCheck(PlayerArmorVisibilityEvent event) {
+        switch (event.getSlot()) {
+            case HEAD -> {
+                if (!hideHelmets.get()) return;
+                if (!showCosmetics.get()) { // helmet is hidden regardless, no extra logic needed
+                    event.setVisible(false);
+                    return;
+                }
+
+                Entity entity = ((EntityRenderStateExtension) event.getRenderState()).getEntity();
+                if (!(entity instanceof AbstractClientPlayer player)) return;
+
+                // Only not visible if the item isn't cosmetic.
+                ItemStack headItem = player.getItemBySlot(event.getSlot());
+                if (headItem.getItem() != Items.POTION) {
+                    event.setVisible(false);
+                }
+            }
+            case CHEST -> {
+                if (hideChestplates.get()) {
+                    event.setVisible(false);
+                }
+            }
+            case LEGS -> {
+                if (hideLeggings.get()) {
+                    event.setVisible(false);
+                }
+            }
+            case FEET -> {
+                if (hideBoots.get()) {
+                    event.setVisible(false);
                 }
             }
         }

--- a/common/src/main/java/com/wynntils/features/players/PlayerGhostTransparencyFeature.java
+++ b/common/src/main/java/com/wynntils/features/players/PlayerGhostTransparencyFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.config.ConfigProfile;
 import com.wynntils.mc.event.PlayerRenderLayerEvent;
 import com.wynntils.mc.event.RenderTranslucentCheckEvent;
 import com.wynntils.mc.extension.EntityRenderStateExtension;
+import com.wynntils.services.cosmetics.event.PlayerArmorVisibilityEvent;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.world.entity.Entity;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -61,6 +62,17 @@ public class PlayerGhostTransparencyFeature extends Feature {
 
         if (Models.Player.isPlayerGhost(player)) {
             event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public void onPlayerArmorVisibilityCheck(PlayerArmorVisibilityEvent event) {
+        if (!transparentPlayerGhostArmor.get()) return;
+        Entity entity = ((EntityRenderStateExtension) event.getRenderState()).getEntity();
+        if (!(entity instanceof AbstractClientPlayer player)) return;
+
+        if (Models.Player.isPlayerGhost(player)) {
+            event.setVisible(false);
         }
     }
 }

--- a/common/src/main/java/com/wynntils/services/cosmetics/event/PlayerArmorVisibilityEvent.java
+++ b/common/src/main/java/com/wynntils/services/cosmetics/event/PlayerArmorVisibilityEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.services.cosmetics.event;
+
+import net.minecraft.client.renderer.entity.state.AvatarRenderState;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.neoforged.bus.api.Event;
+
+public class PlayerArmorVisibilityEvent extends Event {
+    private final EquipmentSlot slot;
+    private final AvatarRenderState renderState;
+
+    private boolean isVisible = true;
+
+    public PlayerArmorVisibilityEvent(EquipmentSlot slot, AvatarRenderState renderState) {
+        this.slot = slot;
+        this.renderState = renderState;
+    }
+
+    public void setVisible(boolean isVisible) {
+        this.isVisible = isVisible;
+    }
+
+    public boolean isVisible() {
+        return isVisible;
+    }
+
+    public EquipmentSlot getSlot() {
+        return slot;
+    }
+
+    public AvatarRenderState getRenderState() {
+        return renderState;
+    }
+}

--- a/common/src/main/java/com/wynntils/services/cosmetics/type/WynntilsCapeLayer.java
+++ b/common/src/main/java/com/wynntils/services/cosmetics/type/WynntilsCapeLayer.java
@@ -29,7 +29,6 @@ import net.minecraft.client.resources.model.EquipmentClientInfo;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.PlayerSkin;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.equipment.Equippable;
 
@@ -63,38 +62,33 @@ public final class WynntilsCapeLayer extends WynntilsLayer {
         if (texture == null) return;
 
         if (!renderState.isInvisible && renderState.showCape) {
-            PlayerSkin playerSkin = renderState.skin;
-            if (playerSkin.cape() != null) {
-                if (!this.hasLayer(renderState.chestEquipment, EquipmentClientInfo.LayerType.WINGS)) {
-                    poseStack.pushPose();
-                    if (this.hasLayer(renderState.chestEquipment, EquipmentClientInfo.LayerType.HUMANOID)) {
-                        poseStack.translate(0.0F, -0.053125F, 0.06875F);
-                    }
-
-                    RenderTranslucentCheckEvent.Cape translucentCheckEvent =
-                            new RenderTranslucentCheckEvent.Cape(false, renderState, 1.0f);
-                    MixinHelper.post(translucentCheckEvent);
-
-                    RenderType renderType = translucentCheckEvent.getTranslucence() == 1.0f
-                            ? RenderTypes.entityCutout(texture)
-                            : RenderTypes.entityTranslucent(texture);
-
-                    nodeCollector.submitModel(
-                            this.model,
-                            renderState,
-                            poseStack,
-                            renderType,
-                            packedLight,
-                            OverlayTexture.NO_OVERLAY,
-                            CommonColors.WHITE
-                                    .withAlpha(translucentCheckEvent.getTranslucence())
-                                    .asInt(),
-                            null,
-                            renderState.outlineColor,
-                            null);
-                    poseStack.popPose();
-                }
+            poseStack.pushPose();
+            if (this.hasLayer(renderState.chestEquipment, EquipmentClientInfo.LayerType.HUMANOID)) {
+                poseStack.translate(0.0F, -0.053125F, 0.06875F);
             }
+
+            RenderTranslucentCheckEvent.Cape translucentCheckEvent =
+                    new RenderTranslucentCheckEvent.Cape(false, renderState, 1.0f);
+            MixinHelper.post(translucentCheckEvent);
+
+            RenderType renderType = translucentCheckEvent.getTranslucence() == 1.0f
+                    ? RenderTypes.entityCutout(texture)
+                    : RenderTypes.entityTranslucent(texture);
+
+            nodeCollector.submitModel(
+                    this.model,
+                    renderState,
+                    poseStack,
+                    renderType,
+                    packedLight,
+                    OverlayTexture.NO_OVERLAY,
+                    CommonColors.WHITE
+                            .withAlpha(translucentCheckEvent.getTranslucence())
+                            .asInt(),
+                    null,
+                    renderState.outlineColor,
+                    null);
+            poseStack.popPose();
         }
     }
 


### PR DESCRIPTION
Removed the check that the player has a vanilla cape before rendering a Wynntils cape and also removed the check for elytra as you can't wear one on Wynncraft anyway.

And also finally decided to fix the issue of floating capes when you have armour hidden via the glint or have armour rendering disabled via one of the features