### PR TITLE
fix: Prevent a few input cancelling features from working whilst in wardrobe

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HealthPotionBlockerFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -72,6 +72,7 @@ public class HealthPotionBlockerFeature extends Feature {
     private boolean checkPotionUse() {
         ItemStack itemStack = McUtils.inventory().getSelected();
         if (!isHealingPotion(itemStack)) return false;
+        if (Models.WorldState.inCharacterWardrobe()) return false;
 
         Optional<CappedValue> healthOpt = Models.CharacterStats.getHealth();
         if (healthOpt.isEmpty()) {

--- a/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/HorseMountFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -79,6 +79,7 @@ public class HorseMountFeature extends Feature {
     @SubscribeEvent
     public void onUseItem(UseItemEvent event) {
         if (!guaranteedMount.get()) return;
+        if (Models.WorldState.inCharacterWardrobe()) return;
 
         ItemStack itemStack = McUtils.player().getMainHandItem();
         Optional<HorseItem> horseItemOpt = Models.Item.asWynnItem(itemStack, HorseItem.class);

--- a/common/src/main/java/com/wynntils/features/combat/PreventTradesDuelsFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/PreventTradesDuelsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -53,6 +53,7 @@ public class PreventTradesDuelsFeature extends Feature {
 
     private void handlePlayerClick(ICancellableEvent event, Player player, ItemStack itemStack, Entity target) {
         if (!player.isShiftKeyDown() || !(target instanceof Player p) || !Models.Player.isLocalPlayer(p)) return;
+        if (Models.WorldState.inCharacterWardrobe()) return;
 
         int timeSinceLastFight =
                 (int) ((System.currentTimeMillis() - Models.Combat.getLastDamageDealtTimestamp()) / 1000);

--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.combat;
@@ -93,6 +93,8 @@ public class QuickCastFeature extends Feature {
 
     @SubscribeEvent
     public void onUseItem(UseItemEvent event) {
+        if (Models.WorldState.inCharacterWardrobe()) return;
+
         lastSpellTick = McUtils.player().tickCount;
 
         if (!blockAttacks.get()) return;

--- a/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/WynntilsContentBookFeature.java
@@ -1,9 +1,10 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.ui;
 
+import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
@@ -165,6 +166,7 @@ public class WynntilsContentBookFeature extends Feature {
     @SubscribeEvent
     public void onWrappedScreenOpen(WrappedScreenOpenEvent event) {
         if (event.getWrappedScreenClass() != WynntilsContentBookScreen.class) return;
+        if (Models.WorldState.inCharacterWardrobe()) return;
 
         boolean shouldOpen = false;
 
@@ -191,6 +193,8 @@ public class WynntilsContentBookFeature extends Feature {
     }
 
     private void handleClick(ICancellableEvent cancellableEvent) {
+        if (Models.WorldState.inCharacterWardrobe()) return;
+
         shiftClickedBookItem = McUtils.player().isShiftKeyDown();
 
         ItemStack itemInHand = McUtils.player().getItemInHand(InteractionHand.MAIN_HAND);


### PR DESCRIPTION
Since you are still holding your original item whilst in the wardrobe, some of our logic continues to run despite you not actually being in a situation where you would want the input blocked.

Since right click is used to exit the wardrobe this can lead to soft locks where the only way out is to relog or disable the feature temporarily 