### PR TITLE
fix: Don't apply resource pack if not using OpenGL

### DIFF
--- a/common/src/main/java/com/wynntils/services/resourcepack/ResourcePackService.java
+++ b/common/src/main/java/com/wynntils/services/resourcepack/ResourcePackService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.resourcepack;
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.mc.event.ConnectionEvent;
 import com.wynntils.mc.event.ServerResourcePackEvent;
+import com.wynntils.utils.SystemUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.Pair;
 import java.util.ArrayList;
@@ -41,6 +42,8 @@ public final class ResourcePackService extends Service {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onServerResourcePackLoad(ServerResourcePackEvent.Load event) {
+        if (!SystemUtils.usingOpenGL()) return;
+
         Pack preloadedPack = getPreloadedPack();
 
         // 1. We have no preloaded pack
@@ -78,6 +81,8 @@ public final class ResourcePackService extends Service {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onServerResourcePackClear(ServerResourcePackEvent.Clear event) {
+        if (!SystemUtils.usingOpenGL()) return;
+
         PackRepository resourcePackRepository = McUtils.mc().getResourcePackRepository();
 
         Pack preloadedPack = getPreloadedPack();
@@ -117,6 +122,8 @@ public final class ResourcePackService extends Service {
 
     @SubscribeEvent
     public void onConnect(ConnectionEvent.ConnectingEvent event) {
+        if (!SystemUtils.usingOpenGL()) return;
+
         // Reset the flag, as we are connecting to a new server
         serverHasResourcePack = false;
 
@@ -140,6 +147,8 @@ public final class ResourcePackService extends Service {
     }
 
     public boolean preloadResourcePack() {
+        if (!SystemUtils.usingOpenGL()) return false;
+
         PackRepository resourcePackRepository = McUtils.mc().getResourcePackRepository();
 
         // Remove all preloaded packs from the selected list

--- a/common/src/main/java/com/wynntils/utils/SystemUtils.java
+++ b/common/src/main/java/com/wynntils/utils/SystemUtils.java
@@ -5,8 +5,10 @@
 package com.wynntils.utils;
 
 import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.opengl.GlDevice;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.TextureFormat;
@@ -29,6 +31,12 @@ public final class SystemUtils {
         String waylandDisplay = System.getenv("WAYLAND_DISPLAY");
         String sessionType = System.getenv("XDG_SESSION_TYPE");
         return (waylandDisplay != null && !waylandDisplay.isEmpty()) || ("wayland".equalsIgnoreCase(sessionType));
+    }
+
+    public static boolean usingOpenGL() {
+        GpuDevice gpuDevice = RenderSystem.getDevice();
+
+        return gpuDevice instanceof GlDevice;
     }
 
     public static void copyImageToClipboard(BufferedImage bi) {


### PR DESCRIPTION
This should properly fix https://github.com/Wynntils/Wynntils/issues/3332 so that no action is required on the users side for compatibility. I simply don't think we can make the feature work with VulkanMod so this is the best solution to prevent any issues.

When using VulkanMod, the `GpuDevice` will now be instance of [VkGpuDevice](https://github.com/xCollateral/VulkanMod/blob/dev/src/main/java/net/vulkanmod/render/engine/VkGpuDevice.java) so the pack will never be applied