### PR TITLE
fix: Don't decay negative crafted stats

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/block/CustomIdentificationDataTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/block/CustomIdentificationDataTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.encoding.impl.block;
@@ -88,10 +88,12 @@ public class CustomIdentificationDataTransformer extends DataTransformer<CustomI
             // The next bytes are the identification's max value bytes, which are assembled into an integer.
             int maxValue = (int) UnsignedByteUtils.decodeVariableSizedInteger(byteReader);
 
-            //  For crafted items, the max values can be used to calculate the minimum values (10% of the maximum,
-            // rounded).
-            possibleValues.add(new StatPossibleValues(
-                    statType, RangedValue.of(Math.round(maxValue * 0.1f), maxValue), maxValue, false));
+            // For positive stats on crafted items, the max values can be used to calculate the minimum values (10%
+            // of the maximum, rounded). Negative stats do not decay so are always the maximum.
+            RangedValue range = maxValue <= 0
+                    ? RangedValue.of(maxValue, maxValue)
+                    : RangedValue.of(Math.round(maxValue * 0.1f), maxValue);
+            possibleValues.add(new StatPossibleValues(statType, range, maxValue, false));
         }
 
         return ErrorOr.of(new CustomIdentificationsData(possibleValues));

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.encoding.impl.item;
@@ -102,11 +102,13 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
             // For crafted items, the max values can be used to calculate the current values (from the overall
             // effectiveness).
             identifications = identificationsData.possibleValues().stream()
-                    .map(statPossibleValues -> new StatActualValue(
-                            statPossibleValues.statType(),
-                            Math.round(statPossibleValues.range().high() * effectStrength / 100f),
-                            0,
-                            RangedValue.NONE))
+                    .map(statPossibleValues -> {
+                        int max = statPossibleValues.range().high();
+                        // Negative stats do not decay, they always stay at the max
+                        int value = (max <= 0) ? max : Math.round(max * effectStrength / 100f);
+
+                        return new StatActualValue(statPossibleValues.statType(), value, 0, RangedValue.NONE);
+                    })
                     .toList();
         }
 

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.wynnitem.parsing;
@@ -410,8 +410,9 @@ public final class WynnItemParser {
                 // parse possible values for this stat
                 if (statMatcher.group(4) != null && possibleValuesMap != null) {
                     int maxValue = Integer.parseInt(statMatcher.group(4));
-                    // minimum value is 10% of maximum value, rounded
-                    int minValue = (int) Math.round(maxValue * 0.1);
+                    // For positive stats, minimum value is 10% of maximum value, rounded.
+                    // For negative stats, minimum value is always the same as maximum
+                    int minValue = maxValue <= 0 ? maxValue : (int) Math.round(maxValue * 0.1);
 
                     // Add possible values for this stat
                     StatPossibleValues calculatedPossibleValues =


### PR DESCRIPTION
Real item
<img width="448" height="516" alt="image" src="https://github.com/user-attachments/assets/ba900020-38d2-406f-be54-02cfcbbe3a1c" />

Decoded (Bugged)
<img width="364" height="476" alt="image" src="https://github.com/user-attachments/assets/51219d3c-8a7a-4045-b09a-d7746ea0ada5" />

Decoded (Fixed)
<img width="364" height="476" alt="image" src="https://github.com/user-attachments/assets/4cc29b72-a45d-4814-b83a-38284853ef77" />
