### PR TITLE
feat: Add show level config for extended item count

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ExtendedItemCountFeature.java
@@ -31,6 +31,9 @@ public class ExtendedItemCountFeature extends Feature {
     @Persisted
     private final Config<Boolean> hotbarTextOverlayEnabled = new Config<>(true);
 
+    @Persisted
+    private final Config<Boolean> showLevel = new Config<>(true);
+
     private boolean isInventory;
 
     public ExtendedItemCountFeature() {
@@ -57,7 +60,8 @@ public class ExtendedItemCountFeature extends Feature {
 
         WynnItem wynnItem = wynnItemOpt.get();
 
-        if (wynnItem instanceof LeveledItemProperty leveledItem
+        if (showLevel.get()
+                && wynnItem instanceof LeveledItemProperty leveledItem
                 && KeyboardUtils.isKeyDown(GLFW.GLFW_KEY_LEFT_CONTROL)
                 && isInventory) {
             event.setCountString(String.valueOf(leveledItem.getLevel()));

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -594,6 +594,8 @@
   "feature.wynntils.extendedItemCount.inventoryTextOverlayEnabled.description": "Should we draw extended item counts for items in the inventory?",
   "feature.wynntils.extendedItemCount.inventoryTextOverlayEnabled.name": "Extended Inventory Item Counts",
   "feature.wynntils.extendedItemCount.name": "Extended Item Count",
+  "feature.wynntils.extendedItemCount.showLevel.description": "Should item levels be shown when holding ctrl?",
+  "feature.wynntils.extendedItemCount.showLevel.name": "Hold Ctrl to Show Level",
   "feature.wynntils.extendedSeasonLeaderboard.description": "Adds data to the season leaderboard to show more information.",
   "feature.wynntils.extendedSeasonLeaderboard.guildHighlightColor.description": "If the Highlight Own Guild option is enabled, what color should it be highlighted?",
   "feature.wynntils.extendedSeasonLeaderboard.guildHighlightColor.name": "Guild Highlight Color",


### PR DESCRIPTION
Had a few requests for turning this off recently without disabling the whole feature