### PR TITLE
chore: Set build version to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ def usingHotswapAgent = project.hasProperty("wynntils.hotswap") ? project.getPro
 
 // On the release branches, this string will be automatically updated by the bots
 // Do not change this in the main branch!
-version = "3.0.0-SNAPSHOT"
+version = "4.0.0-SNAPSHOT"
 
 subprojects {
     apply plugin: "dev.architectury.loom"


### PR DESCRIPTION
Will need this for when starting the next beta cycle for Fruma.

I'll see if I can make the workflow automatically set this