### PR TITLE
fix: Rebuild render order when disabling an overlay

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/OverlayManager.java
@@ -90,6 +90,8 @@ public final class OverlayManager extends Manager {
         WynntilsMod.unregisterEventListener(disabledOverlay);
 
         disabledOverlay.getConfigOptionFromString("userEnabled").ifPresent(disabledOverlay::callOnConfigUpdate);
+
+        rebuildRenderOrder();
     }
 
     public void enableOverlays(Feature parent) {


### PR DESCRIPTION
As the render order map is never rebuilt after disabling, that overlay will just stay rendering in its previous state