### PR TITLE
feat: Shift click icon filter buttons to exclude/include other icons

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/WaypointManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/WaypointManagementScreen.java
@@ -633,9 +633,19 @@ public final class WaypointManagementScreen extends WynntilsScreen {
         populateWaypoints();
     }
 
-    public void toggleIcon(Texture icon, boolean used) {
-        filteredIcons.put(icon, used);
+    public void toggleIcon(Texture icon, boolean used, boolean excludeOthers) {
+        if (excludeOthers) {
+            filteredIcons.forEach((key, value) -> {
+                if (key != icon) {
+                    filteredIcons.put(key, !used);
+                }
+            });
+            filteredIcons.put(icon, used);
+        } else {
+            filteredIcons.put(icon, used);
+        }
 
+        updateAllUsedIcons();
         populateWaypoints();
     }
 

--- a/common/src/main/java/com/wynntils/screens/maps/widgets/IconButton.java
+++ b/common/src/main/java/com/wynntils/screens/maps/widgets/IconButton.java
@@ -4,13 +4,17 @@
  */
 package com.wynntils.screens.maps.widgets;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import com.wynntils.screens.maps.PoiCreationScreen;
 import com.wynntils.screens.maps.WaypointManagementScreen;
 import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.mc.ComponentUtils;
+import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import java.util.List;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
@@ -62,6 +66,21 @@ public class IconButton extends AbstractWidget {
         }
 
         if (this.isHovered) {
+            if (McUtils.screen() instanceof WaypointManagementScreen) {
+                guiGraphics.setTooltipForNextFrame(
+                        Lists.transform(
+                                ComponentUtils.wrapTooltips(
+                                        List.of(
+                                                Component.translatable(
+                                                        "screens.wynntils.waypointManagementGui.iconFilterTooltip1"),
+                                                Component.translatable(
+                                                        "screens.wynntils.waypointManagementGui.iconFilterTooltip2")),
+                                        250),
+                                Component::getVisualOrderText),
+                        mouseX,
+                        mouseY);
+            }
+
             guiGraphics.requestCursor(CursorTypes.POINTING_HAND);
         }
     }
@@ -73,7 +92,7 @@ public class IconButton extends AbstractWidget {
         } else if (McUtils.screen() instanceof WaypointManagementScreen waypointManagementScreen) {
             this.selected = !selected;
 
-            waypointManagementScreen.toggleIcon(mapIcon, selected);
+            waypointManagementScreen.toggleIcon(mapIcon, selected, KeyboardUtils.isShiftDown());
         }
 
         return true;

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -3325,6 +3325,8 @@
   "screens.wynntils.waypointManagementGui.help2": "Middle click waypoints to set a marker at that waypoint.",
   "screens.wynntils.waypointManagementGui.help3": "Right click to remove marker at that waypoint.",
   "screens.wynntils.waypointManagementGui.icon": "Icon",
+  "screens.wynntils.waypointManagementGui.iconFilterTooltip1": "Left Click to toggle filtering this icon",
+  "screens.wynntils.waypointManagementGui.iconFilterTooltip2": "Shift + Left click to toggle between including or excluding all icons besides this icon",
   "screens.wynntils.waypointManagementGui.import": "Import",
   "screens.wynntils.waypointManagementGui.import.error": "Failed to import waypoints",
   "screens.wynntils.waypointManagementGui.import.success": "Successfully imported %d waypoints",


### PR DESCRIPTION
Adds back a bit of missing functionality from when the icon filter screen was removed. 