### PR TITLE
fix: Territory resource coloring when using hybrid mode data

### DIFF
--- a/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
@@ -85,7 +85,7 @@ public class TerritoryPoi implements Poi {
         TerritoryProfile territoryProfile = getTerritoryProfile();
 
         List<CustomColor> colors;
-        if (isTerritoryInfoUsable()
+        if (territoryInfo != null
                 && McUtils.screen() instanceof GuildMapScreen guildMapScreen
                 && guildMapScreen.isResourceMode()) {
             colors = territoryInfo.getResourceColors();


### PR DESCRIPTION
This uses the previously cached territory info data to still display territory resource colors when the territory owner has been invalidated by hybrid mode.