### PR TITLE
feat: Guild map territory abbreviations toggle

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -46,6 +46,7 @@ import org.lwjgl.glfw.GLFW;
 
 public final class GuildMapScreen extends AbstractMapScreen {
     private boolean resourceMode = false;
+    private boolean territoryNameMode = false;
     private boolean territoryDefenseFilterEnabled = false;
     private boolean territoryTreasuryFilterEnabled = false;
     private boolean hybridMode = true;
@@ -85,6 +86,16 @@ public final class GuildMapScreen extends AbstractMapScreen {
                                 .withStyle(ChatFormatting.GOLD)
                                 .append(Component.translatable("screens.wynntils.guildMap.toggleResourceColor.name")),
                         Component.translatable("screens.wynntils.guildMap.toggleResourceColor.description")
+                                .withStyle(ChatFormatting.GRAY))));
+
+        addMapButton(new MapButton(
+                Texture.SIGN_ICON,
+                (b) -> territoryNameMode = !territoryNameMode,
+                List.of(
+                        Component.literal("[>] ")
+                                .withStyle(ChatFormatting.GOLD)
+                                .append(Component.translatable("screens.wynntils.guildMap.toggleTerritoryNames.name")),
+                        Component.translatable("screens.wynntils.guildMap.toggleTerritoryNames.description")
                                 .withStyle(ChatFormatting.GRAY))));
 
         territoryDefenseFilterButton = new MapButton(
@@ -391,6 +402,10 @@ public final class GuildMapScreen extends AbstractMapScreen {
 
     public boolean isResourceMode() {
         return resourceMode;
+    }
+
+    public boolean isTerritoryNameMode() {
+        return territoryNameMode;
     }
 
     private boolean filterDefense(TerritoryPoi territoryArea) {

--- a/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
+++ b/common/src/main/java/com/wynntils/services/map/pois/TerritoryPoi.java
@@ -20,8 +20,10 @@ import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import net.minecraft.client.gui.GuiGraphics;
 
 public class TerritoryPoi implements Poi {
@@ -118,12 +120,18 @@ public class TerritoryPoi implements Poi {
                     actualRenderX + renderWidth / 2f - Texture.GUILD_HEADQUARTERS.width() / 2f,
                     actualRenderZ + renderHeight / 2f - Texture.GUILD_HEADQUARTERS.height() / 2f);
         } else {
-            String guildPrefix =
-                    isTerritoryInfoUsable() ? territoryInfo.getGuildPrefix() : territoryProfile.getGuildPrefix();
+            String mapText;
+            if (McUtils.screen() instanceof GuildMapScreen guildMapScreen && guildMapScreen.isTerritoryNameMode()) {
+                mapText = Arrays.stream(territoryProfile.getName().split(" "))
+                        .map(s -> s.substring(0, 1))
+                        .collect(Collectors.joining());
+            } else {
+                mapText = isTerritoryInfoUsable() ? territoryInfo.getGuildPrefix() : territoryProfile.getGuildPrefix();
+            }
             FontRenderer.getInstance()
                     .renderAlignedTextInBox(
                             guiGraphics,
-                            StyledText.fromString(guildPrefix),
+                            StyledText.fromString(mapText),
                             actualRenderX,
                             actualRenderX + renderWidth,
                             actualRenderZ,

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -3042,6 +3042,8 @@
   "screens.wynntils.guildMap.mainMap.name": "Main Map",
   "screens.wynntils.guildMap.toggleResourceColor.description": "Click here to switch between resource generation colors and guild colors.",
   "screens.wynntils.guildMap.toggleResourceColor.name": "Use Resource Generation Colors",
+  "screens.wynntils.guildMap.toggleTerritoryNames.description": "Click here to switch between territory abbreviations and guild ownership.",
+  "screens.wynntils.guildMap.toggleTerritoryNames.name": "Use Territory Names",
   "screens.wynntils.iconFilter.done": "Done",
   "screens.wynntils.iconFilter.excludeAll": "Exclude all icons",
   "screens.wynntils.iconFilter.filterExclude.tooltip": "Exclude the icon, %s",


### PR DESCRIPTION
Adds another toggle to the guild territory map that toggles the display to show territory abbreviations instead of the owning guild's tag.
<img width="714" height="722" alt="image" src="https://github.com/user-attachments/assets/ed4bbd9c-fe35-480b-89f8-3f639ff6124d" />
