### PR TITLE
fix: Render waypoints behind dialogue

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -26,6 +26,7 @@ import com.wynntils.utils.render.Texture;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
+import com.wynntils.utils.type.RenderElementType;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.Camera;
@@ -132,7 +133,9 @@ public class WorldWaypointDistanceFeature extends Feature {
     }
 
     @SubscribeEvent
-    public void onRenderGuiPost(RenderEvent.Post event) {
+    public void onRenderGuiPost(RenderEvent.Pre event) {
+        if (event.getType() != RenderElementType.ACTION_BAR) return;
+
         for (RenderedMarkerInfo renderedMarker : renderedMarkers) {
             if (maxWaypointTextDistance.get() != 0 && maxWaypointTextDistance.get() < renderedMarker.distance) continue;
 


### PR DESCRIPTION
Perhaps when we have minimal dialogue parsing we can switch between this and previous behaviour

<img width="830" height="392" alt="image" src="https://github.com/user-attachments/assets/9d163282-b0f1-4e0d-babf-fa70239abf5d" />
