### PR TITLE
refactor: Store download source as an enum

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/DownloadSource.java
+++ b/common/src/main/java/com/wynntils/core/net/DownloadSource.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.net;
+
+import java.util.Optional;
+
+public enum DownloadSource {
+    CDN(Optional.of("https://cdn.wynntils.com/static/")),
+    GITHUB(Optional.of("https://raw.githubusercontent.com/Wynntils/Static-Storage/refs/heads/main/")),
+    CUSTOM(Optional.empty());
+
+    private final Optional<String> url;
+
+    DownloadSource(Optional<String> url) {
+        this.url = url;
+    }
+
+    public Optional<String> getUrl() {
+        return url;
+    }
+}

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers;
@@ -41,6 +41,7 @@ import com.wynntils.core.persisted.upfixers.config.UniversalBarOverlayColorToCol
 import com.wynntils.core.persisted.upfixers.config.WynntilsContentBookReplaceToShiftBehaviourUpfixer;
 import com.wynntils.core.persisted.upfixers.storage.BankPageNameToBankPagePropertyUpfixer;
 import com.wynntils.core.persisted.upfixers.storage.BankToAccountBankUpfixer;
+import com.wynntils.core.persisted.upfixers.storage.DownloadSourceStringToEnumUpfixer;
 import com.wynntils.core.persisted.upfixers.storage.UpdateChangelogToModelUpfixer;
 import java.util.ArrayList;
 import java.util.List;
@@ -91,6 +92,7 @@ public class UpfixerManager extends Manager {
         registerStorageUpfixer(new BankToAccountBankUpfixer());
         registerStorageUpfixer(new UpdateChangelogToModelUpfixer());
         registerStorageUpfixer(new BankPageNameToBankPagePropertyUpfixer());
+        registerStorageUpfixer(new DownloadSourceStringToEnumUpfixer());
     }
 
     private void registerConfigUpfixer(Upfixer upfixer) {

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/DownloadSourceStringToEnumUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/DownloadSourceStringToEnumUpfixer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.persisted.upfixers.storage;
+
+import com.google.gson.JsonObject;
+import com.wynntils.core.net.DownloadSource;
+import com.wynntils.core.persisted.PersistedValue;
+import com.wynntils.core.persisted.upfixers.Upfixer;
+import com.wynntils.utils.EnumUtils;
+import java.util.Set;
+
+public class DownloadSourceStringToEnumUpfixer implements Upfixer {
+    private static final String CUSTOM_SOURCE_KEY_OLD = "manager.url.customSourceurl";
+    private static final String CUSTOM_SOURCE_KEY_NEW = "manager.url.customSourceUrl";
+    private static final String DOWNLOAD_SOURCE_KEY = "manager.url.downloadSourceUrl";
+
+    // Purposely missing the branch in case it was set to the beta branch
+    private static final String GITHUB_VALUE = "https://raw.githubusercontent.com/Wynntils/Static-Storage/refs/heads/";
+
+    @Override
+    public boolean apply(JsonObject configObject, Set<PersistedValue<?>> persisteds) {
+        String customSource = "";
+
+        if (configObject.has(CUSTOM_SOURCE_KEY_OLD)) {
+            customSource = configObject.get(CUSTOM_SOURCE_KEY_OLD).getAsString();
+
+            configObject.remove(CUSTOM_SOURCE_KEY_OLD);
+            configObject.addProperty(CUSTOM_SOURCE_KEY_NEW, customSource);
+        }
+
+        if (configObject.has(DOWNLOAD_SOURCE_KEY)) {
+            String downloadSource = configObject.get(DOWNLOAD_SOURCE_KEY).getAsString();
+
+            if (downloadSource.startsWith(GITHUB_VALUE)) {
+                configObject.addProperty(DOWNLOAD_SOURCE_KEY, EnumUtils.toJsonFormat(DownloadSource.GITHUB));
+            } else if (!customSource.isEmpty()) {
+                configObject.addProperty(DOWNLOAD_SOURCE_KEY, EnumUtils.toJsonFormat(DownloadSource.CUSTOM));
+            } else {
+                // Default to cdn
+                configObject.addProperty(DOWNLOAD_SOURCE_KEY, EnumUtils.toJsonFormat(DownloadSource.CDN));
+            }
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/com/wynntils/screens/downloads/DownloadScreen.java
+++ b/common/src/main/java/com/wynntils/screens/downloads/DownloadScreen.java
@@ -8,6 +8,7 @@ import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.net.DownloadDependencyGraph;
+import com.wynntils.core.net.DownloadSource;
 import com.wynntils.core.net.QueuedDownload;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.features.ui.WynncraftButtonFeature;
@@ -115,9 +116,9 @@ public final class DownloadScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedHeight * 29),
                 20,
                 Component.literal("Wynntils CDN"),
-                Managers.Url.getDownloadSourceUrl().equals(Managers.Url.WYNNTILS_CDN_URL),
+                Managers.Url.getDownloadSource() == DownloadSource.CDN,
                 (int) (dividedWidth * 7),
-                (c, b) -> changeDownloadSource(Managers.Url.WYNNTILS_CDN_URL),
+                (c, b) -> changeDownloadSource(DownloadSource.CDN),
                 List.of(Component.translatable("screens.wynntils.downloads.cdnTooltip")));
         this.addRenderableWidget(cdnCheckbox);
 
@@ -126,9 +127,9 @@ public final class DownloadScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedHeight * 34),
                 20,
                 Component.literal("GitHub"),
-                Managers.Url.getDownloadSourceUrl().equals(Managers.Url.STATIC_STORAGE_GITHUB_URL),
+                Managers.Url.getDownloadSource() == DownloadSource.GITHUB,
                 (int) (dividedWidth * 7),
-                (c, b) -> changeDownloadSource(Managers.Url.STATIC_STORAGE_GITHUB_URL),
+                (c, b) -> changeDownloadSource(DownloadSource.GITHUB),
                 List.of(Component.translatable("screens.wynntils.downloads.githubTooltip")));
         this.addRenderableWidget(githubCheckbox);
 
@@ -137,9 +138,9 @@ public final class DownloadScreen extends WynntilsGridLayoutScreen {
                 (int) (dividedHeight * 40 + 20),
                 20,
                 Component.translatable("screens.wynntils.downloads.customSource"),
-                Managers.Url.usingCustomDownloadSource(),
+                Managers.Url.getDownloadSource() == DownloadSource.CUSTOM,
                 (int) (dividedWidth * 7),
-                (c, b) -> changeDownloadSource(customInput.getTextBoxInput()),
+                (c, b) -> changeDownloadSource(DownloadSource.CUSTOM),
                 List.of(Component.translatable("screens.wynntils.downloads.customCheckboxTooltip")));
         this.addRenderableWidget(customCheckbox);
 
@@ -150,7 +151,7 @@ public final class DownloadScreen extends WynntilsGridLayoutScreen {
                 20,
                 (s) -> {
                     if (customCheckbox.selected) {
-                        changeDownloadSource(s);
+                        changeCustomSource(s);
                     } else {
                         Managers.Url.setCustomSourceUrl(s);
                     }
@@ -406,12 +407,17 @@ public final class DownloadScreen extends WynntilsGridLayoutScreen {
                 .store(show);
     }
 
-    private void changeDownloadSource(String url) {
-        Managers.Url.setDownloadSource(url);
+    private void changeDownloadSource(DownloadSource downloadSource) {
+        Managers.Url.setDownloadSource(downloadSource);
 
-        cdnCheckbox.selected = Managers.Url.getDownloadSourceUrl().equals(Managers.Url.WYNNTILS_CDN_URL);
-        githubCheckbox.selected = Managers.Url.getDownloadSourceUrl().equals(Managers.Url.STATIC_STORAGE_GITHUB_URL);
-        customCheckbox.selected = Managers.Url.usingCustomDownloadSource();
+        DownloadSource newSource = Managers.Url.getDownloadSource();
+        cdnCheckbox.selected = newSource == DownloadSource.CDN;
+        githubCheckbox.selected = newSource == DownloadSource.GITHUB;
+        customCheckbox.selected = newSource == DownloadSource.CUSTOM;
+    }
+
+    private void changeCustomSource(String customSource) {
+        Managers.Url.setCustomSourceUrl(customSource);
     }
 
     private void adjustTimeout(int adjustment) {


### PR DESCRIPTION
This means that when swapping between main and beta releases on the same instance the url will actually update to the beta versions