### PR TITLE
feat: Smart emerald pouch emerald count rendering

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -79,8 +79,7 @@ public class InventoryEmeraldCountFeature extends Feature {
         // and all there is if we combine them, otherwise it is just the
         // container
         boolean isInventory = (event.getScreen().getMenu().containerId == 0);
-        boolean isEmeraldPouch =
-                StyledText.fromComponent(screen.getTitle()).find(EMERALD_POUCH_TITLE_PATTERN);
+        boolean isEmeraldPouch = StyledText.fromComponent(screen.getTitle()).find(EMERALD_POUCH_TITLE_PATTERN);
         boolean applySmartPouch = isEmeraldPouch && smartEmeraldPouchRendering.get();
         int topEmeralds;
         if (isInventory) {
@@ -89,7 +88,8 @@ public class InventoryEmeraldCountFeature extends Feature {
         } else {
             topEmeralds = 0;
             if (showContainerEmeraldCount.get()) topEmeralds += Models.Emerald.getAmountInContainer();
-            // When smart pouch rendering is active, we always show container and inventory separately, so don't combine them into the top count
+            // When smart pouch rendering is active, we always show container and inventory separately, so don't combine
+            // them into the top count
             if (!applySmartPouch && combineInventoryAndContainer.get() && showInventoryEmeraldCount.get()) {
                 topEmeralds += Models.Emerald.getAmountInInventory();
             }

--- a/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/InventoryEmeraldCountFeature.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.mc.event.ContainerRenderEvent;
 import com.wynntils.models.containers.containers.CharacterInfoContainer;
+import com.wynntils.models.containers.containers.EmeraldPouchContainer;
 import com.wynntils.models.containers.containers.personal.PersonalStorageContainer;
 import com.wynntils.models.emeralds.type.EmeraldUnits;
 import com.wynntils.screens.bulkbuy.widgets.BulkBuyWidget;
@@ -31,7 +32,6 @@ import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.Arrays;
-import java.util.regex.Pattern;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.screens.Screen;
@@ -42,7 +42,6 @@ import org.lwjgl.glfw.GLFW;
 @ConfigCategory(Category.INVENTORY)
 public class InventoryEmeraldCountFeature extends Feature {
     private static final int TEXTURE_SIZE = 28;
-    private static final Pattern EMERALD_POUCH_TITLE_PATTERN = Pattern.compile("EmeraldÀÀÀÀPouchÀ");
 
     @Persisted
     private final Config<EmeraldCountType> emeraldCountType = new Config<>(EmeraldCountType.TEXTURE);
@@ -79,8 +78,8 @@ public class InventoryEmeraldCountFeature extends Feature {
         // and all there is if we combine them, otherwise it is just the
         // container
         boolean isInventory = (event.getScreen().getMenu().containerId == 0);
-        boolean isEmeraldPouch = StyledText.fromComponent(screen.getTitle()).find(EMERALD_POUCH_TITLE_PATTERN);
-        boolean applySmartPouch = isEmeraldPouch && smartEmeraldPouchRendering.get();
+        boolean applySmartPouch = Models.Container.getCurrentContainer() instanceof EmeraldPouchContainer
+                && smartEmeraldPouchRendering.get();
         int topEmeralds;
         if (isInventory) {
             if (!showInventoryEmeraldCount.get()) return;

--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.containers;
@@ -16,6 +16,7 @@ import com.wynntils.models.containers.containers.CharacterSelectionContainer;
 import com.wynntils.models.containers.containers.ContentBookContainer;
 import com.wynntils.models.containers.containers.CosmeticContainer;
 import com.wynntils.models.containers.containers.CraftingStationContainer;
+import com.wynntils.models.containers.containers.EmeraldPouchContainer;
 import com.wynntils.models.containers.containers.GuildBadgesContainer;
 import com.wynntils.models.containers.containers.GuildBankContainer;
 import com.wynntils.models.containers.containers.GuildLogContainer;
@@ -130,6 +131,7 @@ public final class ContainerModel extends Model {
         registerContainer(new ContentBookContainer());
         registerContainer(new CosmeticContainer());
         registerContainer(new DailyRewardContainer());
+        registerContainer(new EmeraldPouchContainer());
         registerContainer(new EventContainer());
         registerContainer(new FlyingChestContainer());
         registerContainer(new GuildBadgesContainer());

--- a/common/src/main/java/com/wynntils/models/containers/containers/EmeraldPouchContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/EmeraldPouchContainer.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.containers;
+
+import com.wynntils.models.containers.Container;
+import java.util.regex.Pattern;
+
+public class EmeraldPouchContainer extends Container {
+    private static final Pattern TITLE_PATTERN = Pattern.compile("EmeraldÀÀÀÀPouchÀ");
+
+    public EmeraldPouchContainer() {
+        super(TITLE_PATTERN);
+    }
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -758,6 +758,8 @@
   "feature.wynntils.inventoryEmeraldCount.showInventoryEmeraldCount.name": "Show Emerald Count in Inventory",
   "feature.wynntils.inventoryEmeraldCount.showZerosInEmeraldCount.description": "Should your emerald count display zero values instead of hiding them?",
   "feature.wynntils.inventoryEmeraldCount.showZerosInEmeraldCount.name": "Show Zero Values in Emerald Count",
+  "feature.wynntils.inventoryEmeraldCount.smartEmeraldPouchRendering.description": "When viewing an Emerald Pouch, the lower emerald count will display your inventory total without the open pouch's value, avoiding duplication.",
+  "feature.wynntils.inventoryEmeraldCount.smartEmeraldPouchRendering.name": "Smart Emerald Pouch Rendering",
   "feature.wynntils.inventoryEmeraldCount.textDisplaySide.description": "Should the text be displayed on the right or left side of the inventory?",
   "feature.wynntils.inventoryEmeraldCount.textDisplaySide.name": "Text Display Side",
   "feature.wynntils.inventoryRedirect.description": "Adds the ability to redirect certain inventory pickup messages to the game update overlay.",


### PR DESCRIPTION
Changes the emerald pouch count rendering to show the amount in the pouch (top) and the remaining in your inventory (bottom) instead of just duplicating the amount in the pouch across both top and bottom