### PR TITLE
fix: Fix content book dump and activity tracking state

### DIFF
--- a/common/src/main/java/com/wynntils/features/debug/ContentBookDumpFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/ContentBookDumpFeature.java
@@ -17,13 +17,15 @@ import com.wynntils.core.keybinds.KeyBindDefinition;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.mc.event.SetSpawnEvent;
+import com.wynntils.models.activities.beacons.ActivityBeaconMarkerKind;
 import com.wynntils.models.activities.type.ActivityDifficulty;
 import com.wynntils.models.activities.type.ActivityInfo;
 import com.wynntils.models.activities.type.ActivityLength;
 import com.wynntils.models.activities.type.ActivityRequirements;
 import com.wynntils.models.activities.type.ActivityRewardType;
 import com.wynntils.models.activities.type.ActivityType;
+import com.wynntils.models.beacons.event.BeaconMarkerEvent;
+import com.wynntils.models.beacons.type.BeaconMarker;
 import com.wynntils.models.profession.type.ProfessionType;
 import com.wynntils.utils.EnumUtils;
 import com.wynntils.utils.FileUtils;
@@ -79,7 +81,9 @@ public class ContentBookDumpFeature extends Feature {
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onSetSpawn(SetSpawnEvent event) {
+    public void onBeaconMarkerAdded(BeaconMarkerEvent.Added event) {
+        BeaconMarker beaconMarker = event.getBeaconMarker();
+        if (!(beaconMarker.beaconMarkerKind() instanceof ActivityBeaconMarkerKind)) return;
         if (currentlyTracking == null) return;
 
         Optional<Location> spawnLocationOpt = Models.Activity.ACTIVITY_MARKER_PROVIDER.getSpawnLocation();

--- a/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/ActivityModel.java
@@ -89,7 +89,7 @@ public final class ActivityModel extends Model {
     private static final Pattern REWARD_HEADER_PATTERN = Pattern.compile("^\uDB00\uDC0E§dRewards:$");
     private static final Pattern REWARD_PATTERN = Pattern.compile("^§d\uDB00\uDC04(- )?§7\\+?(?<reward>.+)$");
     private static final Pattern TRACKING_PATTERN =
-            Pattern.compile(".+§f\uE000 §#[a-f0-9]{8}§lClick To (Untrack|Track)");
+            Pattern.compile(".+§f\uF000 §#[a-f0-9]{8}§lClick To (Untrack|Track)");
     private static final Pattern REQUIRES_HERO_PLUS_PATTERN = Pattern.compile(".+§7Requires §f\uE08A");
     private static final Pattern OVERALL_PROGRESS_PATTERN = Pattern.compile("^\\S*§7(\\d+) of (\\d+) completed$");
     private static final Pattern WIKI_REDIRECT_PATTERN = Pattern.compile("#REDIRECT \\[\\[(?<redirectname>.+)\\]\\]");


### PR DESCRIPTION
Set spawn event is no longer used for placing beacons, we just check the spawn position from this event