### PR TITLE
feat: Add support for tier 7 powders, update stats and guide tooltip

### DIFF
--- a/common/src/main/java/com/wynntils/models/elements/ElementModel.java
+++ b/common/src/main/java/com/wynntils/models/elements/ElementModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements;
@@ -55,35 +55,40 @@ public final class ElementModel extends Model {
 
     private List<PowderTierInfo> buildPowderTierInfo() {
         return List.of(
-                new PowderTierInfo(Powder.WATER, 1, 3, 4, 13, 3, 1),
-                new PowderTierInfo(Powder.WATER, 2, 4, 6, 15, 6, 1),
-                new PowderTierInfo(Powder.WATER, 3, 5, 8, 17, 11, 2),
-                new PowderTierInfo(Powder.WATER, 4, 6, 8, 21, 18, 4),
-                new PowderTierInfo(Powder.WATER, 5, 7, 10, 26, 28, 7),
-                new PowderTierInfo(Powder.WATER, 6, 9, 11, 32, 40, 10),
-                new PowderTierInfo(Powder.FIRE, 1, 2, 5, 14, 3, 1),
-                new PowderTierInfo(Powder.FIRE, 2, 4, 8, 16, 5, 2),
-                new PowderTierInfo(Powder.FIRE, 3, 5, 9, 19, 9, 3),
-                new PowderTierInfo(Powder.FIRE, 4, 6, 9, 24, 16, 5),
-                new PowderTierInfo(Powder.FIRE, 5, 8, 10, 30, 25, 9),
-                new PowderTierInfo(Powder.FIRE, 6, 10, 12, 37, 36, 13),
-                new PowderTierInfo(Powder.AIR, 1, 2, 6, 11, 3, 1),
-                new PowderTierInfo(Powder.AIR, 2, 3, 10, 14, 6, 2),
-                new PowderTierInfo(Powder.AIR, 3, 4, 11, 17, 10, 3),
-                new PowderTierInfo(Powder.AIR, 4, 5, 11, 22, 16, 5),
-                new PowderTierInfo(Powder.AIR, 5, 7, 12, 28, 24, 9),
-                new PowderTierInfo(Powder.AIR, 6, 8, 14, 35, 34, 13),
-                new PowderTierInfo(Powder.EARTH, 1, 3, 6, 17, 2, 1),
-                new PowderTierInfo(Powder.EARTH, 2, 5, 8, 21, 4, 2),
-                new PowderTierInfo(Powder.EARTH, 3, 6, 10, 25, 8, 3),
-                new PowderTierInfo(Powder.EARTH, 4, 7, 10, 31, 14, 5),
-                new PowderTierInfo(Powder.EARTH, 5, 9, 11, 38, 22, 9),
-                new PowderTierInfo(Powder.EARTH, 6, 11, 13, 46, 30, 13),
-                new PowderTierInfo(Powder.THUNDER, 1, 1, 8, 9, 3, 1),
-                new PowderTierInfo(Powder.THUNDER, 2, 1, 12, 11, 5, 1),
-                new PowderTierInfo(Powder.THUNDER, 3, 2, 15, 13, 9, 2),
-                new PowderTierInfo(Powder.THUNDER, 4, 3, 15, 17, 14, 4),
-                new PowderTierInfo(Powder.THUNDER, 5, 4, 17, 22, 20, 7),
-                new PowderTierInfo(Powder.THUNDER, 6, 5, 20, 28, 28, 10));
+                new PowderTierInfo(Powder.WATER, 1, 3, 4, 13, 5, 3, 1),
+                new PowderTierInfo(Powder.WATER, 2, 5, 6, 15, 10, 6, 1),
+                new PowderTierInfo(Powder.WATER, 3, 6, 8, 17, 20, 11, 3),
+                new PowderTierInfo(Powder.WATER, 4, 7, 8, 21, 30, 16, 4),
+                new PowderTierInfo(Powder.WATER, 5, 8, 10, 26, 45, 23, 6),
+                new PowderTierInfo(Powder.WATER, 6, 10, 13, 32, 60, 32, 10),
+                new PowderTierInfo(Powder.WATER, 7, 11, 15, 38, 75, 40, 15),
+                new PowderTierInfo(Powder.FIRE, 1, 2, 5, 14, 5, 3, 1),
+                new PowderTierInfo(Powder.FIRE, 2, 4, 7, 16, 10, 6, 1),
+                new PowderTierInfo(Powder.FIRE, 3, 5, 9, 19, 20, 10, 2),
+                new PowderTierInfo(Powder.FIRE, 4, 6, 9, 24, 30, 15, 3),
+                new PowderTierInfo(Powder.FIRE, 5, 7, 11, 30, 45, 22, 5),
+                new PowderTierInfo(Powder.FIRE, 6, 9, 14, 37, 60, 31, 9),
+                new PowderTierInfo(Powder.FIRE, 7, 10, 16, 44, 75, 39, 14),
+                new PowderTierInfo(Powder.AIR, 1, 2, 6, 11, 5, 3, 1),
+                new PowderTierInfo(Powder.AIR, 2, 3, 9, 14, 10, 6, 2),
+                new PowderTierInfo(Powder.AIR, 3, 4, 11, 17, 20, 10, 3),
+                new PowderTierInfo(Powder.AIR, 4, 5, 11, 22, 30, 16, 5),
+                new PowderTierInfo(Powder.AIR, 5, 7, 12, 28, 45, 23, 7),
+                new PowderTierInfo(Powder.AIR, 6, 8, 15, 35, 60, 30, 8),
+                new PowderTierInfo(Powder.AIR, 7, 9, 17, 42, 75, 38, 13),
+                new PowderTierInfo(Powder.EARTH, 1, 4, 5, 17, 5, 2, 1),
+                new PowderTierInfo(Powder.EARTH, 2, 6, 7, 21, 10, 5, 2),
+                new PowderTierInfo(Powder.EARTH, 3, 7, 9, 25, 20, 9, 3),
+                new PowderTierInfo(Powder.EARTH, 4, 8, 9, 31, 30, 14, 4),
+                new PowderTierInfo(Powder.EARTH, 5, 9, 11, 38, 45, 22, 7),
+                new PowderTierInfo(Powder.EARTH, 6, 11, 12, 46, 60, 29, 7),
+                new PowderTierInfo(Powder.EARTH, 7, 12, 14, 52, 75, 37, 12),
+                new PowderTierInfo(Powder.THUNDER, 1, 1, 8, 9, 5, 2, 1),
+                new PowderTierInfo(Powder.THUNDER, 2, 1, 12, 11, 10, 4, 1),
+                new PowderTierInfo(Powder.THUNDER, 3, 2, 14, 13, 20, 8, 2),
+                new PowderTierInfo(Powder.THUNDER, 4, 2, 15, 17, 30, 13, 3),
+                new PowderTierInfo(Powder.THUNDER, 5, 3, 17, 22, 45, 20, 5),
+                new PowderTierInfo(Powder.THUNDER, 6, 4, 19, 28, 60, 28, 6),
+                new PowderTierInfo(Powder.THUNDER, 7, 5, 21, 32, 75, 36, 11));
     }
 }

--- a/common/src/main/java/com/wynntils/models/elements/type/PowderTierInfo.java
+++ b/common/src/main/java/com/wynntils/models/elements/type/PowderTierInfo.java
@@ -1,8 +1,15 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.elements.type;
 
 public record PowderTierInfo(
-        Powder element, int tier, int min, int max, int convertedFromNeutral, int addedDefence, int removedDefence) {}
+        Powder element,
+        int tier,
+        int min,
+        int max,
+        int convertedFromNeutral,
+        int health,
+        int addedDefence,
+        int removedDefence) {}

--- a/common/src/main/java/com/wynntils/screens/guides/powder/GuidePowderItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/powder/GuidePowderItemStack.java
@@ -101,6 +101,8 @@ public final class GuidePowderItemStack extends GuideItemStack {
                 .append(Component.literal(element.getLightColor() + " " + name)));
         itemLore.add(Component.empty());
         itemLore.add(Component.literal("Effect on Armour:").withStyle(element.getDarkColor()));
+        itemLore.add(
+                Component.literal("- +" + powderTierInfo.health() + " Health").withStyle(ChatFormatting.GRAY));
         itemLore.add(Component.empty()
                 .append(Component.literal(element.getDarkColor() + "— " + ChatFormatting.GRAY + "+"
                         + powderTierInfo.addedDefence() + " " + element.getLightColor()))
@@ -122,7 +124,7 @@ public final class GuidePowderItemStack extends GuideItemStack {
                         + ChatFormatting.GRAY + "Defence")));
         itemLore.add(Component.empty());
         itemLore.add(Component.literal(
-                        "Add this powder to your items by visiting a Powder Master or use it as an ingredient when crafting.")
+                        "Add this powder to your items by holding the item in your cursor and right-clicking a piece of equipment with an available Powder Socket or use it as an ingredient when crafting.")
                 .withStyle(ChatFormatting.DARK_GRAY));
 
         if (tier > 3) {


### PR DESCRIPTION
Actually having 7 powders per line is very satisfying to look at

<img width="422" height="361" alt="image" src="https://github.com/user-attachments/assets/16bf7107-1b60-4a4c-8d24-ebf06ac6ebb3" />
