### PR TITLE
fix: Fix StyledText font inheritance

### DIFF
--- a/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
+++ b/common/src/main/java/com/wynntils/core/text/StyledTextPart.java
@@ -64,6 +64,9 @@ public final class StyledTextPart {
         List<StyledTextPart> parts = new ArrayList<>();
 
         Style currentStyle = style;
+        // Preserve inherited font across color code resets
+        Style inheritedStyle = parentStyle == null ? style : style.applyTo(parentStyle);
+        FontDescription inheritedFont = inheritedStyle.getFont();
         StringBuilder currentString = new StringBuilder();
 
         boolean nextIsFormatting = false;
@@ -131,14 +134,13 @@ public final class StyledTextPart {
                     currentString = new StringBuilder();
                 }
 
-                // Color formatting resets the style besides the font
+                // Color formatting resets the style
                 if (formatting.isColor()) {
                     currentStyle = Style.EMPTY.withColor(formatting);
 
-                    // Check if the current style had a font,
-                    // if so we need to keep it as color formatting resets the style
-                    if (currentStyle.font != null) {
-                        currentStyle = currentStyle.withFont(style.getFont());
+                    // But we keep the inherited font
+                    if (inheritedFont != null) {
+                        currentStyle = currentStyle.withFont(inheritedFont);
                     }
                 } else {
                     currentStyle = currentStyle.applyFormat(formatting);


### PR DESCRIPTION
Hopefully this is the final fix

It works for the status effect that's always troublesome
<img width="295" height="97" alt="image" src="https://github.com/user-attachments/assets/047083f8-c65e-4978-b421-c4db0c208725" />

And dialogue works
<img width="1010" height="338" alt="image" src="https://github.com/user-attachments/assets/15ca9754-3b39-403a-8947-ece96f0fdcb6" />
