### PR TITLE
feat: Add sources jar to releases

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -271,7 +271,9 @@ jobs:
           curseforge-id: 303451
           curseforge-token: ${{ secrets.CF_API_TOKEN }}
 
-          files: "**/build/libs/*-${{ matrix.modloader }}*.jar"
+          files: |
+            "**/build/libs/*-${{ matrix.modloader }}!(*-sources).jar"
+            "**/build/libs/*-${{ matrix.modloader }}*-sources.jar"
 
           name: Wynntils (${{ matrix.modloader }}) v${{ needs.set-version.outputs.tag }}
           version: v${{ needs.set-version.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,9 @@ jobs:
           curseforge-id: 303451
           curseforge-token: ${{ secrets.CF_API_TOKEN }}
 
-          files: "**/build/libs/*-${{ matrix.modloader }}*.jar"
+          files: |
+            "**/build/libs/*-${{ matrix.modloader }}!(*-sources).jar"
+            "**/build/libs/*-${{ matrix.modloader }}*-sources.jar"
 
           name: Wynntils (${{ matrix.modloader }}) ${{ needs.set-version.outputs.tag }}
           version: ${{ needs.set-version.outputs.tag }}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -105,3 +105,9 @@ sourcesJar {
     dependsOn commonSources
     from commonSources.archiveFile.map { zipTree(it) }
 }
+
+remapSourcesJar {
+    inputFile.set sourcesJar.archiveFile
+    dependsOn sourcesJar
+    archiveClassifier = "fabric+MC-${minecraft_version}-sources"
+}

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -74,6 +74,18 @@ remapJar {
     atAccessWideners.add loom.accessWidenerPath.get().asFile.name
 }
 
+sourcesJar {
+    def commonSources = project(":common").sourcesJar
+    dependsOn commonSources
+    from commonSources.archiveFile.map { zipTree(it) }
+}
+
+remapSourcesJar {
+    inputFile.set sourcesJar.archiveFile
+    dependsOn sourcesJar
+    archiveClassifier = "neoforge+MC-${minecraft_version}-sources"
+}
+
 jar {
     archiveClassifier = "dev"
 }


### PR DESCRIPTION
When developing a mod that depends on Wynntils, having access to sources jar would come in handy as decompiled classes are sometimes hard to read as it doesn't have access to all the names and formatting. With Modrinth Maven, the sources file will automatically appear there allowing for IDEs to easily pick it up, making development really easy as everything should happen automatically. This means for best ease of use and full autonomy of IDEs the sources jar needs to be named the same as main jar but with a `-sources` suffix, I also made it do that for both Fabric and Neoforge.
In shot, it makes it a bit easier to develop mods, while not adding any downsides for us, other than version upload taking a second or two longer.

This is not something I could test, so please make sure I did not make any mistakes as I think it could negatively affect publishing of the mod. (Also note Mc-Publish uploads main jar and sources jar by default, we just never set it up to upload sources with the custom path)