### PR TITLE
feat: Render tripwires as invisible

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -12,6 +12,7 @@ import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.features.DiscordRichPresenceFeature;
 import com.wynntils.features.ExtendedSeasonLeaderboardFeature;
+import com.wynntils.features.HideTripwiresFeature;
 import com.wynntils.features.LootrunFeature;
 import com.wynntils.features.TerritoryDefenseMessageFeature;
 import com.wynntils.features.ValuableFoundFeature;
@@ -411,6 +412,7 @@ public final class FeatureManager extends Manager {
         // region uncategorized
         registerFeature(new DiscordRichPresenceFeature());
         registerFeature(new ExtendedSeasonLeaderboardFeature());
+        registerFeature(new HideTripwiresFeature());
         registerFeature(new TerritoryDefenseMessageFeature());
         registerFeature(new ValuableFoundFeature());
         // endregion

--- a/common/src/main/java/com/wynntils/features/HideTripwiresFeature.java
+++ b/common/src/main/java/com/wynntils/features/HideTripwiresFeature.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features;
+
+import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.ProfileDefault;
+import com.wynntils.mc.event.BlockRenderShapeEvent;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RenderShape;
+import net.neoforged.bus.api.SubscribeEvent;
+
+public class HideTripwiresFeature extends Feature {
+    public HideTripwiresFeature() {
+        super(ProfileDefault.ENABLED);
+    }
+
+    @SubscribeEvent
+    public void onGetBlockRenderShape(BlockRenderShapeEvent event) {
+        // Set tripwires as invisible as the resource pack makes them invisible but when using Sodium they become black
+        // lines
+        if (event.getBlockState().is(Blocks.TRIPWIRE)) {
+            event.setRenderShape(RenderShape.INVISIBLE);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/event/BlockRenderShapeEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/BlockRenderShapeEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.event;
+
+import com.wynntils.core.events.EventThread;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.Event;
+
+@EventThread(EventThread.Type.ANY)
+public class BlockRenderShapeEvent extends Event {
+    private final BlockState blockState;
+
+    private RenderShape renderShape = null;
+
+    public BlockRenderShapeEvent(BlockState blockState) {
+        this.blockState = blockState;
+    }
+
+    public BlockState getBlockState() {
+        return blockState;
+    }
+
+    public RenderShape getRenderShape() {
+        return renderShape;
+    }
+
+    public void setRenderShape(RenderShape renderShape) {
+        this.renderShape = renderShape;
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/BlockBehaviourMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BlockBehaviourMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.mc.mixin;
+
+import com.wynntils.core.events.MixinHelper;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockBehaviour.class)
+public class BlockBehaviourMixin {
+    @Inject(
+            method =
+                    "getRenderShape(Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/RenderShape;",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void hideTripwire(BlockState blockState, CallbackInfoReturnable<RenderShape> cir) {
+        if (!MixinHelper.onWynncraft()) return;
+
+        // Set tripwires as invisible as the resource pack makes them invisible but when using Sodium they become black
+        // lines
+        if (blockState.is(Blocks.TRIPWIRE)) {
+            cir.setReturnValue(RenderShape.INVISIBLE);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/mc/mixin/BlockBehaviourMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/BlockBehaviourMixin.java
@@ -5,7 +5,7 @@
 package com.wynntils.mc.mixin;
 
 import com.wynntils.core.events.MixinHelper;
-import net.minecraft.world.level.block.Blocks;
+import com.wynntils.mc.event.BlockRenderShapeEvent;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
@@ -22,12 +22,11 @@ public class BlockBehaviourMixin {
             at = @At("HEAD"),
             cancellable = true)
     private void hideTripwire(BlockState blockState, CallbackInfoReturnable<RenderShape> cir) {
-        if (!MixinHelper.onWynncraft()) return;
+        BlockRenderShapeEvent event = new BlockRenderShapeEvent(blockState);
+        MixinHelper.post(event);
 
-        // Set tripwires as invisible as the resource pack makes them invisible but when using Sodium they become black
-        // lines
-        if (blockState.is(Blocks.TRIPWIRE)) {
-            cir.setReturnValue(RenderShape.INVISIBLE);
+        if (event.getRenderShape() != null) {
+            cir.setReturnValue(event.getRenderShape());
         }
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -724,6 +724,8 @@
   "feature.wynntils.hideLabels.name": "Hide Labels",
   "feature.wynntils.hideSwapItemAnimation.description": "Hides the animation of swapping items when pressing the swap item key.",
   "feature.wynntils.hideSwapItemAnimation.name": "Hide Swap Item Animation",
+  "feature.wynntils.hideTripwires.description": "Renders tripwires as invisible to fix an incompatibility between Sodium and the Wynncraft resource pack.",
+  "feature.wynntils.hideTripwires.name": "Hide Tripwires",
   "feature.wynntils.horseMount.alreadyRiding": "You are already riding a horse.",
   "feature.wynntils.horseMount.conflictingSlots": "You must free up a slot in your hotbar to mount your horse.",
   "feature.wynntils.horseMount.description": "Adds the ability to mount horses with a keybind.",

--- a/common/src/main/resources/wynntils.mixins.json
+++ b/common/src/main/resources/wynntils.mixins.json
@@ -4,6 +4,7 @@
     "AbstractContainerScreenMixin",
     "AbstractRecipeBookScreenMixin",
     "AvatarRendererMixin",
+    "BlockBehaviourMixin",
     "BossHealthOverlayMixin",
     "CapeLayerMixin",
     "ChatComponentMixin",


### PR DESCRIPTION
Fixes an incompatibility between Sodium and the Wynncraft resource pack that causes tripwires to render as black lines at certain angles. Opted to not make it a feature and instead just default behaviour as I can't see why anyone would want this off.

Current w/ Sodium (See under concrete powder)
<img width="1195" height="641" alt="nofix" src="https://github.com/user-attachments/assets/a5bca108-ef27-453e-9aaf-d468119b90b5" />

Fix w/ Sodium
<img width="1195" height="641" alt="fix" src="https://github.com/user-attachments/assets/06025073-65eb-4457-ae2a-157408648b01" />



