### PR TITLE
fix: Keep powder and abilities on item swap

### DIFF
--- a/common/src/main/java/com/wynntils/models/abilities/ShamanTotemModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShamanTotemModel.java
@@ -11,7 +11,6 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.labels.event.TextDisplayChangedEvent;
 import com.wynntils.mc.event.AddEntityEvent;
-import com.wynntils.mc.event.ChangeCarriedItemEvent;
 import com.wynntils.mc.event.RemoveEntitiesEvent;
 import com.wynntils.models.abilities.event.TotemEvent;
 import com.wynntils.models.abilities.type.ShamanTotem;
@@ -217,11 +216,6 @@ public final class ShamanTotemModel extends Model {
 
     @SubscribeEvent
     public void onClassChange(CharacterUpdateEvent e) {
-        removeAllTotems();
-    }
-
-    @SubscribeEvent
-    public void onHeldItemChange(ChangeCarriedItemEvent e) {
         removeAllTotems();
     }
 

--- a/common/src/main/java/com/wynntils/models/abilities/ShieldModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities;
@@ -8,7 +8,6 @@ import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.mc.event.AddEntityEvent;
-import com.wynntils.mc.event.ChangeCarriedItemEvent;
 import com.wynntils.mc.event.RemoveEntitiesEvent;
 import com.wynntils.models.abilities.type.ArrowShield;
 import com.wynntils.models.abilities.type.GuardianAngelsShield;
@@ -114,11 +113,6 @@ public final class ShieldModel extends Model {
 
     @SubscribeEvent
     public void onClassChange(CharacterUpdateEvent e) {
-        removeShield();
-    }
-
-    @SubscribeEvent
-    public void onHeldItemChange(ChangeCarriedItemEvent e) {
         removeShield();
     }
 

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -10,7 +10,6 @@ import com.wynntils.core.components.Models;
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 import com.wynntils.handlers.actionbar.event.ActionBarRenderEvent;
 import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
-import com.wynntils.mc.event.ChangeCarriedItemEvent;
 import com.wynntils.models.characterstats.actionbar.matchers.HealthBarSegmentMatcher;
 import com.wynntils.models.characterstats.actionbar.matchers.HealthTextSegmentMatcher;
 import com.wynntils.models.characterstats.actionbar.matchers.HotbarSegmentMatcher;
@@ -105,12 +104,6 @@ public final class CharacterStatsModel extends Model {
         // This segment must be updated last, as it updates the level based on the
         // the current experience segment, which are updated above.
         event.runIfPresent(LevelSegment.class, this::updateLevel);
-    }
-
-    @SubscribeEvent
-    public void onHeldItemChanged(ChangeCarriedItemEvent event) {
-        // powders are always reset when held item is changed on Wynn, this ensures consistent behavior
-        powderSpecialInfo = PowderSpecialInfo.EMPTY;
     }
 
     public double getBlocksAboveGround() {

--- a/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/PowderSpecialBarOverlay.java
@@ -45,7 +45,7 @@ public class PowderSpecialBarOverlay extends Overlay {
     private final Config<UniversalTexture> barTexture = new Config<>(UniversalTexture.A);
 
     @Persisted
-    private final Config<Boolean> onlyIfWeaponHeld = new Config<>(true);
+    private final Config<Boolean> onlyIfWeaponHeld = new Config<>(false);
 
     @Persisted
     private final Config<Boolean> hideIfNoCharge = new Config<>(true);


### PR DESCRIPTION
Powder and abilities are no longer wiped when swapping item.

Have also changed the default value for the powder bar config to not hide when you're not holding a weapon anymore as it makes sense to see it at all times now with this new behaviour