### PR TITLE
fix: handle non-string enum json tokens safely in upfixer

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/EnumNamingUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/EnumNamingUpfixer.java
@@ -55,7 +55,7 @@ public class EnumNamingUpfixer implements Upfixer {
         public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
             if (!type.getRawType().isEnum()) return null;
 
-            Class<E> enumClazz = (Class<E>) (Class<?>) type.getRawType();
+            Class<E> enumClazz = (Class<E>) type.getRawType();
             return (TypeAdapter<T>) new EnumConverter<>(enumClazz);
         }
     }

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/EnumNamingUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/EnumNamingUpfixer.java
@@ -51,10 +51,11 @@ public class EnumNamingUpfixer implements Upfixer {
 
     private static final class EnumConverterFactory<E extends Enum<E>> implements TypeAdapterFactory {
         @Override
+        @SuppressWarnings("unchecked")
         public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
             if (!type.getRawType().isEnum()) return null;
 
-            Class<E> enumClazz = (Class<E>) type.getRawType();
+            Class<E> enumClazz = (Class<E>) (Class<?>) type.getRawType();
             return (TypeAdapter<T>) new EnumConverter<>(enumClazz);
         }
     }
@@ -73,9 +74,15 @@ public class EnumNamingUpfixer implements Upfixer {
 
         @Override
         public T read(JsonReader in) throws IOException {
-            if (in.peek() != JsonToken.STRING) {
+            JsonToken token = in.peek();
+            if (token == JsonToken.NULL) {
                 in.nextNull();
                 return null;
+            }
+            if (token != JsonToken.STRING) {
+                WynntilsMod.warn("Invalid json type " + token + " for enum " + enumClazz.getName());
+                in.skipValue();
+                return replacement();
             }
 
             String jsonString = in.nextString();

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/EnumNamingUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/EnumNamingUpfixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.persisted.upfixers.config;

--- a/fabric/src/test/java/TestEnumNamingUpfixer.java
+++ b/fabric/src/test/java/TestEnumNamingUpfixer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+import com.google.gson.Gson;
+import com.wynntils.core.persisted.upfixers.config.EnumNamingUpfixer;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestEnumNamingUpfixer {
+    private enum SampleEnum {
+        DEFAULT,
+        VALUE
+    }
+
+    @Test
+    public void testStringValueParsesAsExpected() throws Exception {
+        Gson gson = getUpfixerGson();
+        Assertions.assertEquals(SampleEnum.VALUE, gson.fromJson("\"VALUE\"", SampleEnum.class));
+    }
+
+    @Test
+    public void testNullValueParsesAsNull() throws Exception {
+        Gson gson = getUpfixerGson();
+        Assertions.assertNull(gson.fromJson("null", SampleEnum.class));
+    }
+
+    @Test
+    public void testNumberValueFallsBackToFirstEnumValue() throws Exception {
+        Gson gson = getUpfixerGson();
+        Assertions.assertEquals(SampleEnum.DEFAULT, gson.fromJson("1", SampleEnum.class));
+    }
+
+    @Test
+    public void testBooleanValueFallsBackToFirstEnumValue() throws Exception {
+        Gson gson = getUpfixerGson();
+        Assertions.assertEquals(SampleEnum.DEFAULT, gson.fromJson("true", SampleEnum.class));
+    }
+
+    private static Gson getUpfixerGson() throws Exception {
+        Field field = EnumNamingUpfixer.class.getDeclaredField("GSON");
+        field.setAccessible(true);
+        return (Gson) field.get(null);
+    }
+}

--- a/fabric/src/test/java/TestEnumNamingUpfixer.java
+++ b/fabric/src/test/java/TestEnumNamingUpfixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Wynntils 2026.
+ * Copyright © Wynntils 2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 import com.google.gson.Gson;


### PR DESCRIPTION
#### Problem: for non-string non-null tokens like `1` or `true`, `nextNull()` is invalid and throws.

To fix this, we explicitly branch on token type: 
1. `STRING` is parsed. 
2. `NULL` is consumed with `nextNull()`.
3. All other tokens are skipped with `skipValue()` and replaced with a safe enum fallback.

Not sure how often this actually occurs, but I can see it causing some annoying issues.