### PR TITLE
feat: Change Content Tracker into TextOverlay and add Text Fit config

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -472,6 +472,7 @@ public final class FunctionManager extends Manager {
 
         // Regular Functions
         registerFunction(new ActivityFunctions.ActivityColorFunction());
+        registerFunction(new ActivityFunctions.ActivityIconFunction());
         registerFunction(new ActivityFunctions.ActivityNameFunction());
         registerFunction(new ActivityFunctions.ActivityTaskFunction());
         registerFunction(new ActivityFunctions.ActivityTypeFunction());

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
@@ -80,7 +80,7 @@ public abstract class TextOverlay extends DynamicOverlay {
                         renderX + this.getWidth(),
                         renderY,
                         renderY + this.getHeight(),
-                        0,
+                        shouldTextFit() ? this.getWidth() : 0,
                         this.getRenderColor(),
                         this.getRenderHorizontalAlignment(),
                         this.getRenderVerticalAlignment(),
@@ -109,6 +109,10 @@ public abstract class TextOverlay extends DynamicOverlay {
 
     private float getTextScale() {
         return fontScale.get();
+    }
+
+    protected boolean shouldTextFit() {
+        return false;
     }
 
     protected abstract String getTemplate();

--- a/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/TextOverlay.java
@@ -28,6 +28,9 @@ public abstract class TextOverlay extends DynamicOverlay {
     @Persisted(i18nKey = "overlay.wynntils.textOverlay.fontScale")
     protected final Config<Float> fontScale = new Config<>(1.0f);
 
+    @Persisted(i18nKey = "overlay.wynntils.textOverlay.fontScale.fitText")
+    protected final Config<Boolean> fitText = new Config<>(false);
+
     private StyledText[] cachedLines = new StyledText[0];
 
     protected TextOverlay(OverlayPosition position, float width, float height) {
@@ -80,7 +83,7 @@ public abstract class TextOverlay extends DynamicOverlay {
                         renderX + this.getWidth(),
                         renderY,
                         renderY + this.getHeight(),
-                        shouldTextFit() ? this.getWidth() : 0,
+                        fitText.get() ? this.getWidth() : 0,
                         this.getRenderColor(),
                         this.getRenderHorizontalAlignment(),
                         this.getRenderVerticalAlignment(),
@@ -109,10 +112,6 @@ public abstract class TextOverlay extends DynamicOverlay {
 
     private float getTextScale() {
         return fontScale.get();
-    }
-
-    protected boolean shouldTextFit() {
-        return false;
     }
 
     protected abstract String getTemplate();

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
@@ -72,7 +72,6 @@ public class UpfixerManager extends Manager {
         registerConfigUpfixer(new CustomBankQuickJumpsBankNameUpfixer());
         registerConfigUpfixer(new NpcDialoguesRenamedUpfixer());
         registerConfigUpfixer(new NpcDialoguesOverlayConfigsMovedUpfixer());
-        registerConfigUpfixer(new ContentTrackerTextOverlayUpfixer());
         registerConfigUpfixer(new TowerAuraVignetteNameUpfixer());
         registerConfigUpfixer(new TowerAuraVignetteAndOverlayMovedToCommonFeature());
         registerConfigUpfixer(new CombatXpGainToXpGainUpfixer());
@@ -89,6 +88,7 @@ public class UpfixerManager extends Manager {
         registerConfigUpfixer(new MythicBlockerToChestBlockerUpfixer());
         registerConfigUpfixer(new MaxItensityToMaxIntensityUpfixer());
         registerConfigUpfixer(new ShowAdditonalTextAboveToShowAdditionalTextAboveUpfixer());
+        registerConfigUpfixer(new ContentTrackerTextOverlayUpfixer());
 
         // Register storage upfixers here, in order of run priority
         registerStorageUpfixer(new BankToAccountBankUpfixer());

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/UpfixerManager.java
@@ -11,6 +11,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Manager;
 import com.wynntils.core.persisted.PersistedValue;
 import com.wynntils.core.persisted.upfixers.config.CombatXpGainToXpGainUpfixer;
+import com.wynntils.core.persisted.upfixers.config.ContentTrackerTextOverlayUpfixer;
 import com.wynntils.core.persisted.upfixers.config.CustomBankQuickJumpsBankNameUpfixer;
 import com.wynntils.core.persisted.upfixers.config.CustomBankQuickJumpsUpfixer;
 import com.wynntils.core.persisted.upfixers.config.CustomCommandKeybindSlashStartUpfixer;
@@ -71,6 +72,7 @@ public class UpfixerManager extends Manager {
         registerConfigUpfixer(new CustomBankQuickJumpsBankNameUpfixer());
         registerConfigUpfixer(new NpcDialoguesRenamedUpfixer());
         registerConfigUpfixer(new NpcDialoguesOverlayConfigsMovedUpfixer());
+        registerConfigUpfixer(new ContentTrackerTextOverlayUpfixer());
         registerConfigUpfixer(new TowerAuraVignetteNameUpfixer());
         registerConfigUpfixer(new TowerAuraVignetteAndOverlayMovedToCommonFeature());
         registerConfigUpfixer(new CombatXpGainToXpGainUpfixer());

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/config/ContentTrackerTextOverlayUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/config/ContentTrackerTextOverlayUpfixer.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.persisted.upfixers.config;
+
+import com.wynntils.core.persisted.upfixers.RenamedPrefixesUpfixer;
+import com.wynntils.utils.type.Pair;
+import java.util.List;
+
+public class ContentTrackerTextOverlayUpfixer extends RenamedPrefixesUpfixer {
+    private static final List<Pair<String, String>> RENAMED_PREFIXES = List.of(Pair.of(
+            "contentTrackerOverlayFeature.contentTrackerOverlay",
+            "contentTrackerOverlayFeature.contentTrackerOverlay1"));
+
+    @Override
+    protected List<Pair<String, String>> getRenamedPrefixes() {
+        return RENAMED_PREFIXES;
+    }
+}

--- a/common/src/main/java/com/wynntils/functions/ActivityFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/ActivityFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.functions;
@@ -8,6 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.functions.Function;
 import com.wynntils.core.consumers.functions.arguments.Argument;
 import com.wynntils.core.consumers.functions.arguments.FunctionArguments;
+import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.type.StyleType;
 import com.wynntils.models.activities.type.ActivityType;
 import com.wynntils.utils.colors.CustomColor;
@@ -55,6 +56,14 @@ public class ActivityFunctions {
         public CustomColor getValue(FunctionArguments arguments) {
             ActivityType type = Models.Activity.getTrackedType();
             return type != null ? type.getColor() : CustomColor.NONE;
+        }
+    }
+
+    public static class ActivityIconFunction extends Function<StyledText> {
+        @Override
+        public StyledText getValue(FunctionArguments arguments) {
+            ActivityType type = Models.Activity.getTrackedType();
+            return type != null ? StyledText.fromPart(type.getIcon()) : StyledText.EMPTY;
         }
     }
 }

--- a/common/src/main/java/com/wynntils/models/activities/type/ActivityType.java
+++ b/common/src/main/java/com/wynntils/models/activities/type/ActivityType.java
@@ -53,7 +53,6 @@ public enum ActivityType {
                 Identifier.withDefaultNamespace("items"),
                 Identifier.withDefaultNamespace("wynn/gui/content_book/" + fontIcon + "_active"));
     }
-    ;
 
     public static ActivityType from(CustomColor color, String displayName) {
         for (ActivityType type : values()) {

--- a/common/src/main/java/com/wynntils/models/activities/type/ActivityType.java
+++ b/common/src/main/java/com/wynntils/models/activities/type/ActivityType.java
@@ -1,40 +1,59 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities.type;
 
+import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.render.Texture;
 import java.util.Objects;
+import net.minecraft.network.chat.FontDescription;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.Identifier;
 
 public enum ActivityType {
-    RECOMMENDED("Recommended", "recommended", null, null),
-    QUEST("Quest", "quests", CustomColor.fromInt(0x29cc96), Texture.QUEST_ICON),
-    STORYLINE_QUEST("Quest", "quests", CustomColor.fromInt(0x33b33b), Texture.STORYLINE_QUEST_ICON),
-    MINI_QUEST("Mini-Quest", "mini-quests", CustomColor.fromInt(0xb38fad), Texture.MINI_QUEST_ICON),
-    WORLD_EVENT("World Event", "world events", CustomColor.fromInt(0x00bdbf), Texture.WORLD_EVENT_ICON),
-    SECRET_DISCOVERY("Secret Discovery", "secret discoveries", CustomColor.fromInt(0xa1c3e6), Texture.DISCOVERY_ICON),
-    WORLD_DISCOVERY("World Discovery", "world discoveries", CustomColor.fromInt(0xa1c3e6), Texture.DISCOVERY_ICON),
+    RECOMMENDED("Recommended", "recommended", null, null, null),
+    QUEST("Quest", "quests", CustomColor.fromInt(0x29cc96), Texture.QUEST_ICON, "quest"),
+    STORYLINE_QUEST("Quest", "quests", CustomColor.fromInt(0x33b33b), Texture.STORYLINE_QUEST_ICON, "story_quest"),
+    MINI_QUEST("Mini-Quest", "mini-quests", CustomColor.fromInt(0xb38fad), Texture.MINI_QUEST_ICON, "mini_quest"),
+    WORLD_EVENT("World Event", "world events", CustomColor.fromInt(0x00bdbf), Texture.WORLD_EVENT_ICON, "world_event"),
+    SECRET_DISCOVERY(
+            "Secret Discovery",
+            "secret discoveries",
+            CustomColor.fromInt(0xa1c3e6),
+            Texture.DISCOVERY_ICON,
+            "discovery"),
+    WORLD_DISCOVERY(
+            "World Discovery", "world discoveries", CustomColor.fromInt(0xa1c3e6), Texture.DISCOVERY_ICON, "discovery"),
     TERRITORIAL_DISCOVERY(
-            "Territorial Discovery", "territorial discoveries", CustomColor.fromInt(0xa1c3e6), Texture.DISCOVERY_ICON),
-    CAVE("Cave", "caves", CustomColor.fromInt(0xff8c19), Texture.CAVE),
-    DUNGEON("Dungeon", "dungeons", CustomColor.fromInt(0xcc6677), Texture.DUNGEON_ENTRANCE),
-    RAID("Raid", "raids", CustomColor.fromInt(0xd6401e), Texture.RAID_ENTRANCE),
-    BOSS_ALTAR("Boss Altar", "boss altars", CustomColor.fromInt(0xf2d349), Texture.BOSS_ALTAR),
-    LOOTRUN_CAMP("Lootrun Camp", "lootrun camps", CustomColor.fromInt(0x3399cc), Texture.LOOTRUN_CAMP);
+            "Territorial Discovery",
+            "territorial discoveries",
+            CustomColor.fromInt(0xa1c3e6),
+            Texture.DISCOVERY_ICON,
+            "discovery"),
+    CAVE("Cave", "caves", CustomColor.fromInt(0xff8c19), Texture.CAVE, "cave"),
+    DUNGEON("Dungeon", "dungeons", CustomColor.fromInt(0xcc6677), Texture.DUNGEON_ENTRANCE, "dungeon"),
+    RAID("Raid", "raids", CustomColor.fromInt(0xd6401e), Texture.RAID_ENTRANCE, "raid"),
+    BOSS_ALTAR("Boss Altar", "boss altars", CustomColor.fromInt(0xf2d349), Texture.BOSS_ALTAR, "boss_altar"),
+    LOOTRUN_CAMP("Lootrun Camp", "lootrun camps", CustomColor.fromInt(0x3399cc), Texture.LOOTRUN_CAMP, "loot_camp");
 
     private final String displayName;
     private final String groupName;
     private final CustomColor color;
     private final Texture texture;
+    private final FontDescription fontIcon;
 
-    ActivityType(String displayName, String groupName, CustomColor color, Texture texture) {
+    ActivityType(String displayName, String groupName, CustomColor color, Texture texture, String fontIcon) {
         this.displayName = displayName;
         this.groupName = groupName;
         this.color = color;
         this.texture = texture;
+        this.fontIcon = new FontDescription.AtlasSprite(
+                Identifier.withDefaultNamespace("items"),
+                Identifier.withDefaultNamespace("wynn/gui/content_book/" + fontIcon + "_active"));
     }
+    ;
 
     public static ActivityType from(CustomColor color, String displayName) {
         for (ActivityType type : values()) {
@@ -89,5 +108,9 @@ public enum ActivityType {
             case STORYLINE_QUEST, MINI_QUEST -> activityType == this || activityType == QUEST;
             default -> activityType == this;
         };
+    }
+
+    public StyledTextPart getIcon() {
+        return new StyledTextPart("A", Style.EMPTY.withFont(fontIcon), null, null);
     }
 }

--- a/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
@@ -24,6 +24,9 @@ public class ContentTrackerOverlay extends TextOverlay {
     @Persisted
     private final Config<Boolean> disableTrackerOnScoreboard = new Config<>(true);
 
+    @Persisted
+    private final Config<Style> displayStyle = new Config<>(Style.MODERN);
+
     public ContentTrackerOverlay() {
         super(
                 new OverlayPosition(
@@ -47,10 +50,7 @@ public class ContentTrackerOverlay extends TextOverlay {
 
     @Override
     protected String getTemplate() {
-        return """
-                {activity_icon}§r{with_color(styled_text(concat(activity_type; " — "; activity_name));activity_color)}§r
-                {activity_task(true)}
-                """;
+        return displayStyle.get().template;
     }
 
     @Override
@@ -75,5 +75,30 @@ public class ContentTrackerOverlay extends TextOverlay {
     @Override
     protected boolean isVisible() {
         return Models.Activity.isTracking();
+    }
+
+    private enum Style {
+        MODERN(
+                """
+                {activity_icon}§r{with_color(styled_text(concat(activity_type; " — "; activity_name));activity_color)}§r
+                {activity_task(true)}
+                """),
+        NO_ICON(
+                """
+                {with_color(styled_text(concat(activity_type; " — "; activity_name));activity_color)}§r
+                {activity_task(true)}
+                """),
+        LEGACY(
+                """
+                §aTracked {activity_type}:
+                §6{activity_name}§r
+                {activity_task(true)}
+                """);
+
+        public final String template;
+
+        Style(String template) {
+            this.template = template;
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
@@ -6,48 +6,23 @@ package com.wynntils.overlays;
 
 import com.mojang.blaze3d.platform.Window;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.OverlayPosition;
 import com.wynntils.core.consumers.overlays.OverlaySize;
+import com.wynntils.core.consumers.overlays.TextOverlay;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
-import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.scoreboard.event.ScoreboardSegmentAdditionEvent;
 import com.wynntils.models.activities.ActivityTrackerScoreboardPart;
-import com.wynntils.utils.colors.CommonColors;
-import com.wynntils.utils.colors.CustomColor;
-import com.wynntils.utils.render.FontRenderer;
-import com.wynntils.utils.render.TextRenderSetting;
-import com.wynntils.utils.render.TextRenderTask;
 import com.wynntils.utils.render.type.HorizontalAlignment;
-import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
-import java.util.ArrayList;
-import java.util.List;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.resources.language.I18n;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
-public class ContentTrackerOverlay extends Overlay {
-    private static final String PREVIEW_TASK = """
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer \
-                    tempus purus in lacus pulvinar dictum. Quisque suscipit erat \
-                    pellentesque egestas volutpat. \
-                    """;
-
+public class ContentTrackerOverlay extends TextOverlay {
     @Persisted
     private final Config<Boolean> disableTrackerOnScoreboard = new Config<>(true);
-
-    @Persisted
-    private final Config<TextShadow> textShadow = new Config<>(TextShadow.OUTLINE);
-
-    private static final List<CustomColor> TEXT_COLORS =
-            List.of(CommonColors.GREEN, CommonColors.ORANGE, CommonColors.WHITE);
-
-    private final List<TextRenderTask> toRender = createRenderTaskList();
-    private final List<TextRenderTask> toRenderPreview = createRenderTaskList();
 
     public ContentTrackerOverlay() {
         super(
@@ -60,14 +35,6 @@ public class ContentTrackerOverlay extends Overlay {
                 new OverlaySize(300, 50),
                 HorizontalAlignment.LEFT,
                 VerticalAlignment.MIDDLE);
-
-        toRenderPreview
-                .get(0)
-                .setText(I18n.get("feature.wynntils.contentTrackerOverlay.overlay.contentTracker.title") + " Quest:");
-        toRenderPreview
-                .get(1)
-                .setText(I18n.get("feature.wynntils.contentTrackerOverlay.overlay.contentTracker.testQuestName") + ":");
-        toRenderPreview.get(2).setText(PREVIEW_TASK);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -79,73 +46,34 @@ public class ContentTrackerOverlay extends Overlay {
     }
 
     @Override
-    protected void onConfigUpdate(Config<?> config) {
-        updateTextRenderSettings(toRender);
+    protected String getTemplate() {
+        return """
+                {activity_icon}§r{with_color(styled_text(concat(activity_type; " — "; activity_name));activity_color)}§r
+                {activity_task(true)}
+                """;
+    }
+
+    @Override
+    protected String getPreviewTemplate() {
+        return """
+                     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer \
+                    tempus purus in lacus pulvinar dictum. Quisque suscipit erat \
+                    pellentesque egestas volutpat. \
+                    """;
+    }
+
+    @Override
+    protected boolean shouldTextFit() {
+        return true;
     }
 
     @Override
     public void render(GuiGraphics guiGraphics, DeltaTracker deltaTracker, Window window) {
-        if (!Models.Activity.isTracking()) {
-            return;
-        }
-
-        toRender.get(0)
-                .setText(I18n.get("feature.wynntils.contentTrackerOverlay.overlay.contentTracker.title") + " "
-                        + Models.Activity.getTrackedType().getDisplayName() + ":");
-        toRender.get(1).setText(Models.Activity.getTrackedName());
-        toRender.get(2).setText(Models.Activity.getTrackedTask());
-
-        FontRenderer.getInstance()
-                .renderTextsWithAlignment(
-                        guiGraphics,
-                        this.getRenderX(),
-                        this.getRenderY(),
-                        toRender,
-                        this.getWidth(),
-                        this.getHeight(),
-                        this.getRenderHorizontalAlignment(),
-                        this.getRenderVerticalAlignment());
+        super.render(guiGraphics, deltaTracker, window);
     }
 
     @Override
-    public void renderPreview(GuiGraphics guiGraphics, DeltaTracker deltaTracker, Window window) {
-        updateTextRenderSettings(toRenderPreview); // we have to force update every time
-
-        FontRenderer.getInstance()
-                .renderTextsWithAlignment(
-                        guiGraphics,
-                        this.getRenderX(),
-                        this.getRenderY(),
-                        toRenderPreview,
-                        this.getWidth(),
-                        this.getHeight(),
-                        this.getRenderHorizontalAlignment(),
-                        this.getRenderVerticalAlignment());
-    }
-
-    private List<TextRenderTask> createRenderTaskList() {
-        List<TextRenderTask> renderTaskList = new ArrayList<>(3);
-        for (int i = 0; i < 3; i++) {
-            renderTaskList.add(new TextRenderTask(
-                    StyledText.EMPTY,
-                    TextRenderSetting.DEFAULT
-                            .withMaxWidth(this.getWidth())
-                            .withCustomColor(TEXT_COLORS.get(i))
-                            .withHorizontalAlignment(this.getRenderHorizontalAlignment())
-                            .withTextShadow(this.textShadow.get())));
-        }
-        return renderTaskList;
-    }
-
-    private void updateTextRenderSettings(List<TextRenderTask> renderTasks) {
-        for (int i = 0; i < 3; i++) {
-            renderTasks
-                    .get(i)
-                    .setSetting(TextRenderSetting.DEFAULT
-                            .withMaxWidth(this.getWidth())
-                            .withCustomColor(TEXT_COLORS.get(i))
-                            .withHorizontalAlignment(this.getRenderHorizontalAlignment())
-                            .withTextShadow(this.textShadow.get()));
-        }
+    protected boolean isVisible() {
+        return Models.Activity.isTracking();
     }
 }

--- a/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
@@ -80,12 +80,12 @@ public class ContentTrackerOverlay extends TextOverlay {
     private enum Style {
         MODERN(
                 """
-                {activity_icon}§r{with_color(styled_text(concat(activity_type; " — "; activity_name));activity_color)}§r
+                {activity_icon}§rÀ{with_font(with_color(styled_text(concat(activity_type; " - "; activity_name));activity_color);"language/wynncraft")}§r
                 {activity_task(true)}
                 """),
         NO_ICON(
                 """
-                {with_color(styled_text(concat(activity_type; " — "; activity_name));activity_color)}§r
+                {with_font(with_color(styled_text(concat(activity_type; " - "; activity_name));activity_color);"language/wynncraft")}§r
                 {activity_task(true)}
                 """),
         LEGACY(

--- a/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
@@ -38,6 +38,7 @@ public class ContentTrackerOverlay extends TextOverlay {
                 new OverlaySize(300, 50),
                 HorizontalAlignment.LEFT,
                 VerticalAlignment.MIDDLE);
+        fitText.store(true);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -60,11 +61,6 @@ public class ContentTrackerOverlay extends TextOverlay {
                You can select any overlay from Overlay Manager and edit it freely, moving, resizing and changing its rendering order.
                You can also hover over it while editing to show a tooltip with keyboard shortcuts!
                """;
-    }
-
-    @Override
-    protected boolean shouldTextFit() {
-        return true;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/ContentTrackerOverlay.java
@@ -56,10 +56,10 @@ public class ContentTrackerOverlay extends TextOverlay {
     @Override
     protected String getPreviewTemplate() {
         return """
-                     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer \
-                    tempus purus in lacus pulvinar dictum. Quisque suscipit erat \
-                    pellentesque egestas volutpat. \
-                    """;
+               {with_atlas_sprite_font(styled_text("A");"items";"wynn/gui/content_book/quest_active")}§r§#29cc96ffQuest — Moving Wynntils Overlays§r
+               You can select any overlay from Overlay Manager and edit it freely, moving, resizing and changing its rendering order.
+               You can also hover over it while editing to show a tooltip with keyboard shortcuts!
+               """;
     }
 
     @Override

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -394,6 +394,8 @@
   "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.description": "Display information about the currently tracked content",
   "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.disableTrackerOnScoreboard.description": "Should tracked segment be removed from the scoreboard? This option only works if trackerOverlay is turned on.",
   "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.disableTrackerOnScoreboard.name": "Disable Scoreboard Tracker",
+  "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.displayStyle.description": "Determines the style of how the Content Tracker displays its content.",
+  "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.displayStyle.name": "Display style",
   "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.name": "Content Tracker",
   "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.testQuestName": "Test quest",
   "feature.wynntils.contentTrackerOverlay.overlay.contentTracker.textShadow.description": "What should the text shadow look like?",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1788,6 +1788,8 @@
   "function.wynntils.accessoryDurability.name": "Accessory Durability",
   "function.wynntils.activityColor.description": "The CustomColor of the current tracked activity type",
   "function.wynntils.activityColor.name": "Activity Color",
+  "function.wynntils.activityIcon.description": "Returns the icon of tracked activity",
+  "function.wynntils.activityIcon.name": "Activity Icon",
   "function.wynntils.activityName.description": "The name of the current tracked activity",
   "function.wynntils.activityName.name": "Activity Name",
   "function.wynntils.activityTask.argument.formatted": "Whether to retain color codes",

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2905,6 +2905,8 @@
   "overlay.wynntils.overlay.verticalAlignmentOverride.description": "Set this if you want to override the position vertical alignment",
   "overlay.wynntils.overlay.verticalAlignmentOverride.name": "Vertical Alignment Override",
   "overlay.wynntils.textOverlay.fontScale.description": "How large should the text be?",
+  "overlay.wynntils.textOverlay.fontScale.fitText.description": "Whether the text should fit the width of this overlay",
+  "overlay.wynntils.textOverlay.fontScale.fitText.name": "Fit Text",
   "overlay.wynntils.textOverlay.fontScale.name": "Font Scale",
   "overlay.wynntils.textOverlay.textShadow.description": "Should the text be drawn with a shadow?",
   "overlay.wynntils.textOverlay.textShadow.name": "Text Shadow",


### PR DESCRIPTION
Depends on #3810
<img width="944" height="156" alt="image" src="https://github.com/user-attachments/assets/993a2d1c-66f7-4bcd-b85e-a522ab5d9a7f" />
Remakes Content Tracker into a TextOverlay, functions provide all and more info about currently tracked activity. I redesigned the look of it to match the description in our custom content book as well as add a little icon which I think looks nice.
This also required adding a way for TextOverlay to fit the text into its size to match original behavior of this overlay.
With that the overlay is modernized and has frequently asked setting for font size.

The only limitation is that our activity detection doesn't detect everything like mini quests or story quests while it does in the custom content book creating a little disparity.
There is also a custom made quest as a preview message
<img width="1049" height="281" alt="image" src="https://github.com/user-attachments/assets/379245d5-6366-41d2-bafb-95fc723cfe31" />
