### PR TITLE
feat: Add option to always show bombs from the current world for grouped bombs

### DIFF
--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds;
@@ -147,14 +147,49 @@ public final class BombModel extends Model {
     }
 
     public Stream<BombInfo> getBombBellStream(boolean group, BombSortOrder sortOrder, int maxPerGroup) {
+        return getBombBellStream(group, sortOrder, maxPerGroup, false);
+    }
+
+    public Stream<BombInfo> getBombBellStream(
+            boolean group, BombSortOrder sortOrder, int maxPerGroup, boolean alwaysShowCurrentWorld) {
         Stream<BombInfo> stream = getBombBells().stream();
         Comparator<BombInfo> comparator = sortOrder == BombSortOrder.NEWEST
                 ? Comparator.comparing(BombInfo::getRemainingLong).reversed()
                 : Comparator.comparing(BombInfo::getRemainingLong);
 
         if (group) {
+            String currentWorld = Models.WorldState.getCurrentWorldName();
+
             return stream.collect(Collectors.groupingBy(BombInfo::bomb)).values().stream()
-                    .flatMap(list -> list.stream().sorted(comparator).limit(maxPerGroup));
+                    .flatMap(list -> {
+                        List<BombInfo> sorted = list.stream().sorted(comparator).toList();
+                        if (!alwaysShowCurrentWorld
+                                || maxPerGroup <= 0
+                                || currentWorld == null
+                                || currentWorld.isBlank()) {
+                            return sorted.stream().limit(maxPerGroup);
+                        }
+
+                        BombInfo currentWorldBomb = sorted.stream()
+                                .filter(bomb -> currentWorld.equals(bomb.server()))
+                                .findFirst()
+                                .orElse(null);
+
+                        List<BombInfo> selected =
+                                sorted.stream().limit(maxPerGroup).collect(Collectors.toList());
+                        if (currentWorldBomb == null || selected.contains(currentWorldBomb)) {
+                            return selected.stream();
+                        }
+
+                        if (selected.isEmpty()) {
+                            return Stream.of(currentWorldBomb);
+                        }
+
+                        // Keep per-group size fixed: replace the lowest-priority selected bomb with current-world bomb.
+                        selected.remove(selected.size() - 1);
+                        selected.add(currentWorldBomb);
+                        return selected.stream().sorted(comparator);
+                    });
         } else {
             return stream.sorted(comparator).limit(maxPerGroup);
         }

--- a/common/src/main/java/com/wynntils/overlays/BombBellOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/BombBellOverlay.java
@@ -64,6 +64,9 @@ public class BombBellOverlay extends Overlay {
     @Persisted
     private final Config<Boolean> showProfessionSpeedBombs = new Config<>(true);
 
+    @Persisted
+    private final Config<Boolean> alwaysShowCurrentWorld = new Config<>(false);
+
     private final Map<BombType, Supplier<Boolean>> bombTypeMap = Map.ofEntries(
             Map.entry(BombType.COMBAT_XP, showCombatBombs::get),
             Map.entry(BombType.DUNGEON, showDungeonBombs::get),
@@ -144,7 +147,7 @@ public class BombBellOverlay extends Overlay {
     @Override
     public void tick() {
         Stream<BombInfo> bombsToRender = Models.Bomb.getBombBellStream(
-                        groupBombs.get(), sortOrder.get(), maxBombs.get())
+                        groupBombs.get(), sortOrder.get(), maxBombs.get(), alwaysShowCurrentWorld.get())
                 .filter(bombInfo -> {
                     BombType bombType = bombInfo.bomb();
                     Supplier<Boolean> bombTypeSupplier = bombTypeMap.get(bombType);

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -146,6 +146,8 @@
   "feature.wynntils.betaWarning.usingReleaseOnBetaServer": "You are using a release version of Wynntils. This version is not supported on the Wynncraft Beta and various features may be broken. Please connect to the normal Wynncraft server or use a beta version of Wynntils which you can find in our Discord at %s.",
   "feature.wynntils.bombBellOverlay.description": "Adds an overlay to see active bombs.",
   "feature.wynntils.bombBellOverlay.name": "Bomb Bell",
+  "feature.wynntils.bombBellOverlay.overlay.bombBell.alwaysShowCurrentWorld.description": "Should bombs in the current world always be shown?",
+  "feature.wynntils.bombBellOverlay.overlay.bombBell.alwaysShowCurrentWorld.name": "Always Show Bombs in Current World",
   "feature.wynntils.bombBellOverlay.overlay.bombBell.fontScale.description": "How large should the bomb bell text be?",
   "feature.wynntils.bombBellOverlay.overlay.bombBell.fontScale.name": "Font Scale",
   "feature.wynntils.bombBellOverlay.overlay.bombBell.groupBombs.description": "Should bombs be grouped together by type?",


### PR DESCRIPTION
Unrelated to tickets, just a feature I was missing personally since I dont like waiting for the to boss bar to cycle to show the current bomb(s)