### PR TITLE
feat: Update item tooltip backgrounds

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -289,7 +289,6 @@ public class ChatItemFeature extends Feature {
 
         ItemStack itemStack = new FakeItemStack(wynnItem, "From chat");
 
-        // FIXME: Doesn't work?
         itemStack.set(DataComponents.TOOLTIP_STYLE, tooltipStyle);
 
         style = style.withHoverEvent(new HoverEvent.ShowItem(itemStack));

--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -50,10 +51,12 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.Style;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.EventPriority;
@@ -269,11 +272,26 @@ public class ChatItemFeature extends Feature {
 
         Style style = Style.EMPTY.applyFormat(ChatFormatting.UNDERLINE).withColor(ChatFormatting.GOLD);
 
+        Identifier tooltipStyle = null;
+
         if (wynnItem instanceof GearTierItemProperty tierItemProperty) {
             style = style.withColor(tierItemProperty.getGearTier().getChatFormatting());
+
+            String tooltipStyleName = tierItemProperty.getGearTier().name().toLowerCase(Locale.ROOT);
+
+            if (wynnItem instanceof ShinyItemProperty shiny
+                    && shiny.getShinyStat().isPresent()) {
+                tooltipStyleName += "_shiny";
+            }
+
+            tooltipStyle = Identifier.withDefaultNamespace(tooltipStyleName);
         }
 
         ItemStack itemStack = new FakeItemStack(wynnItem, "From chat");
+
+        // FIXME: Doesn't work?
+        itemStack.set(DataComponents.TOOLTIP_STYLE, tooltipStyle);
+
         style = style.withHoverEvent(new HoverEvent.ShowItem(itemStack));
 
         // Add the item name

--- a/common/src/main/java/com/wynntils/models/aspects/AspectInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/aspects/AspectInfoRegistry.java
@@ -114,7 +114,7 @@ public class AspectInfoRegistry {
             String name = json.get("name").getAsString();
             GearTier gearTier = GearTier.fromString(json.get("rarity").getAsString());
             ClassType classType = ClassType.fromName(json.get("requiredClass").getAsString());
-            ItemMaterial itemMaterial = parseMaterial(json);
+            ItemMaterial itemMaterial = parseMaterial(json, null);
 
             List<Pair<Integer, List<StyledText>>> tiers = new ArrayList<>();
 

--- a/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
@@ -125,7 +125,7 @@ public class GearInfoRegistry {
 
             int powderSlots = JsonUtils.getNullableJsonInt(json, "powderSlots");
 
-            GearMetaInfo metaInfo = parseMetaInfo(json, internalName, type);
+            GearMetaInfo metaInfo = parseMetaInfo(json, internalName, type, tier);
             GearRequirements requirements = parseRequirements(json, type);
             FixedStats fixedStats = parseFixedStats(json);
             List<Pair<StatType, StatPossibleValues>> variableStats = parseVariableStats(json, "identifications");

--- a/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/ingredients/IngredientInfoRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.ingredients;
@@ -38,11 +38,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import net.minecraft.resources.Identifier;
 
 public class IngredientInfoRegistry {
     private static final Gson GSON = new GsonBuilder()
             .registerTypeHierarchyAdapter(IngredientInfo.class, new IngredientInfoDeserializer())
             .create();
+    private static final Identifier TOOLTIP_STYLE = Identifier.withDefaultNamespace("profession_ingredient");
 
     private List<IngredientInfo> ingredientInfoRegistry = List.of();
     private Map<String, IngredientInfo> ingredientInfoLookup = Map.of();
@@ -171,11 +173,11 @@ public class IngredientInfoRegistry {
         }
 
         private ItemMaterial parseMaterial(JsonObject json, String name) {
-            ItemMaterial material = parseMaterial(json);
+            ItemMaterial material = parseMaterial(json, TOOLTIP_STYLE);
 
             if (material == null) {
                 WynntilsMod.warn("Ingredient DB is missing material for " + name);
-                return ItemMaterial.fromItemId("minecraft:air", 0);
+                return ItemMaterial.fromItemId("minecraft:air", 0, TOOLTIP_STYLE);
             }
 
             return material;

--- a/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
+++ b/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
@@ -49,7 +49,7 @@ public class FakeItemStack extends ItemStack {
 
     @Override
     public ItemStack copy() {
-        return new FakeItemStack(wynnItem, itemStack, source);
+        return new FakeItemStack(wynnItem, this, source);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/rewards/CharmInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/rewards/CharmInfoRegistry.java
@@ -33,10 +33,12 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import net.minecraft.resources.Identifier;
 
 public class CharmInfoRegistry {
     private static final Gson GSON = new GsonBuilder()
@@ -107,7 +109,7 @@ public class CharmInfoRegistry {
                 throw new RuntimeException("Invalid Wynncraft data: charm has no tier");
             }
 
-            GearMetaInfo metaInfo = parseMetaInfo(json, internalName);
+            GearMetaInfo metaInfo = parseMetaInfo(json, internalName, tier);
             CharmRequirements requirements = parseCharmRequirements(json);
 
             // Base stats are parsed the same way as variable stats
@@ -123,9 +125,10 @@ public class CharmInfoRegistry {
                     Stream.concat(baseStats.stream(), variableStats.stream()).toList());
         }
 
-        private GearMetaInfo parseMetaInfo(JsonObject json, String apiName) {
+        private GearMetaInfo parseMetaInfo(JsonObject json, String apiName, GearTier tier) {
             GearRestrictions restrictions = parseRestrictions(json);
-            ItemMaterial material = parseMaterial(json, apiName);
+            ItemMaterial material = parseMaterial(
+                    json, apiName, Identifier.withDefaultNamespace(tier.name().toLowerCase(Locale.ROOT)));
 
             List<ItemObtainInfo> obtainInfo = parseObtainInfo(json);
 
@@ -133,12 +136,12 @@ public class CharmInfoRegistry {
                     restrictions, material, obtainInfo, Optional.empty(), Optional.empty(), true, false);
         }
 
-        private ItemMaterial parseMaterial(JsonObject json, String name) {
-            ItemMaterial material = parseMaterial(json);
+        private ItemMaterial parseMaterial(JsonObject json, String name, Identifier tooltipStyle) {
+            ItemMaterial material = parseMaterial(json, tooltipStyle);
 
             if (material == null) {
                 WynntilsMod.warn("Charm DB is missing material for " + name);
-                return ItemMaterial.getDefaultCharmItemMaterial();
+                return ItemMaterial.getDefaultCharmItemMaterial(tooltipStyle);
             }
 
             return material;

--- a/common/src/main/java/com/wynntils/models/rewards/TomeInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/rewards/TomeInfoRegistry.java
@@ -33,10 +33,12 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import net.minecraft.resources.Identifier;
 
 public class TomeInfoRegistry {
     private static final Gson GSON = new GsonBuilder()
@@ -112,7 +114,7 @@ public class TomeInfoRegistry {
                 throw new RuntimeException("Invalid Wynncraft data: tome has no tier");
             }
 
-            GearMetaInfo metaInfo = parseMetaInfo(json, internalName);
+            GearMetaInfo metaInfo = parseMetaInfo(json, internalName, tier);
             TomeRequirements requirements = parseTomeRequirements(json);
 
             JsonObject identifications = JsonUtils.getNullableJsonObject(json, "identifications");
@@ -122,9 +124,10 @@ public class TomeInfoRegistry {
             return new TomeInfo(displayName, type, tier, metaInfo, requirements, variableStats);
         }
 
-        private GearMetaInfo parseMetaInfo(JsonObject json, String apiName) {
+        private GearMetaInfo parseMetaInfo(JsonObject json, String apiName, GearTier tier) {
             GearRestrictions restrictions = parseRestrictions(json);
-            ItemMaterial material = parseMaterial(json, apiName);
+            ItemMaterial material = parseMaterial(
+                    json, apiName, Identifier.withDefaultNamespace(tier.name().toLowerCase(Locale.ROOT)));
 
             List<ItemObtainInfo> obtainInfo = parseObtainInfo(json);
 
@@ -132,12 +135,12 @@ public class TomeInfoRegistry {
                     restrictions, material, obtainInfo, Optional.empty(), Optional.empty(), true, false);
         }
 
-        private ItemMaterial parseMaterial(JsonObject json, String name) {
-            ItemMaterial material = parseMaterial(json);
+        private ItemMaterial parseMaterial(JsonObject json, String name, Identifier tooltipStyle) {
+            ItemMaterial material = parseMaterial(json, tooltipStyle);
 
             if (material == null) {
                 WynntilsMod.warn("Tome DB is missing material for " + name);
-                return ItemMaterial.getDefaultTomeItemMaterial();
+                return ItemMaterial.getDefaultTomeItemMaterial(tooltipStyle);
             }
 
             return material;

--- a/common/src/main/java/com/wynntils/models/wynnitem/AbstractItemInfoDeserializer.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/AbstractItemInfoDeserializer.java
@@ -21,6 +21,7 @@ import com.wynntils.models.gear.type.GearMajorId;
 import com.wynntils.models.gear.type.GearMetaInfo;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearRestrictions;
+import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.stats.StatCalculator;
 import com.wynntils.models.stats.type.DamageType;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import net.minecraft.resources.Identifier;
 
 public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserializer<T> {
     protected Pair<String, String> parseNames(JsonObject json) {
@@ -78,13 +80,14 @@ public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserialize
         return GearType.fromString(typeString);
     }
 
-    protected GearMetaInfo parseMetaInfo(JsonObject json, String apiName, GearType type) {
+    protected GearMetaInfo parseMetaInfo(JsonObject json, String apiName, GearType type, GearTier tier) {
         GearRestrictions restrictions = parseRestrictions(json);
-        ItemMaterial material = parseMaterial(json, type);
+        Identifier tooltipStyle = Identifier.withDefaultNamespace(tier.name().toLowerCase(Locale.ROOT));
+        ItemMaterial material = parseMaterial(json, type, tooltipStyle);
 
         if (material == null || material.itemStack().isEmpty()) {
             WynntilsMod.warn("Failed to parse material for " + json.get("name").getAsString());
-            material = ItemMaterial.fromItemId("minecraft:air", 0);
+            material = ItemMaterial.fromItemId("minecraft:air", 0, tooltipStyle);
         }
 
         List<ItemObtainInfo> obtainInfo = parseObtainInfo(json);
@@ -209,47 +212,47 @@ public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserialize
         return List.copyOf(types);
     }
 
-    private ItemMaterial parseMaterial(JsonObject json, GearType type) {
+    private ItemMaterial parseMaterial(JsonObject json, GearType type, Identifier tooltip) {
         if (type == GearType.HELMET && json.has("armourMaterial")) {
             // Helmets that use vanilla blocks/items use the armourMaterial field instead of icon
             switch (json.get("armourMaterial").getAsString()) {
                 case "creeper" -> {
-                    return ItemMaterial.fromItemId("minecraft:creeper_head", 0);
+                    return ItemMaterial.fromItemId("minecraft:creeper_head", 0, tooltip);
                 }
                 case "zombie" -> {
-                    return ItemMaterial.fromItemId("minecraft:zombie_head", 0);
+                    return ItemMaterial.fromItemId("minecraft:zombie_head", 0, tooltip);
                 }
                 case "pumpkin" -> {
-                    return ItemMaterial.fromItemId("minecraft:carved_pumpkin", 0);
+                    return ItemMaterial.fromItemId("minecraft:carved_pumpkin", 0, tooltip);
                 }
                 case "jackolantern" -> {
-                    return ItemMaterial.fromItemId("minecraft:jack_o_lantern", 0);
+                    return ItemMaterial.fromItemId("minecraft:jack_o_lantern", 0, tooltip);
                 }
                 // These are not currently used so they are just guesses at the moment
                 case "skeleton" -> {
-                    return ItemMaterial.fromItemId("minecraft:skeleton_skull", 0);
+                    return ItemMaterial.fromItemId("minecraft:skeleton_skull", 0, tooltip);
                 }
                 case "witherskeleton" -> {
-                    return ItemMaterial.fromItemId("minecraft:wither_skeleton_skull", 0);
+                    return ItemMaterial.fromItemId("minecraft:wither_skeleton_skull", 0, tooltip);
                 }
                 case "piglin" -> {
-                    return ItemMaterial.fromItemId("minecraft:piglin_head", 0);
+                    return ItemMaterial.fromItemId("minecraft:piglin_head", 0, tooltip);
                 }
                 default -> {
                     // Unknown material, try parsing normally
-                    return parseMaterial(json);
+                    return parseMaterial(json, tooltip);
                 }
             }
         } else {
-            return parseMaterial(json);
+            return parseMaterial(json, tooltip);
         }
     }
 
-    protected ItemMaterial parseMaterial(JsonObject json) {
+    protected ItemMaterial parseMaterial(JsonObject json, Identifier tooltipStyle) {
         if (!json.has("icon")) {
             WynntilsMod.warn(
                     "Item DB does not contain an icon for " + json.get("name").getAsString());
-            return ItemMaterial.fromItemId("minecraft:air", 0);
+            return ItemMaterial.fromItemId("minecraft:air", 0, tooltipStyle);
         }
 
         JsonObject icon = json.getAsJsonObject("icon");
@@ -267,7 +270,8 @@ public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserialize
                     if (modelDataOpt.isPresent()) {
                         return ItemMaterial.fromItemId(
                                 value.get("id").getAsString(),
-                                modelDataOpt.get().intValue());
+                                modelDataOpt.get().intValue(),
+                                tooltipStyle);
                     }
                 }
 
@@ -283,7 +287,7 @@ public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserialize
                     } else {
                         WynntilsMod.warn("Item DB does not contain custom model data for "
                                 + json.get("name").getAsString());
-                        return ItemMaterial.fromItemId("minecraft:air", 0);
+                        return ItemMaterial.fromItemId("minecraft:air", 0, tooltipStyle);
                     }
                 } else if (customModelData.isJsonPrimitive()) {
                     // Original format, only the single model data was sent as either a string or an int
@@ -295,20 +299,20 @@ public abstract class AbstractItemInfoDeserializer<T> implements JsonDeserialize
                 } else {
                     WynntilsMod.warn("Unexpected custom model data format for "
                             + json.get("name").getAsString());
-                    return ItemMaterial.fromItemId("minecraft:air", 0);
+                    return ItemMaterial.fromItemId("minecraft:air", 0, tooltipStyle);
                 }
 
-                return ItemMaterial.fromItemId(value.get("id").getAsString(), customModelDataInt);
+                return ItemMaterial.fromItemId(value.get("id").getAsString(), customModelDataInt, tooltipStyle);
             }
             case "skin" -> {
-                return ItemMaterial.fromPlayerHeadUUID(icon.get("value").getAsString());
+                return ItemMaterial.fromPlayerHeadUUID(icon.get("value").getAsString(), tooltipStyle);
             }
             case "legacy" -> {
                 String material = icon.get("value").getAsString();
                 String[] materialArray = material.split(":");
                 int itemTypeCode = Integer.parseInt(materialArray[0]);
                 int damageCode = materialArray.length > 1 ? Integer.parseInt(materialArray[1]) : 0;
-                return ItemMaterial.fromItemTypeCode(itemTypeCode, damageCode);
+                return ItemMaterial.fromItemTypeCode(itemTypeCode, damageCode, tooltipStyle);
             }
         }
 

--- a/common/src/main/java/com/wynntils/models/wynnitem/type/ItemMaterial.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/type/ItemMaterial.java
@@ -5,7 +5,6 @@
 package com.wynntils.models.wynnitem.type;
 
 import com.wynntils.core.components.Models;
-import com.wynntils.models.gear.type.GearType;
 import com.wynntils.utils.mc.SkinUtils;
 import java.util.List;
 import java.util.Optional;
@@ -21,37 +20,30 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomModelData;
 
 public record ItemMaterial(ItemStack itemStack) {
-    public static ItemMaterial getDefaultTomeItemMaterial() {
-        ItemStack itemStack = createItemStack(Items.ENCHANTED_BOOK, 0);
+    public static ItemMaterial getDefaultTomeItemMaterial(Identifier tooltipStyle) {
+        ItemStack itemStack = createItemStack(Items.ENCHANTED_BOOK, 0, tooltipStyle);
         return new ItemMaterial(itemStack);
     }
 
-    public static ItemMaterial getDefaultCharmItemMaterial() {
+    public static ItemMaterial getDefaultCharmItemMaterial(Identifier tooltipStyle) {
         // All charms are different items, this is as good as any other item
-        ItemStack itemStack = createItemStack(Items.CLAY, 0);
+        ItemStack itemStack = createItemStack(Items.CLAY, 0, tooltipStyle);
         return new ItemMaterial(itemStack);
     }
 
-    public static ItemMaterial fromPlayerHeadUUID(String uuid) {
-        ItemStack itemStack = createItemStack(Items.PLAYER_HEAD, 0);
+    public static ItemMaterial fromPlayerHeadUUID(String uuid, Identifier tooltipStyle) {
+        ItemStack itemStack = createItemStack(Items.PLAYER_HEAD, 0, tooltipStyle);
         SkinUtils.setPlayerHeadFromUUID(itemStack, uuid);
 
         return new ItemMaterial(itemStack);
     }
 
-    public static ItemMaterial fromGearType(GearType gearType) {
-        // Material is missing, so just give generic icon for this type of gear (weapon or accessory)
-        ItemStack itemStack = createItemStack(gearType.getDefaultItem(), gearType.getDefaultModel());
-
+    public static ItemMaterial fromItemId(String itemId, int customModelData, Identifier tooltip) {
+        ItemStack itemStack = createItemStack(getItem(itemId), customModelData, tooltip);
         return new ItemMaterial(itemStack);
     }
 
-    public static ItemMaterial fromItemId(String itemId, int customModelData) {
-        ItemStack itemStack = createItemStack(getItem(itemId), customModelData);
-        return new ItemMaterial(itemStack);
-    }
-
-    public static ItemMaterial fromItemTypeCode(int itemTypeCode, int damageCode) {
+    public static ItemMaterial fromItemTypeCode(int itemTypeCode, int damageCode, Identifier tooltipStyle) {
         String itemId;
 
         Optional<String> materialNameOverrideOpt = Models.WynnItem.getMaterialName(itemTypeCode, damageCode);
@@ -65,24 +57,26 @@ public record ItemMaterial(ItemStack itemStack) {
             itemId = alternativeName != null ? alternativeName : toIdString;
         }
 
-        ItemStack itemStack = createItemStackFromDamage(getItem(itemId), damageCode);
+        ItemStack itemStack = createItemStackFromDamage(getItem(itemId), damageCode, tooltipStyle);
         return new ItemMaterial(itemStack);
     }
 
-    private static ItemStack createItemStack(Item item, float modelValue) {
+    private static ItemStack createItemStack(Item item, float modelValue, Identifier tooltipStyle) {
         ItemStack itemStack = new ItemStack(item);
 
         CustomModelData customModelData = new CustomModelData(List.of(modelValue), List.of(), List.of(), List.of());
         itemStack.set(DataComponents.CUSTOM_MODEL_DATA, customModelData);
         itemStack.set(DataComponents.UNBREAKABLE, Unit.INSTANCE);
+        itemStack.set(DataComponents.TOOLTIP_STYLE, tooltipStyle);
         return itemStack;
     }
 
-    private static ItemStack createItemStackFromDamage(Item item, int damageValue) {
+    private static ItemStack createItemStackFromDamage(Item item, int damageValue, Identifier tooltipStyle) {
         ItemStack itemStack = new ItemStack(item);
 
         itemStack.set(DataComponents.DAMAGE, damageValue);
         itemStack.set(DataComponents.UNBREAKABLE, Unit.INSTANCE);
+        itemStack.set(DataComponents.TOOLTIP_STYLE, tooltipStyle);
         return itemStack;
     }
 

--- a/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/itemsharing/ItemSharingScreen.java
@@ -16,8 +16,10 @@ import com.wynntils.models.items.encoding.type.EncodingSettings;
 import com.wynntils.models.items.items.game.CraftedConsumableItem;
 import com.wynntils.models.items.items.game.CraftedGearItem;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.models.items.properties.GearTierItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.items.properties.NamedItemProperty;
+import com.wynntils.models.items.properties.ShinyItemProperty;
 import com.wynntils.screens.base.widgets.WynntilsCheckbox;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.colors.CommonColors;
@@ -33,13 +35,16 @@ import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.ErrorOr;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
 
 public final class ItemSharingScreen extends WynntilsScreen {
@@ -162,6 +167,17 @@ public final class ItemSharingScreen extends WynntilsScreen {
         WynnItem renderedItem = errorOrDecodedByteBuffer.getValue();
 
         previewItemStack = new FakeItemStack(renderedItem, "From chat");
+
+        if (renderedItem instanceof GearTierItemProperty gearTier) {
+            String tooltipStyle = gearTier.getGearTier().name().toLowerCase(Locale.ROOT);
+
+            if (renderedItem instanceof ShinyItemProperty shiny
+                    && shiny.getShinyStat().isPresent()) {
+                tooltipStyle += "_shiny";
+            }
+
+            previewItemStack.set(DataComponents.TOOLTIP_STYLE, Identifier.withDefaultNamespace(tooltipStyle));
+        }
 
         // Find the width of the tooltip
         int tooltipWidth = LoreUtils.getTooltipLines(previewItemStack).stream()

--- a/common/src/main/java/com/wynntils/screens/playerviewer/PlayerViewerScreen.java
+++ b/common/src/main/java/com/wynntils/screens/playerviewer/PlayerViewerScreen.java
@@ -27,6 +27,7 @@ import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
@@ -40,6 +41,7 @@ import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
@@ -133,6 +135,13 @@ public final class PlayerViewerScreen extends WynntilsContainerScreen<PlayerView
 
         if (wynnItem instanceof GearItem gearItem) {
             itemStack = gearItem.getItemInfo().metaInfo().material().itemStack();
+
+            if (gearItem.getShinyStat().isPresent()) {
+                itemStack.set(
+                        DataComponents.TOOLTIP_STYLE,
+                        Identifier.withDefaultNamespace(
+                                gearItem.getGearTier().name().toLowerCase(Locale.ROOT) + "_shiny"));
+            }
         } else if (wynnItem instanceof CraftedGearItem craftedGearItem) {
             // Armor and weapons are sent by Wynn so we can use those itemstacks, accessories we will have to use
             // a default texture
@@ -152,6 +161,8 @@ public final class PlayerViewerScreen extends WynntilsContainerScreen<PlayerView
                         DataComponentMap.builder().set(DataComponents.CUSTOM_MODEL_DATA, customModelData);
                 itemStack.applyComponents(componentsBuilder.build());
             }
+
+            itemStack.set(DataComponents.TOOLTIP_STYLE, Identifier.withDefaultNamespace("crafted"));
         }
 
         return new FakeItemStack(wynnItem, itemStack, "From " + player.getScoreboardName());


### PR DESCRIPTION
Makes screens that render item tooltips use the new background styles. It doesn't seem to work for chat items, potentially they are forced to use the default tooltip so we may need to do some extra work to make them use it
<img width="902" height="838" alt="image" src="https://github.com/user-attachments/assets/957a080a-a6cb-4c45-b48e-9c925bf2ccbd" />

<img width="866" height="707" alt="image" src="https://github.com/user-attachments/assets/c0b6567f-2a51-43c7-a18a-7858c4531851" />


<img width="1477" height="705" alt="image" src="https://github.com/user-attachments/assets/ef65bd09-0bba-457e-b18b-f2d67c17742b" />
