### PR TITLE
fix: Don't open compatibility screen if unknown version

### DIFF
--- a/common/src/main/java/com/wynntils/services/athena/CompatibilityService.java
+++ b/common/src/main/java/com/wynntils/services/athena/CompatibilityService.java
@@ -63,9 +63,10 @@ public class CompatibilityService extends Service {
     @SubscribeEvent
     public void onWorldStateChange(WorldStateEvent event) {
         if (WynntilsMod.isDevelopmentEnvironment() || WynntilsMod.isDevelopmentBuild()) return;
+        if (wynncraftVersion == null) return;
 
         if (event.getNewState() == WorldState.WORLD && event.isFirstJoinWorld()) {
-            if (compatibilityTier.shouldChatPrompt()) {
+            if (compatibilityTier.shouldToastPrompt()) {
                 MutableComponent toastMessage = Component.empty()
                         .append(Component.translatable("service.wynntils.compatibility.toastMessage1"))
                         .append(Component.literal("Y").withStyle(Style.EMPTY.withFont(WYNNTILS_KEYBIND_FONT)))

--- a/common/src/main/java/com/wynntils/services/athena/type/CompatibilityTier.java
+++ b/common/src/main/java/com/wynntils/services/athena/type/CompatibilityTier.java
@@ -33,7 +33,7 @@ public enum CompatibilityTier {
         return shouldScreenPrompt;
     }
 
-    public boolean shouldChatPrompt() {
+    public boolean shouldToastPrompt() {
         return shouldToastPrompt;
     }
 


### PR DESCRIPTION
If you disconnect during a raid and rejoin it skips the character selection screen so the version is never parsed but currently this will cause the toast prompt to show and opening it will then crash as the version was null.

Also renamed the method as it was never changed when I swapped from chat prompt to toast prompt