### PR TITLE
fix: damage colors

### DIFF
--- a/common/src/main/java/com/wynntils/models/combat/label/DamageLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/combat/label/DamageLabelParser.java
@@ -32,12 +32,12 @@ public class DamageLabelParser implements LabelParser<DamageLabelInfo> {
 
     private static final Map<Character, DamageType> TYPE_BY_COLOR = Map.of(
             '2', DamageType.EARTH,
-            '5', DamageType.WATER,
-            'b', DamageType.AIR,
+            'b', DamageType.WATER,
+            'f', DamageType.AIR,
             'c', DamageType.FIRE,
             'e', DamageType.THUNDER,
-            'f', DamageType.NEUTRAL,
-            '4', DamageType.NEUTRAL);
+            '4', DamageType.NEUTRAL,
+            '5', DamageType.POISON);
 
     @Override
     public DamageLabelInfo getInfo(StyledText label, Location location, Entity entity) {

--- a/common/src/main/java/com/wynntils/models/combat/label/DamageLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/combat/label/DamageLabelParser.java
@@ -21,7 +21,7 @@ public class DamageLabelParser implements LabelParser<DamageLabelInfo> {
     private static final String TYPE_COLOR = "§([245bcef])";
     private static final String NUMBER = "(\\d+(?:\\.\\d+)?)";
     private static final String SUFFIX = "([kKmMbB]?)";
-    private static final String SEP_OR_END = "(?:\uDB80\uDC0A|$)";
+    private static final String SEP_OR_END = "(?:\uDB00\uDC0A|$)";
 
     private static final String DAMAGE_LABEL_PART =
             FMT_NOISE + TYPE_COLOR + FMT_NOISE + NUMBER + SUFFIX + FMT_NOISE + SEP_OR_END;

--- a/common/src/main/java/com/wynntils/models/combat/label/DamageLabelParser.java
+++ b/common/src/main/java/com/wynntils/models/combat/label/DamageLabelParser.java
@@ -21,7 +21,7 @@ public class DamageLabelParser implements LabelParser<DamageLabelInfo> {
     private static final String TYPE_COLOR = "§([245bcef])";
     private static final String NUMBER = "(\\d+(?:\\.\\d+)?)";
     private static final String SUFFIX = "([kKmMbB]?)";
-    private static final String SEP_OR_END = "(?:󐀊|$)";
+    private static final String SEP_OR_END = "(?:\uDB80\uDC0A|$)";
 
     private static final String DAMAGE_LABEL_PART =
             FMT_NOISE + TYPE_COLOR + FMT_NOISE + NUMBER + SUFFIX + FMT_NOISE + SEP_OR_END;

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -223,10 +223,9 @@ public class TestRegex {
         PatternTester p = new PatternTester(DamageLabelParser.class, "DAMAGE_LABEL_PATTERN");
         p.shouldMatch("§e509");
         p.shouldMatch("§42.8k");
-        p.shouldMatch("§2§{fr:minecraft:language/five}2.8k");
-        p.shouldMatch("§42.8k󐀊§419.7k󐀊§47.1k󐀊§47.9k󐀊§412.8k");
-        p.shouldMatch("§c1.2k󐀊§b300󐀊§e45.6k󐀊§f999");
-        p.shouldMatch("§42.8k");
+        p.shouldMatch("§5200k");
+        p.shouldMatch("§42.8k\uDB80\uDC0A§e19.7k\uDB80\uDC0A§c7.1k\uDB80\uDC0A§b7.9k\uDB80\uDC0A§f12.8k");
+        p.shouldMatch("§c1.2k\uDB80\uDC0A§b300\uDB80\uDC0A§e45.6k\uDB80\uDC0A§f999");
     }
 
     @Test

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -222,9 +222,9 @@ public class TestRegex {
     public void DamageLabelParser_DAMAGE_LABEL_PATTERN() {
         PatternTester p = new PatternTester(DamageLabelParser.class, "DAMAGE_LABEL_PATTERN");
         p.shouldMatch("§e509");
-        p.shouldMatch("§52.8k");
-        p.shouldMatch("§5§{fr:minecraft:language/five}2.8k");
-        p.shouldMatch("§56.2k󐀊§519.7k󐀊§57.1k󐀊§57.9k󐀊§512.8k");
+        p.shouldMatch("§42.8k");
+        p.shouldMatch("§2§{fr:minecraft:language/five}2.8k");
+        p.shouldMatch("§42.8k󐀊§419.7k󐀊§47.1k󐀊§47.9k󐀊§412.8k");
         p.shouldMatch("§c1.2k󐀊§b300󐀊§e45.6k󐀊§f999");
         p.shouldMatch("§42.8k");
     }

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -224,8 +224,8 @@ public class TestRegex {
         p.shouldMatch("§e509");
         p.shouldMatch("§42.8k");
         p.shouldMatch("§5200k");
-        p.shouldMatch("§42.8k\uDB80\uDC0A§e19.7k\uDB80\uDC0A§c7.1k\uDB80\uDC0A§b7.9k\uDB80\uDC0A§f12.8k");
-        p.shouldMatch("§c1.2k\uDB80\uDC0A§b300\uDB80\uDC0A§e45.6k\uDB80\uDC0A§f999");
+        p.shouldMatch("§42.8k\uDB00\uDC0A§e19.7k\uDB00\uDC0A§c7.1k\uDB00\uDC0A§b7.9k\uDB00\uDC0A§f12.8k");
+        p.shouldMatch("§c1.2k\uDB00\uDC0A§b300\uDB00\uDC0A§e45.6k\uDB00\uDC0A§f999");
     }
 
     @Test


### PR DESCRIPTION
Fixes incorrect damage parsing (my mistake, should've caught it ealier), will always round up.

<img width="2440" height="851" alt="image" src="https://github.com/user-attachments/assets/2abda04f-0875-4bcd-a6d1-6dc5f52e07b2" />
<img width="253" height="69" alt="image" src="https://github.com/user-attachments/assets/30418b39-2d1e-4125-b1f8-05a183e9cf43" />
