### PR TITLE
fix: stop input transcription buttons from appearing off Wynncraft after resize

### DIFF
--- a/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ScreenMixin.java
@@ -51,12 +51,28 @@ public abstract class ScreenMixin implements ScreenExtension {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;init()V"))
     private void onScreenInitPre(CallbackInfo ci) {
         // This is called whenever a screen is re-inited (e.g. when the window is resized)
-        MixinHelper.postAlways(new ScreenInitEvent.Pre((Screen) (Object) this, false));
+        Screen screen = (Screen) (Object) this;
+
+        if (screen instanceof TitleScreen) {
+            // Title screen rebuilds must still run off-server so the Wynncraft button survives resize.
+            MixinHelper.postAlways(new ScreenInitEvent.Pre(screen, false));
+            return;
+        }
+
+        MixinHelper.post(new ScreenInitEvent.Pre(screen, false));
     }
 
     @Inject(method = "rebuildWidgets()V", at = @At("RETURN"))
     private void onScreenInitPost(CallbackInfo ci) {
-        MixinHelper.postAlways(new ScreenInitEvent.Post((Screen) (Object) this, false));
+        Screen screen = (Screen) (Object) this;
+
+        if (screen instanceof TitleScreen) {
+            // Keep title-screen rebuild behavior aligned with the pre event.
+            MixinHelper.postAlways(new ScreenInitEvent.Post(screen, false));
+            return;
+        }
+
+        MixinHelper.post(new ScreenInitEvent.Post(screen, false));
     }
 
     @Inject(


### PR DESCRIPTION
## Summary
- stop non-title ScreenInitEvent rebuilds from posting off-server
- keep the existing title-screen behavior so the Wynncraft button still survives resize
- fix input transcription buttons appearing after resizing chat off Wynncraft

## Root cause
ScreenInitEvent rebuild events were being posted off-server during widget rebuilds. That allowed chat UI features to inject widgets after a resize even when not on Wynncraft.

## Testing
- reproduced the issue before the change
- verified off-Wynncraft chat resize no longer shows transcription buttons
- verified on-Wynncraft chat resize still keeps transcription buttons working
- verified the title-screen Wynncraft button still survives resize

Fixes #3171