### PR TITLE
fix: route McUtils chat opening through ChatComponent

### DIFF
--- a/common/src/main/java/com/wynntils/utils/mc/McUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/McUtils.java
@@ -180,9 +180,8 @@ public final class McUtils {
     }
 
     public static void openChatScreen(String keybindCommand) {
-        ChatComponent.ChatMethod chatMethod = keybindCommand.startsWith("/")
-                ? ChatComponent.ChatMethod.COMMAND
-                : ChatComponent.ChatMethod.MESSAGE;
+        ChatComponent.ChatMethod chatMethod =
+                keybindCommand.startsWith("/") ? ChatComponent.ChatMethod.COMMAND : ChatComponent.ChatMethod.MESSAGE;
 
         // Route through ChatComponent so the existing createScreen mixin can post ChatScreenCreateEvent.
         mc().gui.getChat().saveAsDraft(keybindCommand);

--- a/common/src/main/java/com/wynntils/utils/mc/McUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/McUtils.java
@@ -9,12 +9,12 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.mc.event.ChatScreenCreateEvent;
 import java.io.File;
 import java.util.UUID;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
+import net.minecraft.client.gui.components.ChatComponent;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.prediction.PredictiveAction;
@@ -180,11 +180,12 @@ public final class McUtils {
     }
 
     public static void openChatScreen(String keybindCommand) {
-        // TODO: Improve mixin to not require event posting here
-        Screen chatScreen = new ChatScreen(keybindCommand, false);
-        ChatScreenCreateEvent event = new ChatScreenCreateEvent(chatScreen, keybindCommand, false);
-        WynntilsMod.postEvent(event);
+        ChatComponent.ChatMethod chatMethod = keybindCommand.startsWith("/")
+                ? ChatComponent.ChatMethod.COMMAND
+                : ChatComponent.ChatMethod.MESSAGE;
 
-        setScreen(event.getScreen());
+        // Route through ChatComponent so the existing createScreen mixin can post ChatScreenCreateEvent.
+        mc().gui.getChat().saveAsDraft(keybindCommand);
+        mc().gui.getChat().openScreen(chatMethod, ChatScreen::new);
     }
 }


### PR DESCRIPTION
## Summary
- route `McUtils.openChatScreen(...)` through `ChatComponent` instead of constructing and posting `ChatScreenCreateEvent` manually
- make suggested chat opens follow the same `ChatScreenCreateEvent` path as normal chat creation
- remove the `McUtils` special-case event posting path

## Root cause
Normal chat creation already went through `ChatComponent.createScreen(...)`, which is wrapped in `ChatComponentMixin` and posts `ChatScreenCreateEvent`.

`McUtils.openChatScreen(...)` bypassed that path by constructing `new ChatScreen(...)` directly, so it had to post `ChatScreenCreateEvent` itself.

## Testing
- verified command suggest chat opens correctly
- verified player viewer message flow opens correctly with prefilled command text
- trade market quick search could not be tested because the trade market was unavailable on the server

Closes #3696

*apologies for the FWL blame [jj](https://github.com/jj-vcs/jj)!!!*