### PR TITLE
fix: prevent auto attack during active spell input

### DIFF
--- a/common/src/main/java/com/wynntils/features/combat/AutoAttackFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/AutoAttackFeature.java
@@ -96,6 +96,7 @@ public class AutoAttackFeature extends Feature {
                 true,
                 true,
                 Models.SpellCaster.isSendingInputs(),
+                Models.Spell.hasActiveSpellInputs(),
                 Managers.Feature.getFeatureInstance(QuickCastFeature.class)
                         .isNormalAutoAttackTriggerActingAsSpellModifier(),
                 Models.Raid.isParasiteOvertaken(),
@@ -111,6 +112,7 @@ public class AutoAttackFeature extends Feature {
             boolean playerPresent,
             boolean onWorld,
             boolean spellCasterSending,
+            boolean spellInputsActive,
             boolean actingAsSpellModifier,
             boolean parasiteOvertaken,
             boolean inSpellInputWindow,
@@ -118,6 +120,7 @@ public class AutoAttackFeature extends Feature {
         if (!playerPresent) return false;
         if (!onWorld) return false;
         if (spellCasterSending) return false;
+        if (spellInputsActive) return false;
         if (actingAsSpellModifier) return false;
         if (parasiteOvertaken) return false;
         if (inSpellInputWindow) return false;

--- a/common/src/main/java/com/wynntils/models/spells/SpellModel.java
+++ b/common/src/main/java/com/wynntils/models/spells/SpellModel.java
@@ -50,8 +50,11 @@ public final class SpellModel extends Model {
     private int repeatedSpellCount = 0;
     private int ticksSinceCastBurst = 0;
     private int ticksSinceCast = 0;
+    private int ticksSinceSpellInputActivity = SPELL_COST_RESET_TICKS;
 
     private boolean expireNextClear = false;
+    private boolean ignoreSpellInputsUntilClear = false;
+    private boolean spellInputsActive = false;
     // This keeps track of if the spell cast text is currently displayed so that we don't send multiple events
     private boolean spellTextActive = false;
 
@@ -112,6 +115,12 @@ public final class SpellModel extends Model {
         if (!lastSpellName.isEmpty()) {
             ticksSinceCast++;
         }
+        if (spellInputsActive && ticksSinceSpellInputActivity < SPELL_COST_RESET_TICKS) {
+            ticksSinceSpellInputActivity++;
+            if (ticksSinceSpellInputActivity >= SPELL_COST_RESET_TICKS) {
+                spellInputsActive = false;
+            }
+        }
 
         if (ticksSinceCastBurst >= SPELL_COST_RESET_TICKS) {
             lastBurstSpellName = "";
@@ -131,14 +140,13 @@ public final class SpellModel extends Model {
         ticksSinceCastBurst = 0;
         ticksSinceCast = 0;
         ticksSinceSpecificSpellMap.clear();
+        clearSpellInputActivity();
+        ignoreSpellInputsUntilClear = true;
     }
 
     @SubscribeEvent
     public void onHeldItemChange(ChangeCarriedItemEvent event) {
-        // We need to reset lastSpell here as the actual inputs are now cleared, but they are still visible
-        // so we don't post the expired event until the action bar has actually updated with the cleared inputs
-        lastSpell = SpellDirection.NO_SPELL;
-        expireNextClear = true;
+        clearSpellInputsForHeldItemChange();
     }
 
     public void addSpellToQueue(List<SpellDirection> spell) {
@@ -179,6 +187,14 @@ public final class SpellModel extends Model {
         return lastSpell.clone();
     }
 
+    public boolean hasActiveSpellInputs() {
+        return spellInputsActive;
+    }
+
+    public boolean isSpellCastActive() {
+        return spellTextActive;
+    }
+
     public int getRepeatedBurstSpellCount() {
         return repeatedBurstSpellCount;
     }
@@ -200,6 +216,21 @@ public final class SpellModel extends Model {
     }
 
     private void updateFromSpellSegment(SpellInputsSegment spellInputsSegment) {
+        if (ignoreSpellInputsUntilClear) {
+            if (spellInputsSegment.getDirections().length == 0) {
+                ignoreSpellInputsUntilClear = false;
+                if (expireNextClear) {
+                    expireNextClear = false;
+                    WynntilsMod.postEvent(new SpellEvent.Expired());
+                }
+            }
+            clearSpellInputActivity();
+            return;
+        }
+
+        spellInputsActive = spellInputsSegment.getDirections().length > 0;
+        ticksSinceSpellInputActivity = spellInputsActive ? 0 : SPELL_COST_RESET_TICKS;
+
         // noop if the spell state hasn't changed
         if (Arrays.equals(spellInputsSegment.getDirections(), lastSpell)) return;
         lastSpell = spellInputsSegment.getDirections();
@@ -218,6 +249,9 @@ public final class SpellModel extends Model {
     }
 
     private void handleExpiredSpell() {
+        ignoreSpellInputsUntilClear = false;
+        clearSpellInputActivity();
+
         if (lastSpell.length != 0) {
             if (lastSpell.length != 3) {
                 lastSpell = SpellDirection.NO_SPELL;
@@ -242,5 +276,19 @@ public final class SpellModel extends Model {
 
         spellTextActive = false;
         WynntilsMod.postEvent(new SpellEvent.CastExpired());
+    }
+
+    private void clearSpellInputsForHeldItemChange() {
+        // The actual input state is cleared immediately, but the action bar may still show stale inputs
+        // until the next packet, so keep the deferred Expired event behavior.
+        lastSpell = SpellDirection.NO_SPELL;
+        clearSpellInputActivity();
+        expireNextClear = true;
+        ignoreSpellInputsUntilClear = true;
+    }
+
+    private void clearSpellInputActivity() {
+        spellInputsActive = false;
+        ticksSinceSpellInputActivity = SPELL_COST_RESET_TICKS;
     }
 }

--- a/fabric/src/test/java/com/wynntils/features/combat/TestAutoAttackFeature.java
+++ b/fabric/src/test/java/com/wynntils/features/combat/TestAutoAttackFeature.java
@@ -11,26 +11,38 @@ public class TestAutoAttackFeature {
     @Test
     public void queuesHeldAutoAttackWhenTriggerIsHeldOutsideSpellWindows() {
         Assertions.assertTrue(
-                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, false, false, false, true));
+                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, false, false, false, false, true));
     }
 
     @Test
     public void doesNotQueueHeldAutoAttackWhileQuickCastUsesTheTriggerAsModifier() {
         Assertions.assertFalse(
-                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, true, false, false, true));
+                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, false, true, false, false, true));
+    }
+
+    @Test
+    public void doesNotQueueHeldAutoAttackWhileSpellInputsAreActive() {
+        Assertions.assertFalse(
+                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, true, false, false, false, true));
+    }
+
+    @Test
+    public void queuesHeldAutoAttackWhenOnlySpellCastTextRemainsActive() {
+        Assertions.assertTrue(
+                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, false, false, false, false, true));
     }
 
     @Test
     public void doesNotQueueHeldAutoAttackInsideSpellWindow() {
         Assertions.assertFalse(
-                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, false, false, true, true));
+                AutoAttackFeature.shouldQueueHeldAutoAttack(true, true, false, false, false, false, true, true));
     }
 
     @Test
     public void doesNotQueueHeldAutoAttackWithoutPlayerOrWorld() {
         Assertions.assertFalse(
-                AutoAttackFeature.shouldQueueHeldAutoAttack(false, true, false, false, false, false, true));
+                AutoAttackFeature.shouldQueueHeldAutoAttack(false, true, false, false, false, false, false, true));
         Assertions.assertFalse(
-                AutoAttackFeature.shouldQueueHeldAutoAttack(true, false, false, false, false, false, true));
+                AutoAttackFeature.shouldQueueHeldAutoAttack(true, false, false, false, false, false, false, true));
     }
 }

--- a/fabric/src/test/java/com/wynntils/models/spells/TestSpellModel.java
+++ b/fabric/src/test/java/com/wynntils/models/spells/TestSpellModel.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.spells;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Models;
+import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
+import com.wynntils.mc.event.ChangeCarriedItemEvent;
+import com.wynntils.mc.event.TickEvent;
+import com.wynntils.models.spells.actionbar.segments.SpellCastSegment;
+import com.wynntils.models.spells.actionbar.segments.SpellInputsSegment;
+import com.wynntils.models.spells.event.SpellEvent;
+import com.wynntils.models.spells.type.SpellDirection;
+import com.wynntils.models.spells.type.SpellType;
+import com.wynntils.models.worlds.event.WorldStateEvent;
+import com.wynntils.models.worlds.type.WorldState;
+import java.util.List;
+import net.neoforged.bus.api.SubscribeEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestSpellModel {
+    private SpellLifecycleRecorder recorder;
+
+    @BeforeAll
+    public static void setup() {
+        WynntilsMod.setupTestEnv();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        resetSpellModelState();
+
+        recorder = new SpellLifecycleRecorder();
+        WynntilsMod.registerEventListener(recorder);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        WynntilsMod.unregisterEventListener(recorder);
+        resetSpellModelState();
+    }
+
+    @Test
+    public void heldItemChangeDoesNotResetActiveCastStateOrDuplicateCastEvents() {
+        Models.Spell.onActionBarUpdate(castActionBarUpdate());
+
+        Assertions.assertEquals(1, recorder.castCount);
+        Assertions.assertTrue(Models.Spell.isSpellCastActive());
+
+        Models.Spell.onHeldItemChange(new ChangeCarriedItemEvent());
+
+        Assertions.assertTrue(Models.Spell.isSpellCastActive());
+
+        Models.Spell.onActionBarUpdate(castActionBarUpdate());
+
+        Assertions.assertEquals(1, recorder.castCount);
+        Assertions.assertTrue(Models.Spell.isSpellCastActive());
+
+        Models.Spell.onActionBarUpdate(emptyActionBarUpdate());
+
+        Assertions.assertEquals(1, recorder.castExpiredCount);
+        Assertions.assertFalse(Models.Spell.isSpellCastActive());
+    }
+
+    @Test
+    public void worldChangeDoesNotPreventPendingCastExpire() {
+        Models.Spell.onActionBarUpdate(castActionBarUpdate());
+
+        Assertions.assertEquals(1, recorder.castCount);
+        Assertions.assertTrue(Models.Spell.isSpellCastActive());
+
+        Models.Spell.onWorldStateChange(new WorldStateEvent(WorldState.HUB, WorldState.WORLD, "test", false));
+
+        Assertions.assertTrue(Models.Spell.isSpellCastActive());
+
+        Models.Spell.onActionBarUpdate(emptyActionBarUpdate());
+
+        Assertions.assertEquals(1, recorder.castExpiredCount);
+        Assertions.assertFalse(Models.Spell.isSpellCastActive());
+    }
+
+    @Test
+    public void heldItemChangeIgnoresStaleSpellInputSegmentsUntilTheyClear() {
+        Models.Spell.onActionBarUpdate(spellInputsActionBarUpdate(SpellDirection.RIGHT));
+
+        Assertions.assertEquals(1, recorder.partialCount);
+        Assertions.assertTrue(Models.Spell.hasActiveSpellInputs());
+
+        Models.Spell.onHeldItemChange(new ChangeCarriedItemEvent());
+
+        Assertions.assertFalse(Models.Spell.hasActiveSpellInputs());
+
+        Models.Spell.onActionBarUpdate(spellInputsActionBarUpdate(SpellDirection.RIGHT));
+
+        Assertions.assertEquals(1, recorder.partialCount);
+        Assertions.assertFalse(Models.Spell.hasActiveSpellInputs());
+
+        Models.Spell.onActionBarUpdate(emptyActionBarUpdate());
+
+        Assertions.assertEquals(1, recorder.expiredCount);
+    }
+
+    @Test
+    public void spellInputsActiveExpiresWithoutActionBarUpdates() {
+        Models.Spell.onActionBarUpdate(spellInputsActionBarUpdate(SpellDirection.RIGHT));
+
+        Assertions.assertTrue(Models.Spell.hasActiveSpellInputs());
+
+        for (int i = 0; i < SpellModel.SPELL_COST_RESET_TICKS - 1; i++) {
+            Models.Spell.onTick(new TickEvent());
+        }
+
+        Assertions.assertTrue(Models.Spell.hasActiveSpellInputs());
+
+        Models.Spell.onTick(new TickEvent());
+
+        Assertions.assertFalse(Models.Spell.hasActiveSpellInputs());
+    }
+
+    private static void resetSpellModelState() {
+        Models.Spell.onActionBarUpdate(emptyActionBarUpdate());
+        Models.Spell.onWorldStateChange(new WorldStateEvent(WorldState.HUB, WorldState.WORLD, "test", false));
+        Models.Spell.onActionBarUpdate(emptyActionBarUpdate());
+    }
+
+    private static ActionBarUpdatedEvent castActionBarUpdate() {
+        return new ActionBarUpdatedEvent(List.of(new SpellCastSegment("cast", 0, 4, SpellType.FIRST_SPELL, 0, 0)));
+    }
+
+    private static ActionBarUpdatedEvent spellInputsActionBarUpdate(SpellDirection... directions) {
+        return new ActionBarUpdatedEvent(List.of(new SpellInputsSegment("inputs", 0, 6, directions)));
+    }
+
+    private static ActionBarUpdatedEvent emptyActionBarUpdate() {
+        return new ActionBarUpdatedEvent(List.of());
+    }
+
+    private static final class SpellLifecycleRecorder {
+        private int castCount = 0;
+        private int castExpiredCount = 0;
+        private int expiredCount = 0;
+        private int partialCount = 0;
+
+        @SubscribeEvent
+        public void onSpellCast(SpellEvent.Cast event) {
+            castCount++;
+        }
+
+        @SubscribeEvent
+        public void onSpellCastExpired(SpellEvent.CastExpired event) {
+            castExpiredCount++;
+        }
+
+        @SubscribeEvent
+        public void onSpellExpired(SpellEvent.Expired event) {
+            expiredCount++;
+        }
+
+        @SubscribeEvent
+        public void onSpellPartial(SpellEvent.Partial event) {
+            partialCount++;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- stop stale spell-input state from lingering after selected-slot held-item updates
- only re-arm post-reset spell input tracking from trusted spell-starter inputs
- handle `ClassType.NONE` by falling back to the held weapon class during reset windows

## Notes
This is kind of a band-aid solution and doesn't solve the larger item detection issues of course, but it's a good short-term solution IMHO