### PR TITLE
fix: powerup -> boost & jump height stat on horses/adasaurs

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -432,10 +432,11 @@ public class ItemTextOverlayFeature extends Feature {
             return switch (mountItemStat.get()) {
                 case ACCELERATION -> item.getAcceleration().current();
                 case ALTITUDE -> item.getAltitude().current();
+                case JUMP_HEIGHT -> item.getJumpHeight().current();
                 case ENERGY -> item.getEnergy().current();
                 case HANDLING -> item.getHandling().current();
                 case POTENTIAL -> item.getPotential();
-                case POWERUP -> item.getPowerup().current();
+                case BOOST -> item.getBoost().current();
                 case SPEED -> item.getSpeed().current();
                 case TOUGHNESS -> item.getToughness().current();
                 case TRAINING -> item.getTraining().current();

--- a/common/src/main/java/com/wynntils/functions/MountFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/MountFunctions.java
@@ -110,10 +110,11 @@ public class MountFunctions {
         return switch (stat) {
             case ACCELERATION -> mount.getAcceleration().current();
             case ALTITUDE -> mount.getAltitude().current();
+            case JUMP_HEIGHT -> mount.getJumpHeight().current();
             case ENERGY -> mount.getEnergy().current();
             case HANDLING -> mount.getHandling().current();
             case POTENTIAL -> mount.getPotential();
-            case POWERUP -> mount.getPowerup().current();
+            case BOOST -> mount.getBoost().current();
             case SPEED -> mount.getSpeed().current();
             case TOUGHNESS -> mount.getToughness().current();
             case TRAINING -> mount.getTraining().current();
@@ -124,9 +125,10 @@ public class MountFunctions {
         return switch (stat) {
             case ACCELERATION -> mount.getAcceleration();
             case ALTITUDE -> mount.getAltitude();
+            case JUMP_HEIGHT -> mount.getJumpHeight();
             case ENERGY -> mount.getEnergy();
             case HANDLING -> mount.getHandling();
-            case POWERUP -> mount.getPowerup();
+            case BOOST -> mount.getBoost();
             case SPEED -> mount.getSpeed();
             case TOUGHNESS -> mount.getToughness();
             case TRAINING -> mount.getTraining();

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MountAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MountAnnotator.java
@@ -27,9 +27,10 @@ public final class MountAnnotator implements GameItemAnnotator {
     private static final Map<MountStat, Pattern> CAPPED_STAT_PATTERNS = Map.of(
             MountStat.ACCELERATION, Pattern.compile("\\bAcceleration\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.ALTITUDE, Pattern.compile("\\bAltitude\\b.*?(\\d+)/(\\d+)\\b"),
+            MountStat.JUMP_HEIGHT, Pattern.compile("\\bJump Height\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.ENERGY, Pattern.compile("\\bEnergy\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.HANDLING, Pattern.compile("\\bHandling\\b.*?(\\d+)/(\\d+)\\b"),
-            MountStat.POWERUP, Pattern.compile("\\bPowerup\\b.*?(\\d+)/(\\d+)\\b"),
+            MountStat.BOOST, Pattern.compile("\\Boost\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.SPEED, Pattern.compile("\\bSpeed\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.TOUGHNESS, Pattern.compile("\\bToughness\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.TRAINING, Pattern.compile("\\bTraining\\b.*?(\\d+)/(\\d+)\\b"));
@@ -54,10 +55,11 @@ public final class MountAnnotator implements GameItemAnnotator {
                 stats.value(MountStat.ENERGY),
                 stats.value(MountStat.ACCELERATION),
                 stats.value(MountStat.ALTITUDE),
+                stats.value(MountStat.JUMP_HEIGHT),
                 stats.value(MountStat.ENERGY),
                 stats.value(MountStat.HANDLING),
                 stats.potentialValue(),
-                stats.value(MountStat.POWERUP),
+                stats.value(MountStat.BOOST),
                 stats.value(MountStat.SPEED),
                 stats.value(MountStat.TOUGHNESS),
                 stats.value(MountStat.TRAINING));

--- a/common/src/main/java/com/wynntils/models/items/annotators/game/MountAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/MountAnnotator.java
@@ -30,7 +30,7 @@ public final class MountAnnotator implements GameItemAnnotator {
             MountStat.JUMP_HEIGHT, Pattern.compile("\\bJump Height\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.ENERGY, Pattern.compile("\\bEnergy\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.HANDLING, Pattern.compile("\\bHandling\\b.*?(\\d+)/(\\d+)\\b"),
-            MountStat.BOOST, Pattern.compile("\\Boost\\b.*?(\\d+)/(\\d+)\\b"),
+            MountStat.BOOST, Pattern.compile("\\bBoost\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.SPEED, Pattern.compile("\\bSpeed\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.TOUGHNESS, Pattern.compile("\\bToughness\\b.*?(\\d+)/(\\d+)\\b"),
             MountStat.TRAINING, Pattern.compile("\\bTraining\\b.*?(\\d+)/(\\d+)\\b"));

--- a/common/src/main/java/com/wynntils/models/items/items/game/MountItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/MountItem.java
@@ -98,7 +98,7 @@ public class MountItem extends GameItem {
         return "MountItem{" + "name='" + name + '\'' + ", potential=" + potential + ", energy=" + energy
                 + ", acceleration=" + acceleration + ", jumpHeight=" + jumpHeight
                 + ", altitude=" + altitude + ", energyStat=" + energyStat + ", handling=" + handling
-                + ", powerup=" + boost + ", speed=" + speed + ", toughness=" + toughness + ", training="
+                + ", boost=" + boost + ", speed=" + speed + ", toughness=" + toughness + ", training="
                 + training + '}';
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/game/MountItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/MountItem.java
@@ -12,10 +12,11 @@ public class MountItem extends GameItem {
     private final CappedValue energy;
     private final CappedValue acceleration;
     private final CappedValue altitude;
+    private final CappedValue jumpHeight;
     private final CappedValue energyStat;
     private final CappedValue handling;
     private final int potential;
-    private final CappedValue powerup;
+    private final CappedValue boost;
     private final CappedValue speed;
     private final CappedValue toughness;
     private final CappedValue training;
@@ -25,6 +26,7 @@ public class MountItem extends GameItem {
             CappedValue energy,
             CappedValue acceleration,
             CappedValue altitude,
+            CappedValue jumpHeight,
             CappedValue energyStat,
             CappedValue handling,
             int potential,
@@ -36,10 +38,11 @@ public class MountItem extends GameItem {
         this.energy = energy;
         this.acceleration = acceleration;
         this.altitude = altitude;
+        this.jumpHeight = jumpHeight;
         this.energyStat = energyStat;
         this.handling = handling;
         this.potential = potential;
-        this.powerup = powerup;
+        this.boost = powerup;
         this.speed = speed;
         this.toughness = toughness;
         this.training = training;
@@ -62,6 +65,10 @@ public class MountItem extends GameItem {
         return altitude;
     }
 
+    public CappedValue getJumpHeight() {
+        return jumpHeight;
+    }
+
     public CappedValue getHandling() {
         return handling;
     }
@@ -70,8 +77,8 @@ public class MountItem extends GameItem {
         return potential;
     }
 
-    public CappedValue getPowerup() {
-        return powerup;
+    public CappedValue getBoost() {
+        return boost;
     }
 
     public CappedValue getSpeed() {
@@ -89,9 +96,9 @@ public class MountItem extends GameItem {
     @Override
     public String toString() {
         return "MountItem{" + "name='" + name + '\'' + ", potential=" + potential + ", energy=" + energy
-                + ", acceleration=" + acceleration
+                + ", acceleration=" + acceleration + ", jumpHeight=" + jumpHeight
                 + ", altitude=" + altitude + ", energyStat=" + energyStat + ", handling=" + handling
-                + ", powerup=" + powerup + ", speed=" + speed + ", toughness=" + toughness + ", training="
+                + ", powerup=" + boost + ", speed=" + speed + ", toughness=" + toughness + ", training="
                 + training + '}';
     }
 }

--- a/common/src/main/java/com/wynntils/models/mount/type/MountStat.java
+++ b/common/src/main/java/com/wynntils/models/mount/type/MountStat.java
@@ -9,10 +9,11 @@ import java.util.Optional;
 public enum MountStat {
     ACCELERATION("acceleration", true),
     ALTITUDE("altitude", true),
+    JUMP_HEIGHT("jumpHeight", true),
     ENERGY("energy", true),
     HANDLING("handling", true),
     POTENTIAL("potential", false),
-    POWERUP("powerup", true),
+    BOOST("powerup", true),
     SPEED("speed", true),
     TOUGHNESS("toughness", true),
     TRAINING("training", true);


### PR DESCRIPTION
Fixes a last minute change Wynncraft did to mounts:

`Powerup` is now called `Boost`
For Adasaurs and Horses `Altitude` got changed with `Jump Height`

Argument for the mount functions for jump height is `jumpHeight`