### PR TITLE
ci: create update-urls PRs with WynntilsBot

### DIFF
--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
           labels: auto-generated
           committer: 'WynntilsBot <admin@wynntils.com>'
           commit-message: "chore: [auto-generated] Update urls.json [ci skip]"


### PR DESCRIPTION
## Summary

Currently `update-urls.yml` opens its PRs as via github-actions because `create-pull-request` is not given the `secrets.PRIVATE_TOKEN`

This *tiny* change makes the workflow use the same pattern as the other bot-authored PR workflows, so the generated `urls.json` PRs are created by `WynntilsBot` instead.

Fixes #3884 

*hopefully the automatic review request doesn't annoy anyone :fearful:*