### PR TITLE
fix: CustomColor functions not coloring text

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -65,6 +65,7 @@ import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 
 /** Manage all built-in {@link Function}s */
 public final class FunctionManager extends Manager {
@@ -231,8 +232,9 @@ public final class FunctionManager extends Manager {
     private StyledText formatStyledText(Object value, boolean formatted, int decimals) {
         if (value instanceof StyledText styledText) {
             return styledText;
+        } else if (value instanceof CustomColor color) {
+            return new StyledText(Style.EMPTY.withColor(color.asInt()));
         }
-
         return StyledText.fromString(format(value, formatted, decimals));
     }
 

--- a/common/src/main/java/com/wynntils/core/text/StyledText.java
+++ b/common/src/main/java/com/wynntils/core/text/StyledText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.text;
@@ -61,6 +61,12 @@ public final class StyledText implements Iterable<StyledTextPart> {
                 .collect(Collectors.toList());
         this.clickEvents = Collections.unmodifiableList(clickEvents);
         this.hoverEvents = Collections.unmodifiableList(hoverEvents);
+    }
+
+    public StyledText(Style style) {
+        this.parts = List.of(new StyledTextPart("", style, null, null));
+        this.clickEvents = null;
+        this.hoverEvents = null;
     }
 
     public static StyledText fromComponent(Component component) {


### PR DESCRIPTION
Ever since StyledText functions were added, it broke CustomColor functions, originally putting it at top level caused it to color the text according to that color, it was really useful with shader functions so that you don't have to make yourself a cheat sheet with what hex color is what shader, but parsing it StyledText made it completely ignored, that means all previous functions that used it now don't work like they should and need to be adapted by using `with_color` function, which returns a StyledText and not a String meaning potentially people would need to make bigger changes to their functions because of it.

I believe this fix is a bit dirty and is not a proper fix, I don't know why parts with empty text are omitted, but it causes this regression as they were parsed as only color codes making them empty, ideally a bigger rewrite of function parsing is needed but it's too big for what I can do. This adds a completely isolated StyledText that is not used anywhere but function parsing, so it shouldn't break anything either.