### PR TITLE
fix: Content book forwarded items don't update on click

### DIFF
--- a/common/src/main/java/com/wynntils/screens/activities/ContentBookHolder.java
+++ b/common/src/main/java/com/wynntils/screens/activities/ContentBookHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.screens.activities;
@@ -59,25 +59,27 @@ public class ContentBookHolder extends WrappedScreenHolder<WynntilsContentBookSc
     @SubscribeEvent
     public void onSetSlot(ContainerSetSlotEvent.Post event) {
         if (!(McUtils.screen() instanceof WynntilsContentBookScreen contentBookScreen)) return;
+        if (wrappedScreen == null) return;
 
-        if (event.getContainerId() == McUtils.inventoryMenu().containerId) {
-            for (Pair<Integer, Integer> slotPair : ACTION_SLOTS) {
-                if (slotPair.a() == event.getSlot()) {
-                    handleActionSlot(event.getItemStack(), slotPair.b());
-                    return;
-                }
-            }
-        } else if (event.getContainerId()
-                == wrappedScreen.getWrappedScreenInfo().containerId()) {
-            if (event.getItemStack().isEmpty()) {
-                activities.remove(event.getSlot());
-                contentBookScreen.reloadContentBookWidgets(true);
-                return;
-            }
+        int wrappedContainerId = wrappedScreen.getWrappedScreenInfo().containerId();
+        int eventContainerId = event.getContainerId();
+        if (eventContainerId != McUtils.inventoryMenu().containerId && eventContainerId != wrappedContainerId) return;
 
-            boolean resetPage = handleActivityItem(event.getItemStack(), event.getSlot());
-            contentBookScreen.reloadContentBookWidgets(resetPage);
+        Optional<Integer> actionSlot = getActionSlotForSetSlot(event.getSlot());
+        if (actionSlot.isPresent()) {
+            handleActionSlot(event.getItemStack(), actionSlot.get());
+            return;
         }
+
+        if (eventContainerId != wrappedContainerId) return;
+        if (event.getItemStack().isEmpty()) {
+            activities.remove(event.getSlot());
+            contentBookScreen.reloadContentBookWidgets(true);
+            return;
+        }
+
+        boolean resetPage = handleActivityItem(event.getItemStack(), event.getSlot());
+        contentBookScreen.reloadContentBookWidgets(resetPage);
     }
 
     @SubscribeEvent
@@ -180,6 +182,16 @@ public class ContentBookHolder extends WrappedScreenHolder<WynntilsContentBookSc
             activities.remove(slot);
             return true;
         }
+    }
+
+    private Optional<Integer> getActionSlotForSetSlot(int slot) {
+        for (Pair<Integer, Integer> slotPair : ACTION_SLOTS) {
+            if (slotPair.a() == slot || slotPair.b() == slot) {
+                return Optional.of(slotPair.b());
+            }
+        }
+
+        return Optional.empty();
     }
 
     private void handleActionSlot(ItemStack itemStack, int slot) {


### PR DESCRIPTION
Fixes:
https://discord.com/channels/394189072635133952/1257255311589511189/1491500119588208680
https://discord.com/channels/394189072635133952/1257255311589511189/1491529762680737901
by handling Content Book action button SetSlot updates for both relevant container IDs and both slot index mappings