### PR TITLE
Fix: Distortion amount reset properly on death or /class

### DIFF
--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/DistortionBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/DistortionBar.java
@@ -29,4 +29,11 @@ public final class DistortionBar extends TrackedBar {
             WynntilsMod.error(String.format("Failed to parse current for distortion bar (%s)", match.group(1)));
         }
     }
+
+    @Override
+    public void reset(){
+        super.reset();
+
+        current = 0;
+    }
 }

--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/DistortionBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/DistortionBar.java
@@ -31,7 +31,7 @@ public final class DistortionBar extends TrackedBar {
     }
 
     @Override
-    public void reset(){
+    public void reset() {
         super.reset();
 
         current = 0;


### PR DESCRIPTION
Before and after /kill

<img width="643" height="41" alt="image" src="https://github.com/user-attachments/assets/9739113e-1324-45ee-b930-df997fb89fa4" />

now reset the distortion amount properly
