### PR TITLE
fix: rune annotators

### DIFF
--- a/common/src/main/java/com/wynntils/models/items/annotators/game/RuneAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/game/RuneAnnotator.java
@@ -16,7 +16,8 @@ import net.minecraft.world.item.ItemStack;
 
 public final class RuneAnnotator implements GameItemAnnotator {
     // Test in RuneAnnotator_RUNE_PATTERN
-    private static final Pattern RUNE_PATTERN = Pattern.compile("§[b432]([A-Z][a-z]{1,2}) Rune");
+    private static final Pattern RUNE_PATTERN =
+            Pattern.compile("\uDAFC\uDC00§#[0-9a-fA-F]{8}([A-Z][a-z]{1,2}) Rune\uDAFC\uDC00");
 
     @Override
     public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {

--- a/common/src/main/java/com/wynntils/models/rewards/type/RuneType.java
+++ b/common/src/main/java/com/wynntils/models/rewards/type/RuneType.java
@@ -9,9 +9,10 @@ import net.minecraft.ChatFormatting;
 
 public enum RuneType {
     AZ(CustomColor.fromChatFormatting(ChatFormatting.AQUA)),
-    NII(CustomColor.fromChatFormatting(ChatFormatting.DARK_RED)),
+    NII(CustomColor.fromChatFormatting(ChatFormatting.LIGHT_PURPLE)),
     UTH(CustomColor.fromChatFormatting(ChatFormatting.DARK_AQUA)),
-    TOL(CustomColor.fromChatFormatting(ChatFormatting.DARK_GREEN));
+    TOL(CustomColor.fromChatFormatting(ChatFormatting.DARK_GREEN)),
+    EK(CustomColor.fromChatFormatting(ChatFormatting.YELLOW));
 
     private CustomColor color;
 

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -716,10 +716,11 @@ public class TestRegex {
     @Test
     public void RuneAnnotator_RUNE_PATTERN() {
         PatternTester p = new PatternTester(RuneAnnotator.class, "RUNE_PATTERN");
-        p.shouldMatch("§bAz Rune");
-        p.shouldMatch("§4Nii Rune");
-        p.shouldMatch("§3Uth Rune");
-        p.shouldMatch("§2Tol Rune");
+        p.shouldMatch("\uDAFC\uDC00§#b0f3fcffAz Rune\uDAFC\uDC00");
+        p.shouldMatch("\uDAFC\uDC00§#fdb9feffNii Rune\uDAFC\uDC00");
+        p.shouldMatch("\uDAFC\uDC00§#bacefbffUth Rune\uDAFC\uDC00");
+        p.shouldMatch("\uDAFC\uDC00§#b8fcb3ffTol Rune\uDAFC\uDC00");
+        p.shouldMatch("\uDAFC\uDC00§#ffd39effEk Rune\uDAFC\uDC00");
     }
 
     @Test


### PR DESCRIPTION
Fixes the rune annotators not working with the new color codes
<img width="567" height="481" alt="image" src="https://github.com/user-attachments/assets/3e29fc7f-4c6b-4b5e-8e97-57b2c0b7d8a4" />
<img width="699" height="481" alt="image" src="https://github.com/user-attachments/assets/7b58242e-c7a6-4be1-bca8-d4aad5670e78" />
