### PR TITLE
fix: handle null values in AbstractTextSegmentMatcher parsing

### DIFF
--- a/common/src/main/java/com/wynntils/models/characterstats/actionbar/matchers/AbstractTextSegmentMatcher.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/actionbar/matchers/AbstractTextSegmentMatcher.java
@@ -91,6 +91,8 @@ public abstract class AbstractTextSegmentMatcher implements ActionBarSegmentMatc
             // Parse the value from the display characters
             CappedValue value = valueFromDisplayCharacters(matcher.group("value"));
 
+            if (value == null) return null;
+
             return createSegment(segmentText, matcher.start(), matcher.end(), value);
         } while (matcher.find());
 
@@ -120,7 +122,7 @@ public abstract class AbstractTextSegmentMatcher implements ActionBarSegmentMatc
 
         if (!matcher.matches()) {
             WynntilsMod.warn("Could not parse text action bar segment value as capped: " + value);
-            return CappedValue.EMPTY;
+            return null;
         }
 
         long current = parseShortNumber(matcher.group("current"));
@@ -128,12 +130,12 @@ public abstract class AbstractTextSegmentMatcher implements ActionBarSegmentMatc
 
         if (current > Integer.MAX_VALUE) {
             WynntilsMod.warn("Current health/mana value is too large: " + current);
-            return CappedValue.EMPTY;
+            return null;
         }
 
         if (max > Integer.MAX_VALUE) {
             WynntilsMod.warn("Max health/mana value is too large: " + max);
-            return CappedValue.EMPTY;
+            return null;
         }
 
         // The value is capped at 100


### PR DESCRIPTION
This is not the best or fullest solution, however this is an okay patch for now. The actual underlying issue is that we have to account for fonts now, not only Unicode characters. Mana bar text and dialogue selection background has the same Unicode char, however they represent different things. I suspect the other, NPC dialogue parsing related issue is the same as this.

Fixes https://github.com/Wynntils/Wynntils/issues/3918, however a continuation ticket with that moves action bar parsing to account for fonts would be appreciated. 

<img width="3440" height="1382" alt="2026-04-12_17 20 48" src="https://github.com/user-attachments/assets/28276d01-dd42-4c9d-b4b6-bc990fb498c7" />
<img width="3440" height="1382" alt="2026-04-12_17 20 59" src="https://github.com/user-attachments/assets/049a4755-bf7c-4f16-b10b-8f787f736b5c" />
