### PR TITLE
fix: critical dmg stat and charm id ranges

### DIFF
--- a/common/src/main/java/com/wynntils/models/rewards/CharmInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/rewards/CharmInfoRegistry.java
@@ -151,14 +151,11 @@ public class CharmInfoRegistry {
             }
 
             int level = JsonUtils.getNullableJsonInt(requirementsJson, "level");
-            // FIXME: Currently missing from API
-            //            JsonObject levelRangeJson = JsonUtils.getNullableJsonObject(requirementsJson, "levelRange");
-            //            int min = levelRangeJson.get("min").getAsInt();
-            //            int max = levelRangeJson.get("max").getAsInt();
-            int min = level;
-            int max = level;
 
-            return new CharmRequirements(level, RangedValue.of(min, max));
+            int max = level + 20;
+
+            // Minimum is always the required level of the charm
+            return new CharmRequirements(level, RangedValue.of(level, max));
         }
     }
 }

--- a/common/src/main/java/com/wynntils/models/stats/builders/DamageStatBuilder.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/DamageStatBuilder.java
@@ -29,7 +29,7 @@ public final class DamageStatBuilder extends StatBuilder<DamageStatType> {
         // If a raw critical damage bonus stat is added, add to AttackType
         callback.accept(new DamageStatType(
                 "CRITICAL_DAMAGE_BONUS",
-                "Critical Damage Bonus",
+                "Critical Damage",
                 "criticalDamageBonus",
                 "CRITICAL_DAMAGE_BONUS",
                 StatUnit.PERCENT));

--- a/common/src/main/java/com/wynntils/models/stats/builders/DamageStatBuilder.java
+++ b/common/src/main/java/com/wynntils/models/stats/builders/DamageStatBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.stats.builders;
@@ -81,8 +81,8 @@ public final class DamageStatBuilder extends StatBuilder<DamageStatType> {
 
     private static String buildInternalRollName(String apiName) {
         return switch (apiName) {
-                // A few damage stats do not follow normal rules, but instead has legacy names
-                // This list comes from Wynncraft internals, courtesy of HeyZeer0
+            // A few damage stats do not follow normal rules, but instead has legacy names
+            // This list comes from Wynncraft internals, courtesy of HeyZeer0
             case "spellDamageBonus" -> "SPELLDAMAGE";
             case "spellDamageBonusRaw" -> "SPELLDAMAGERAW";
             case "mainAttackDamageBonus" -> "DAMAGEBONUS";


### PR DESCRIPTION
Another identification that got a different display name! Also fixes the level ranges for "Damage from mobs from x - y content"