### PR TITLE
feat: Add AutoExpandUseItems feature

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -137,6 +137,7 @@ import com.wynntils.features.trademarket.TradeMarketDefaultSortOrderFeature;
 import com.wynntils.features.trademarket.TradeMarketPriceConversionFeature;
 import com.wynntils.features.trademarket.TradeMarketPriceMatchFeature;
 import com.wynntils.features.trademarket.TradeMarketQuickSearchFeature;
+import com.wynntils.features.ui.AutoExpandUseItems;
 import com.wynntils.features.ui.BulkBuyFeature;
 import com.wynntils.features.ui.ContainerScrollFeature;
 import com.wynntils.features.ui.CraftingProfessionLevelProgressBarFeature;
@@ -365,6 +366,7 @@ public final class FeatureManager extends Manager {
         // endregion
 
         // region ui
+        registerFeature(new AutoExpandUseItems());
         registerFeature(new BulkBuyFeature());
         registerFeature(new ContainerScrollFeature());
         registerFeature(new CraftingProfessionLevelProgressBarFeature());

--- a/common/src/main/java/com/wynntils/features/ui/AutoExpandUseItems.java
+++ b/common/src/main/java/com/wynntils/features/ui/AutoExpandUseItems.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.ui;
+
+import com.wynntils.core.components.Models;
+import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.ProfileDefault;
+import com.wynntils.core.persisted.config.Category;
+import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.core.persisted.config.ConfigProfile;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.mc.event.ContainerSetContentEvent;
+import com.wynntils.models.containers.containers.StoreContainer;
+import com.wynntils.utils.wynn.ContainerUtils;
+import java.util.List;
+import java.util.regex.Pattern;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import org.lwjgl.glfw.GLFW;
+
+@ConfigCategory(Category.UI)
+public class AutoExpandUseItems extends Feature {
+    private static final int USE_ITEM_SLOT = 53;
+    private static final Pattern USE_ITEM_PATTERN = Pattern.compile("§#a0c84bff§lUse Items(§f\uF001)?");
+
+    public AutoExpandUseItems() {
+        super(new ProfileDefault.Builder()
+                .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
+                .build());
+    }
+
+    @SubscribeEvent
+    public void onContainerSetContent(ContainerSetContentEvent.Post event) {
+        if (!(Models.Container.getCurrentContainer() instanceof StoreContainer)) return;
+
+        List<ItemStack> items = event.getItems();
+        if (!StyledText.fromComponent(items.get(USE_ITEM_SLOT).getHoverName()).matches(USE_ITEM_PATTERN)) return;
+
+        ContainerUtils.clickOnSlot(USE_ITEM_SLOT, event.getContainerId(), GLFW.GLFW_MOUSE_BUTTON_LEFT, items);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
+++ b/common/src/main/java/com/wynntils/models/containers/ContainerModel.java
@@ -41,6 +41,7 @@ import com.wynntils.models.containers.containers.RatingRewardsContainer;
 import com.wynntils.models.containers.containers.ScrapMenuContainer;
 import com.wynntils.models.containers.containers.SeaskipperContainer;
 import com.wynntils.models.containers.containers.StoreContainer;
+import com.wynntils.models.containers.containers.StorePageContainer;
 import com.wynntils.models.containers.containers.personal.AccountBankContainer;
 import com.wynntils.models.containers.containers.personal.BookshelfContainer;
 import com.wynntils.models.containers.containers.personal.CharacterBankContainer;
@@ -163,6 +164,7 @@ public final class ContainerModel extends Model {
         registerContainer(new RatingRewardsContainer());
         registerContainer(new ScrapMenuContainer());
         registerContainer(new SeaskipperContainer());
+        registerContainer(new StoreContainer());
         registerContainer(new TradeMarketBuyContainer());
         registerContainer(new TradeMarketContainer());
         registerContainer(new TradeMarketFiltersContainer());
@@ -183,7 +185,7 @@ public final class ContainerModel extends Model {
         }
 
         for (StoreItemType type : StoreItemType.values()) {
-            registerContainer(new StoreContainer(type));
+            registerContainer(new StorePageContainer(type));
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/containers/containers/StoreContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/StoreContainer.java
@@ -1,40 +1,17 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.containers.containers;
 
 import com.wynntils.models.containers.Container;
-import com.wynntils.models.containers.type.ScrollableContainerProperty;
-import com.wynntils.models.store.type.StoreItemType;
 import java.util.regex.Pattern;
 
-public class StoreContainer extends Container implements ScrollableContainerProperty {
-    private static final String TITLE_START = "\uDAFF\uDFF4\uE02D\uDAFF\uDF7C";
-    private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");
-    private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Previous Page");
+public class StoreContainer extends Container {
+    public static Pattern TITLE_PATTERN = Pattern.compile(
+            "\uDAFF\uDFF4\uE02C\uDAFF\uDF7C\uF027\uDAFF\uDF52\uDB00\uDC3D.\uDAFF\uDF22\uDB00\uDC40.\uDAFF\uDF2F");
 
-    public StoreContainer(StoreItemType storeItemType) {
-        super(Pattern.compile(TITLE_START + storeItemType.getTitleCharacter() + ".*"));
-    }
-
-    @Override
-    public Pattern getNextItemPattern() {
-        return NEXT_PAGE_PATTERN;
-    }
-
-    @Override
-    public Pattern getPreviousItemPattern() {
-        return PREVIOUS_PAGE_PATTERN;
-    }
-
-    @Override
-    public int getNextItemSlot() {
-        return 53;
-    }
-
-    @Override
-    public int getPreviousItemSlot() {
-        return 51;
+    public StoreContainer() {
+        super(TITLE_PATTERN);
     }
 }

--- a/common/src/main/java/com/wynntils/models/containers/containers/StorePageContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/StorePageContainer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © Wynntils 2025-2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.containers.containers;
+
+import com.wynntils.models.containers.Container;
+import com.wynntils.models.containers.type.ScrollableContainerProperty;
+import com.wynntils.models.store.type.StoreItemType;
+import java.util.regex.Pattern;
+
+public class StorePageContainer extends Container implements ScrollableContainerProperty {
+    private static final String TITLE_START = "\uDAFF\uDFF4\uE02D\uDAFF\uDF7C";
+    private static final Pattern NEXT_PAGE_PATTERN = Pattern.compile("§7Next Page");
+    private static final Pattern PREVIOUS_PAGE_PATTERN = Pattern.compile("§7Previous Page");
+
+    public StorePageContainer(StoreItemType storeItemType) {
+        super(Pattern.compile(TITLE_START + storeItemType.getTitleCharacter() + ".*"));
+    }
+
+    @Override
+    public Pattern getNextItemPattern() {
+        return NEXT_PAGE_PATTERN;
+    }
+
+    @Override
+    public Pattern getPreviousItemPattern() {
+        return PREVIOUS_PAGE_PATTERN;
+    }
+
+    @Override
+    public int getNextItemSlot() {
+        return 53;
+    }
+
+    @Override
+    public int getPreviousItemSlot() {
+        return 51;
+    }
+}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -122,6 +122,8 @@
   "feature.wynntils.autoAttack.adaptiveLagCorrection.name": "Adaptive Lag Correction",
   "feature.wynntils.autoAttack.description": "Automatically continues melee attacking while holding down the normal attack input.",
   "feature.wynntils.autoAttack.name": "Auto Attack",
+  "feature.wynntils.autoExpandUseItems.description": "Automatically expands the Use Items category in the Store.",
+  "feature.wynntils.autoExpandUseItems.name": "Auto Expand Use Items",
   "feature.wynntils.autoJoinParty.description": "Adds the ability to automatically join a party when a friend invites you.",
   "feature.wynntils.autoJoinParty.name": "Auto Join Parties",
   "feature.wynntils.autoJoinParty.onlyFriends.description": "Should we only auto join party invites from friends?",


### PR DESCRIPTION
This feature automatically clicks on the "Use Items" menu when opening the Store & Wardrobe. Why it is necessary to click on this item to get to consumables, pets, the wardrobe, etc. is one of these Wynn mysteries. This menu serves no reasonable function as it only hides elements of the UI until clicked on. More importantly, once clicked, the menu stays open through reopening this menu, switching classes or worlds. Only disconecting and reconecting causes this menu to close again.

Before clicking:
<img width="617" height="173" alt="image" src="https://github.com/user-attachments/assets/5fad1918-5bad-4ac8-8dbf-43e348116155" />

after:
<img width="617" height="173" alt="image" src="https://github.com/user-attachments/assets/a0786d08-2ede-4da3-ae70-9cf6a4425c82" />
