### PR TITLE
fix: Fix chat issues related to chat manipulation

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -38,7 +38,6 @@ import com.wynntils.screens.itemsharing.SavedItemsScreen;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import com.wynntils.utils.type.ErrorOr;
 import com.wynntils.utils.type.IterationDecision;
 import java.util.ArrayList;
@@ -145,15 +144,13 @@ public class ChatItemFeature extends Feature {
 
         StyledText message = e.getMessage();
 
-        StyledText unwrapped = StyledTextUtils.unwrap(message);
-
         // Decode old chat item encoding
-        StyledText modified = unwrapped.iterate((part, changes) -> {
+        StyledText modified = message.iterate((part, changes) -> {
             decodeChatEncoding(changes, part);
             return IterationDecision.CONTINUE;
         });
 
-        if (modified.equals(unwrapped)) return;
+        if (modified.equals(message)) return;
 
         // If the message had any chat items, we use our unwrapped version
         // FIXME: This edited message could be re-wrapped if it is too long, to match the original message's style

--- a/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/MessageFilterFeature.java
@@ -12,7 +12,6 @@ import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.List;
 import java.util.regex.Pattern;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -71,14 +70,12 @@ public class MessageFilterFeature extends Feature {
             return;
         }
 
-        StyledText unwrapped = StyledTextUtils.unwrap(msg).stripAlignment();
-
-        if (hideSystemInfo.get() && processFilter(unwrapped, List.of(SYSTEM_INFO))) {
+        if (hideSystemInfo.get() && processFilter(msg, List.of(SYSTEM_INFO))) {
             e.cancelChat();
             return;
         }
 
-        if (hidePartyFinder.get() && processFilter(unwrapped, List.of(PARTY_FINDER))) {
+        if (hidePartyFinder.get() && processFilter(msg, List.of(PARTY_FINDER))) {
             e.cancelChat();
             return;
         }

--- a/common/src/main/java/com/wynntils/features/chat/RemoveWynncraftChatWrapFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/RemoveWynncraftChatWrapFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.chat;

--- a/common/src/main/java/com/wynntils/features/chat/RemoveWynncraftChatWrapFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/RemoveWynncraftChatWrapFeature.java
@@ -22,5 +22,6 @@ public class RemoveWynncraftChatWrapFeature extends Feature {
     @SubscribeEvent(priority = EventPriority.LOW)
     public void onChatReceived(ChatMessageEvent.Edit event) {
         event.setMessage(StyledTextUtils.unwrap(event.getMessage()));
+        event.disableRewrap();
     }
 }

--- a/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
+++ b/common/src/main/java/com/wynntils/features/redirects/ChatRedirectFeature.java
@@ -16,7 +16,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.models.players.type.PlayerRank;
 import com.wynntils.utils.StringUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -147,7 +146,7 @@ public class ChatRedirectFeature extends Feature {
 
     @SubscribeEvent
     public void onChatMessage(ChatMessageEvent.Match e) {
-        StyledText message = StyledTextUtils.unwrap(e.getMessage()).stripAlignment();
+        StyledText message = e.getMessage();
         for (Redirector redirector : redirectors) {
             RedirectAction action = redirector.getAction();
             if (action == RedirectAction.KEEP) continue;

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -11,6 +11,7 @@ import com.wynntils.core.text.type.StyleType;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.handlers.chat.type.RecipientType;
 import com.wynntils.mc.event.SystemMessageEvent;
+import com.wynntils.utils.mc.StyledTextUtils;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -32,6 +33,8 @@ import net.neoforged.bus.api.SubscribeEvent;
  * stage).
  */
 public final class ChatHandler extends Handler {
+    private RecipientType lastRecipientType = RecipientType.INFO;
+
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onSystemChatReceived(SystemMessageEvent.ChatReceivedEvent event) {
         handleIncomingChatMessage(event);
@@ -58,13 +61,42 @@ public final class ChatHandler extends Handler {
         WynntilsMod.info("[CHAT/" + recipientType + "] "
                 + message.getString(StyleType.COMPLETE).replace("§", "&"));
 
+        // Prefix color is not null for any RecipientTypes that make use of Wynns chat type prefixes
+        if (recipientType.getPrefixColor() != null) {
+            return processTabbedChatMessage(message, recipientType);
+        } else {
+            return processUntabbedChatMessage(message, recipientType);
+        }
+    }
+
+    private StyledText processUntabbedChatMessage(StyledText message, RecipientType recipientType) {
         ChatMessageEvent.Match receivedEvent = new ChatMessageEvent.Match(message, recipientType);
         WynntilsMod.postEvent(receivedEvent);
         if (receivedEvent.isChatCanceled()) return null;
 
         ChatMessageEvent.Edit rewriteEvent = new ChatMessageEvent.Edit(message, recipientType);
         WynntilsMod.postEvent(rewriteEvent);
+
+        lastRecipientType = recipientType;
         return rewriteEvent.getMessage();
+    }
+
+    private StyledText processTabbedChatMessage(StyledText message, RecipientType recipientType) {
+        StyledText unwrapped = StyledTextUtils.unwrap(message);
+        StyledText unprefixed = StyledTextUtils.unwrap(StyledTextUtils.removePrefix(message, recipientType));
+
+        ChatMessageEvent.Match receivedEvent = new ChatMessageEvent.Match(unwrapped.stripAlignment(), recipientType);
+        WynntilsMod.postEvent(receivedEvent);
+        if (receivedEvent.isChatCanceled()) return null;
+
+        ChatMessageEvent.Edit rewriteEvent = new ChatMessageEvent.Edit(unprefixed, recipientType);
+        WynntilsMod.postEvent(rewriteEvent);
+
+        StyledText prefixed =
+                StyledTextUtils.addPrefix(rewriteEvent.getMessage(), recipientType, lastRecipientType == recipientType);
+
+        lastRecipientType = recipientType;
+        return prefixed;
     }
 
     public RecipientType getRecipientType(StyledText codedMessage) {

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -61,15 +61,14 @@ public final class ChatHandler extends Handler {
         WynntilsMod.info("[CHAT/" + recipientType + "] "
                 + message.getString(StyleType.COMPLETE).replace("§", "&"));
 
-        // Prefix color is not null for any RecipientTypes that make use of Wynns chat type prefixes
-        if (recipientType.getPrefixColor() != null) {
-            return processTabbedChatMessage(message, recipientType);
+        if (!recipientType.hasPrefix()) {
+            return processPrefixedChatMessage(message, recipientType);
         } else {
-            return processUntabbedChatMessage(message, recipientType);
+            return processNormalChatMessage(message, recipientType);
         }
     }
 
-    private StyledText processUntabbedChatMessage(StyledText message, RecipientType recipientType) {
+    private StyledText processNormalChatMessage(StyledText message, RecipientType recipientType) {
         ChatMessageEvent.Match receivedEvent = new ChatMessageEvent.Match(message, recipientType);
         WynntilsMod.postEvent(receivedEvent);
         if (receivedEvent.isChatCanceled()) return null;
@@ -81,7 +80,7 @@ public final class ChatHandler extends Handler {
         return rewriteEvent.getMessage();
     }
 
-    private StyledText processTabbedChatMessage(StyledText message, RecipientType recipientType) {
+    private StyledText processPrefixedChatMessage(StyledText message, RecipientType recipientType) {
         // We unwrap and strip the alignment of all messages in the soft wrapped format to better match content.
         StyledText preprocessed = StyledTextUtils.unwrap(message).stripAlignment();
         ChatMessageEvent.Match receivedEvent = new ChatMessageEvent.Match(preprocessed, recipientType);
@@ -92,14 +91,14 @@ public final class ChatHandler extends Handler {
         WynntilsMod.postEvent(rewriteEvent);
         StyledText rewritten = rewriteEvent.getMessage();
 
-        if (!rewritten.equals(message)) {
+        if (!rewritten.equals(message) && rewriteEvent.isRewrapAllowed()) {
             // We have altered the message so we need to manually rewrap it to avoid visual breakage.
-            rewritten = StyledTextUtils.tabWrap(StyledTextUtils.unwrap(rewritten), recipientType);
+            rewritten = StyledTextUtils.prefixWrap(StyledTextUtils.unwrap(rewritten), recipientType);
         }
 
         // We may have filtered or inserted messages so we need to strip the prefix and reapply the correct one
         boolean isContinuation = lastRecipientType == recipientType;
-        StyledText unprefixed = StyledTextUtils.removePrefix(rewritten, recipientType);
+        StyledText unprefixed = StyledTextUtils.removeFirstPrefix(rewritten, recipientType);
         StyledText prefixed = StyledTextUtils.addPrefix(unprefixed, recipientType, isContinuation);
 
         lastRecipientType = recipientType;

--- a/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/ChatHandler.java
@@ -82,18 +82,25 @@ public final class ChatHandler extends Handler {
     }
 
     private StyledText processTabbedChatMessage(StyledText message, RecipientType recipientType) {
-        StyledText unwrapped = StyledTextUtils.unwrap(message);
-        StyledText unprefixed = StyledTextUtils.unwrap(StyledTextUtils.removePrefix(message, recipientType));
-
-        ChatMessageEvent.Match receivedEvent = new ChatMessageEvent.Match(unwrapped.stripAlignment(), recipientType);
+        // We unwrap and strip the alignment of all messages in the soft wrapped format to better match content.
+        StyledText preprocessed = StyledTextUtils.unwrap(message).stripAlignment();
+        ChatMessageEvent.Match receivedEvent = new ChatMessageEvent.Match(preprocessed, recipientType);
         WynntilsMod.postEvent(receivedEvent);
         if (receivedEvent.isChatCanceled()) return null;
 
-        ChatMessageEvent.Edit rewriteEvent = new ChatMessageEvent.Edit(unprefixed, recipientType);
+        ChatMessageEvent.Edit rewriteEvent = new ChatMessageEvent.Edit(message, recipientType);
         WynntilsMod.postEvent(rewriteEvent);
+        StyledText rewritten = rewriteEvent.getMessage();
 
-        StyledText prefixed =
-                StyledTextUtils.addPrefix(rewriteEvent.getMessage(), recipientType, lastRecipientType == recipientType);
+        if (!rewritten.equals(message)) {
+            // We have altered the message so we need to manually rewrap it to avoid visual breakage.
+            rewritten = StyledTextUtils.tabWrap(StyledTextUtils.unwrap(rewritten), recipientType);
+        }
+
+        // We may have filtered or inserted messages so we need to strip the prefix and reapply the correct one
+        boolean isContinuation = lastRecipientType == recipientType;
+        StyledText unprefixed = StyledTextUtils.removePrefix(rewritten, recipientType);
+        StyledText prefixed = StyledTextUtils.addPrefix(unprefixed, recipientType, isContinuation);
 
         lastRecipientType = recipientType;
         return prefixed;

--- a/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/event/ChatMessageEvent.java
@@ -51,6 +51,7 @@ public abstract class ChatMessageEvent extends Event {
      */
     public static class Edit extends ChatMessageEvent {
         private StyledText editedMessage = null;
+        private boolean allowRewrap = true;
 
         public Edit(StyledText message, RecipientType recipientType) {
             super(message, recipientType);
@@ -62,6 +63,14 @@ public abstract class ChatMessageEvent extends Event {
 
         public void setMessage(StyledText message) {
             this.editedMessage = message;
+        }
+
+        public void disableRewrap() {
+            allowRewrap = false;
+        }
+
+        public boolean isRewrapAllowed() {
+            return allowRewrap;
         }
     }
 }

--- a/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
@@ -6,38 +6,73 @@ package com.wynntils.handlers.chat.type;
 
 import com.wynntils.core.text.StyledText;
 import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.TextColor;
 
 public enum RecipientType {
     INFO(null, "Info"),
     CLIENTSIDE(null, "Clientside"),
+    WYNNTILS("2", '\uE100', null, "Wynntils"),
     // Test in RecipientType_GLOBAL_pattern
     GLOBAL("^§7[\uE040-\uE059]{2}[\uE060-\uE069]{1,3}§r .+", "Global"),
     // Test in RecipientType_LOCAL_pattern
     LOCAL("^§f[\uE040-\uE059]{2}[\uE060-\uE069]{1,3}(?:§r)? .+", "Local"),
     // Test in RecipientType_GUILD_pattern
-    GUILD("^§b((\uDAFF\uDFFC\uE006\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)).*$", "Guild"),
+    GUILD("b", '\uE006', null, "Guild"),
     // Test in RecipientType_PARTY_pattern
-    PARTY("^§e((\uDAFF\uDFFC\uE005\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) .*$", "Party"),
+    PARTY("e", '\uE005', null, "Party"),
     // Test in RecipientType_PRIVATE_pattern
-    PRIVATE(
-            "^§#ddcc99ff((\uDAFF\uDFFC\uE007\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) .* \uE003 .*:(§#ddcc99ff)? §f.*$",
-            "Private"),
+    PRIVATE("#ddcc99ff", '\uE007', ".* \uE003 .*:(§#ddcc99ff)? §f.+", "Private"),
     // Test in RecipientType_SHOUT_pattern
-    SHOUT(
-            "^§#bd45ffff((\uDAFF\uDFFC\uE015\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) (§o)?.+?(§r§#bd45ffff)? .+?§#bd45ffff shouts: .+$",
-            "Shout"),
+    SHOUT("#bd45ffff", '\uE015', "(§o)?.+?(§r§#bd45ffff)? .+?§#bd45ffff shouts: .+", "Shout"),
     // Test in RecipientType_PETS_pattern
-    PETS(
-            "^§6((\uDAFF\uDFFC\uE016\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) (§o)?.+?(§r§6)?: §#ffdd99ff(§o)?.+$",
-            "Pets"),
+    PETS("6", '\uE016', "(§o)?.+?(§r§6)?: §#ffdd99ff(§o)?.+", "Pets"),
+    // Test in RecipientType_BOMB_BELL_pattern
+    BOMB_BELL("#fddd5cff", '\uE01E', null, "Bomb Bell"),
+    // Test in RecipientType_BOMB_pattern
+    BOMB("#a0c84bff", '\uE014', null, "Bomb"),
+    // Test in RecipientType_WORLD_EVENT_pattern
+    WORLD_EVENT("#00bdbfff", '\uE00D', null, "World Event"),
+    // Test in RecipientType_SYSTEM_INFO_pattern
+    SYSTEM_INFO("#a0aec0ff", '\uE01B', null, "System Info"),
+    // Test in RecipientType_MERCHANT_pattern
+    MERCHANT("5", '\uE00A', null, "Merchant"), // Blacksmith, Trade Market, Merchants, Party Finder
+    // Test in RecipientType_ERROR_OR_WARNING_pattern
+    ERROR_OR_WARNING("4", '\uE008', null, "Error or Warning"),
+    RAID("#d6401eff", '\uE009', null, "Raid"),
+    // Test in RecipientType_COMMAND_pattern
+    COMMAND("a", '\uE008', null, "Command"),
     GAME_MESSAGE("^§7[A-Z0-9].*$", "Game Message"); // Like dialogues but not uttered by an NPC
 
     private final Pattern pattern;
+    private final TextColor prefixColor;
+    private final char prefixIcon;
     private final String name;
 
     RecipientType(String pattern, String name) {
         this.pattern = (pattern == null ? null : Pattern.compile(pattern, Pattern.DOTALL));
+        this.prefixColor = null;
+        this.prefixIcon = '\0';
+        this.name = name;
+    }
 
+    RecipientType(String color, char icon, String contentPattern, String name) {
+        StringBuilder builder = new StringBuilder()
+                .append("^§")
+                .append(color)
+                .append("((\uDAFF\uDFFC")
+                .append(icon)
+                .append("\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) (?<content>")
+                .append(contentPattern == null ? ".*" : contentPattern)
+                .append(")$");
+        this.pattern = Pattern.compile(builder.toString(), Pattern.DOTALL);
+        if (color.charAt(0) == '#') {
+            // The complete color string includes alpha, but we are only interested in the rgb part
+            this.prefixColor = TextColor.fromRgb(Integer.parseInt(color.substring(1, 7), 16));
+        } else {
+            this.prefixColor = TextColor.fromLegacyFormat(ChatFormatting.getByCode(color.charAt(0)));
+        }
+        this.prefixIcon = icon;
         this.name = name;
     }
 
@@ -57,7 +92,19 @@ public enum RecipientType {
         return null;
     }
 
+    public Pattern getPattern() {
+        return pattern;
+    }
+
     public String getName() {
         return name;
+    }
+
+    public TextColor getPrefixColor() {
+        return prefixColor;
+    }
+
+    public char getPrefixIcon() {
+        return prefixIcon;
     }
 }

--- a/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
@@ -46,6 +46,9 @@ public enum RecipientType {
     MOUNT("#8f663dff", '\uE01F', null, "Mount"),
     GAME_MESSAGE("^§7[A-Z0-9].*$", "Game Message"); // Like dialogues but not uttered by an NPC
 
+    private static final String PREFIX_PATTERN_FORMAT =
+            "^§%s((\uDAFF\uDFFC%c\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) (?<content>%s)$";
+
     private final Pattern pattern;
     private final TextColor prefixColor;
     private final char prefixIcon;
@@ -59,15 +62,9 @@ public enum RecipientType {
     }
 
     RecipientType(String color, char icon, String contentPattern, String name) {
-        StringBuilder builder = new StringBuilder()
-                .append("^§")
-                .append(color)
-                .append("((\uDAFF\uDFFC")
-                .append(icon)
-                .append("\uDAFF\uDFFF\uE002\uDAFF\uDFFE)|(\uDAFF\uDFFC\uE001\uDB00\uDC06)) (?<content>")
-                .append(contentPattern == null ? ".*" : contentPattern)
-                .append(")$");
-        this.pattern = Pattern.compile(builder.toString(), Pattern.DOTALL);
+        this.pattern = Pattern.compile(
+                PREFIX_PATTERN_FORMAT.formatted(color, icon, contentPattern == null ? ".*" : contentPattern),
+                Pattern.DOTALL);
         if (color.charAt(0) == '#') {
             // The complete color string includes alpha, but we are only interested in the rgb part
             this.prefixColor = TextColor.fromRgb(Integer.parseInt(color.substring(1, 7), 16));
@@ -92,6 +89,10 @@ public enum RecipientType {
         }
 
         return null;
+    }
+
+    public boolean hasPrefix() {
+        return prefixColor != null;
     }
 
     public Pattern getPattern() {

--- a/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
+++ b/common/src/main/java/com/wynntils/handlers/chat/type/RecipientType.java
@@ -42,6 +42,8 @@ public enum RecipientType {
     RAID("#d6401eff", '\uE009', null, "Raid"),
     // Test in RecipientType_COMMAND_pattern
     COMMAND("a", '\uE008', null, "Command"),
+    // Test in RecipientType_MOUNT_pattern
+    MOUNT("#8f663dff", '\uE01F', null, "Mount"),
     GAME_MESSAGE("^§7[A-Z0-9].*$", "Game Message"); // Like dialogues but not uttered by an NPC
 
     private final Pattern pattern;

--- a/common/src/main/java/com/wynntils/models/abilities/ShamanSummonModel.java
+++ b/common/src/main/java/com/wynntils/models/abilities/ShamanSummonModel.java
@@ -16,7 +16,6 @@ import com.wynntils.models.abilities.label.ShamanPuppetParser;
 import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,7 @@ public class ShamanSummonModel extends Model {
 
     @SubscribeEvent
     public void onChatMessage(ChatMessageEvent.Match event) {
-        StyledText message = StyledTextUtils.unwrap(event.getMessage().stripAlignment());
+        StyledText message = event.getMessage();
         if (message.matches(HUMMINGBIRD_RETURN_PATTERN)) {
             hummingBirdsState = false;
         } else if (message.matches(HUMMINGBIRD_SENT_PATTERN)) {

--- a/common/src/main/java/com/wynntils/models/activities/worldevents/WorldEventModel.java
+++ b/common/src/main/java/com/wynntils/models/activities/worldevents/WorldEventModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2024-2025.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.activities.worldevents;
@@ -36,7 +36,6 @@ import com.wynntils.models.items.items.game.CorruptedCacheItem;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.utils.VectorUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import com.wynntils.utils.type.Time;
 import java.util.HashMap;
 import java.util.List;
@@ -143,7 +142,7 @@ public final class WorldEventModel extends Model {
 
     @SubscribeEvent
     public void onChatMessage(ChatMessageEvent.Match event) {
-        StyledText styledText = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+        StyledText styledText = event.getMessage();
 
         if (styledText.matches(IN_RADIUS_PATTERN)) {
             inWorldEventRadius = true;

--- a/common/src/main/java/com/wynntils/models/guild/GuildModel.java
+++ b/common/src/main/java/com/wynntils/models/guild/GuildModel.java
@@ -39,7 +39,6 @@ import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import com.wynntils.utils.type.CappedValue;
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -192,9 +191,7 @@ public final class GuildModel extends Model {
             return;
         }
 
-        StyledText unwrapped = StyledTextUtils.unwrap(message).stripAlignment();
-
-        Matcher memberLeftMatcher = unwrapped.getMatcher(MEMBER_LEFT);
+        Matcher memberLeftMatcher = message.getMatcher(MEMBER_LEFT);
         if (memberLeftMatcher.matches()) {
             String playerName = memberLeftMatcher.group(2);
             WynntilsMod.info("Player " + playerName + " left guild");
@@ -204,7 +201,7 @@ public final class GuildModel extends Model {
             return;
         }
 
-        Matcher memberJoinedMatcher = unwrapped.getMatcher(MEMBER_JOIN);
+        Matcher memberJoinedMatcher = message.getMatcher(MEMBER_JOIN);
         if (memberJoinedMatcher.matches()) {
             String playerName = memberJoinedMatcher.group(2);
             WynntilsMod.info("Player " + playerName + " joined guild");
@@ -214,7 +211,7 @@ public final class GuildModel extends Model {
             return;
         }
 
-        Matcher memberKickedMatcher = unwrapped.getMatcher(MEMBER_KICKED);
+        Matcher memberKickedMatcher = message.getMatcher(MEMBER_KICKED);
         if (memberKickedMatcher.matches()) {
             String playerName = memberKickedMatcher.group(2);
 

--- a/common/src/main/java/com/wynntils/models/housing/HousingModel.java
+++ b/common/src/main/java/com/wynntils/models/housing/HousingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.housing;
@@ -9,7 +9,6 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,7 +37,7 @@ public class HousingModel extends Model {
     public void onChatMessage(ChatMessageEvent.Match event) {
         if (!onHousing) return;
 
-        StyledText message = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+        StyledText message = event.getMessage();
 
         Matcher matcher = message.getMatcher(HOUSING_EDIT_PATTERN);
         if (matcher.matches()) {

--- a/common/src/main/java/com/wynntils/models/players/FriendsModel.java
+++ b/common/src/main/java/com/wynntils/models/players/FriendsModel.java
@@ -16,7 +16,6 @@ import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -102,7 +101,7 @@ public final class FriendsModel extends Model {
 
     @SubscribeEvent
     public void onChatReceived(ChatMessageEvent.Match event) {
-        StyledText styledText = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+        StyledText styledText = event.getMessage();
         String unformatted = styledText.getStringWithoutFormatting();
 
         Matcher joinMatcher = styledText.getMatcher(JOIN_PATTERN);

--- a/common/src/main/java/com/wynntils/models/players/PartyModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PartyModel.java
@@ -132,7 +132,7 @@ public final class PartyModel extends Model {
 
     @SubscribeEvent
     public void onChatReceived(ChatMessageEvent.Match event) {
-        StyledText chatMessage = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+        StyledText chatMessage = event.getMessage();
 
         if (tryParsePartyMessages(chatMessage)) return;
 

--- a/common/src/main/java/com/wynntils/models/raid/RaidModel.java
+++ b/common/src/main/java/com/wynntils/models/raid/RaidModel.java
@@ -178,10 +178,8 @@ public final class RaidModel extends Model {
             return;
         }
 
-        StyledText unwrapped = StyledTextUtils.unwrap(styledText).stripAlignment();
-
         if (inBuffRoom) {
-            Matcher matcher = unwrapped.getMatcher(RAID_CHOOSE_BUFF_PATTERN);
+            Matcher matcher = styledText.getMatcher(RAID_CHOOSE_BUFF_PATTERN);
             if (matcher.matches()) {
                 String playerName = matcher.group(4);
                 // if the player is nicknamed
@@ -201,7 +199,7 @@ public final class RaidModel extends Model {
             return;
         }
 
-        Matcher matcher = unwrapped.getMatcher(PARASITE_OVERTAKEN_PATTERN);
+        Matcher matcher = styledText.getMatcher(PARASITE_OVERTAKEN_PATTERN);
         if (matcher.matches()) {
             parasiteOvertaken = matcher.group("player").equals(McUtils.playerName());
             return;

--- a/common/src/main/java/com/wynntils/models/spells/SpellModel.java
+++ b/common/src/main/java/com/wynntils/models/spells/SpellModel.java
@@ -8,7 +8,6 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
-import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 import com.wynntils.handlers.actionbar.event.ActionBarRenderEvent;
 import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
@@ -26,7 +25,6 @@ import com.wynntils.models.spells.type.SpellDirection;
 import com.wynntils.models.spells.type.SpellFailureReason;
 import com.wynntils.models.spells.type.SpellType;
 import com.wynntils.models.worlds.event.WorldStateEvent;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -83,9 +81,7 @@ public final class SpellModel extends Model {
 
     @SubscribeEvent
     public void onChatMessage(ChatMessageEvent.Match e) {
-        StyledText message = StyledTextUtils.unwrap(e.getMessage()).stripAlignment();
-
-        failureReason = SpellFailureReason.fromMsg(message);
+        failureReason = SpellFailureReason.fromMsg(e.getMessage());
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/models/territories/GuildAttackTimerModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/GuildAttackTimerModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.territories;
@@ -19,7 +19,6 @@ import com.wynntils.models.territories.markers.GuildAttackMarkerProvider;
 import com.wynntils.models.territories.profile.TerritoryProfile;
 import com.wynntils.models.territories.type.GuildResourceValues;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import com.wynntils.utils.type.TimedSet;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,7 +75,7 @@ public final class GuildAttackTimerModel extends Model {
     public void onMessage(ChatMessageEvent.Match event) {
         // TODO: Once RecipientType supports Wynncraft 2.1 messages, we can check for RecipientType.GUILD
 
-        StyledText cleanMessage = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+        StyledText cleanMessage = event.getMessage();
         Matcher matcher = cleanMessage.getMatcher(WAR_MESSAGE_PATTERN);
         if (matcher.matches()) {
             long timerEnd = System.currentTimeMillis();

--- a/common/src/main/java/com/wynntils/models/trademarket/TradeMarketModel.java
+++ b/common/src/main/java/com/wynntils/models/trademarket/TradeMarketModel.java
@@ -36,7 +36,6 @@ import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.screens.trademarket.TradeMarketSearchResultHolder;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -178,7 +177,7 @@ public final class TradeMarketModel extends Model {
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onChatMessageReceive(ChatMessageEvent.Match event) {
-        StyledText styledText = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
+        StyledText styledText = event.getMessage();
 
         TradeMarketState newState;
 

--- a/common/src/main/java/com/wynntils/models/worlds/BombModel.java
+++ b/common/src/main/java/com/wynntils/models/worlds/BombModel.java
@@ -17,7 +17,6 @@ import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.BombInfo;
 import com.wynntils.models.worlds.type.BombSortOrder;
 import com.wynntils.models.worlds.type.BombType;
-import com.wynntils.utils.mc.StyledTextUtils;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
@@ -59,9 +58,8 @@ public final class BombModel extends Model {
     @SubscribeEvent
     public void onChat(ChatMessageEvent.Match event) {
         StyledText message = event.getMessage();
-        StyledText unwrapped = StyledTextUtils.unwrap(event.getMessage()).stripAlignment();
 
-        Matcher bellMatcher = unwrapped.getMatcher(BOMB_BELL_PATTERN);
+        Matcher bellMatcher = message.getMatcher(BOMB_BELL_PATTERN);
         if (bellMatcher.matches()) {
             BombInfo bombInfo = addBombFromChat(
                     bellMatcher.group("user"),
@@ -69,13 +67,13 @@ public final class BombModel extends Model {
                     bellMatcher.group("server").trim());
             if (bombInfo == null) return;
 
-            BombEvent.BombBell bombEvent = new BombEvent.BombBell(bombInfo, message);
+            BombEvent.BombBell bombEvent = new BombEvent.BombBell(bombInfo);
             WynntilsMod.postEvent(bombEvent);
 
             return;
         }
 
-        Matcher localMatcher = unwrapped.getMatcher(BOMB_THROWN_PATTERN);
+        Matcher localMatcher = message.getMatcher(BOMB_THROWN_PATTERN);
         if (localMatcher.matches()) {
             // FIXME: User is sent on following chat line, we don't currently use the name anywhere but if we do in
             //  the future then this needs fixing
@@ -83,12 +81,12 @@ public final class BombModel extends Model {
                     addBombFromChat("", localMatcher.group("bomb"), Models.WorldState.getCurrentWorldName());
             if (bombInfo == null) return;
 
-            BombEvent.Local bombEvent = new BombEvent.Local(bombInfo, message);
+            BombEvent.Local bombEvent = new BombEvent.Local(bombInfo);
             WynntilsMod.postEvent(bombEvent);
             return;
         }
 
-        Matcher expiredMatcher = unwrapped.getMatcher(BOMB_EXPIRED_PATTERN);
+        Matcher expiredMatcher = message.getMatcher(BOMB_EXPIRED_PATTERN);
         if (expiredMatcher.matches()) {
             String bomb = expiredMatcher.group("bomb");
 
@@ -125,7 +123,7 @@ public final class BombModel extends Model {
         CURRENT_SERVER_BOMBS.put(bombInfo.bomb(), bombInfo);
 
         BOMBS.add(bombInfo);
-        WynntilsMod.postEvent(new BombEvent.Local(bombInfo, null));
+        WynntilsMod.postEvent(new BombEvent.Local(bombInfo));
     }
 
     public boolean isBombActive(BombType bombType) {

--- a/common/src/main/java/com/wynntils/models/worlds/event/BombEvent.java
+++ b/common/src/main/java/com/wynntils/models/worlds/event/BombEvent.java
@@ -1,39 +1,32 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.worlds.event;
 
-import com.wynntils.core.text.StyledText;
 import com.wynntils.models.worlds.type.BombInfo;
 import net.neoforged.bus.api.Event;
 
 public abstract class BombEvent extends Event {
     private final BombInfo bombInfo;
-    private final StyledText message;
 
-    protected BombEvent(BombInfo bombInfo, StyledText message) {
+    protected BombEvent(BombInfo bombInfo) {
         this.bombInfo = bombInfo;
-        this.message = message;
     }
 
     public static final class Local extends BombEvent {
-        public Local(BombInfo bombInfo, StyledText message) {
-            super(bombInfo, message);
+        public Local(BombInfo bombInfo) {
+            super(bombInfo);
         }
     }
 
     public static final class BombBell extends BombEvent {
-        public BombBell(BombInfo bombInfo, StyledText message) {
-            super(bombInfo, message);
+        public BombBell(BombInfo bombInfo) {
+            super(bombInfo);
         }
     }
 
     public BombInfo getBombInfo() {
         return bombInfo;
-    }
-
-    public StyledText getMessage() {
-        return message;
     }
 }

--- a/common/src/main/java/com/wynntils/utils/mc/McUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/McUtils.java
@@ -145,7 +145,7 @@ public final class McUtils {
 
     public static void sendWynntilsPrefixMessage(Component component) {
         StyledText styledText = StyledText.fromComponent(component);
-        StyledText wrapedText = StyledTextUtils.addWynntilsPrefix(styledText);
+        StyledText wrapedText = StyledTextUtils.softWrapWithWynntilsPrefix(styledText);
 
         sendMessageToClient(wrapedText.getComponent());
     }

--- a/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
@@ -8,6 +8,7 @@ import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.StyledTextPart;
 import com.wynntils.core.text.type.StyleType;
+import com.wynntils.handlers.chat.type.RecipientType;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.type.IterationDecision;
@@ -40,9 +41,7 @@ public final class StyledTextUtils {
 
     private static final FontDescription CHAT_PREFIX_FONT =
             new FontDescription.Resource(Identifier.fromNamespaceAndPath("wynntils", "prefix"));
-    private static final Style CHAT_PREFIX_STYLE =
-            Style.EMPTY.withFont(CHAT_PREFIX_FONT).withColor(ChatFormatting.DARK_GREEN);
-    private static final String CHAT_PREFIX_FIRST_LINE = "\uDAFF\uDFFC\uE100\uDAFF\uDFFF\uE002\uDAFF\uDFFE ";
+    private static final String CHAT_PREFIX_FIRST_LINE_FORMAT = "\uDAFF\uDFFC%c\uDAFF\uDFFF\uE002\uDAFF\uDFFE ";
     private static final String CHAT_PREFIX_LINE_PREFIX = "\uDAFF\uDFFC\uE001\uDB00\uDC06 ";
 
     public static StyledTextPart createLocationPart(Location location) {
@@ -91,8 +90,8 @@ public final class StyledTextUtils {
 
     public static List<StyledText> stripEventsAndLinks(List<StyledText> lines) {
         List<StyledText> linesWithoutEvents = lines.stream()
-                .map(s -> s.getString())
-                .map(str -> StyledText.fromString(str))
+                .map(StyledText::getString)
+                .map(StyledText::fromString)
                 .toList();
         return linesWithoutEvents;
     }
@@ -152,19 +151,13 @@ public final class StyledTextUtils {
                             && newParts.getLast().getPartStyle().equals(lastWrappedPart.getPartStyle())) {
                         StyledTextPart lastPart = newParts.removeLast();
                         lastPartWithoutNewline = lastPart.getString(null, StyleType.NONE) + lastPartWithoutNewline;
-
-                        newParts.add(new StyledTextPart(
-                                lastPartWithoutNewline,
-                                lastWrappedPart.getPartStyle().getStyle(),
-                                null,
-                                null));
-                    } else {
-                        newParts.add(new StyledTextPart(
-                                lastPartWithoutNewline,
-                                lastWrappedPart.getPartStyle().getStyle(),
-                                null,
-                                null));
                     }
+
+                    newParts.add(new StyledTextPart(
+                            lastPartWithoutNewline,
+                            lastWrappedPart.getPartStyle().getStyle(),
+                            null,
+                            null));
 
                     // After a soft wrap, we need to insert a space
                     if (!newParts.getLast().getString(null, StyleType.NONE).equals(" ")) {
@@ -254,14 +247,18 @@ public final class StyledTextUtils {
     private static int wrapPartAsWords(
             StyledTextPart part, int maxWidth, int lastWidth, List<StyledTextPart> newParts) {
         int currentWidth = lastWidth;
+        int spaceWidth = FontRenderer.getInstance().getFont().width(" ");
         Style partStyle = part.getPartStyle().getStyle();
 
-        StyledText[] split = StyledText.fromPart(part).split("\s+");
+        StyledTextPart spacePart = new StyledTextPart(" ", partStyle, null, null);
+        StyledTextPart newlinePart = new StyledTextPart(NEWLINE_PREPARATION, partStyle, null, null);
+
+        StyledText[] split = StyledText.fromPart(part).split("\\s+");
         for (StyledText splitText : split) {
             if (splitText.getPartCount() == 0) {
                 // If orignal part started with space
                 currentWidth += FontRenderer.getInstance().getFont().width(" ");
-                newParts.add(new StyledTextPart(" ", partStyle, null, null));
+                newParts.add(spacePart);
                 continue;
             }
 
@@ -280,20 +277,50 @@ public final class StyledTextUtils {
             if (currentWidth + splitDisplayLength <= maxWidth) {
                 currentWidth += splitDisplayLength;
                 newParts.add(splitPart);
-                newParts.add(new StyledTextPart(" ", partStyle, null, null));
+                newParts.add(spacePart);
+                continue;
+            }
+
+            // Check if the word itself is too long to fit on max width (even on a fresh line)
+            int wordWidth = FontRenderer.getInstance().getFont().width(splitPart.getComponent());
+            if (wordWidth > maxWidth) {
+                // Word is too long, must split it character-by-character
+                // Move to next line if not already at start
+                if (currentWidth > 0) {
+                    newParts.add(newlinePart);
+                }
+                currentWidth = wrapPartAsChars(splitPart, maxWidth, 0, newParts);
+
+                // Check if space fits on the current line; if not, add it to the next line
+                if (currentWidth + spaceWidth <= maxWidth) {
+                    newParts.add(spacePart);
+                    currentWidth += spaceWidth;
+                } else {
+                    newParts.add(newlinePart);
+                    newParts.add(spacePart);
+                    currentWidth = spaceWidth;
+                }
                 continue;
             }
 
             if (currentWidth <= 0) {
                 currentWidth = wrapPartAsChars(splitPart, maxWidth, currentWidth, newParts);
-                newParts.add(new StyledTextPart(" ", partStyle, null, null));
-                currentWidth += FontRenderer.getInstance().getFont().width(" ");
+
+                // Check if space fits on the current line; if not, add it to the next line
+                if (currentWidth + spaceWidth <= maxWidth) {
+                    newParts.add(spacePart);
+                    currentWidth += spaceWidth;
+                } else {
+                    newParts.add(newlinePart);
+                    newParts.add(spacePart);
+                    currentWidth = spaceWidth;
+                }
                 continue;
             }
 
-            newParts.add(new StyledTextPart(NEWLINE_PREPARATION, partStyle, null, null));
+            newParts.add(newlinePart);
             newParts.add(splitPart);
-            newParts.add(new StyledTextPart(" ", partStyle, null, null));
+            newParts.add(spacePart);
             currentWidth = splitDisplayLength;
         }
 
@@ -332,23 +359,56 @@ public final class StyledTextUtils {
     }
 
     /**
+     * Remove the text prefix Wynn gives to all messages post 2.1.
+     *
+     * @param styledText The styled text to remove the prefix from
+     * @return The text without a prefix
+     */
+    public static StyledText removePrefix(StyledText styledText, RecipientType recipientType) {
+        Matcher matcher = styledText.getMatcher(recipientType.getPattern());
+        if (!matcher.matches()) return styledText;
+
+        // Extract the content group span and return a styled substring that preserves part styles/events.
+        int contentStart = matcher.start("content");
+        int contentEnd = matcher.end("content");
+        return styledText.substring(contentStart, contentEnd, StyleType.DEFAULT);
+    }
+
+    /**
      * Adds a prefix like Wynn gives to all messages post 2.1.
      *
      * @param styledText The styled text to add a prefix to
      * @return The text with a prefix
      */
     public static StyledText addWynntilsPrefix(StyledText styledText) {
+        return addPrefix(styledText, RecipientType.WYNNTILS, false);
+    }
+
+    /**
+     * Wrap styledText in a Wynn-like prefix.
+     *
+     * @param styledText The styled text to add a prefix to
+     * @param recipientType The recipient type to emulate
+     * @param isContinuation Whether this message is a continuation of the previous message
+     * @return The text with a prefix
+     */
+    public static StyledText addPrefix(StyledText styledText, RecipientType recipientType, boolean isContinuation) {
+        String firstLine = isContinuation
+                ? CHAT_PREFIX_LINE_PREFIX
+                : String.format(CHAT_PREFIX_FIRST_LINE_FORMAT, recipientType.getPrefixIcon());
+        Style prefixStyle = Style.EMPTY.withFont(CHAT_PREFIX_FONT).withColor(recipientType.getPrefixColor());
+
         int maxWidth = McUtils.getChatWidth()
                 - FontRenderer.getInstance()
                         .getFont()
-                        .width(Component.literal(CHAT_PREFIX_FIRST_LINE).setStyle(CHAT_PREFIX_STYLE));
+                        .width(Component.literal(firstLine).setStyle(prefixStyle));
 
-        StyledText text = softWrap(styledText, maxWidth)
-                .prependPart(new StyledTextPart(CHAT_PREFIX_FIRST_LINE, CHAT_PREFIX_STYLE, null, null));
+        StyledText text =
+                softWrap(styledText, maxWidth).prependPart(new StyledTextPart(firstLine, prefixStyle, null, null));
 
         return text.iterate((current, changes) -> {
             if (current.endsWith("\n")) {
-                changes.add(new StyledTextPart(CHAT_PREFIX_LINE_PREFIX, CHAT_PREFIX_STYLE, null, null));
+                changes.add(new StyledTextPart(CHAT_PREFIX_LINE_PREFIX, prefixStyle, null, null));
             }
 
             return IterationDecision.CONTINUE;

--- a/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
@@ -359,6 +359,23 @@ public final class StyledTextUtils {
     }
 
     /**
+     * Add a Wynn-style prefix to a message
+     *
+     * @param styledText The styled text to add a prefix to
+     * @param recipientType he recipient type to emulate
+     * @param isContinuation Whether this message is a continuation of the previous message
+     * @return The text with a prefix
+     */
+    public static StyledText addPrefix(StyledText styledText, RecipientType recipientType, boolean isContinuation) {
+        String firstLine = isContinuation
+                ? CHAT_PREFIX_LINE_PREFIX
+                : String.format(CHAT_PREFIX_FIRST_LINE_FORMAT, recipientType.getPrefixIcon());
+        Style prefixStyle = Style.EMPTY.withFont(CHAT_PREFIX_FONT).withColor(recipientType.getPrefixColor());
+
+        return styledText.prependPart(new StyledTextPart(firstLine, prefixStyle, null, null));
+    }
+
+    /**
      * Remove the text prefix Wynn gives to all messages post 2.1.
      *
      * @param styledText The styled text to remove the prefix from
@@ -380,31 +397,43 @@ public final class StyledTextUtils {
      * @param styledText The styled text to add a prefix to
      * @return The text with a prefix
      */
-    public static StyledText addWynntilsPrefix(StyledText styledText) {
-        return addPrefix(styledText, RecipientType.WYNNTILS, false);
+    public static StyledText softWrapWithWynntilsPrefix(StyledText styledText) {
+        Style prefixStyle = Style.EMPTY.withFont(CHAT_PREFIX_FONT).withColor(RecipientType.WYNNTILS.getPrefixColor());
+
+        int maxWidth = McUtils.getChatWidth()
+                - FontRenderer.getInstance()
+                        .getFont()
+                        .width(Component.literal(CHAT_PREFIX_LINE_PREFIX).setStyle(prefixStyle));
+
+        String prefix = String.format(CHAT_PREFIX_FIRST_LINE_FORMAT, RecipientType.WYNNTILS.getPrefixIcon());
+        StyledTextPart prefixPart = new StyledTextPart(prefix, prefixStyle, null, null);
+        StyledText wrapped = softWrap(styledText, maxWidth).prependPart(prefixPart);
+
+        return wrapped.iterate((current, changes) -> {
+            if (current.endsWith("\n")) {
+                changes.add(new StyledTextPart(CHAT_PREFIX_LINE_PREFIX, prefixStyle, null, null));
+            }
+
+            return IterationDecision.CONTINUE;
+        });
     }
 
     /**
-     * Wrap styledText in a Wynn-like prefix.
+     * Wrap styledText in a Wynn-like tab.
      *
-     * @param styledText The styled text to add a prefix to
+     * @param styledText The styled text to wrap
      * @param recipientType The recipient type to emulate
-     * @param isContinuation Whether this message is a continuation of the previous message
-     * @return The text with a prefix
+     * @return The text wrapped in Wynn-like tab format
      */
-    public static StyledText addPrefix(StyledText styledText, RecipientType recipientType, boolean isContinuation) {
-        String firstLine = isContinuation
-                ? CHAT_PREFIX_LINE_PREFIX
-                : String.format(CHAT_PREFIX_FIRST_LINE_FORMAT, recipientType.getPrefixIcon());
+    public static StyledText tabWrap(StyledText styledText, RecipientType recipientType) {
         Style prefixStyle = Style.EMPTY.withFont(CHAT_PREFIX_FONT).withColor(recipientType.getPrefixColor());
 
         int maxWidth = McUtils.getChatWidth()
                 - FontRenderer.getInstance()
                         .getFont()
-                        .width(Component.literal(firstLine).setStyle(prefixStyle));
+                        .width(Component.literal(CHAT_PREFIX_LINE_PREFIX).setStyle(prefixStyle));
 
-        StyledText text =
-                softWrap(styledText, maxWidth).prependPart(new StyledTextPart(firstLine, prefixStyle, null, null));
+        StyledText text = softWrap(styledText, maxWidth);
 
         return text.iterate((current, changes) -> {
             if (current.endsWith("\n")) {

--- a/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/StyledTextUtils.java
@@ -376,12 +376,12 @@ public final class StyledTextUtils {
     }
 
     /**
-     * Remove the text prefix Wynn gives to all messages post 2.1.
+     * Remove the first text prefix Wynn gives to all messages post 2.1.
      *
      * @param styledText The styled text to remove the prefix from
      * @return The text without a prefix
      */
-    public static StyledText removePrefix(StyledText styledText, RecipientType recipientType) {
+    public static StyledText removeFirstPrefix(StyledText styledText, RecipientType recipientType) {
         Matcher matcher = styledText.getMatcher(recipientType.getPattern());
         if (!matcher.matches()) return styledText;
 
@@ -419,13 +419,13 @@ public final class StyledTextUtils {
     }
 
     /**
-     * Wrap styledText in a Wynn-like tab.
+     * Wrap styledText in a Wynn-like prefix.
      *
      * @param styledText The styled text to wrap
      * @param recipientType The recipient type to emulate
-     * @return The text wrapped in Wynn-like tab format
+     * @return The text wrapped in Wynn-like prefix format
      */
-    public static StyledText tabWrap(StyledText styledText, RecipientType recipientType) {
+    public static StyledText prefixWrap(StyledText styledText, RecipientType recipientType) {
         Style prefixStyle = Style.EMPTY.withFont(CHAT_PREFIX_FONT).withColor(recipientType.getPrefixColor());
 
         int maxWidth = McUtils.getChatWidth()

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -752,6 +752,67 @@ public class TestRegex {
     }
 
     @Test
+    public void RecipientType_BOMB_BELL_pattern() {
+        PatternTester p = new PatternTester(RecipientType.BOMB_BELL, "pattern");
+        p.shouldMatch(
+                "§#fddd5cff\uDAFF\uDFFC\uE01E\uDAFF\uDFFF\uE002\uDAFF\uDFFE FoXr8 has thrown a §#f3e6b2ffCombat Experience Bomb§#fddd5cff on §#f3e6b2ff§nAS14");
+        p.shouldMatch(
+                "§#fddd5cff\uDAFF\uDFFC\uE001\uDB00\uDC06 _Smm has thrown a §#f3e6b2ffProfession Speed Bomb§#fddd5cff on §#f3e6b2ff§nAS13");
+    }
+
+    @Test
+    public void RecipientType_BOMB_pattern() {
+        PatternTester p = new PatternTester(RecipientType.BOMB, "pattern");
+        p.shouldMatch(
+                "§#a0c84bff\uDAFF\uDFFC\uE014\uDAFF\uDFFF\uE002\uDAFF\uDFFE §#ffd750ffBritishLesbian§#a0c84bff Profession Speed Bomb has expired!\n\uDAFF\uDFFC\uE001\uDB00\uDC06 Get your own bombs at §#ffd750ff§n§[1]wynncraft.com/store");
+        p.shouldMatch("§#a0c84bff\uDAFF\uDFFC\uE014\uDAFF\uDFFF\uE002\uDAFF\uDFFE \uDB00\uDC4C§lProfession Speed Bomb");
+        p.shouldMatch(
+                "§#a0c84bff\uDAFF\uDFFC\uE014\uDAFF\uDFFF\uE002\uDAFF\uDFFE Flyxdre has gotten a §#dd55ffffFuturistic Relik§#a0c84bff from their crate!\n\uDAFF\uDFFC\uE001\uDB00\uDC06 Get your own at §#ffd750ff§[1]wynncraft.com/store§#a0c84bff or type §#ffd750ff§[2]/store");
+    }
+
+    @Test
+    public void RecipientType_WORLD_EVENT_pattern() {
+        PatternTester p = new PatternTester(RecipientType.WORLD_EVENT, "pattern");
+        p.shouldMatch("§#00bdbfff\uDAFF\uDFFC\uE00D\uDAFF\uDFFF\uE002\uDAFF\uDFFE You are now within the event radius");
+        p.shouldMatch("§#00bdbfff\uDAFF\uDFFC\uE001\uDB00\uDC06 Create a party to play with others");
+        p.shouldMatch(
+                "§#00bdbfff\uDAFF\uDFFC\uE001\uDB00\uDC06 \uDB00\uDC78\uE060\uDAFF\uDFFF\uE046\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE03B\uDAFF\uDFFF\uE033\uDAFF\uDFFF\uE061\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE045\uDAFF\uDFFF\uE034\uDAFF\uDFFF\uE03D\uDAFF\uDFFF\uE043\uDAFF\uDFFF\uE062\uDAFF\uDFBE§0\uE016\uE00E\uE011\uE00B\uE003 \uE004\uE015\uE004\uE00D\uE013\uDB00\uDC02");
+        p.shouldMatch("§#00bdbfff\uDAFF\uDFFC\uE001\uDB00\uDC06 \uDB00\uDC72§fEvent Completed");
+        // The completed message contains empty ones (just the prefix)
+        p.shouldMatch("§#00bdbfff\uDAFF\uDFFC\uE001\uDB00\uDC06 ");
+    }
+
+    @Test
+    public void RecipientType_SYSTEM_INFO_pattern() {
+        PatternTester p = new PatternTester(RecipientType.SYSTEM_INFO, "pattern");
+        p.shouldMatch(
+                "§#a0aec0ff\uDAFF\uDFFC\uE01B\uDAFF\uDFFF\uE002\uDAFF\uDFFE §#da43e8ff&lFestival of the Heroes:§#a0aec0ff §#deabebffGrab 3 free Gilded Heroes\n§#a0aec0ff\uDAFF\uDFFC\uE001\uDB00\uDC06 §#deabebffCrates on our store at §#5198fcff&n§[1]wynncraft.com/store!§#deabebff The festival\n§#a0aec0ff\uDAFF\uDFFC\uE001\uDB00\uDC06 §#deabebffcloses its doors in §#da43e8ff15 days.");
+    }
+
+    @Test
+    public void RecipientType_MERCHANT_pattern() {
+        PatternTester p = new PatternTester(RecipientType.MERCHANT, "pattern");
+        p.shouldMatch(
+                "§5\uDAFF\uDFFC\uE00A\uDAFF\uDFFF\uE002\uDAFF\uDFFE Party Finder:§d Hey Flyxdre, over here! Join the §bNest of the\n§5\uDAFF\uDFFC\uE001\uDB00\uDC06 §bGrootslangs§d queue and match up with §e2§d other players!");
+        p.shouldMatch(
+                "§5\uDAFF\uDFFC\uE00A\uDAFF\uDFFF\uE002\uDAFF\uDFFE Blacksmith: §dYou have sold §51 item&d for §a3²");
+    }
+
+    @Test
+    public void RecipientType_ERROR_OR_WARNING_pattern() {
+        PatternTester p = new PatternTester(RecipientType.ERROR_OR_WARNING, "pattern");
+        p.shouldMatch(
+                "§4\uDAFF\uDFFC\uE008\uDAFF\uDFFF\uE002\uDAFF\uDFFE Sorry, you can't teleport... Try moving away from blocks.");
+    }
+
+    @Test
+    public void RecipientType_COMMAND_pattern() {
+        PatternTester p = new PatternTester(RecipientType.COMMAND, "pattern");
+        p.shouldMatch(
+                "§a\uDAFF\uDFFC\uE008\uDAFF\uDFFF\uE002\uDAFF\uDFFE You can no longer see level 100 popups in game!");
+    }
+
+    @Test
     public void RuneAnnotator_RUNE_PATTERN() {
         PatternTester p = new PatternTester(RuneAnnotator.class, "RUNE_PATTERN");
         p.shouldMatch("\uDAFC\uDC00§#b0f3fcffAz Rune\uDAFC\uDC00");

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -813,6 +813,13 @@ public class TestRegex {
     }
 
     @Test
+    public void RecipientType_MOUNT_pattern() {
+        PatternTester p = new PatternTester(RecipientType.MOUNT, "pattern");
+        p.shouldMatch(
+                "§#8f663dff\uDAFF\uDFFC\uE01F\uDAFF\uDFFF\uE002\uDAFF\uDFFE You have destroyed the item used to summon your mount.");
+    }
+
+    @Test
     public void RuneAnnotator_RUNE_PATTERN() {
         PatternTester p = new PatternTester(RuneAnnotator.class, "RUNE_PATTERN");
         p.shouldMatch("\uDAFC\uDC00§#b0f3fcffAz Rune\uDAFC\uDC00");


### PR DESCRIPTION
There exist a number of visual chat related issues that are caused by wynntils either filtering or redirecting messages or by modifying them in place, e. g. elongating them.

Unwrap and Rewrap all messages following Wynn chat tab style to eliminate the bulk of these.

Extend RecipientType to recognise (hopefully) all different types of soft-wrapped message types. Refactor chat handling to make use of this invariant and remove duplicated efforts to unwrap and strip alignment.

## A few examples of what this is fixing:

Filtered message in between:
<img width="183" height="68" alt="Screenshot From 2026-04-24 23-50-18" src="https://github.com/user-attachments/assets/80f333c2-7316-43ee-954e-ea1b1cae9228" />

Formatting breaking due to an edit elongating the message (here: nickname replacement).
<img width="656" height="121" alt="Screenshot From 2026-04-24 23-52-14" src="https://github.com/user-attachments/assets/e473c3ea-f308-407c-88e9-aa27397df747" />

Clientside message in between:
<img width="181" height="74" alt="image" src="https://github.com/user-attachments/assets/c6a4bc8d-05bb-4f39-9939-c26f0a6ee98c" />


This does break the UnwrapChat feature, but as the feature pretty much existed to make the effects of bugs fixed in here less pronounced it may be fine to remove the feature.

Given #4003 there are may be some odd spacing issues in some cases.



