### PR TITLE
fix: rework Gambit detection

### DIFF
--- a/common/src/main/java/com/wynntils/models/containers/containers/RaidStartContainer.java
+++ b/common/src/main/java/com/wynntils/models/containers/containers/RaidStartContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.containers.containers;
@@ -12,6 +12,7 @@ public class RaidStartContainer extends Container {
     private static final Pattern TITLE_PATTERN = Pattern.compile("\uDAFF\uDFE1\uE00C");
 
     private static final List<Integer> GAMBIT_SLOTS = List.of(1, 3, 5, 7);
+    private static final List<Integer> PLAYER_SLOTS = List.of(18, 19, 20, 21);
 
     public RaidStartContainer() {
         super(TITLE_PATTERN);
@@ -19,5 +20,9 @@ public class RaidStartContainer extends Container {
 
     public static List<Integer> getGambitSlots() {
         return GAMBIT_SLOTS;
+    }
+
+    public static List<Integer> getPlayerSlots() {
+        return PLAYER_SLOTS;
     }
 }

--- a/common/src/main/java/com/wynntils/models/gambits/GambitModel.java
+++ b/common/src/main/java/com/wynntils/models/gambits/GambitModel.java
@@ -4,16 +4,14 @@
  */
 package com.wynntils.models.gambits;
 
-import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.mc.event.ContainerSetSlotEvent;
 import com.wynntils.models.containers.containers.RaidStartContainer;
 import com.wynntils.models.gambits.type.Gambit;
-import com.wynntils.models.gambits.type.GambitStatus;
-import com.wynntils.models.items.items.gui.GambitItem;
-import java.util.ArrayList;
+import com.wynntils.models.items.items.gui.RaidPlayerItem;
+import com.wynntils.utils.mc.McUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -21,8 +19,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class GambitModel extends Model {
-    private final List<Gambit> activeGambits = new ArrayList<>();
-    private final List<GambitItem> gambitItems = new ArrayList<>();
+    private List<Gambit> activeGambits = List.of();
 
     public GambitModel() {
         super(List.of());
@@ -36,60 +33,33 @@ public final class GambitModel extends Model {
     public void onContentSet(ContainerSetContentEvent.Pre event) {
         if (!(Models.Container.getCurrentContainer() instanceof RaidStartContainer container)) return;
 
-        activeGambits.clear();
-        gambitItems.clear();
-        for (int slot : container.getGambitSlots()) {
-            ItemStack itemStack = event.getItems().get(slot);
-            if (itemStack.isEmpty()) continue;
-
-            Optional<GambitItem> gambitItem = Models.Item.asWynnItem(itemStack, GambitItem.class);
-            if (gambitItem.isEmpty()) {
-                WynntilsMod.warn("Failed to parse GambitItem.");
-                return;
-            }
-
-            gambitItems.add(gambitItem.get());
+        for (int slot : container.getPlayerSlots()) {
+            parsePlayerItem(event.getItems().get(slot));
         }
-
-        parseGambitItems();
     }
 
     @SubscribeEvent
     public void onSlotSet(ContainerSetSlotEvent.Pre event) {
         if (!(Models.Container.getCurrentContainer() instanceof RaidStartContainer container)) return;
-        if (gambitItems.size() != 4) return;
 
-        List<Integer> gambitSlots = new ArrayList<>(container.getGambitSlots());
-        for (int i = 0; i < gambitSlots.size(); i++) {
-            int slot = gambitSlots.get(i);
+        for (int slot : container.getPlayerSlots()) {
             if (slot == event.getSlot()) {
-                ItemStack itemStack = event.getItemStack();
-                if (itemStack.isEmpty()) return;
-
-                Optional<GambitItem> gambitItem = Models.Item.asWynnItem(itemStack, GambitItem.class);
-                if (gambitItem.isEmpty()) return;
-
-                gambitItems.set(i, gambitItem.get());
-                parseGambitItems();
+                parsePlayerItem(event.getItemStack());
                 return;
             }
         }
     }
 
-    private void parseGambitItems() {
-        boolean isFirst = true;
-        for (GambitItem item : gambitItems) {
-            GambitStatus status = item.getGambitStatus();
+    private void parsePlayerItem(ItemStack itemStack) {
+        if (itemStack.isEmpty()) return;
 
-            // only clear the gambits before adding the first item, skip if player is readied up
-            if (isFirst && (status != GambitStatus.PLAYER_READY)) {
-                isFirst = false;
-                activeGambits.clear();
-            }
+        Optional<RaidPlayerItem> playerItemOptional = Models.Item.asWynnItem(itemStack, RaidPlayerItem.class);
+        if (playerItemOptional.isEmpty()) return;
 
-            if (status == GambitStatus.ENABLED) {
-                activeGambits.add(item.getGambit());
-            }
-        }
+        RaidPlayerItem playerItem = playerItemOptional.get();
+
+        if (!McUtils.playerName().equals(playerItem.getPlayerName())) return;
+
+        activeGambits = playerItem.getEnabledGambits();
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/ItemModel.java
+++ b/common/src/main/java/com/wynntils/models/items/ItemModel.java
@@ -47,6 +47,7 @@ import com.wynntils.models.items.annotators.gui.GambitAnnotator;
 import com.wynntils.models.items.annotators.gui.GuildLogAnnotator;
 import com.wynntils.models.items.annotators.gui.IngredientPouchAnnotator;
 import com.wynntils.models.items.annotators.gui.LeaderboardSeasonAnnotator;
+import com.wynntils.models.items.annotators.gui.RaidPlayerAnnotator;
 import com.wynntils.models.items.annotators.gui.SeaskipperDestinationAnnotator;
 import com.wynntils.models.items.annotators.gui.ServerAnnotator;
 import com.wynntils.models.items.annotators.gui.SkillCrystalAnnotator;
@@ -105,6 +106,7 @@ public final class ItemModel extends Model {
         Handlers.Item.registerAnnotator(new GuildLogAnnotator());
         Handlers.Item.registerAnnotator(new IngredientPouchAnnotator());
         Handlers.Item.registerAnnotator(new LeaderboardSeasonAnnotator());
+        Handlers.Item.registerAnnotator(new RaidPlayerAnnotator());
         Handlers.Item.registerAnnotator(new SeaskipperDestinationAnnotator());
         Handlers.Item.registerAnnotator(new ServerAnnotator());
         Handlers.Item.registerAnnotator(new SkillCrystalAnnotator());

--- a/common/src/main/java/com/wynntils/models/items/annotators/gui/RaidPlayerAnnotator.java
+++ b/common/src/main/java/com/wynntils/models/items/annotators/gui/RaidPlayerAnnotator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.annotators.gui;
+
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.item.GuiItemAnnotator;
+import com.wynntils.handlers.item.ItemAnnotation;
+import com.wynntils.models.gambits.type.Gambit;
+import com.wynntils.models.items.items.gui.RaidPlayerItem;
+import com.wynntils.utils.mc.LoreUtils;
+import com.wynntils.utils.mc.StyledTextUtils;
+import com.wynntils.utils.type.Pair;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public class RaidPlayerAnnotator implements GuiItemAnnotator {
+    private static final Pattern NAME_PATTERN =
+            Pattern.compile("^([\uE022\uE024\uE01B\uE08A\uE017] )?§(#[0-9A-Fa-f]{6,8})(§o)?(?<player>.+)$");
+    private static final Pattern LEVEL_PATTERN = Pattern.compile("^§a✔ §7Combat Level: §f[0-9]+$");
+    private static final Pattern GAMBIT_PATTERN = Pattern.compile("^§a- §7(?<gambit>.+? Gambit)$");
+
+    @Override
+    public ItemAnnotation getAnnotation(ItemStack itemStack, StyledText name) {
+        if (itemStack.getItem() != Items.PLAYER_HEAD) return null;
+
+        Matcher matcher = name.getMatcher(NAME_PATTERN);
+        if (!matcher.matches()) return null;
+
+        // The pattern is pretty broad, so we need to figure out based on the lore if this is really a Raid Player
+        List<StyledText> lore = LoreUtils.getLore(itemStack);
+        if (lore.isEmpty()) return null;
+
+        if (!lore.getLast().getMatcher(LEVEL_PATTERN).matches()) return null;
+
+        StyledText customName = StyledText.fromComponent(itemStack.get(DataComponents.CUSTOM_NAME));
+        Pair<String, String> userAndNick = StyledTextUtils.extractNameAndNick(customName);
+
+        String player = userAndNick == null ? matcher.group("player") : userAndNick.a();
+
+        List<Gambit> gambits = lore.stream()
+                .map(line -> line.getMatcher(GAMBIT_PATTERN))
+                .filter(Matcher::matches)
+                .map(m -> Gambit.fromItemName(m.group("gambit")))
+                .toList();
+
+        return new RaidPlayerItem(player, gambits);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/items/items/gui/GambitItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/GambitItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.gui;
@@ -46,5 +46,15 @@ public class GambitItem extends GuiItem {
 
     public List<StyledText> getDescription() {
         return Collections.unmodifiableList(description);
+    }
+
+    @Override
+    public String toString() {
+        return "GambitItem{" + "gambit="
+                + gambit + ", name="
+                + name + ", color="
+                + color + ", description="
+                + description + ", gambitStatus="
+                + gambitStatus + '}';
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/items/gui/RaidPlayerItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/gui/RaidPlayerItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.items.items.gui;
+
+import com.wynntils.models.gambits.type.Gambit;
+import java.util.Collections;
+import java.util.List;
+
+public class RaidPlayerItem extends GuiItem {
+    private final String playerName;
+    private final List<Gambit> enabledGambits;
+
+    public RaidPlayerItem(String playerName, List<Gambit> enabledGambits) {
+        this.playerName = playerName;
+        this.enabledGambits = enabledGambits;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public List<Gambit> getEnabledGambits() {
+        return Collections.unmodifiableList(enabledGambits);
+    }
+
+    @Override
+    public String toString() {
+        return "RaidPlayerItem{" + "playerName=" + playerName + ", enabledGambits=" + enabledGambits + '}';
+    }
+}


### PR DESCRIPTION
Base the gambit detection of the player info in the same menu. There is a player info menu for every current party member, so we annotate all and filter only the one matching the current player. This system should be more robust as it only relies on one item to parse current gambits.

Tested by doing a raid with 3 gambits.