### PR TITLE
fix: status effects doesn't show the color code before the effect name in some case

### DIFF
--- a/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
@@ -47,7 +47,7 @@ public final class StatusEffectModel extends Model {
 
     // Test in StatusEffectModel_STATUS_EFFECT_PATTERN
     private static final Pattern STATUS_EFFECT_PATTERN = Pattern.compile(
-            "(?<prefix>.+?)(§\\w)?\\s?(?<modifier>(\\-|\\+)?([\\-\\.\\d]+))?(?<modifierSuffix>((\\/\\d+s)|%)?)?\\s?(?<name>\\+?['a-zA-Z\\/\\s]+?)\\s(?<timer>§[84a]\\((?<minutes>(\\d{2}|\\*{2})):(?<seconds>(\\d{2}|\\*{2}))\\))");
+            "(?<prefix>.+?)(?:§[0-9a-fk-or])*\\s?(?<modifier>(\\-|\\+)?([\\-\\.\\d,]+))?(?<modifierSuffix>((\\/\\d+s)|%))?\\s?(?<name>\\+?['a-zA-Z\\/\\s]+?)\\s+(?<timer>§[84ac]\\((?<minutes>(\\d{2}|\\*{2})):(?<seconds>(\\d{2}|\\*{2}))\\))");
 
     private static final StyledText STATUS_EFFECTS_TITLE = StyledText.fromString("§d§lStatus Effects");
 
@@ -83,7 +83,7 @@ public final class StatusEffectModel extends Model {
 
         List<StatusEffect> newStatusEffects = new ArrayList<>();
 
-        StyledText[] effects = footer.split("\\s{2}"); // Effects are split up by 2 spaces
+        StyledText[] effects = footer.split("\\n|\\s{2,}"); // Effects are split up by 2 spaces
         for (StyledText effect : effects) {
             StyledText trimmedEffect = effect.trim();
             if (trimmedEffect.isEmpty()) continue;


### PR DESCRIPTION
>Note: Some effects may still have the wrong icon that shows up
<img width="219" height="43" alt="image" src="https://github.com/user-attachments/assets/e926bd3c-153c-476b-be99-e9b33aac2179" />
