### PR TITLE
fix: Hour long status effects not getting recognized

### DIFF
--- a/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
@@ -47,7 +47,7 @@ public final class StatusEffectModel extends Model {
 
     // Test in StatusEffectModel_STATUS_EFFECT_PATTERN
     private static final Pattern STATUS_EFFECT_PATTERN = Pattern.compile(
-            "(?<prefix>.+?)(?:§[0-9a-fk-or])*\\s?(?<modifier>(\\-|\\+)?([\\-\\.\\d,]+))?(?<modifierSuffix>((\\/\\d+s)|%))?\\s?(?<name>\\+?['a-zA-Z\\/\\s]+?)\\s+(?<timer>§[84ac]\\((?<minutes>(\\d{2}|\\*{2})):(?<seconds>(\\d{2}|\\*{2}))\\))");
+            "(?<prefix>.+?)(?:§[0-9a-fk-or])*\\s?(?<modifier>(\\-|\\+)?([\\-\\.\\d,]+))?(?<modifierSuffix>((\\/\\d+s)|%))?\\s?(?<name>\\+?['a-zA-Z\\/\\s]+?)\\s+(?<timer>§[84ac]\\((?<hours>\\d{2})?:?(?<minutes>(\\d{2}|\\*{2})):(?<seconds>(\\d{2}|\\*{2}))\\))");
 
     private static final StyledText STATUS_EFFECTS_TITLE = StyledText.fromString("§d§lStatus Effects");
 
@@ -103,7 +103,12 @@ public final class StatusEffectModel extends Model {
             int duration = -1;
 
             try {
-                duration = Integer.parseInt(minutes.getString()) * 60 + Integer.parseInt(seconds.getString());
+                int hours = 0;
+                String hoursString = m.group("hours");
+                if (hoursString != null) hours = Integer.parseInt(hoursString);
+                duration = hours * 3600
+                        + Integer.parseInt(minutes.getString()) * 60
+                        + Integer.parseInt(seconds.getString());
             } catch (NumberFormatException ignored) {
             }
 

--- a/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/StatusEffectModel.java
@@ -103,12 +103,14 @@ public final class StatusEffectModel extends Model {
             int duration = -1;
 
             try {
-                int hours = 0;
+                duration = Integer.parseInt(minutes.getString()) * 60 + Integer.parseInt(seconds.getString());
+
+                // Hours are optional and don't always appear
                 String hoursString = m.group("hours");
-                if (hoursString != null) hours = Integer.parseInt(hoursString);
-                duration = hours * 3600
-                        + Integer.parseInt(minutes.getString()) * 60
-                        + Integer.parseInt(seconds.getString());
+                if (hoursString != null) {
+                    duration += Integer.parseInt(hoursString) * 3600;
+                }
+
             } catch (NumberFormatException ignored) {
             }
 

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -818,6 +818,7 @@ public class TestRegex {
         p.shouldMatch("§8⬤ §7Vanish §a(00:04)");
         p.shouldMatch("§fⒺ§7 +250/3s Life Steal §8(00:41)");
         p.shouldMatch("§8⬤ §7Boiling Blood §a(00:02)");
+        p.shouldMatch("§fⒶ§7 +65% Air Defence §8(01:38:09)");
     }
 
     @Test


### PR DESCRIPTION
<img width="767" height="253" alt="image" src="https://github.com/user-attachments/assets/ac543194-9012-4391-b0df-0f250b6b5d80" />
<img width="884" height="45" alt="image" src="https://github.com/user-attachments/assets/d1dde4ce-f889-4e30-b7de-51c3df3c48e4" />
The duration screenshot was taken half a minute later, the math is right