### PR TITLE
Strip item-name markers from lootrun dry streak message

### DIFF
--- a/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
@@ -154,7 +154,8 @@ public class ValuableFoundFeature extends Feature {
                 }
 
                 if (!showDryStreakMessage.get()) return;
-                sendLootrunDryStreakMessage(resolveItemName(itemStack, event.getItem().getHoverName()));
+                sendLootrunDryStreakMessage(
+                        resolveItemName(itemStack, event.getItem().getHoverName()));
             }
         }
 

--- a/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
@@ -20,8 +20,10 @@ import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.items.game.InsulatorItem;
 import com.wynntils.models.items.items.game.SimulatorItem;
 import com.wynntils.models.items.items.game.TomeItem;
+import com.wynntils.models.items.properties.NamedItemProperty;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.wynn.WynnUtils;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -152,8 +154,7 @@ public class ValuableFoundFeature extends Feature {
                 }
 
                 if (!showDryStreakMessage.get()) return;
-                sendLootrunDryStreakMessage(
-                        StyledText.fromComponent(event.getItem().getHoverName()));
+                sendLootrunDryStreakMessage(resolveItemName(itemStack, event.getItem().getHoverName()));
             }
         }
 
@@ -207,6 +208,23 @@ public class ValuableFoundFeature extends Feature {
                 }
             }
         }
+    }
+
+    /**
+     * Resolves a clean item name for dry-streak messages. Wynncraft surrounds certain
+     * item names with non-printable boundary markers in the raw hover name, which leak
+     * through to the chat message via {@code StyledText.fromComponent(getHoverName())}
+     * (see #4016). Prefer the WynnItem's {@link NamedItemProperty#getName()} when
+     * available, then fall back to stripping the marker characters from the hover name.
+     */
+    private static StyledText resolveItemName(ItemStack itemStack, Component hoverName) {
+        Optional<NamedItemProperty> namedItemProperty =
+                Models.Item.asWynnItemProperty(itemStack, NamedItemProperty.class);
+        if (namedItemProperty.isPresent()) {
+            return StyledText.fromString(namedItemProperty.get().getName());
+        }
+        StyledText hover = StyledText.fromComponent(hoverName);
+        return StyledText.fromString(WynnUtils.stripItemNameMarkers(hover.getString()));
     }
 
     private void sendLootrunDryStreakMessage(StyledText itemName) {


### PR DESCRIPTION
Closes #4016.

## Problem

Wynncraft surrounds certain item names (e.g. shiny mythics) with non-printable boundary marker characters in the raw item hover name. `StyledText.fromComponent(event.getItem().getHoverName())` carries those markers straight into the lootrun dry-streak chat message, so the item name renders with garbled prefix/suffix glyphs - matching the screenshot in the issue.

## Fix

Per the issue (ShadowCat117), pick the cleaner of two strategies on a per-item-stack basis:

1. If the WynnItem implements `NamedItemProperty` (Aspect, EmeraldPouch, Ingredient, Powder, etc.), use `NamedItemProperty.getName()` directly. This is the same API `ChatItemFeature.createItemPart` already uses for chat-item rendering.
2. Otherwise, fall back to `WynnUtils.stripItemNameMarkers` on the hover-name string. This is the same helper `ItemScreenshotFeature` already uses to clean filenames.

The helper lives next to the existing dry-streak message methods so the call site stays a one-liner and `sendLootrunDryStreakMessage`'s signature is unchanged.

## Scope

Only the lootrun-reward path the issue cites is changed. Other dry-streak paths in the same file (chest, raid, world event, emerald pouch) are untouched and can adopt the same helper in a follow-up if they show the same symptom.

## Verification

- `git diff --stat`: one file, +20 / -2.
- Manual reading of the renamed call site preserves all existing behavior except for the substitution of the item name.
- The repo's gradle build can't be run here (no JDK in this environment); maintainer CI on Wynntils/Wynntils builds the change against all mod loaders.
