### PR TITLE
feat: Add actual player stats from the CharacterInfo Screen

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -526,6 +526,8 @@ public final class FunctionManager extends Manager {
         registerFunction(new CharacterFunctions.PuppetsInTimeRangeFunction());
         registerFunction(new CharacterFunctions.SnakeCountFunction());
         registerFunction(new CharacterFunctions.SprintFunction());
+        registerFunction(new CharacterFunctions.PlayerStatFunction());
+        registerFunction(new CharacterFunctions.PlayerStatRawFunction());
 
         registerFunction(new CombatFunctions.AreaDamageAverageFunction());
         registerFunction(new CombatFunctions.AreaDamagePerSecondFunction());

--- a/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
@@ -10,6 +10,7 @@ import com.wynntils.core.consumers.functions.arguments.Argument;
 import com.wynntils.core.consumers.functions.arguments.FunctionArguments;
 import com.wynntils.models.abilities.label.ShamanPuppetInfo;
 import com.wynntils.models.character.type.VehicleType;
+import com.wynntils.models.characterstats.type.PlayerStat;
 import com.wynntils.models.characterstats.type.PowderSpecialInfo;
 import com.wynntils.models.objectives.WynnObjective;
 import com.wynntils.services.leaderboard.type.LeaderboardType;
@@ -524,6 +525,36 @@ public class CharacterFunctions {
         @Override
         public Integer getValue(FunctionArguments arguments) {
             return Models.ArcherBeast.getActiveSnakeCount();
+        }
+    }
+
+    public static class PlayerStatFunction extends Function<String> {
+
+        @Override
+        public FunctionArguments.Builder getArgumentsBuilder() {
+            return new FunctionArguments.RequiredArgumentBuilder(
+                    List.of(new Argument<>("name", String.class, null)));
+        }
+        @Override
+        public String getValue(FunctionArguments arguments) {
+            return Models.CharacterStats
+                    .getStatByApiName(arguments.getArgument("name").getStringValue())
+                    .orElse(PlayerStat.NONE).toDisplay();
+        }
+    }
+
+    public static class PlayerStatRawFunction extends Function<Integer> {
+
+        @Override
+        public FunctionArguments.Builder getArgumentsBuilder() {
+            return new FunctionArguments.RequiredArgumentBuilder(
+                    List.of(new Argument<>("name", String.class, null)));
+        }
+        @Override
+        public Integer getValue(FunctionArguments arguments) {
+            return Models.CharacterStats
+                    .getStatByApiName(arguments.getArgument("name").getStringValue())
+                    .orElse(PlayerStat.NONE).value();
         }
     }
 }

--- a/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/CharacterFunctions.java
@@ -529,32 +529,32 @@ public class CharacterFunctions {
     }
 
     public static class PlayerStatFunction extends Function<String> {
-
         @Override
         public FunctionArguments.Builder getArgumentsBuilder() {
-            return new FunctionArguments.RequiredArgumentBuilder(
-                    List.of(new Argument<>("name", String.class, null)));
+            return new FunctionArguments.RequiredArgumentBuilder(List.of(new Argument<>("name", String.class, null)));
         }
+
         @Override
         public String getValue(FunctionArguments arguments) {
-            return Models.CharacterStats
-                    .getStatByApiName(arguments.getArgument("name").getStringValue())
-                    .orElse(PlayerStat.NONE).toDisplay();
+            return Models.CharacterStats.getStatByApiName(
+                            arguments.getArgument("name").getStringValue())
+                    .orElse(PlayerStat.NONE)
+                    .toDisplay();
         }
     }
 
     public static class PlayerStatRawFunction extends Function<Integer> {
-
         @Override
         public FunctionArguments.Builder getArgumentsBuilder() {
-            return new FunctionArguments.RequiredArgumentBuilder(
-                    List.of(new Argument<>("name", String.class, null)));
+            return new FunctionArguments.RequiredArgumentBuilder(List.of(new Argument<>("name", String.class, null)));
         }
+
         @Override
         public Integer getValue(FunctionArguments arguments) {
-            return Models.CharacterStats
-                    .getStatByApiName(arguments.getArgument("name").getStringValue())
-                    .orElse(PlayerStat.NONE).value();
+            return Models.CharacterStats.getStatByApiName(
+                            arguments.getArgument("name").getStringValue())
+                    .orElse(PlayerStat.NONE)
+                    .value();
         }
     }
 }

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -10,6 +10,8 @@ import com.wynntils.core.components.Models;
 import com.wynntils.handlers.actionbar.ActionBarSegment;
 import com.wynntils.handlers.actionbar.event.ActionBarRenderEvent;
 import com.wynntils.handlers.actionbar.event.ActionBarUpdatedEvent;
+import com.wynntils.mc.event.ScreenOpenedEvent;
+import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.characterstats.actionbar.matchers.HealthBarSegmentMatcher;
 import com.wynntils.models.characterstats.actionbar.matchers.HealthTextSegmentMatcher;
 import com.wynntils.models.characterstats.actionbar.matchers.HotbarSegmentMatcher;
@@ -35,10 +37,13 @@ import com.wynntils.models.characterstats.actionbar.segments.ManaTextSegment;
 import com.wynntils.models.characterstats.actionbar.segments.MeterBarSegment;
 import com.wynntils.models.characterstats.actionbar.segments.PowderSpecialSegment;
 import com.wynntils.models.characterstats.actionbar.segments.ProfessionExperienceSegment;
+import com.wynntils.models.characterstats.parser.CharacterStatsParser;
 import com.wynntils.models.characterstats.type.MeterBarInfo;
+import com.wynntils.models.characterstats.type.PlayerStat;
 import com.wynntils.models.characterstats.type.PowderSpecialInfo;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.models.stats.type.StatType;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.wynn.InventoryUtils;
@@ -47,6 +52,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.HashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
@@ -55,6 +61,8 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class CharacterStatsModel extends Model {
+    public static final int TICKS_BETWEEN_STAT_LOOKUP = 20 * 20; // 20 seconds
+    private static final CharacterStatsParser CHARACTER_STATS_PARSER = new CharacterStatsParser();
     private final Set<Class<? extends ActionBarSegment>> hiddenSegments = new HashSet<>();
 
     private int level = 0;
@@ -62,6 +70,7 @@ public final class CharacterStatsModel extends Model {
     private CappedValue mana = CappedValue.EMPTY;
     private CappedValue sprint = CappedValue.EMPTY;
     private PowderSpecialInfo powderSpecialInfo = PowderSpecialInfo.EMPTY;
+    private final HashMap<StatType, PlayerStat> playerStats = new HashMap<>();
 
     private boolean isProfessionExperience = false;
 
@@ -85,6 +94,23 @@ public final class CharacterStatsModel extends Model {
         Handlers.ActionBar.registerSegment(new HealthTextSegmentMatcher());
         Handlers.ActionBar.registerSegment(new PowderSpecialSegmentMatcher());
         Handlers.ActionBar.registerSegment(new ProfessionExperienceSegmentMatcher());
+    }
+
+    @SubscribeEvent
+    public void onOpenScreen(ScreenOpenedEvent.Pre event) {
+        CHARACTER_STATS_PARSER.postponeQuery();
+    }
+
+    private int ticksUntilNextLookup = 0;
+    @SubscribeEvent
+    public void onTick(TickEvent event) {
+        if (ticksUntilNextLookup > 0) {
+            ticksUntilNextLookup--;
+            return;
+        }
+
+        CHARACTER_STATS_PARSER.queryPlayerStats(stat -> playerStats.put(stat.statType(), stat));
+        ticksUntilNextLookup = TICKS_BETWEEN_STAT_LOOKUP;
     }
 
     @SubscribeEvent
@@ -200,6 +226,16 @@ public final class CharacterStatsModel extends Model {
     public Optional<CappedValue> getSprint() {
         if (sprint == CappedValue.EMPTY) return Optional.empty();
         return Optional.of(sprint);
+    }
+
+    public HashMap<StatType, PlayerStat> getPlayerStats() {
+        return playerStats;
+    }
+
+    public Optional<PlayerStat> getStatByApiName(String statName) {
+        StatType type = Models.Stat.fromApiName(statName);
+        if(type == null) return Optional.empty();
+        return Optional.of(this.playerStats.getOrDefault(type, null));
     }
 
     public Optional<PowderSpecialInfo> getPowderSpecialInfo() {

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -48,11 +48,11 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.wynn.InventoryUtils;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.HashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
@@ -102,6 +102,7 @@ public final class CharacterStatsModel extends Model {
     }
 
     private int ticksUntilNextLookup = 0;
+
     @SubscribeEvent
     public void onTick(TickEvent event) {
         if (ticksUntilNextLookup > 0) {
@@ -234,7 +235,7 @@ public final class CharacterStatsModel extends Model {
 
     public Optional<PlayerStat> getStatByApiName(String statName) {
         StatType type = Models.Stat.fromApiName(statName);
-        if(type == null) return Optional.empty();
+        if (type == null) return Optional.empty();
         return Optional.of(this.playerStats.getOrDefault(type, null));
     }
 

--- a/common/src/main/java/com/wynntils/models/characterstats/parser/CharacterStatsParser.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/parser/CharacterStatsParser.java
@@ -1,0 +1,99 @@
+package com.wynntils.models.characterstats.parser;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Handlers;
+import com.wynntils.core.components.Models;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.handlers.container.scriptedquery.QueryStep;
+import com.wynntils.handlers.container.scriptedquery.ScriptedContainerQuery;
+import com.wynntils.handlers.container.type.ContainerContent;
+import com.wynntils.models.characterstats.type.PlayerStat;
+import com.wynntils.models.containers.containers.CharacterInfoContainer;
+import com.wynntils.models.stats.type.StatType;
+import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.wynn.InventoryUtils;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CharacterStatsParser {
+
+    private static final int CHARACTER_STAT_SLOT = 7;
+
+    private final Pattern PLAYERSTAT_IDENTIFICATION_PATTERN = Pattern.compile("§dIdentifications: ");
+    private final Pattern PLAYERSTAT_ITEM_PATTERN = Pattern.compile("§7(?!§)(.*?)(?<statName>[\\w ]+): (?<positiveNegative>§a|§c)(?<value>[-+\\d]+)(?<unit>.*?$)");
+    private final Pattern PLAYERSTAT_END_PATTERN = Pattern.compile("§5 ");
+    private int pageCount = 0;
+    private Consumer<PlayerStat> playerStatConsumer;
+
+    public void queryPlayerStats(Consumer<PlayerStat> playerStatConsumer) {
+        if (McUtils.player() == null) return;
+        this.playerStatConsumer = playerStatConsumer;
+
+        ScriptedContainerQuery query = ScriptedContainerQuery.builder("Player Stats Query")
+                .onError(msg -> WynntilsMod.warn("Player stats querying: " + msg))
+
+                .then(QueryStep.useItemInHotbar(InventoryUtils.COMPASS_SLOT_NUM)
+                        .expectContainer(CharacterInfoContainer.class))
+
+                .execute(() -> pageCount = 0)
+                .reprocess(this::processPage)
+                .repeat((c) -> {
+                    pageCount++;
+                    return pageCount < 4;
+                }, QueryStep.clickOnSlot(CHARACTER_STAT_SLOT)
+                        .verifyContentChange((a, b, c) -> true)
+                        .processIncomingContainer(this::processPage))
+
+                .build();
+
+        query.executeQuery();
+    }
+
+    public void postponeQuery() {
+        Handlers.ContainerQuery.endAllQueries();
+    }
+
+    private void processPage(ContainerContent content) {
+        ItemStack stack = content.items().get(CHARACTER_STAT_SLOT);
+
+        List<Component> lore = stack.getTooltipLines(Item.TooltipContext.EMPTY, null, TooltipFlag.NORMAL);
+
+        boolean reachedIdentifications = false;
+        for (Component component : lore) {
+            StyledText styledText = StyledText.fromComponent(component);
+            if (styledText.matches(PLAYERSTAT_IDENTIFICATION_PATTERN)) {
+                reachedIdentifications = true;
+                continue;
+            }
+
+            if (!reachedIdentifications) continue;
+
+            if (styledText.matches(PLAYERSTAT_END_PATTERN)) {
+                break;
+            }
+
+            Matcher matcher = styledText.getMatcher(PLAYERSTAT_ITEM_PATTERN);
+            if (matcher.find()) {
+                String statName = matcher.group("statName");
+                String positiveNegative = matcher.group("positiveNegative");
+                int value = Integer.parseInt(matcher.group("value"));
+                String unit = matcher.group("unit");
+
+                StatType statType = Models.Stat.fromDisplayName(statName, unit);
+                if (statType != null) {
+                    PlayerStat playerStat = new PlayerStat(statType, value, positiveNegative.equals("§a"));
+                    playerStatConsumer.accept(playerStat);
+                } else {
+                    WynntilsMod.warn("Could not find stat type for " + statName + " with unit " + unit);
+                }
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/models/characterstats/parser/CharacterStatsParser.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/parser/CharacterStatsParser.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.models.characterstats.parser;
 
 import com.wynntils.core.WynntilsMod;
@@ -12,22 +16,21 @@ import com.wynntils.models.containers.containers.CharacterInfoContainer;
 import com.wynntils.models.stats.type.StatType;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.wynn.InventoryUtils;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class CharacterStatsParser {
-
     private static final int CHARACTER_STAT_SLOT = 7;
 
     private final Pattern PLAYERSTAT_IDENTIFICATION_PATTERN = Pattern.compile("§dIdentifications: ");
-    private final Pattern PLAYERSTAT_ITEM_PATTERN = Pattern.compile("§7(?!§)(.*?)(?<statName>[\\w ]+): (?<positiveNegative>§a|§c)(?<value>[-+\\d]+)(?<unit>.*?$)");
+    private final Pattern PLAYERSTAT_ITEM_PATTERN = Pattern.compile(
+            "§7(?!§)(.*?)(?<statName>[\\w ]+): (?<positiveNegative>§a|§c)(?<value>[-+\\d]+)(?<unit>.*?$)");
     private final Pattern PLAYERSTAT_END_PATTERN = Pattern.compile("§5 ");
     private int pageCount = 0;
     private Consumer<PlayerStat> playerStatConsumer;
@@ -38,19 +41,18 @@ public class CharacterStatsParser {
 
         ScriptedContainerQuery query = ScriptedContainerQuery.builder("Player Stats Query")
                 .onError(msg -> WynntilsMod.warn("Player stats querying: " + msg))
-
                 .then(QueryStep.useItemInHotbar(InventoryUtils.COMPASS_SLOT_NUM)
                         .expectContainer(CharacterInfoContainer.class))
-
                 .execute(() -> pageCount = 0)
                 .reprocess(this::processPage)
-                .repeat((c) -> {
-                    pageCount++;
-                    return pageCount < 4;
-                }, QueryStep.clickOnSlot(CHARACTER_STAT_SLOT)
-                        .verifyContentChange((a, b, c) -> true)
-                        .processIncomingContainer(this::processPage))
-
+                .repeat(
+                        (c) -> {
+                            pageCount++;
+                            return pageCount < 4;
+                        },
+                        QueryStep.clickOnSlot(CHARACTER_STAT_SLOT)
+                                .verifyContentChange((a, b, c) -> true)
+                                .processIncomingContainer(this::processPage))
                 .build();
 
         query.executeQuery();

--- a/common/src/main/java/com/wynntils/models/characterstats/type/PlayerStat.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/type/PlayerStat.java
@@ -1,0 +1,12 @@
+package com.wynntils.models.characterstats.type;
+
+import com.wynntils.models.stats.type.StatType;
+
+public record PlayerStat(StatType statType, int value, boolean isPositive) {
+    public static final PlayerStat NONE = new PlayerStat(null, 0, false);
+
+    public String toDisplay() {
+        if(statType == null) return "";
+        return (isPositive ? "+" : "") + value + statType.getUnit().getDisplayName();
+    }
+}

--- a/common/src/main/java/com/wynntils/models/characterstats/type/PlayerStat.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/type/PlayerStat.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.models.characterstats.type;
 
 import com.wynntils.models.stats.type.StatType;
@@ -6,7 +10,7 @@ public record PlayerStat(StatType statType, int value, boolean isPositive) {
     public static final PlayerStat NONE = new PlayerStat(null, 0, false);
 
     public String toDisplay() {
-        if(statType == null) return "";
+        if (statType == null) return "";
         return (isPositive ? "+" : "") + value + statType.getUnit().getDisplayName();
     }
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -3848,5 +3848,12 @@
   "wynntils.keybind.toggleFavorite": "Favorite/Unfavorite Item",
   "wynntils.keybind.toggleSilencer": "Toggle Silencer",
   "wynntils.keybind.toggleStopwatch": "Toggle Stopwatch",
-  "wynntils.keybind.viewPlayer": "View Player"
+  "wynntils.keybind.viewPlayer": "View Player",
+
+  "function.wynntils.playerStat.name": "Player statistic",
+  "function.wynntils.playerStat.description": "Player statistic",
+  "function.wynntils.playerStatRaw.name": "Player statistic (raw number)",
+  "function.wynntils.playerStatRaw.description": "Player statistic (raw number)",
+  "function.wynntils.playerStat.argument.name": "Stat API name",
+  "function.wynntils.playerStatRaw.argument.name": "Stat API name"
 }

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -2688,6 +2688,12 @@
   "function.wynntils.ping.name": "Ping",
   "function.wynntils.playerName.description": "Your username",
   "function.wynntils.playerName.name": "Player Name",
+  "function.wynntils.playerStat.argument.name": "Stat API name",
+  "function.wynntils.playerStat.description": "Player statistic",
+  "function.wynntils.playerStat.name": "Player statistic",
+  "function.wynntils.playerStatRaw.argument.name": "Stat API name",
+  "function.wynntils.playerStatRaw.description": "Player statistic (raw number)",
+  "function.wynntils.playerStatRaw.name": "Player statistic (raw number)",
   "function.wynntils.playerUuid.description": "Your UUID",
   "function.wynntils.playerUuid.name": "Player UUID",
   "function.wynntils.powderSpecialCharge.description": "The percent of charge of your powder special",
@@ -3848,12 +3854,5 @@
   "wynntils.keybind.toggleFavorite": "Favorite/Unfavorite Item",
   "wynntils.keybind.toggleSilencer": "Toggle Silencer",
   "wynntils.keybind.toggleStopwatch": "Toggle Stopwatch",
-  "wynntils.keybind.viewPlayer": "View Player",
-
-  "function.wynntils.playerStat.name": "Player statistic",
-  "function.wynntils.playerStat.description": "Player statistic",
-  "function.wynntils.playerStatRaw.name": "Player statistic (raw number)",
-  "function.wynntils.playerStatRaw.description": "Player statistic (raw number)",
-  "function.wynntils.playerStat.argument.name": "Stat API name",
-  "function.wynntils.playerStatRaw.argument.name": "Stat API name"
+  "wynntils.keybind.viewPlayer": "View Player"
 }


### PR DESCRIPTION
This pr adds rudimentary lookup of character stats by going through the CharacterInfo screen and reading the data on the player head.

This is a very basic implementation that "just works". But as discussed in the Wynntils discord server this addition should be unobtrusive to the player. As using a ContainerQuery disables the usage of any UIs.

Currently its implemented as running a new container query every 20 seconds and cancelling that query if a user opens a screen.
There may be more cases where this query should be cancelled and I'd be happy to implement them.

Any and all feedback welcome!