### PR TITLE
fix: dry streak messages

### DIFF
--- a/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
@@ -193,8 +193,10 @@ public class ValuableFoundFeature extends Feature {
                                 tomeFoundSound.get().getSoundEvent(), soundVolume.get(), soundPitch.get());
                     }
                     if (showTomeDryStreakMessage.get()) {
-                        sendTomeDryStreakMessage(
-                                StyledText.fromComponent(event.getItem().getHoverName()));
+                        StyledText itemName = buildItemName(
+                                event.getItem().getHoverName().getString(),
+                                tomeItem.get().getGearTier().getChatFormatting());
+                        sendTomeDryStreakMessage(itemName);
                     }
                     return;
                 }

--- a/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
+++ b/common/src/main/java/com/wynntils/features/ValuableFoundFeature.java
@@ -22,9 +22,11 @@ import com.wynntils.models.items.items.game.SimulatorItem;
 import com.wynntils.models.items.items.game.TomeItem;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.wynn.WynnUtils;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.ItemStack;
@@ -99,8 +101,11 @@ public class ValuableFoundFeature extends Feature {
                         }
 
                         if (!showDryStreakMessage.get()) return;
-                        sendNormalDryStreakMessage(
-                                StyledText.fromComponent(event.getItem().getHoverName()));
+
+                        StyledText itemName = buildItemName(
+                                event.getItem().getHoverName().getString(),
+                                gearBoxItem.get().getGearTier().getChatFormatting());
+                        sendNormalDryStreakMessage(itemName);
                     }
                     return;
                 }
@@ -132,18 +137,22 @@ public class ValuableFoundFeature extends Feature {
                 && (showDryStreakMessage.get() || lootrunSound.get() != ValuableFoundSound.NONE)) {
             boolean validLootrunMythic = false;
             Optional<GearItem> gearItem = Models.Item.asWynnItem(itemStack, GearItem.class);
+            ChatFormatting color = ChatFormatting.DARK_PURPLE;
             if (gearItem.isPresent()) {
                 validLootrunMythic = true;
+                color = gearItem.get().getGearTier().getChatFormatting();
             }
 
             Optional<InsulatorItem> insulatorItem = Models.Item.asWynnItem(itemStack, InsulatorItem.class);
             if (insulatorItem.isPresent()) {
                 validLootrunMythic = true;
+                color = insulatorItem.get().getGearTier().getChatFormatting();
             }
 
             Optional<SimulatorItem> simulatorItem = Models.Item.asWynnItem(itemStack, SimulatorItem.class);
             if (simulatorItem.isPresent()) {
                 validLootrunMythic = true;
+                color = simulatorItem.get().getGearTier().getChatFormatting();
             }
 
             if (validLootrunMythic) {
@@ -152,8 +161,10 @@ public class ValuableFoundFeature extends Feature {
                 }
 
                 if (!showDryStreakMessage.get()) return;
-                sendLootrunDryStreakMessage(
-                        StyledText.fromComponent(event.getItem().getHoverName()));
+
+                StyledText itemName =
+                        buildItemName(event.getItem().getHoverName().getString(), color);
+                sendLootrunDryStreakMessage(itemName);
             }
         }
 
@@ -292,6 +303,13 @@ public class ValuableFoundFeature extends Feature {
                 .append(Component.literal(numPulls + " " + pullType + " pulls").withStyle(ChatFormatting.GOLD))
                 .append(Component.literal(" without a mythic."))
                 .withStyle(ChatFormatting.LIGHT_PURPLE));
+    }
+
+    private static StyledText buildItemName(String itemName, ChatFormatting chatFormatting) {
+        MutableComponent nameComponent =
+                Component.empty().withStyle(chatFormatting).append(WynnUtils.stripItemNameMarkers(itemName));
+
+        return StyledText.fromComponent(nameComponent);
     }
 
     private enum ValuableFoundSound {

--- a/common/src/main/java/com/wynntils/utils/wynn/WynnUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/WynnUtils.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class WynnUtils {
     private static final String ITEM_NAME_MARKER = "\uDAFC\uDC00";
     private static final String UNIDENTIFIED_ITEM_MARKER = "\uDB00\uDC02";
+    private static final String UNKNOWN_MARKER = "\uE008";
 
     /**
      * Removes the characters 'À' ('\u00c0') and ֎ ('\u058e') that is sometimes added in Wynn APIs and
@@ -27,6 +28,8 @@ public final class WynnUtils {
      */
     public static String stripItemNameMarkers(String input) {
         if (input == null) return "";
-        return input.replace(ITEM_NAME_MARKER, "").replace(UNIDENTIFIED_ITEM_MARKER, "");
+        return input.replace(ITEM_NAME_MARKER, "")
+                .replace(UNIDENTIFIED_ITEM_MARKER, "")
+                .replace(UNKNOWN_MARKER, "");
     }
 }

--- a/common/src/main/java/com/wynntils/utils/wynn/WynnUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/WynnUtils.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class WynnUtils {
     private static final String ITEM_NAME_MARKER = "\uDAFC\uDC00";
     private static final String UNIDENTIFIED_ITEM_MARKER = "\uDB00\uDC02";
+    // This marker's purpose is currently unknown but is present on some items.
     private static final String UNKNOWN_MARKER = "\uE008";
 
     /**


### PR DESCRIPTION
<img width="967" height="60" alt="image" src="https://github.com/user-attachments/assets/4403b007-2193-4c0d-ab83-cef28d5220a8" />
<img width="968" height="67" alt="image" src="https://github.com/user-attachments/assets/076e81b2-19c4-474f-ba6e-91fcdff7f9fd" />

Fixes https://github.com/Wynntils/Wynntils/issues/4016
Had to add a new marker to  `WynnUtils#stripItemNameMarkers`, but this is an unknown marker for now. Unless anyone knows what it is used for.