### PR TITLE
fix: status effect parsing

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/features/FeatureManager.java
@@ -55,6 +55,7 @@ import com.wynntils.features.debug.ItemDebugTooltipsFeature;
 import com.wynntils.features.debug.LogItemInfoFeature;
 import com.wynntils.features.debug.MappingProgressFeature;
 import com.wynntils.features.debug.PacketDebuggerFeature;
+import com.wynntils.features.debug.PlayerInfoFooterDebuggerFeature;
 import com.wynntils.features.embellishments.RemoveShinyGlintFeature;
 import com.wynntils.features.embellishments.WarHornFeature;
 import com.wynntils.features.embellishments.WybelSoundFeature;
@@ -215,6 +216,7 @@ public final class FeatureManager extends Manager {
         registerFeature(new LogItemInfoFeature());
         registerFeature(new MappingProgressFeature());
         registerFeature(new PacketDebuggerFeature());
+        registerFeature(new PlayerInfoFooterDebuggerFeature());
 
         // always on
         registerFeature(new LootrunFeature());

--- a/common/src/main/java/com/wynntils/features/debug/PlayerInfoFooterDebuggerFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/PlayerInfoFooterDebuggerFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2026.
+ * Copyright © Wynntils 2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.features.debug;

--- a/common/src/main/java/com/wynntils/features/debug/PlayerInfoFooterDebuggerFeature.java
+++ b/common/src/main/java/com/wynntils/features/debug/PlayerInfoFooterDebuggerFeature.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Wynntils 2023-2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.features.debug;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.JsonOps;
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.consumers.features.Feature;
+import com.wynntils.core.consumers.features.ProfileDefault;
+import com.wynntils.core.persisted.config.Category;
+import com.wynntils.core.persisted.config.ConfigCategory;
+import com.wynntils.mc.event.PlayerInfoFooterChangedEvent;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.neoforged.bus.api.SubscribeEvent;
+
+@ConfigCategory(Category.DEBUG)
+public class PlayerInfoFooterDebuggerFeature extends Feature {
+    private static final String LOG_PREFIX = "[PlayerInfoFooterChangedEvent]";
+
+    public PlayerInfoFooterDebuggerFeature() {
+        super(ProfileDefault.DISABLED);
+    }
+
+    @SubscribeEvent
+    public void onPlayerInfoFooterChanged(PlayerInfoFooterChangedEvent event) {
+        String footerString = event.getFooter().getString();
+        if (footerString.isEmpty()) return;
+
+        WynntilsMod.info(LOG_PREFIX + " string=" + footerString);
+
+        JsonElement footerJson = ComponentSerialization.CODEC
+                .encodeStart(JsonOps.INSTANCE, event.getFooter().getComponent())
+                .result()
+                .orElse(null);
+
+        if (footerJson == null) {
+            WynntilsMod.warn(LOG_PREFIX + " Failed to serialize footer to JSON");
+            return;
+        }
+
+        WynntilsMod.info(LOG_PREFIX + " json=" + WynntilsMod.GSON.toJson(footerJson));
+    }
+}

--- a/common/src/main/java/com/wynntils/models/statuseffects/type/StatusEffect.java
+++ b/common/src/main/java/com/wynntils/models/statuseffects/type/StatusEffect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.statuseffects.type;
@@ -39,8 +39,9 @@ public class StatusEffect implements Comparable<StatusEffect> {
                 name,
                 StyledText.fromString(" "),
                 displayedTime);
-        this.modifierValue =
-                modifier == StyledText.EMPTY ? null : Double.parseDouble(modifier.getStringWithoutFormatting());
+        this.modifierValue = modifier == StyledText.EMPTY
+                ? null
+                : Double.parseDouble(modifier.getStringWithoutFormatting().replace(",", ""));
         this.duration = duration;
     }
 

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1278,6 +1278,8 @@
   "feature.wynntils.playerGhostTransparency.playerGhostTranslucenceLevel.name": "Player Ghost Translucence",
   "feature.wynntils.playerGhostTransparency.transparentPlayerGhostArmor.description": "Should player ghosts' armor be transparent?",
   "feature.wynntils.playerGhostTransparency.transparentPlayerGhostArmor.name": "Transparent Ghost Armor",
+  "feature.wynntils.playerInfoFooterDebugger.description": "Logs player info footer updates, including a JSON component form.",
+  "feature.wynntils.playerInfoFooterDebugger.name": "Player Info Footer Debugger",
   "feature.wynntils.playerViewer.description": "Adds the ability to view other players in a GUI.",
   "feature.wynntils.playerViewer.name": "Player Viewer",
   "feature.wynntils.powderSpecialBarOverlay.description": "Adds an overlay to see the current powder special bar.",


### PR DESCRIPTION
Fixes an issue with status effects not parsing correctly
<img width="482" height="617" alt="image" src="https://github.com/user-attachments/assets/189e4086-29ec-4ad4-b7ec-6c5af15a61be" />

Also adds a debug feature for the PlayerInfoFooterChangedEvent