### PR TITLE
fix: Functions not preserving style to new lines

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
+++ b/common/src/main/java/com/wynntils/core/consumers/functions/FunctionManager.java
@@ -56,7 +56,6 @@ import com.wynntils.utils.type.ErrorOr;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -297,9 +296,7 @@ public final class FunctionManager extends Manager {
         calculatedString = calculatedString.replace("\\]\\", "}");
         calculatedString = calculatedString.replace("\\&\\", "&");
 
-        return Arrays.stream(calculatedString.split("\n"))
-                .map(StyledText::fromString)
-                .toArray(StyledText[]::new);
+        return StyledText.fromString(calculatedString).split("\n");
     }
 
     private String parseColorCodes(String toProcess) {


### PR DESCRIPTION
With the previous change to function evaluation, it made it, so style reset on new lines, that caused issues with StyledText functions as putting new lines in the function would only make first styled which is unintuitive. This fix changes the order of how StyledText lines are made, now whole string is turned into StyledText and then the lines are split instead of in reverse. This might affect some old functions, but I think this way is far more intuitive than having to repeat the styling for single line.

Test function: `{with_font(st("line1\nline2\n&2line3 with color\nline4");"language/five")}\nline5\n&4line6 with color\nline7`

| Before | After |
| :---: | :---: |
| <img width="461" height="299" alt="f1wLXeDHxX" src="https://github.com/user-attachments/assets/4c2065ac-afa7-4342-8138-ab52d8dc0851" /> | <img width="461" height="299" alt="EmkLWDoGkU" src="https://github.com/user-attachments/assets/d56f7619-4a35-4d7d-ab73-71029b86b78e" /> |

This also might be an issue with creating StyledText because as you can see, line 3 originally got the font back while rest of the lines didn't and that line has color set. Additionally even after the font is not preserved between the lines after the with_font function, but overall it works as expected.
