### PR TITLE
fix: decode chat items when not in world

### DIFF
--- a/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
+++ b/common/src/main/java/com/wynntils/features/chat/ChatItemFeature.java
@@ -141,8 +141,6 @@ public class ChatItemFeature extends Feature {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onChatReceived(ChatMessageEvent.Edit e) {
-        if (!Models.WorldState.onWorld()) return;
-
         StyledText message = e.getMessage();
 
         StyledText unwrapped = StyledTextUtils.unwrap(message);


### PR DESCRIPTION
Fixes an old issue (since Wynncraft 2.1.1 if I remember correctly) where chat items don't get decoded when not in world or in /class menu, and just show up as boxes instead