### PR TITLE
fix: Send player and online member command responses on main thread

### DIFF
--- a/common/src/main/java/com/wynntils/commands/OnlineMembersCommand.java
+++ b/common/src/main/java/com/wynntils/commands/OnlineMembersCommand.java
@@ -58,15 +58,19 @@ public class OnlineMembersCommand extends Command {
 
         completableFuture.whenComplete((guild, throwable) -> {
             if (throwable != null) {
-                McUtils.sendWynntilsPrefixMessage(Component.literal(
-                                "Unable to view online members for " + context.getArgument("guildName", String.class))
-                        .withStyle(ChatFormatting.RED));
+                McUtils.mc().execute(() -> {
+                    McUtils.sendWynntilsPrefixMessage(Component.literal("Unable to view online members for "
+                                    + context.getArgument("guildName", String.class))
+                            .withStyle(ChatFormatting.RED));
+                });
                 WynntilsMod.error("Error trying to parse guild online members", throwable);
             } else {
                 if (guild == null) {
-                    McUtils.sendWynntilsPrefixMessage(
-                            Component.literal("Unknown guild " + context.getArgument("guildName", String.class))
-                                    .withStyle(ChatFormatting.RED));
+                    McUtils.mc().execute(() -> {
+                        McUtils.sendWynntilsPrefixMessage(
+                                Component.literal("Unknown guild " + context.getArgument("guildName", String.class))
+                                        .withStyle(ChatFormatting.RED));
+                    });
                     return;
                 }
 
@@ -106,7 +110,9 @@ public class OnlineMembersCommand extends Command {
                     }
                 }
 
-                McUtils.sendWynntilsPrefixMessage(response);
+                McUtils.mc().execute(() -> {
+                    McUtils.sendWynntilsPrefixMessage(response);
+                });
             }
         });
 

--- a/common/src/main/java/com/wynntils/commands/PlayerCommand.java
+++ b/common/src/main/java/com/wynntils/commands/PlayerCommand.java
@@ -70,15 +70,19 @@ public class PlayerCommand extends Command {
 
         completableFuture.whenComplete((player, throwable) -> {
             if (throwable != null) {
-                McUtils.sendWynntilsPrefixMessage(Component.literal(
-                                "Unable to view player guild for " + context.getArgument("username", String.class))
-                        .withStyle(ChatFormatting.RED));
+                McUtils.mc().execute(() -> {
+                    McUtils.sendWynntilsPrefixMessage(Component.literal(
+                                    "Unable to view player guild for " + context.getArgument("username", String.class))
+                            .withStyle(ChatFormatting.RED));
+                });
                 WynntilsMod.error("Error trying to parse player guild", throwable);
             } else {
                 if (player == null) {
-                    McUtils.sendWynntilsPrefixMessage(
-                            Component.literal("Unknown player " + context.getArgument("username", String.class))
-                                    .withStyle(ChatFormatting.RED));
+                    McUtils.mc().execute(() -> {
+                        McUtils.sendWynntilsPrefixMessage(
+                                Component.literal("Unknown player " + context.getArgument("username", String.class))
+                                        .withStyle(ChatFormatting.RED));
+                    });
                     return;
                 }
 
@@ -112,7 +116,9 @@ public class PlayerCommand extends Command {
                     response.append(Component.literal(" is not in a guild").withStyle(ChatFormatting.GRAY));
                 }
 
-                McUtils.sendWynntilsPrefixMessage(response);
+                McUtils.mc().execute(() -> {
+                    McUtils.sendWynntilsPrefixMessage(response);
+                });
             }
         });
 
@@ -131,15 +137,19 @@ public class PlayerCommand extends Command {
 
         completableFuture.whenComplete((player, throwable) -> {
             if (throwable != null) {
-                McUtils.sendWynntilsPrefixMessage(Component.literal(
-                                "Unable to view player last seen for " + context.getArgument("username", String.class))
-                        .withStyle(ChatFormatting.RED));
+                McUtils.mc().execute(() -> {
+                    McUtils.sendWynntilsPrefixMessage(Component.literal("Unable to view player last seen for "
+                                    + context.getArgument("username", String.class))
+                            .withStyle(ChatFormatting.RED));
+                });
                 WynntilsMod.error("Error trying to parse player last seen", throwable);
             } else {
                 if (player == null) {
-                    McUtils.sendWynntilsPrefixMessage(
-                            Component.literal("Unknown player " + context.getArgument("username", String.class))
-                                    .withStyle(ChatFormatting.RED));
+                    McUtils.mc().execute(() -> {
+                        McUtils.sendWynntilsPrefixMessage(
+                                Component.literal("Unknown player " + context.getArgument("username", String.class))
+                                        .withStyle(ChatFormatting.RED));
+                    });
                     return;
                 }
 
@@ -170,7 +180,9 @@ public class PlayerCommand extends Command {
                                     .withUnderlined(true)));
                 }
 
-                McUtils.sendWynntilsPrefixMessage(response);
+                McUtils.mc().execute(() -> {
+                    McUtils.sendWynntilsPrefixMessage(response);
+                });
             }
         });
 


### PR DESCRIPTION
This is how vanilla does their async command `/fetchprofile`

<img width="1185" height="154" alt="image" src="https://github.com/user-attachments/assets/13a0bdd3-8413-41d0-949c-ec01e8f10681" />
