### PR TITLE
refactor: Get socials from tablist instead of commands

### DIFF
--- a/common/src/main/java/com/wynntils/core/components/Handlers.java
+++ b/common/src/main/java/com/wynntils/core/components/Handlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.components;

--- a/common/src/main/java/com/wynntils/core/components/Handlers.java
+++ b/common/src/main/java/com/wynntils/core/components/Handlers.java
@@ -12,6 +12,7 @@ import com.wynntils.handlers.container.ContainerQueryHandler;
 import com.wynntils.handlers.item.ItemHandler;
 import com.wynntils.handlers.labels.LabelHandler;
 import com.wynntils.handlers.particle.ParticleHandler;
+import com.wynntils.handlers.playerlist.PlayerListHandler;
 import com.wynntils.handlers.scoreboard.ScoreboardHandler;
 import com.wynntils.handlers.tooltip.TooltipHandler;
 import com.wynntils.handlers.wrappedscreen.WrappedScreenHandler;
@@ -25,6 +26,7 @@ public final class Handlers {
     public static final ItemHandler Item = new ItemHandler();
     public static final LabelHandler Label = new LabelHandler();
     public static final ParticleHandler Particle = new ParticleHandler();
+    public static final PlayerListHandler PlayerList = new PlayerListHandler();
     public static final ScoreboardHandler Scoreboard = new ScoreboardHandler();
     public static final TooltipHandler Tooltip = new TooltipHandler();
     public static final WrappedScreenHandler WrappedScreen = new WrappedScreenHandler();

--- a/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
@@ -4,12 +4,18 @@
  */
 package com.wynntils.handlers.playerlist;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handler;
+import com.wynntils.handlers.playerlist.event.PlayerListColumnUpdatedEvent;
 import com.wynntils.mc.event.PlayerInfoUpdateEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -34,6 +40,9 @@ public class PlayerListHandler extends Handler {
     public void onWorldStateChange(WorldStateEvent event) {
         if (event.getNewState() == WorldState.WORLD) return;
 
+        // Friends and guild don't change often through world swap.
+        party.clear();
+
         recordingColumn = Column.Unknown;
     }
 
@@ -52,7 +61,6 @@ public class PlayerListHandler extends Handler {
                 || !event.getActions().contains(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME)) return;
 
         ClientboundPlayerInfoUpdatePacket.Entry entry = entries.getFirst();
-        System.out.println(entry.displayName().getString().equals(FRIEND_COLUMN_TITLE));
         if (entry.displayName().getString().equals(FRIEND_COLUMN_TITLE)) {
             newFriends = new ArrayList<>();
             newParty = new ArrayList<>();
@@ -72,26 +80,45 @@ public class PlayerListHandler extends Handler {
             return;
         }
 
+        boolean emptyOrOffline = entry.displayName().getString().isEmpty() ||
+                entry.displayName().getString().startsWith(ChatFormatting.GRAY.toString());
+
         if (recordingColumn == Column.Guild) {
-            if (!entry.displayName().getString().isEmpty()) {
+            if (!emptyOrOffline) {
                 newGuild.add(entry);
             }
 
             // We have reached the end.
             // 19 since each column is of size 20 including the title.
-            if (entry.displayName().getString().isEmpty() || guild.size() >= 19) {
+            if (emptyOrOffline || guild.size() >= 19) {
                 recordingColumn = Column.Unknown;
-                friends = newFriends;
-                party = newParty;
-                guild = newGuild;
+
+                // Only send the event if the old list was empty and we found something or if something changed.
+                if (isListDifferent(friends, newFriends) || friends.removeAll(newFriends)) {
+                    WynntilsMod.postEvent(new PlayerListColumnUpdatedEvent.Friends(new ArrayList<>(friends)));
+                }
+                if  (isListDifferent(party, newParty) || party.removeAll(newParty)) {
+                    WynntilsMod.postEvent(new PlayerListColumnUpdatedEvent.Party(newParty));
+                }
+                if  (isListDifferent(guild, newGuild) || guild.removeAll(newGuild)) {
+                    WynntilsMod.postEvent(new PlayerListColumnUpdatedEvent.Guild(newGuild));
+                }
+
+                this.friends = newFriends;
+                this.party = newParty;
+                this.guild = newGuild;
             }
-        } else if (entry.displayName().getString().isEmpty()) {
+        } else if (emptyOrOffline) {
             return;
         } else if (recordingColumn == Column.Friends) {
             newFriends.add(entry);
         } else if (recordingColumn == Column.Party) {
             newParty.add(entry);
         }
+    }
+
+    private boolean isListDifferent(List<ClientboundPlayerInfoUpdatePacket.Entry> list1, List<ClientboundPlayerInfoUpdatePacket.Entry> list2) {
+        return list1.size() != list2.size() || !new HashSet<>(list1).equals(new HashSet<>(list2));
     }
 
     private enum Column {

--- a/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
@@ -1,0 +1,100 @@
+package com.wynntils.handlers.playerlist;
+
+import com.wynntils.core.components.Handler;
+import com.wynntils.mc.event.PlayerInfoUpdateEvent;
+import com.wynntils.models.worlds.event.WorldStateEvent;
+import com.wynntils.models.worlds.type.WorldState;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.SubscribeEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PlayerListHandler extends Handler {
+    private static final String FRIEND_COLUMN_TITLE = "§a  §lFriends";
+    private static final String PARTY_COLUMN_TITLE = "§e  §lParty";
+    private static final String GUILD_COLUMN_TITLE = "§b§l  Guild";
+    private static final String GLOBAL_COLUMN_TITLE_PREFIX = "§f  §lGlobal";
+
+    private Column recordingColumn = Column.Unknown;
+
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> friends = new ArrayList<>();
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> party = new ArrayList<>();
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> guild = new ArrayList<>();
+
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> newFriends = new ArrayList<>();
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> newParty = new ArrayList<>();
+    private List<ClientboundPlayerInfoUpdatePacket.Entry> newGuild = new ArrayList<>();
+
+    @SubscribeEvent
+    public void onWorldStateChange(WorldStateEvent event) {
+        if (event.getNewState() == WorldState.WORLD) return;
+
+        recordingColumn = Column.Unknown;
+    }
+
+    /**
+     * Wynn initially sends a packet with 80 fake players using all player info actions. Later-on, these fake players
+     * are updated using upto 80 packets but only with the UPDATE_DISPLAY_NAME action. Thus we will start recording
+     * these entries if there is only 1 player in the packet and only the UPDATE_DISPLAY_NAME action is used. We will
+     * then record next packets and ignore all empty or null ones.
+     * @param event contains information regarding the player list.
+     */
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onPlayerUpdateEvent(PlayerInfoUpdateEvent event) {
+        List<ClientboundPlayerInfoUpdatePacket.Entry> entries = event.getEntries();
+        if (entries.size() != 1) return;
+        if (event.getActions().size() != 1 || !event.getActions().contains(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME)) return;
+
+        ClientboundPlayerInfoUpdatePacket.Entry entry = entries.getFirst();
+        System.out.println(entry.displayName().getString().equals(FRIEND_COLUMN_TITLE));
+        if (entry.displayName().getString().equals(FRIEND_COLUMN_TITLE)) {
+            newFriends = new ArrayList<>();
+            newParty = new ArrayList<>();
+            newGuild = new ArrayList<>();
+            recordingColumn = Column.Friends;
+            return; // We don't record the title
+        } else if (entry.displayName().getString().startsWith(GLOBAL_COLUMN_TITLE_PREFIX)) {
+            recordingColumn = Column.Global;
+            return;
+        } else if (entry.displayName().getString().equals(PARTY_COLUMN_TITLE)) {
+            recordingColumn = Column.Party;
+            return; // We don't record the title
+        } else if (entry.displayName().getString().equals(GUILD_COLUMN_TITLE)) {
+            recordingColumn = Column.Guild;
+            return; // We don't record the title
+        } else if (recordingColumn == Column.Unknown || recordingColumn == Column.Global) {
+            return;
+        }
+
+        if (recordingColumn == Column.Guild) {
+            if (!entry.displayName().getString().isEmpty()) {
+                newGuild.add(entry);
+            }
+
+            // We have reached the end.
+            // 19 since each column is of size 20 including the title.
+            if (entry.displayName().getString().isEmpty() || guild.size() >= 19){
+                recordingColumn = Column.Unknown;
+                friends = newFriends;
+                party = newParty;
+                guild = newGuild;
+            }
+        } else if (entry.displayName().getString().isEmpty()) {
+            return;
+        } else if (recordingColumn == Column.Friends) {
+            newFriends.add(entry);
+        } else if (recordingColumn == Column.Party) {
+            newParty.add(entry);
+        }
+    }
+
+    private enum Column {
+        Unknown,
+        Friends,
+        Global,
+        Party,
+        Guild,
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
@@ -1,15 +1,18 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.handlers.playerlist;
 
 import com.wynntils.core.components.Handler;
 import com.wynntils.mc.event.PlayerInfoUpdateEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class PlayerListHandler extends Handler {
     private static final String FRIEND_COLUMN_TITLE = "§a  §lFriends";
@@ -45,7 +48,8 @@ public class PlayerListHandler extends Handler {
     public void onPlayerUpdateEvent(PlayerInfoUpdateEvent event) {
         List<ClientboundPlayerInfoUpdatePacket.Entry> entries = event.getEntries();
         if (entries.size() != 1) return;
-        if (event.getActions().size() != 1 || !event.getActions().contains(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME)) return;
+        if (event.getActions().size() != 1
+                || !event.getActions().contains(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME)) return;
 
         ClientboundPlayerInfoUpdatePacket.Entry entry = entries.getFirst();
         System.out.println(entry.displayName().getString().equals(FRIEND_COLUMN_TITLE));
@@ -75,7 +79,7 @@ public class PlayerListHandler extends Handler {
 
             // We have reached the end.
             // 19 since each column is of size 20 including the title.
-            if (entry.displayName().getString().isEmpty() || guild.size() >= 19){
+            if (entry.displayName().getString().isEmpty() || guild.size() >= 19) {
                 recordingColumn = Column.Unknown;
                 friends = newFriends;
                 party = newParty;

--- a/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/PlayerListHandler.java
@@ -13,8 +13,6 @@ import com.wynntils.models.worlds.type.WorldState;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.EventPriority;
@@ -80,8 +78,8 @@ public class PlayerListHandler extends Handler {
             return;
         }
 
-        boolean emptyOrOffline = entry.displayName().getString().isEmpty() ||
-                entry.displayName().getString().startsWith(ChatFormatting.GRAY.toString());
+        boolean emptyOrOffline = entry.displayName().getString().isEmpty()
+                || entry.displayName().getString().startsWith(ChatFormatting.GRAY.toString());
 
         if (recordingColumn == Column.Guild) {
             if (!emptyOrOffline) {
@@ -97,10 +95,10 @@ public class PlayerListHandler extends Handler {
                 if (isListDifferent(friends, newFriends) || friends.removeAll(newFriends)) {
                     WynntilsMod.postEvent(new PlayerListColumnUpdatedEvent.Friends(new ArrayList<>(friends)));
                 }
-                if  (isListDifferent(party, newParty) || party.removeAll(newParty)) {
+                if (isListDifferent(party, newParty) || party.removeAll(newParty)) {
                     WynntilsMod.postEvent(new PlayerListColumnUpdatedEvent.Party(newParty));
                 }
-                if  (isListDifferent(guild, newGuild) || guild.removeAll(newGuild)) {
+                if (isListDifferent(guild, newGuild) || guild.removeAll(newGuild)) {
                     WynntilsMod.postEvent(new PlayerListColumnUpdatedEvent.Guild(newGuild));
                 }
 
@@ -117,7 +115,8 @@ public class PlayerListHandler extends Handler {
         }
     }
 
-    private boolean isListDifferent(List<ClientboundPlayerInfoUpdatePacket.Entry> list1, List<ClientboundPlayerInfoUpdatePacket.Entry> list2) {
+    private boolean isListDifferent(
+            List<ClientboundPlayerInfoUpdatePacket.Entry> list1, List<ClientboundPlayerInfoUpdatePacket.Entry> list2) {
         return list1.size() != list2.size() || !new HashSet<>(list1).equals(new HashSet<>(list2));
     }
 

--- a/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
@@ -1,7 +1,10 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
 package com.wynntils.handlers.playerlist.event;
 
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
-public class PlayerListColumnUpdatedEvent extends Event implements ICancellableEvent {
-}
+public class PlayerListColumnUpdatedEvent extends Event implements ICancellableEvent {}

--- a/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
@@ -4,7 +4,44 @@
  */
 package com.wynntils.handlers.playerlist.event;
 
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
-public class PlayerListColumnUpdatedEvent extends Event implements ICancellableEvent {}
+import java.util.List;
+
+public class PlayerListColumnUpdatedEvent extends Event implements ICancellableEvent {
+    private final List<ClientboundPlayerInfoUpdatePacket.Entry> entries;
+
+    protected PlayerListColumnUpdatedEvent(List<ClientboundPlayerInfoUpdatePacket.Entry> entries) {
+        this.entries = entries;
+    }
+
+    public List<ClientboundPlayerInfoUpdatePacket.Entry> getEntries() { return entries; }
+
+    /**
+     * Indicates whether the list is exhaustive, and thus contains all friends or members of the party/guild.
+     * @return true if we know that all names are included (i.e. strictly less than 19 players).
+     */
+    public boolean isExhaustive() {
+        return this.entries.size() < 19;
+    }
+
+    public static class Friends extends PlayerListColumnUpdatedEvent {
+        public Friends(List<ClientboundPlayerInfoUpdatePacket.Entry> entries) {
+            super(entries);
+        }
+    }
+
+    public static class Party extends PlayerListColumnUpdatedEvent {
+        public Party(List<ClientboundPlayerInfoUpdatePacket.Entry> entries) {
+            super(entries);
+        }
+    }
+
+    public static class Guild extends PlayerListColumnUpdatedEvent {
+        public Guild(List<ClientboundPlayerInfoUpdatePacket.Entry> entries) {
+            super(entries);
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
@@ -1,0 +1,7 @@
+package com.wynntils.handlers.playerlist.event;
+
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+public class PlayerListColumnUpdatedEvent extends Event implements ICancellableEvent {
+}

--- a/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
+++ b/common/src/main/java/com/wynntils/handlers/playerlist/event/PlayerListColumnUpdatedEvent.java
@@ -4,11 +4,10 @@
  */
 package com.wynntils.handlers.playerlist.event;
 
+import java.util.List;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
-
-import java.util.List;
 
 public class PlayerListColumnUpdatedEvent extends Event implements ICancellableEvent {
     private final List<ClientboundPlayerInfoUpdatePacket.Entry> entries;
@@ -17,7 +16,9 @@ public class PlayerListColumnUpdatedEvent extends Event implements ICancellableE
         this.entries = entries;
     }
 
-    public List<ClientboundPlayerInfoUpdatePacket.Entry> getEntries() { return entries; }
+    public List<ClientboundPlayerInfoUpdatePacket.Entry> getEntries() {
+        return entries;
+    }
 
     /**
      * Indicates whether the list is exhaustive, and thus contains all friends or members of the party/guild.

--- a/common/src/main/java/com/wynntils/mc/event/PlayerInfoUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerInfoUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.mc.event;

--- a/common/src/main/java/com/wynntils/mc/event/PlayerInfoUpdateEvent.java
+++ b/common/src/main/java/com/wynntils/mc/event/PlayerInfoUpdateEvent.java
@@ -4,19 +4,27 @@
  */
 package com.wynntils.mc.event;
 
+import java.util.EnumSet;
 import java.util.List;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.Event;
 
 public class PlayerInfoUpdateEvent extends Event {
+    private EnumSet<ClientboundPlayerInfoUpdatePacket.Action> actions;
     private List<ClientboundPlayerInfoUpdatePacket.Entry> entries;
     private final List<ClientboundPlayerInfoUpdatePacket.Entry> newEntries;
 
     public PlayerInfoUpdateEvent(
+            EnumSet<ClientboundPlayerInfoUpdatePacket.Action> actions,
             List<ClientboundPlayerInfoUpdatePacket.Entry> entries,
             List<ClientboundPlayerInfoUpdatePacket.Entry> newEntries) {
+        this.actions = actions;
         this.entries = entries;
         this.newEntries = newEntries;
+    }
+
+    public EnumSet<ClientboundPlayerInfoUpdatePacket.Action> getActions() {
+        return this.actions;
     }
 
     public List<ClientboundPlayerInfoUpdatePacket.Entry> getEntries() {

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -45,6 +45,8 @@ import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
 import com.wynntils.utils.mc.McUtils;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.client.gui.screens.Screen;
@@ -176,7 +178,7 @@ public abstract class ClientPacketListenerMixin extends ClientCommonPacketListen
         if (!isRenderThread()) return;
         if (!MixinHelper.onWynncraft()) return;
 
-        PlayerInfoUpdateEvent e = new PlayerInfoUpdateEvent(packet.entries(), packet.newEntries());
+        PlayerInfoUpdateEvent e = new PlayerInfoUpdateEvent(packet.actions(), packet.entries(), packet.newEntries());
         MixinHelper.post(e);
         if (e.getEntries() != packet.entries()) {
             ((ClientboundPlayerInfoUpdatePacketAccessor) packet).setEntries(e.getEntries());

--- a/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/com/wynntils/mc/mixin/ClientPacketListenerMixin.java
@@ -45,8 +45,6 @@ import com.wynntils.mc.mixin.accessors.ClientboundSetPlayerTeamPacketAccessor;
 import com.wynntils.utils.mc.McUtils;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.client.gui.screens.Screen;

--- a/common/src/main/java/com/wynntils/models/players/FriendsModel.java
+++ b/common/src/main/java/com/wynntils/models/players/FriendsModel.java
@@ -18,12 +18,16 @@ import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.StyledTextUtils;
-
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.SubscribeEvent;
 
@@ -32,7 +36,8 @@ public final class FriendsModel extends Model {
     // \uE001  is for the other lines
     private static final String FRIEND_PREFIX_REGEX = "(?:§(?:a|4))?(?:\uE008\uE002|\uE001) ";
 
-    private static final Pattern FRIEND_PLAYER_LIST_REGEX = Pattern.compile("§.\\[(?<server>[A-Z]+\\d{1,3})\\] §.(?<username>\\w{1,16})");
+    private static final Pattern FRIEND_PLAYER_LIST_REGEX =
+            Pattern.compile("§.\\[(?<server>[A-Z]+\\d{1,3})\\] §.(?<username>\\w{1,16})");
 
     // region Friend Regexes
     /*

--- a/common/src/main/java/com/wynntils/models/players/FriendsModel.java
+++ b/common/src/main/java/com/wynntils/models/players/FriendsModel.java
@@ -10,6 +10,7 @@ import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
+import com.wynntils.handlers.playerlist.event.PlayerListColumnUpdatedEvent;
 import com.wynntils.models.players.event.FriendsEvent;
 import com.wynntils.models.players.event.HadesRelationsUpdateEvent;
 import com.wynntils.models.worlds.event.WorldStateEvent;
@@ -17,22 +18,21 @@ import com.wynntils.models.worlds.type.WorldState;
 import com.wynntils.services.hades.event.HadesEvent;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.StyledTextUtils;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class FriendsModel extends Model {
     // \uE008\uE002 is for the first line
     // \uE001  is for the other lines
     private static final String FRIEND_PREFIX_REGEX = "(?:§(?:a|4))?(?:\uE008\uE002|\uE001) ";
+
+    private static final Pattern FRIEND_PLAYER_LIST_REGEX = Pattern.compile("§.\\[(?<server>[A-Z]+\\d{1,3})\\] §.(?<username>\\w{1,16})");
 
     // region Friend Regexes
     /*
@@ -68,6 +68,8 @@ public final class FriendsModel extends Model {
     // endregion
 
     private static final int REQUEST_RATELIMIT = 250;
+
+    private boolean useCommands = false;
 
     private ListStatus friendMessageStatus = ListStatus.IDLE;
     private long lastFriendRequest = 0;
@@ -168,6 +170,31 @@ public final class FriendsModel extends Model {
         }
     }
 
+    @SubscribeEvent
+    public void onPlayerListColumnUpdate(PlayerListColumnUpdatedEvent.Friends event) {
+        if (!event.isExhaustive()) {
+            useCommands = true;
+            if (friends.isEmpty()) {
+                requestData();
+            }
+            return;
+        }
+
+        Set<String> newFriends = new HashSet<>();
+        for (ClientboundPlayerInfoUpdatePacket.Entry entry : event.getEntries()) {
+            String displayName = entry.displayName().getString();
+            Matcher matcher = FRIEND_PLAYER_LIST_REGEX.matcher(displayName);
+
+            String username = matcher.group("username");
+            newFriends.add(username);
+            onlineFriends.put(username, matcher.group("server"));
+        }
+
+        friends = newFriends;
+        WynntilsMod.postEvent(
+                new HadesRelationsUpdateEvent.FriendList(friends, HadesRelationsUpdateEvent.ChangeType.RELOAD));
+    }
+
     private boolean tryParseNoFriendList(StyledText styledText) {
         if (styledText.getMatcher(FRIEND_LIST_FAIL_2).matches()) {
             WynntilsMod.info("Friend list is empty.");
@@ -236,7 +263,7 @@ public final class FriendsModel extends Model {
      * When the response is received, friends will be updated.
      */
     public void requestData() {
-        if (McUtils.player() == null) return;
+        if (!useCommands || McUtils.player() == null) return;
 
         if (System.currentTimeMillis() - lastFriendRequest > REQUEST_RATELIMIT) {
             friendMessageStatus = ListStatus.EXPECTING;

--- a/common/src/main/java/com/wynntils/models/players/PartyModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PartyModel.java
@@ -10,6 +10,7 @@ import com.wynntils.core.components.Model;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.chat.event.ChatMessageEvent;
+import com.wynntils.handlers.playerlist.event.PlayerListColumnUpdatedEvent;
 import com.wynntils.handlers.scoreboard.ScoreboardPart;
 import com.wynntils.mc.event.SetPlayerTeamEvent;
 import com.wynntils.models.players.event.HadesRelationsUpdateEvent;
@@ -32,6 +33,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.SubscribeEvent;
 
 /**
@@ -41,6 +45,8 @@ public final class PartyModel extends Model {
     // \uE005\uE002 is for the first line
     // \uE001  is for the other lines
     private static final String PARTY_PREFIX_REGEX = "§e(?:\uE005\uE002|\uE001) ";
+
+    private static final Pattern PARTY_PLAYER_LIST_REGEX = Pattern.compile("§(?<role>c|e)(?<username>\\w{1,16})");
 
     // region Party Regexes
     /*
@@ -98,6 +104,8 @@ public final class PartyModel extends Model {
 
     public static final int MAX_PARTY_MEMBER_COUNT = 10;
 
+    private boolean useCommands = false;
+
     private boolean expectingPartyMessage = false; // Whether the client is expecting a response from "/party list"
     private long lastPartyRequest = 0; // The last time the client requested party data
 
@@ -143,6 +151,33 @@ public final class PartyModel extends Model {
                 return;
             }
         }
+    }
+
+    @SubscribeEvent
+    public void onPlayerListColumnUpdated(PlayerListColumnUpdatedEvent.Party event) {
+        if (!event.isExhaustive()) {
+            useCommands = true;
+            if (partyLeader.isEmpty()) {
+                requestData();
+            }
+            return;
+        }
+
+        List<String> newParty = new ArrayList<>();
+        for (ClientboundPlayerInfoUpdatePacket.Entry entry : event.getEntries()) {
+            String displayName = entry.displayName().getString();
+            Matcher matcher = PARTY_PLAYER_LIST_REGEX.matcher(displayName);
+
+            String username = matcher.group("username");
+            newParty.add(username);
+            if (matcher.group("role").charAt(0) == ChatFormatting.RED.getChar()) {
+                partyLeader = username;
+            }
+        }
+
+        partyMembers = newParty;
+        WynntilsMod.postEvent(new HadesRelationsUpdateEvent.PartyList(
+                Set.copyOf(partyMembers), HadesRelationsUpdateEvent.ChangeType.RELOAD));
     }
 
     private boolean tryParsePartyMessages(StyledText styledText) {
@@ -348,7 +383,7 @@ public final class PartyModel extends Model {
      * Hades relations will be updated and PartyEvent.Listed will be posted.
      */
     public void requestData() {
-        if (McUtils.player() == null) return;
+        if (!useCommands || McUtils.player() == null) return;
 
         if (System.currentTimeMillis() - lastPartyRequest < 250) {
             WynntilsMod.info("Skipping party list request because it was requested less than 250ms ago.");

--- a/common/src/main/java/com/wynntils/models/players/PartyModel.java
+++ b/common/src/main/java/com/wynntils/models/players/PartyModel.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.neoforged.bus.api.SubscribeEvent;


### PR DESCRIPTION
It has been a while since I last programmed. So please do review thoroughly and provide feedback once I'm done.

This PR aims to get social relations from the tablist instead of commands. As requested in #3928. So far the parsing has largely been completed. This now needs to be integrated with the models. I also plan to ignore offline floks since you cannot see them on the map or view their builds anyway. This allows us to use this method even when people have more than 19 friends or guild members.