### PR TITLE
fix: waypoint y not being scaled properly when far away

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/WorldWaypointDistanceFeature.java
@@ -120,6 +120,7 @@ public class WorldWaypointDistanceFeature extends Feature {
             if (distance > maxDistance) {
                 double posScale = maxDistance / distance;
                 dx *= posScale;
+                dy *= posScale;
                 dz *= posScale;
             }
 


### PR DESCRIPTION
Small update to the `onRenderLevelPost` method in `WorldWaypointDistanceFeature.java` to ensure that the `dy` value is also scaled when the distance exceeds `maxDistance`