### PR TITLE
fix: close Hades connection on server-initiated disconnect and auth failure

### DIFF
--- a/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
@@ -86,11 +86,13 @@ public class HadesClientHandler implements IHadesClientAdapter {
                         "Got invalid token when trying to connect to the remote player server: " + packet.getMessage());
                 userComponent = Component.literal("Got invalid token when connecting the remote player server.")
                         .withStyle(ChatFormatting.RED);
+                hadesConnection.disconnect();
             }
             case ERROR -> {
                 WynntilsMod.error("Got an error trying to connect to the remote player server: " + packet.getMessage());
                 userComponent = Component.literal("Got error when connecting the remote player server.")
                         .withStyle(ChatFormatting.RED);
+                hadesConnection.disconnect();
             }
         }
 
@@ -143,5 +145,6 @@ public class HadesClientHandler implements IHadesClientAdapter {
         }
 
         userRegistry.getHadesUserMap().clear();
+        hadesConnection.disconnect();
     }
 }


### PR DESCRIPTION
## Problem

When analysing the HadesServer logs we observed a high volume of:

```
io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer
```

A "connection reset by peer" (TCP RST) is sent by the client OS when a socket is closed while the remote side is still writing to it, or when data is written to an already-closed socket. Two paths in `HadesClientHandler` were leaving the Netty channel open when they should have closed it, causing the server to hit these RST errors.

---

## Root Causes

### 1. `handleDisconnect` did not close the client channel

When the server sends `HSPacketDisconnect` (e.g. on a 15 s ping timeout), the client handled the packet — cleared the user map, showed a message — but never called `hadesConnection.disconnect()`. The channel stayed open and the ping scheduler continued firing every second. The server closes its end immediately after sending the packet, leaving a half-open connection. Any pings written into that window caused a TCP RST visible on the server as "connection reset by peer".

### 2. Auth failures (`INVALID_TOKEN` / `ERROR`) did not close the client channel

On a failed authentication response the client logged an error and returned, leaving the channel open indefinitely. The ping scheduler had not started yet (it only starts on `HadesEvent.Authenticated`), but the channel remained alive as a zombie until the server's 15 s timeout fired and forcibly disconnected it. These were directly visible in the server logs as `INVALID_TOKEN` warnings followed by a timeout RST ~15 s later.

---

## Fix

Added `hadesConnection.disconnect()` in the three affected paths in `HadesClientHandler`:

- `handleDisconnect` — close the channel when the server tells us to disconnect
- `handleAuthenticationResponse` / `INVALID_TOKEN` — close the channel on auth rejection
- `handleAuthenticationResponse` / `ERROR` — close the channel on auth error

The existing `channelInactive` → `onDisconnect` → ping scheduler shutdown flow handles cleanup correctly once the channel is actually closed, so no further changes were needed.

---

## Note for HadesServer

The server's `HadesConnection.exceptionCaught` currently only calls `cause.printStackTrace()` and does not close the channel. This means when the OS delivers a RST the channel is left in an invalid state and Netty retries the read, producing repeated log noise. A companion fix of `ctx.close()` in `exceptionCaught` on the server side would eliminate the remaining log spam from clients that drop without a graceful shutdown (crash, network loss, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)