### PR TITLE
feat: send gear via HCPacketGearUpdate

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,7 +6,11 @@ dependencies {
     // This dependency is provided by forge naturally and by fabric in its build.gradle
     compileOnly "net.neoforged:bus:${neoforge_eventbus_version}"
 
-    implementation("com.github.wynntils:hades:v${hades_version}")
+    if (file("${rootDir}/../Hades/build/libs/HadesProtocol-${hades_version}.jar").exists()) {
+        implementation(files("${rootDir}/../Hades/build/libs/HadesProtocol-${hades_version}.jar"))
+    } else {
+        implementation("com.github.wynntils:hades:v${hades_version}")
+    }
     implementation("com.github.wynntils:antiope:v${antiope_version}")
 
     implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixinextras_version}"))

--- a/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
@@ -53,7 +53,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
         }
 
         hadesConnection.sendPacketAndFlush(
-                new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_1));
+                new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_2));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesClientHandler.java
@@ -53,7 +53,7 @@ public class HadesClientHandler implements IHadesClientAdapter {
         }
 
         hadesConnection.sendPacketAndFlush(
-                new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_2));
+                new HCPacketAuthenticate(Services.WynntilsAccount.getToken(), HadesVersion.VERSION_0_6_3));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/services/hades/HadesService.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesService.java
@@ -17,6 +17,7 @@ import com.wynntils.hades.protocol.builders.HadesNetworkBuilder;
 import com.wynntils.hades.protocol.enums.PacketAction;
 import com.wynntils.hades.protocol.enums.PacketDirection;
 import com.wynntils.hades.protocol.enums.SocialType;
+import com.wynntils.hades.protocol.packets.client.HCPacketGearUpdate;
 import com.wynntils.hades.protocol.packets.client.HCPacketPing;
 import com.wynntils.hades.protocol.packets.client.HCPacketSocialUpdate;
 import com.wynntils.hades.protocol.packets.client.HCPacketUpdateStatus;
@@ -147,6 +148,7 @@ public final class HadesService extends Service {
             // Send initial world data if Hades login only happened after joining the player's class
             tryResendWorldData();
         }
+        sendGearUpdate();
 
         WynntilsMod.info("Starting Hades Ping Scheduler Task");
 
@@ -266,6 +268,7 @@ public final class HadesService extends Service {
             for (InventoryAccessory accessory : InventoryAccessory.values()) {
                 if (event.getSlot() == accessory.getSlot()) {
                     updateAccessoryCache(accessory);
+                    sendGearUpdate();
                     return;
                 }
             }
@@ -273,12 +276,14 @@ public final class HadesService extends Service {
             for (InventoryArmor armorSlot : InventoryArmor.values()) {
                 if (event.getSlot() == armorSlot.getInventorySlot()) {
                     updateArmorCache(armorSlot);
+                    sendGearUpdate();
                     return;
                 }
             }
 
             if (event.getSlot() == McUtils.player().getInventory().selected) {
                 updateHeldItemCache();
+                sendGearUpdate();
             }
         }
     }
@@ -287,6 +292,7 @@ public final class HadesService extends Service {
     public void onSwappedItem(ChangeCarriedItemEvent event) {
         if (getGearShareOptions().shouldShare()) {
             updateHeldItemCache();
+            sendGearUpdate();
         }
     }
 
@@ -313,32 +319,12 @@ public final class HadesService extends Service {
             float pY = (float) player.getY();
             float pZ = (float) player.getZ();
 
-            PlayerStatus newStatus;
-
-            if (getGearShareOptions().shouldShare()) {
-                newStatus = new PlayerStatus(
-                        pX,
-                        pY,
-                        pZ,
-                        Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY),
-                        Models.CharacterStats.getMana().orElse(CappedValue.EMPTY),
-                        armor.getOrDefault(InventoryArmor.HELMET, ""),
-                        armor.getOrDefault(InventoryArmor.CHESTPLATE, ""),
-                        armor.getOrDefault(InventoryArmor.LEGGINGS, ""),
-                        armor.getOrDefault(InventoryArmor.BOOTS, ""),
-                        accessories.getOrDefault(InventoryAccessory.RING_1, ""),
-                        accessories.getOrDefault(InventoryAccessory.RING_2, ""),
-                        accessories.getOrDefault(InventoryAccessory.BRACELET, ""),
-                        accessories.getOrDefault(InventoryAccessory.NECKLACE, ""),
-                        heldItem);
-            } else {
-                newStatus = new PlayerStatus(
-                        pX,
-                        pY,
-                        pZ,
-                        Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY),
-                        Models.CharacterStats.getMana().orElse(CappedValue.EMPTY));
-            }
+            PlayerStatus newStatus = new PlayerStatus(
+                    pX,
+                    pY,
+                    pZ,
+                    Models.CharacterStats.getHealth().orElse(CappedValue.EMPTY),
+                    Models.CharacterStats.getMana().orElse(CappedValue.EMPTY));
 
             if (newStatus.equals(lastSentStatus)) {
                 tickCountUntilUpdate = 1;
@@ -346,7 +332,6 @@ public final class HadesService extends Service {
             }
 
             tickCountUntilUpdate = TICKS_PER_UPDATE;
-
             lastSentStatus = newStatus;
 
             hadesConnection.sendPacketAndFlush(new HCPacketUpdateStatus(
@@ -356,16 +341,7 @@ public final class HadesService extends Service {
                     lastSentStatus.health().current(),
                     lastSentStatus.health().max(),
                     lastSentStatus.mana().current(),
-                    lastSentStatus.mana().max(),
-                    lastSentStatus.helmet(),
-                    lastSentStatus.chestplate(),
-                    lastSentStatus.leggings(),
-                    lastSentStatus.boots(),
-                    lastSentStatus.ringOne(),
-                    lastSentStatus.ringTwo(),
-                    lastSentStatus.bracelet(),
-                    lastSentStatus.necklace(),
-                    lastSentStatus.heldItem()));
+                    lastSentStatus.mana().max()));
         }
     }
 
@@ -375,6 +351,21 @@ public final class HadesService extends Service {
         hadesConnection.sendPacket(new HCPacketUpdateWorld(
                 Models.WorldState.getCurrentWorldName(),
                 Models.Character.getId().hashCode()));
+    }
+
+    private void sendGearUpdate() {
+        if (!isConnected()) return;
+
+        hadesConnection.sendPacketAndFlush(new HCPacketGearUpdate(
+                armor.getOrDefault(InventoryArmor.HELMET, ""),
+                armor.getOrDefault(InventoryArmor.CHESTPLATE, ""),
+                armor.getOrDefault(InventoryArmor.LEGGINGS, ""),
+                armor.getOrDefault(InventoryArmor.BOOTS, ""),
+                accessories.getOrDefault(InventoryAccessory.RING_1, ""),
+                accessories.getOrDefault(InventoryAccessory.RING_2, ""),
+                accessories.getOrDefault(InventoryAccessory.BRACELET, ""),
+                accessories.getOrDefault(InventoryAccessory.NECKLACE, ""),
+                heldItem));
     }
 
     public void resetSocialType(SocialType socialType) {
@@ -423,6 +414,7 @@ public final class HadesService extends Service {
             }
 
             updateHeldItemCache();
+            sendGearUpdate();
         } else {
             armor.clear();
             armorCache.clear();
@@ -430,6 +422,7 @@ public final class HadesService extends Service {
             accessoriesCache.clear();
             heldItem = "";
             heldItemCache = null;
+            sendGearUpdate();
         }
     }
 

--- a/common/src/main/java/com/wynntils/services/hades/HadesUser.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.hades;

--- a/common/src/main/java/com/wynntils/services/hades/HadesUser.java
+++ b/common/src/main/java/com/wynntils/services/hades/HadesUser.java
@@ -121,31 +121,33 @@ public class HadesUser {
         this.health = new CappedValue(packet.getHealth(), packet.getMaxHealth());
         this.mana = new CappedValue(packet.getMana(), packet.getMaxMana());
 
-        handleArmorData(InventoryArmor.HELMET, GearType.HELMET, packet.getHelmet());
-        handleArmorData(InventoryArmor.CHESTPLATE, GearType.CHESTPLATE, packet.getChestplate());
-        handleArmorData(InventoryArmor.LEGGINGS, GearType.LEGGINGS, packet.getLeggings());
-        handleArmorData(InventoryArmor.BOOTS, GearType.BOOTS, packet.getBoots());
+        if (packet.hasGear()) {
+            handleArmorData(InventoryArmor.HELMET, GearType.HELMET, packet.getHelmet());
+            handleArmorData(InventoryArmor.CHESTPLATE, GearType.CHESTPLATE, packet.getChestplate());
+            handleArmorData(InventoryArmor.LEGGINGS, GearType.LEGGINGS, packet.getLeggings());
+            handleArmorData(InventoryArmor.BOOTS, GearType.BOOTS, packet.getBoots());
 
-        handleAccessoryData(InventoryAccessory.RING_1, GearType.RING, packet.getRingOne());
-        handleAccessoryData(InventoryAccessory.RING_2, GearType.RING, packet.getRingTwo());
-        handleAccessoryData(InventoryAccessory.BRACELET, GearType.BRACELET, packet.getBracelet());
-        handleAccessoryData(InventoryAccessory.NECKLACE, GearType.NECKLACE, packet.getNecklace());
+            handleAccessoryData(InventoryAccessory.RING_1, GearType.RING, packet.getRingOne());
+            handleAccessoryData(InventoryAccessory.RING_2, GearType.RING, packet.getRingTwo());
+            handleAccessoryData(InventoryAccessory.BRACELET, GearType.BRACELET, packet.getBracelet());
+            handleAccessoryData(InventoryAccessory.NECKLACE, GearType.NECKLACE, packet.getNecklace());
 
-        if (packet.getHeldItem().isEmpty()) {
-            this.heldItem = null;
-            this.heldItemCache = "";
-        } else if (!this.heldItemCache.equals(packet.getHeldItem())) {
-            ErrorOr<WynnItem> errorOrDecodedItem = decodeItem(packet.getHeldItem());
+            if (packet.getHeldItem().isEmpty()) {
+                this.heldItem = null;
+                this.heldItemCache = "";
+            } else if (!this.heldItemCache.equals(packet.getHeldItem())) {
+                ErrorOr<WynnItem> errorOrDecodedItem = decodeItem(packet.getHeldItem());
 
-            if (errorOrDecodedItem.hasError()) {
-                WynntilsMod.warn("Failed to decode Hades user held item: " + errorOrDecodedItem.getError());
-            } else {
-                WynnItem item = errorOrDecodedItem.getValue();
+                if (errorOrDecodedItem.hasError()) {
+                    WynntilsMod.warn("Failed to decode Hades user held item: " + errorOrDecodedItem.getError());
+                } else {
+                    WynnItem item = errorOrDecodedItem.getValue();
 
-                if (item instanceof GearTypeItemProperty gearItemType
-                        && gearItemType.getGearType().isWeapon()) {
-                    this.heldItem = item;
-                    this.heldItemCache = packet.getHeldItem();
+                    if (item instanceof GearTypeItemProperty gearItemType
+                            && gearItemType.getGearType().isWeapon()) {
+                        this.heldItem = item;
+                        this.heldItemCache = packet.getHeldItem();
+                    }
                 }
             }
         }

--- a/common/src/main/java/com/wynntils/services/hades/type/PlayerStatus.java
+++ b/common/src/main/java/com/wynntils/services/hades/type/PlayerStatus.java
@@ -6,9 +6,4 @@ package com.wynntils.services.hades.type;
 
 import com.wynntils.utils.type.CappedValue;
 
-public record PlayerStatus(
-        float x,
-        float y,
-        float z,
-        CappedValue health,
-        CappedValue mana) {}
+public record PlayerStatus(float x, float y, float z, CappedValue health, CappedValue mana) {}

--- a/common/src/main/java/com/wynntils/services/hades/type/PlayerStatus.java
+++ b/common/src/main/java/com/wynntils/services/hades/type/PlayerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.services.hades.type;
@@ -11,17 +11,4 @@ public record PlayerStatus(
         float y,
         float z,
         CappedValue health,
-        CappedValue mana,
-        String helmet,
-        String chestplate,
-        String leggings,
-        String boots,
-        String ringOne,
-        String ringTwo,
-        String bracelet,
-        String necklace,
-        String heldItem) {
-    public PlayerStatus(float x, float y, float z, CappedValue health, CappedValue mana) {
-        this(x, y, z, health, mana, "", "", "", "", "", "", "", "", "");
-    }
-}
+        CappedValue mana) {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mixinextras_version=0.5.1
 shadow_version=9.3.0
 
 # Hades
-hades_version=0.6.2
+hades_version=0.6.3
 
 # Antiope
 antiope_version=0.2.2


### PR DESCRIPTION
Gear is no longer bundled into every position/vitals tick.

- `PlayerStatus` record stripped to `(x, y, z, health, mana)` — no gear fields
- `onTick` sends position/vitals only
- New `sendGearUpdate()` fires on login, world load, slot changes, and gear sharing toggle
- `HadesUser.updateFromPacket` skips gear processing when `packet.hasGear()` is false, so displayed gear isn't cleared on position-only updates
- Bumped to `HadesVersion.VERSION_0_6_2`

Requires Hades PR wynntils/Hades#19.