### PR TITLE
fix: handle empty action bar updates

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -48,7 +48,15 @@ public final class ActionBarHandler extends Handler {
         });
 
         if (actionBarText.isEmpty()) {
-            WynntilsMod.warn("Failed to find action bar text in packet: " + packetText.getString());
+            lastParsedActionBarText = packetText;
+            lastMatchedSegments = List.of();
+
+            WynntilsMod.postEvent(new ActionBarUpdatedEvent(lastMatchedSegments));
+
+            if (WynntilsMod.isDevelopmentBuild() || WynntilsMod.isDevelopmentEnvironment()) {
+                WynntilsMod.warn("Failed to find action bar text in packet: " + packetText.getString());
+            }
+
             return;
         }
 

--- a/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/actionbar/ActionBarHandler.java
@@ -38,6 +38,15 @@ public final class ActionBarHandler extends Handler {
     public void onActionBarUpdate(SystemMessageEvent.GameInfoReceivedEvent event) {
         StyledText packetText = StyledText.fromComponent(event.getMessage());
 
+        if (packetText.isEmpty()) {
+            lastParsedActionBarText = packetText;
+            lastMatchedSegments = List.of();
+
+            WynntilsMod.postEvent(new ActionBarUpdatedEvent(lastMatchedSegments));
+
+            return;
+        }
+
         // Separate the action bar text from the coordinates
         StyledText actionBarText = packetText.iterate((part, changes) -> {
             if (part.getPartStyle().getFont().equals(COORDINATES_FONT)) {
@@ -48,11 +57,6 @@ public final class ActionBarHandler extends Handler {
         });
 
         if (actionBarText.isEmpty()) {
-            lastParsedActionBarText = packetText;
-            lastMatchedSegments = List.of();
-
-            WynntilsMod.postEvent(new ActionBarUpdatedEvent(lastMatchedSegments));
-
             if (WynntilsMod.isDevelopmentBuild() || WynntilsMod.isDevelopmentEnvironment()) {
                 WynntilsMod.warn("Failed to find action bar text in packet: " + packetText.getString());
             }


### PR DESCRIPTION
Fixes #4041

Previously, when the parsed action bar text was empty, the handler returned early without posting an `ActionBarUpdatedEvent`, meaning that other parts of Wynntils weren't notified if the action bar had updated to an empty state.

This change handles empty action bar text as a valid update state.

The handler now updates `lastParsedActionBarText`, clears `lastMatchedSegments` with `List.of()`, and posts an `ActionBarUpdatedEvent` with said empty list before returning. This change will allow for listeners to react when the action bar becomes empty instead of the update being skipped over.

The warning is now also limited exclusively to dev environments.

Testing:
- Ran `.\gradlew.bat spotlessCheck`
- Ran `.\gradlew.bat spotlessApply`
- Ran `.\gradlew.bat --refresh-dependencies buildDependents`
- Confirmed build completed successfully