### PR TITLE
feat: Temporary ascended item support, fix parsing items

### DIFF
--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -94,6 +94,18 @@ public final class GearModel extends Model {
             WynntilsMod.warn("Tier for " + gearInfo.name() + " is reported as " + result.tier());
         }
 
+        // Temporary check for ascended items as they have no visible difference beside the stats at the moment
+        if (result.level() != gearInfo.requirements().level() && gearInfo.tier() == GearTier.MYTHIC) {
+            WynntilsMod.warn("Gear level for " + gearInfo.name() + " is reported as " + result.level());
+            GearInfo ascendedGearInfo = Models.Gear.getGearInfoFromDisplayName("Masterwork " + gearInfo.name());
+            if (ascendedGearInfo != null && ascendedGearInfo.requirements().level() == result.level()) {
+                WynntilsMod.info("Parsing " + gearInfo.name() + " as an ascended item");
+                return parseInstance(ascendedGearInfo, itemStack, isUnidentified);
+            } else {
+                WynntilsMod.warn("No ascended gear info found for " + gearInfo.name());
+            }
+        }
+
         GearInstance gearInstance = null;
         if (!isUnidentified) {
             gearInstance = GearInstance.create(

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -54,7 +54,8 @@ public final class WynnItemParser {
     private static final Pattern HEALTH_PATTERN =
             Pattern.compile("^§f\uDB00\uDC02§#(?:[a-f0-9]{8})([+-][\\d,]+)§f Health$");
 
-    private static final Pattern DPS_PATTERN = Pattern.compile("^§f\uDB00\uDC02§#(?:[a-f0-9]{8})([\\d,]+)§f DPS$");
+    // Test in WynnItemParser_DPS_PATTERN
+    private static final Pattern DPS_PATTERN = Pattern.compile("^§#(?:[a-f0-9]{8})([\\d,]+)§f DPS$");
 
     private static final Pattern DURABILITY_PATTERN =
             Pattern.compile("§8\uE023\uDAFF\uDFF7§#.{8}.§7 Durability (\\d+)\\/(\\d+)");
@@ -70,11 +71,11 @@ public final class WynnItemParser {
 
     // Test in WynnItemParser_ITEM_ATTACK_SPEED_PATTERN
     private static final Pattern ITEM_ATTACK_SPEED_PATTERN =
-            Pattern.compile("^§f\uDB00\uDC02\uE007§7 ([\\w ]+) §8\\((\\d+.\\d+) hits\\/s\\)$");
+            Pattern.compile("^§f\uE007§7 ([\\w ]+) §8\\((\\d+.\\d+) hits\\/s\\)$");
 
     // Test in WynnItemParser_ITEM_DAMAGE_PATTERN
     private static final Pattern ITEM_DAMAGE_PATTERN =
-            Pattern.compile("§f[^§]*?(?<spriteSymbol>[\uE000-\uE005])[^§]*?§7(?<range>\\d+-\\d+)");
+            Pattern.compile("§f(?:[^§]|§.)*?(?<spriteSymbol>[\uE000-\uE005])(?:[^§]|§.)*?§7(?<range>\\d+-\\d+)");
 
     private static final String ELEMENTAL_DEFENSES_LINE = "§f\uDB00\uDC02§7Elemental Defences";
 
@@ -203,6 +204,12 @@ public final class WynnItemParser {
             }
 
             if (segment == 1) {
+                StyledTextPart lastPart = normalizedCoded.getLastPart();
+                if (lastPart != null && lastPart.getPartStyle().getFont().equals(DIVIDER_FONT)) {
+                    segment++;
+                    continue;
+                }
+
                 Matcher tierMatcher = normalizedCoded.getMatcher(TIER_PATTERN);
                 if (tierMatcher.matches()) {
                     if (tier == null) {
@@ -266,6 +273,8 @@ public final class WynnItemParser {
                 }
 
                 if (parsingDamages) {
+                    if (normalizedCoded.isEmpty()) continue;
+
                     if (!normalizedCoded.getLastPart().getPartStyle().getFont().equals(DIVIDER_FONT)) {
                         Matcher damageMatcher = normalizedCoded.getMatcher(ITEM_DAMAGE_PATTERN);
 
@@ -294,12 +303,6 @@ public final class WynnItemParser {
                         }
                         continue;
                     }
-                }
-
-                StyledTextPart lastPart = normalizedCoded.getLastPart();
-                if (lastPart != null && lastPart.getPartStyle().getFont().equals(DIVIDER_FONT)) {
-                    segment++;
-                    continue;
                 }
             }
 

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -870,6 +870,15 @@ public class TestRegex {
     }
 
     @Test
+    public void WynnItemParser_DPS_PATTERN() {
+        PatternTester p = new PatternTester(WynnItemParser.class, "DPS_PATTERN");
+        p.shouldMatch("§#f2c2f2ff330§f DPS");
+        p.shouldMatch("§#e0b3e6ff759§f DPS");
+        p.shouldMatch("§#cff9f9ff516§f DPS");
+        p.shouldMatch("§#e0b3e6ff1,009§f DPS");
+    }
+
+    @Test
     public void WynnItemParser_DURABILITY_PATTERN() {
         PatternTester p = new PatternTester(WynnItemParser.class, "DURABILITY_PATTERN");
         p.shouldMatch("§8\uE023\uDAFF\uDFF7§#aed4d4ff\uE01B§7 Durability 163/194");
@@ -881,8 +890,9 @@ public class TestRegex {
     @Test
     public void WynnItemParser_ITEM_ATTACK_SPEED_PATTERN() {
         PatternTester p = new PatternTester(WynnItemParser.class, "ITEM_ATTACK_SPEED_PATTERN");
-        p.shouldMatch("§f\uDB00\uDC02\uE007§7 Slow §8(1.5 hits/s)");
-        p.shouldMatch("§f\uDB00\uDC02\uE007§7 Very Fast §8(3.1 hits/s)");
+        p.shouldMatch("§f\uE007§7 Slow §8(1.5 hits/s)");
+        p.shouldMatch("§f\uE007§7 Very Fast §8(3.1 hits/s)");
+        p.shouldMatch("§f\uE007§7 Normal §8(2.05 hits/s)");
     }
 
     @Test
@@ -904,6 +914,7 @@ public class TestRegex {
         p.shouldFind(
                 "§f\uDB00\uDC02\uDAFF\uDFFF\uE005\uDAFF\uDFFF §766-90§f \uE001\uDAFF\uDFFF §774-139§f \uE002 §7170-310",
                 3);
+        p.shouldFind("§f\uE003§r§f §7215-343", 1);
     }
 
     @Test


### PR DESCRIPTION
Since there is no indication of items being ascended currently and we're just waiting on that, simply check if the parsed level doesn't match and then lookup the ascended version to try and match against that.

In the process of this I discovered a bug where the level wasn't being parsed as the segment to parse never incremented to 2, this should fix the issues where items are randomly not parsed