### PR TITLE
fix: cache overall roll marker values

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -434,9 +434,7 @@ public class ItemTextOverlayFeature extends Feature {
 
         @Override
         public boolean isTextOverlayEnabled() {
-            return overallRollMarkersEnabled.get()
-                    && hasOverallValue
-                    && overallPercentage >= GREEN_OVERALL_MIN;
+            return overallRollMarkersEnabled.get() && hasOverallValue && overallPercentage >= GREEN_OVERALL_MIN;
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ItemTextOverlayFeature.java
@@ -424,22 +424,23 @@ public class ItemTextOverlayFeature extends Feature {
         private static final float PERFECT_OVERALL_MIN = 100.0f;
         private static final String MARKER_SYMBOL = "✦";
 
-        private final IdentifiableItemProperty<?, ?> item;
+        private final boolean hasOverallValue;
+        private final float overallPercentage;
 
         private OverallRollMarkerOverlay(IdentifiableItemProperty<?, ?> item) {
-            this.item = item;
+            hasOverallValue = item.hasOverallValue();
+            overallPercentage = hasOverallValue ? item.getOverallPercentage() : 0.0f;
         }
 
         @Override
         public boolean isTextOverlayEnabled() {
             return overallRollMarkersEnabled.get()
-                    && item.hasOverallValue()
-                    && item.getOverallPercentage() >= GREEN_OVERALL_MIN;
+                    && hasOverallValue
+                    && overallPercentage >= GREEN_OVERALL_MIN;
         }
 
         @Override
         public TextOverlay getTextOverlay() {
-            float overallPercentage = item.getOverallPercentage();
             TextRenderSetting style = TextRenderSetting.DEFAULT.withTextShadow(overallRollMarkersShadow.get());
             TextRenderTask task;
 


### PR DESCRIPTION
## Problem

  Some clients crash natively on the render thread while Wynntils renders item text overlays. The JVM crash report points
  to the overall roll marker overlay:

  ```text
  # A fatal error has been detected by the Java Runtime Environment:
  #  SIGSEGV (0xb)
  # Problematic frame:
  # J ... com.wynntils.features.inventory.ItemTextOverlayFeature$OverallRollMarkerOverlay.isTextOverlayEnabled()Z
```
  ## Fix

  OverallRollMarkerOverlay now caches hasOverallValue and overallPercentage when the overlay is created. During slot
  rendering, isTextOverlayEnabled() reads those cached primitive values instead of repeatedly calling hasOverallValue()
  and getOverallPercentage() on the item.