### PR TITLE
chore: Revert cache removal, bump spotless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,18 @@ jobs:
           distribution: "temurin"
           java-version: 21
 
+      - name: Cache Gradle data
+        uses: actions/cache@v4
+        with:
+          path: .gradle
+          key: ${{ runner.os }}-gradle--${{ hashFiles('**/settings.gradle', '**/gradle.properties') }}
+
+      - name: Cache Gradle shared data
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.home }}/.gradle/caches
+          key: ${{ runner.os }}-gradle-shared--${{ hashFiles('**/settings.gradle', '**/gradle.properties') }}
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -71,13 +71,13 @@ devauth_version=1.2.2
 
 # Spotless
 # Check for latest at https://plugins.gradle.org/plugin/com.diffplug.spotless
-spotless_version=7.2.1
+spotless_version=8.4.0
 
 # Check for latest at https://plugins.gradle.org/plugin/com.palantir.java-format-spotless
-spotless_palantir_version=2.73.0
+spotless_palantir_version=2.90.0
 
 # Check for latest at https://github.com/google/gson/releases
-spotless_gson_version=2.13.1
+spotless_gson_version=2.14.0
 
 # Check for latest at https://groovy.jfrog.io/ui/native/plugins-release/org/codehaus/groovy/groovy-eclipse-integration/4.9.0
 spotless_greclipse_version=4.27


### PR DESCRIPTION
This presumably will reintroduce the issue of spotless not applying to forks but if it fixes the 30+ minute build time it's worth it for now