### PR TITLE
fix: Content book search feature can be inaccurate

### DIFF
--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -472,8 +472,10 @@ public class ContainerSearchFeature extends Feature {
 
             String name = StyledText.fromComponent(itemStack.getHoverName())
                     .getStringWithoutFormatting()
-                    .toLowerCase(Locale.ROOT)
-                    .replace("ààà", " ");
+                    .toLowerCase(Locale.ROOT);
+            if (currentContainer instanceof ContentBookContainer contentBookContainer) {
+                name = name.replace("ààà", " ");
+            }
             boolean filtered = !search.isEmpty() && name.contains(search) && !itemStack.isEmpty();
 
             wynnItemOpt.get().getData().store(WynnItemData.SEARCHED_KEY, filtered);

--- a/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
+++ b/common/src/main/java/com/wynntils/features/inventory/ContainerSearchFeature.java
@@ -472,7 +472,8 @@ public class ContainerSearchFeature extends Feature {
 
             String name = StyledText.fromComponent(itemStack.getHoverName())
                     .getStringWithoutFormatting()
-                    .toLowerCase(Locale.ROOT);
+                    .toLowerCase(Locale.ROOT)
+                    .replace("ààà", " ");
             boolean filtered = !search.isEmpty() && name.contains(search) && !itemStack.isEmpty();
 
             wynnItemOpt.get().getData().store(WynnItemData.SEARCHED_KEY, filtered);


### PR DESCRIPTION
Certain content book items (like Dungeons) were encoding spaces using three in-font single width characters (à) instead of using a normal space, which was breaking the container search feature by making searching a multi-word name sometimes fall through.