### PR TITLE
fix: scoreboard lr functions

### DIFF
--- a/common/src/main/java/com/wynntils/models/lootrun/scoreboard/LootrunScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/scoreboard/LootrunScoreboardPart.java
@@ -100,6 +100,8 @@ public class LootrunScoreboardPart extends ScoreboardPart {
         List<CappedValue> currentMissionProgress = new ArrayList<>();
         List<String> currentTrialObjective = new ArrayList<>();
         List<CappedValue> currentTrialProgress = new ArrayList<>();
+        String currentMission = "";
+        String currentTrial = "";
         MissionAndTrialState state = MissionAndTrialState.UNKNOWN;
         for (int i = 3; i < content.size(); i++) {
             StyledText line = content.get(i);
@@ -108,10 +110,10 @@ public class LootrunScoreboardPart extends ScoreboardPart {
             if (matcher.matches()) {
                 String name = matcher.group("name");
                 if (MissionType.fromName(name) != MissionType.UNKNOWN) {
-                    Models.Lootrun.setCurrentMission(name);
+                    currentMission = name;
                     state = MissionAndTrialState.MISSION;
                 } else if (TrialType.fromName(name) != TrialType.UNKNOWN) {
-                    Models.Lootrun.setCurrentTrial(name);
+                    currentTrial = name;
                     state = MissionAndTrialState.TRIAL;
                 } else {
                     WynntilsMod.warn("Found unknown Lootrun Mission or Trial name: " + line.getString());
@@ -138,6 +140,8 @@ public class LootrunScoreboardPart extends ScoreboardPart {
             // If we hit a line that's neither a Mission nor a Trial break immediately
             break;
         }
+        Models.Lootrun.setCurrentMission(currentMission);
+        Models.Lootrun.setCurrentTrial(currentTrial);
         Models.Lootrun.setCurrentMissionObjective(currentMissionObjective);
         Models.Lootrun.setCurrentMissionProgress(currentMissionProgress);
         Models.Lootrun.setCurrentTrialObjective(currentTrialObjective);

--- a/common/src/main/java/com/wynntils/models/lootrun/scoreboard/LootrunScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/scoreboard/LootrunScoreboardPart.java
@@ -16,12 +16,11 @@ import com.wynntils.models.lootrun.type.LootrunningState;
 import com.wynntils.models.lootrun.type.MissionType;
 import com.wynntils.models.lootrun.type.TrialType;
 import com.wynntils.utils.type.CappedValue;
-import net.minecraft.util.Mth;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.minecraft.util.Mth;
 
 public class LootrunScoreboardPart extends ScoreboardPart {
     private static final Pattern CHOOSE_BEACON_PATTERN = Pattern.compile("^Choose a beacon!$");
@@ -127,7 +126,8 @@ public class LootrunScoreboardPart extends ScoreboardPart {
             if (matcher.matches()) {
                 String name = matcher.group("objectiveStart") + " " + matcher.group("objectiveEnd");
                 CappedValue progress = new CappedValue(
-                        Mth.floor(Float.parseFloat(matcher.group("current"))), Mth.floor(Float.parseFloat(matcher.group("total"))));
+                        Mth.floor(Float.parseFloat(matcher.group("current"))),
+                        Mth.floor(Float.parseFloat(matcher.group("total"))));
                 if (state == MissionAndTrialState.MISSION) {
                     currentMissionObjective.add(name);
                     currentMissionProgress.add(progress);

--- a/common/src/main/java/com/wynntils/models/lootrun/scoreboard/LootrunScoreboardPart.java
+++ b/common/src/main/java/com/wynntils/models/lootrun/scoreboard/LootrunScoreboardPart.java
@@ -16,6 +16,8 @@ import com.wynntils.models.lootrun.type.LootrunningState;
 import com.wynntils.models.lootrun.type.MissionType;
 import com.wynntils.models.lootrun.type.TrialType;
 import com.wynntils.utils.type.CappedValue;
+import net.minecraft.util.Mth;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -38,7 +40,7 @@ public class LootrunScoreboardPart extends ScoreboardPart {
             Pattern.compile("^[-—] Challenges: (\\d+)/(\\d+)(?: \\[[+-]\\d+\\])?$");
     private static final Pattern MISSION_AND_TRIAL_NAME_PATTERN = Pattern.compile("§.(?<name>[^:]+):");
     private static final Pattern MISSION_AND_TRIAL_OBJECTIVE_PATTERN = Pattern.compile(
-            "§.- (?:§.)?(?<objectiveStart>.+) (?:§.)?(?<current>[0-9]+)/(?<total>[0-9]+)m?(?:§.)? (?<objectiveEnd>.+)");
+            "§.- (?:§.)?(?<objectiveStart>.+) (?:§.)?(?<current>[0-9.]+)/(?<total>[0-9.]+)m?(?:§.)? (?<objectiveEnd>.+)");
 
     @Override
     public SegmentMatcher getSegmentMatcher() {
@@ -125,7 +127,7 @@ public class LootrunScoreboardPart extends ScoreboardPart {
             if (matcher.matches()) {
                 String name = matcher.group("objectiveStart") + " " + matcher.group("objectiveEnd");
                 CappedValue progress = new CappedValue(
-                        Integer.parseInt(matcher.group("current")), Integer.parseInt(matcher.group("total")));
+                        Mth.floor(Float.parseFloat(matcher.group("current"))), Mth.floor(Float.parseFloat(matcher.group("total"))));
                 if (state == MissionAndTrialState.MISSION) {
                     currentMissionObjective.add(name);
                     currentMissionProgress.add(progress);

--- a/fabric/src/test/java/TestRegex.java
+++ b/fabric/src/test/java/TestRegex.java
@@ -1181,6 +1181,8 @@ public class TestRegex {
         p.shouldMatch("§e- Get 0/1 Boons");
         p.shouldMatch("§4- §7Complete §f0/12§7 Challenges");
         p.shouldMatch("§c- Complete 0/12 Challenges");
+        p.shouldMatch("§6- §fAdd §f6.5/8m§7 to your timer");
+        p.shouldMatch("§e- Add 6.5/8m to your timer");
     }
 
     @Test


### PR DESCRIPTION
This PR:
- fixes lootrun_current_mission and lootrun_current_trial data persisting after disappearing from scoreboard
- fixes decimal value not parsing for objectives
- adds tests for changed pattern