### PR TITLE
feat: Onlinemembers default argument

### DIFF
--- a/common/src/main/java/com/wynntils/commands/OnlineMembersCommand.java
+++ b/common/src/main/java/com/wynntils/commands/OnlineMembersCommand.java
@@ -54,27 +54,26 @@ public class OnlineMembersCommand extends Command {
 
     private int lookupGuild(CommandContext<CommandSourceStack> context, String guildName) {
         if (guildName.isEmpty()) {
-            context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
+            context.getSource()
+                    .sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
             return 0;
         }
 
-        CompletableFuture<GuildInfo> completableFuture =
-                Models.Guild.getGuild(guildName);
+        CompletableFuture<GuildInfo> completableFuture = Models.Guild.getGuild(guildName);
 
         completableFuture.whenComplete((guild, throwable) -> {
             if (throwable != null) {
                 McUtils.mc().execute(() -> {
-                    McUtils.sendWynntilsPrefixMessage(Component.literal("Unable to view online members for "
-                                    + guildName)
-                            .withStyle(ChatFormatting.RED));
+                    McUtils.sendWynntilsPrefixMessage(
+                            Component.literal("Unable to view online members for " + guildName)
+                                    .withStyle(ChatFormatting.RED));
                 });
                 WynntilsMod.error("Error trying to parse guild online members", throwable);
             } else {
                 if (guild == null) {
                     McUtils.mc().execute(() -> {
                         McUtils.sendWynntilsPrefixMessage(
-                                Component.literal("Unknown guild " + guildName)
-                                        .withStyle(ChatFormatting.RED));
+                                Component.literal("Unknown guild " + guildName).withStyle(ChatFormatting.RED));
                     });
                     return;
                 }

--- a/common/src/main/java/com/wynntils/commands/OnlineMembersCommand.java
+++ b/common/src/main/java/com/wynntils/commands/OnlineMembersCommand.java
@@ -48,19 +48,24 @@ public class OnlineMembersCommand extends Command {
             LiteralArgumentBuilder<CommandSourceStack> base, CommandBuildContext context) {
         return base.then(Commands.argument("guildName", StringArgumentType.greedyString())
                         .suggests(GUILD_SUGGESTION_PROVIDER)
-                        .executes(this::lookupGuild))
-                .executes(this::syntaxError);
+                        .executes(ctx -> lookupGuild(ctx, ctx.getArgument("guildName", String.class))))
+                .executes(ctx -> lookupGuild(ctx, Models.Guild.getGuildName()));
     }
 
-    private int lookupGuild(CommandContext<CommandSourceStack> context) {
+    private int lookupGuild(CommandContext<CommandSourceStack> context, String guildName) {
+        if (guildName.isEmpty()) {
+            context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
+            return 0;
+        }
+
         CompletableFuture<GuildInfo> completableFuture =
-                Models.Guild.getGuild(context.getArgument("guildName", String.class));
+                Models.Guild.getGuild(guildName);
 
         completableFuture.whenComplete((guild, throwable) -> {
             if (throwable != null) {
                 McUtils.mc().execute(() -> {
                     McUtils.sendWynntilsPrefixMessage(Component.literal("Unable to view online members for "
-                                    + context.getArgument("guildName", String.class))
+                                    + guildName)
                             .withStyle(ChatFormatting.RED));
                 });
                 WynntilsMod.error("Error trying to parse guild online members", throwable);
@@ -68,7 +73,7 @@ public class OnlineMembersCommand extends Command {
                 if (guild == null) {
                     McUtils.mc().execute(() -> {
                         McUtils.sendWynntilsPrefixMessage(
-                                Component.literal("Unknown guild " + context.getArgument("guildName", String.class))
+                                Component.literal("Unknown guild " + guildName)
                                         .withStyle(ChatFormatting.RED));
                     });
                     return;
@@ -123,10 +128,5 @@ public class OnlineMembersCommand extends Command {
                         false);
 
         return 1;
-    }
-
-    private int syntaxError(CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(Component.literal("Missing argument").withStyle(ChatFormatting.RED));
-        return 0;
     }
 }


### PR DESCRIPTION
If no argument was provided, tries to use player's guild name from GuildModel as an input. If it was empty, displays same error message as before.