### PR TITLE
fix: Possible fix for overlays resetting alignment

### DIFF
--- a/common/src/main/java/com/wynntils/core/consumers/overlays/DynamicOverlay.java
+++ b/common/src/main/java/com/wynntils/core/consumers/overlays/DynamicOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.consumers.overlays;
@@ -39,9 +39,7 @@ public abstract class DynamicOverlay extends Overlay {
                         VerticalAlignment.MIDDLE,
                         HorizontalAlignment.CENTER,
                         OverlayPosition.AnchorSection.MIDDLE),
-                new OverlaySize(100f, 20f),
-                HorizontalAlignment.CENTER,
-                VerticalAlignment.MIDDLE);
+                new OverlaySize(100f, 20f));
         this.id = id;
     }
 


### PR DESCRIPTION
Possible fix for https://github.com/Wynntils/Wynntils/issues/3956

It's not easy to replicate the issue so I can't say for certain this will fix but it does seem like it would work as the default value for these in the base Overlay class is null

https://github.com/Wynntils/Wynntils/blob/7622cfb22304af100f3b9f0e7855f8711041e1f4/common/src/main/java/com/wynntils/core/consumers/overlays/Overlay.java#L58-L62