### PR TITLE
feat: share crafted item stats in chat

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/components/CraftedGearTooltipComponent.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/components/CraftedGearTooltipComponent.java
@@ -12,13 +12,20 @@ import com.wynntils.handlers.tooltip.impl.identifiable.components.gear.GearToolt
 import com.wynntils.models.activities.quests.QuestInfo;
 import com.wynntils.models.activities.type.ActivityStatus;
 import com.wynntils.models.character.type.ClassType;
+import com.wynntils.models.elements.type.Element;
+import com.wynntils.models.elements.type.Powder;
+import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.items.items.game.CraftedGearItem;
+import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.TooltipUtils;
+import com.wynntils.utils.type.Pair;
+import com.wynntils.utils.type.RangedValue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -79,12 +86,157 @@ public class CraftedGearTooltipComponent extends CraftedTooltipComponent<Crafted
 
     @Override
     public List<Component> buildHeaderTooltip(CraftedGearItem craftedItem) {
-        return List.of(Component.literal(craftedItem.getName()).withStyle(ChatFormatting.DARK_AQUA));
+        // This text-based header is only used as a fallback when there is no real in-game item stack to parse,
+        // i.e. for chat-shared crafted gear (see buildTooltipParts for the in-game path).
+        List<Component> header = new ArrayList<>();
+
+        // name
+        header.add(Component.literal(craftedItem.getName()).withStyle(ChatFormatting.DARK_AQUA));
+
+        // attack speed
+        if (craftedItem.getAttackSpeed().isPresent())
+            header.add(Component.literal(
+                    ChatFormatting.GRAY + craftedItem.getAttackSpeed().get().getName()));
+
+        header.add(Component.literal(""));
+
+        // elemental damages
+        if (!craftedItem.getDamages().isEmpty()) {
+            List<Pair<DamageType, RangedValue>> damages = craftedItem.getDamages();
+            for (Pair<DamageType, RangedValue> damageStat : damages) {
+                DamageType type = damageStat.key();
+                String elementSymbol =
+                        type.getElement().isPresent() ? type.getElement().get().getSymbol() : type.getSymbol();
+                MutableComponent damage = Component.empty()
+                        .withStyle(type.getColorCode())
+                        .append(Component.literal(elementSymbol)
+                                .withStyle(Style.EMPTY.withFont(
+                                        new FontDescription.Resource(Identifier.withDefaultNamespace("common")))))
+                        .append(Component.literal(" " + type.getDisplayName()));
+                damage.append(Component.literal("Damage: " + damageStat.value().asString())
+                        .withStyle(
+                                type == DamageType.NEUTRAL
+                                        ? type.getColorCode()
+                                        : ChatFormatting.GRAY)); // neutral is all gold
+                header.add(damage);
+            }
+
+            header.add(Component.literal(""));
+        }
+
+        // health
+        int health = craftedItem.getHealth();
+        if (health != 0) {
+            MutableComponent healthComp = Component.literal("❤ Health: " + StringUtils.toSignedString(health))
+                    .withStyle(ChatFormatting.DARK_RED);
+            header.add(healthComp);
+        }
+
+        // elemental defenses
+        if (!craftedItem.getDefences().isEmpty()) {
+            List<Pair<Element, Integer>> defenses = craftedItem.getDefences();
+            for (Pair<Element, Integer> defenceStat : defenses) {
+                Element element = defenceStat.key();
+                MutableComponent defense = Component.empty()
+                        .withStyle(element.getColorCode())
+                        .append(Component.literal(element.getSymbol())
+                                .withStyle(Style.EMPTY.withFont(
+                                        new FontDescription.Resource(Identifier.withDefaultNamespace("common")))))
+                        .append(Component.literal(" " + element.getDisplayName()));
+                defense.append(Component.literal(" Defence: " + StringUtils.toSignedString(defenceStat.value()))
+                        .withStyle(ChatFormatting.GRAY));
+                header.add(defense);
+            }
+        }
+
+        if (health != 0 || !craftedItem.getDefences().isEmpty()) {
+            header.add(Component.literal(""));
+        }
+
+        // requirements
+        int requirementsCount = 0;
+        GearRequirements requirements = craftedItem.getRequirements();
+        if (requirements.classType().isPresent()) {
+            ClassType classType = requirements.classType().get();
+            boolean fulfilled = Models.Character.getClassType() == classType;
+            header.add(buildRequirementLine("Class Req: " + classType.getFullName(), fulfilled));
+            requirementsCount++;
+        }
+        if (requirements.quest().isPresent()) {
+            String questName = requirements.quest().get();
+            Optional<QuestInfo> quest = Models.Quest.getQuestFromName(questName);
+            boolean fulfilled = quest.isPresent() && quest.get().status() == ActivityStatus.COMPLETED;
+            header.add(buildRequirementLine("Quest Req: " + questName, fulfilled));
+            requirementsCount++;
+        }
+        int level = requirements.level();
+        if (level != 0) {
+            boolean fulfilled = Models.CombatXp.getCombatLevel().current() >= level;
+            header.add(buildRequirementLine("Combat Lv. Min: " + level, fulfilled));
+            requirementsCount++;
+        }
+        if (!requirements.skills().isEmpty()) {
+            for (Pair<Skill, Integer> skillRequirement : requirements.skills()) {
+                // Skip zero skill requirements, but keep negative ones (they are real)
+                if (skillRequirement.value() == 0) {
+                    continue;
+                }
+                // FIXME: CharacterModel is still missing info about our skill points
+                header.add(buildRequirementLine(
+                        skillRequirement.key().getDisplayName() + " Min: " + skillRequirement.value(), false));
+                requirementsCount++;
+            }
+        }
+        if (requirementsCount > 0) {
+            header.add(Component.literal(""));
+        }
+
+        return header;
     }
 
     @Override
     public List<Component> buildFooterTooltip(CraftedGearItem craftedItem) {
-        return List.of();
+        List<Component> footer = new ArrayList<>();
+
+        footer.add(Component.empty());
+
+        // powder slots
+        if (!craftedItem.getPowders().isEmpty()) {
+            MutableComponent powderLine = Component.literal("["
+                            + craftedItem.getPowders().size() + "/" + craftedItem.getPowderSlots() + "] Powder Slots ")
+                    .withStyle(ChatFormatting.GRAY);
+            MutableComponent powderList = Component.literal("[");
+            for (Powder p : craftedItem.getPowders()) {
+                String symbol = String.valueOf(p.getSymbol());
+                if (!powderList.getSiblings().isEmpty()) {
+                    powderList.append(Component.empty()
+                            .withStyle(Style.EMPTY.withColor(p.getLightColor()))
+                            .append(Component.literal(" "))
+                            .append(Component.literal(symbol)
+                                    .withStyle(Style.EMPTY.withFont(
+                                            new FontDescription.Resource(Identifier.withDefaultNamespace("common"))))));
+                    continue;
+                }
+                powderList.append(Component.literal(symbol)
+                        .withStyle(Style.EMPTY
+                                .withFont(new FontDescription.Resource(Identifier.withDefaultNamespace("common")))
+                                .withColor(p.getLightColor())));
+            }
+            powderList.append(Component.literal("]"));
+            powderLine.append(powderList);
+            footer.add(powderLine);
+        }
+
+        // item type + durability
+        footer.add(Component.literal("Crafted "
+                        + StringUtils.capitalizeFirst(
+                                craftedItem.getGearType().name().toLowerCase(Locale.ROOT)))
+                .withStyle(ChatFormatting.DARK_AQUA)
+                .append(Component.literal(" [" + craftedItem.getDurability().current() + "/"
+                                + craftedItem.getDurability().max() + " Durability]")
+                        .withStyle(ChatFormatting.DARK_GRAY)));
+
+        return footer;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedConsumableItemTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.encoding.impl.item;
@@ -19,6 +19,7 @@ import com.wynntils.models.items.encoding.type.ItemTransformer;
 import com.wynntils.models.items.encoding.type.ItemType;
 import com.wynntils.models.items.items.game.CraftedConsumableItem;
 import com.wynntils.models.stats.type.StatActualValue;
+import com.wynntils.models.stats.type.StatPossibleValues;
 import com.wynntils.models.wynnitem.type.NamedItemEffect;
 import com.wynntils.utils.StringUtils;
 import com.wynntils.utils.type.CappedValue;
@@ -105,9 +106,24 @@ public class CraftedConsumableItemTransformer extends ItemTransformer<CraftedCon
         }
 
         dataList.add(new EffectsData(item.getNamedEffects()));
-        dataList.add(new CustomIdentificationsData(item.getPossibleValues()));
+        dataList.add(new CustomIdentificationsData(getEncodableIdentifications(item)));
 
         return dataList;
+    }
+
+    private List<StatPossibleValues> getEncodableIdentifications(CraftedConsumableItem item) {
+        List<StatPossibleValues> possibleValues = item.getPossibleValues();
+        if (!possibleValues.isEmpty()) {
+            return possibleValues;
+        }
+
+        // The 1.21.11 tooltip format no longer exposes the crafted stat roll ranges, so the parser
+        // cannot populate possible values. Fall back to encoding the actual identification values
+        // (as their own max) so the stats are still shared via chat instead of being dropped.
+        return item.getIdentifications().stream()
+                .map(stat -> new StatPossibleValues(
+                        stat.statType(), RangedValue.of(stat.value(), stat.value()), stat.value(), false))
+                .toList();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -98,7 +98,9 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
 
         CustomIdentificationsData identificationsData = itemDataMap.get(CustomIdentificationsData.class);
         if (identificationsData != null) {
-            possibleValues = identificationsData.possibleValues();
+            // Note: possibleValues is intentionally left empty. The shared data does not carry real roll
+            // ranges for crafted items, so keeping it
+            // empty makes the chat tooltip render the stat values without a fabricated roll percentage/wheel.
             // For crafted items, the max values can be used to calculate the current values (from the overall
             // effectiveness).
             identifications = identificationsData.possibleValues().stream()
@@ -151,10 +153,25 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
 
         dataList.add(new DamageData(item.getAttackSpeed(), item.getDamages()));
         dataList.add(new DefenseData(item.getHealth(), item.getDefences()));
-        dataList.add(new CustomIdentificationsData(item.getPossibleValues()));
+        dataList.add(new CustomIdentificationsData(getEncodableIdentifications(item)));
         dataList.add(PowderData.from(item));
 
         return dataList;
+    }
+
+    private List<StatPossibleValues> getEncodableIdentifications(CraftedGearItem item) {
+        List<StatPossibleValues> possibleValues = item.getPossibleValues();
+        if (!possibleValues.isEmpty()) {
+            return possibleValues;
+        }
+
+        // The 1.21.11 tooltip format no longer exposes the crafted stat roll ranges, so the parser
+        // cannot populate possible values. Fall back to encoding the actual identification values
+        // (as their own max) so the stats are still shared via chat instead of being dropped.
+        return item.getIdentifications().stream()
+                .map(stat -> new StatPossibleValues(
+                        stat.statType(), RangedValue.of(stat.value(), stat.value()), stat.value(), false))
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
## Description

Crafted items can now be shared in chat with their stats, the same way identified gear already works. Previously crafted identifications were dropped, so shared crafted items came through without their stats.
---
<img width="517" height="810" alt="image" src="https://github.com/user-attachments/assets/258f1bb3-334e-4ae5-8c0a-e259b7cc1354" />

<img width="629" height="601" alt="image" src="https://github.com/user-attachments/assets/984228ac-ff51-44d8-93b7-b8c0b282f9e5" />

---

<img width="532" height="430" alt="image" src="https://github.com/user-attachments/assets/aef7c239-3605-4987-949f-7c42e600c34f" />

<img width="580" height="332" alt="image" src="https://github.com/user-attachments/assets/9ac6dc00-8ac6-425d-a773-2c3915f14f95" />

---
<img width="489" height="664" alt="image" src="https://github.com/user-attachments/assets/d7bee22c-16c1-465d-830a-0a72e0a6298a" />

<img width="571" height="456" alt="image" src="https://github.com/user-attachments/assets/0168e394-1222-49b3-886a-4cc43eb54488" />
