### PR TITLE
chore: Add crash protection to chat items, handle invalid weighting json

### DIFF
--- a/common/src/main/java/com/wynntils/core/mod/type/CrashType.java
+++ b/common/src/main/java/com/wynntils/core/mod/type/CrashType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.core.mod.type;
@@ -10,7 +10,8 @@ public enum CrashType {
     FEATURE("Feature"),
     OVERLAY("Overlay"),
     KEYBIND("Key Bind"),
-    SCREEN("Screen");
+    SCREEN("Screen"),
+    TOOLTIP("Tooltip");
 
     private final String name;
 

--- a/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
+++ b/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
@@ -4,7 +4,9 @@
  */
 package com.wynntils.models.items;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
+import com.wynntils.core.mod.type.CrashType;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.items.game.GearItem;
@@ -72,25 +74,38 @@ public class FakeItemStack extends ItemStack {
 
     @Override
     public List<Component> getTooltipLines(Item.TooltipContext context, Player player, TooltipFlag isAdvanced) {
-        // 1. Firstly, cache a tooltip builder with the item's data
-        //    This will be used by TooltipUtils to generate the tooltip
-        TooltipBuilder tooltipBuilder = null;
+        try {
+            // 1. Firstly, cache a tooltip builder with the item's data
+            //    This will be used by TooltipUtils to generate the tooltip
+            TooltipBuilder tooltipBuilder = null;
 
-        if (wynnItem instanceof IdentifiableItemProperty<?, ?> identifiableItem) {
-            tooltipBuilder = wynnItem.getData()
-                    .getOrCalculate(
-                            WynnItemData.TOOLTIP_KEY,
-                            () -> Handlers.Tooltip.buildNew(identifiableItem, false, true, source));
+            if (wynnItem instanceof IdentifiableItemProperty<?, ?> identifiableItem) {
+                tooltipBuilder = wynnItem.getData()
+                        .getOrCalculate(
+                                WynnItemData.TOOLTIP_KEY,
+                                () -> Handlers.Tooltip.buildNew(identifiableItem, false, true, source));
 
-        } else if (wynnItem instanceof CraftedItemProperty craftedItemProperty) {
-            tooltipBuilder = wynnItem.getData()
-                    .getOrCalculate(
-                            WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(craftedItemProperty, source));
+            } else if (wynnItem instanceof CraftedItemProperty craftedItemProperty) {
+                tooltipBuilder = wynnItem.getData()
+                        .getOrCalculate(
+                                WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(craftedItemProperty, source));
+            }
+
+            if (tooltipBuilder == null) return List.of();
+
+            // 2. Now that the tooltip builder is cached, generate the tooltip
+            return TooltipUtils.getWynnItemTooltip(this, wynnItem);
+        } catch (Throwable t) {
+            WynntilsMod.reportCrash(
+                    CrashType.TOOLTIP,
+                    this.getClass().getSimpleName(),
+                    wynnItem.getClass().getName(),
+                    "calculation",
+                    false,
+                    false,
+                    t);
+
+            return super.getTooltipLines(context, player, isAdvanced);
         }
-
-        if (tooltipBuilder == null) return List.of();
-
-        // 2. Now that the tooltip builder is cached, generate the tooltip
-        return TooltipUtils.getWynnItemTooltip(this, wynnItem);
     }
 }

--- a/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
+++ b/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
@@ -7,6 +7,7 @@ package com.wynntils.services.itemweight;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Service;
 import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
@@ -141,7 +142,10 @@ public class ItemWeightService extends Service {
     }
 
     private void handleItemWeights(Reader reader) {
-        JsonObject jsonObject = JsonParser.parseReader(reader).getAsJsonObject();
+        JsonElement root = JsonParser.parseReader(reader);
+        if (!root.isJsonObject()) return;
+
+        JsonObject jsonObject = root.getAsJsonObject();
 
         Map<ItemWeightSource, Map<String, List<ItemWeighting>>> newWeightings = new HashMap<>();
 
@@ -150,8 +154,10 @@ public class ItemWeightService extends Service {
 
             String sourceName = source.name().toLowerCase(Locale.ROOT);
 
-            if (jsonObject.has(sourceName)) {
+            if (jsonObject.has(sourceName) && jsonObject.get(sourceName).isJsonObject()) {
                 parseWeightingGroup(jsonObject.getAsJsonObject(sourceName), source, newWeightings);
+            } else {
+                WynntilsMod.warn("Item weight source " + sourceName + " is not a valid JSON object");
             }
         }
 
@@ -166,12 +172,24 @@ public class ItemWeightService extends Service {
 
         for (Map.Entry<String, JsonElement> itemEntry : group.entrySet()) {
             String itemName = itemEntry.getKey();
+
+            if (!itemEntry.getValue().isJsonObject()) {
+                WynntilsMod.warn("Item weight entry " + itemName + " is not a valid JSON object");
+                continue;
+            }
+
             JsonObject weights = itemEntry.getValue().getAsJsonObject();
 
             List<ItemWeighting> itemWeights = sourceMap.computeIfAbsent(itemName, k -> new ArrayList<>());
 
             for (Map.Entry<String, JsonElement> weightEntry : weights.entrySet()) {
                 String weightName = weightEntry.getKey();
+
+                if (!weightEntry.getValue().isJsonObject()) {
+                    WynntilsMod.warn("Item weight entry " + weightName + " is not a valid JSON object");
+                    continue;
+                }
+
                 JsonObject identificationsObj = weightEntry.getValue().getAsJsonObject();
 
                 Map<String, Double> identifications = identificationsObj.entrySet().stream()


### PR DESCRIPTION
Closes https://github.com/Wynntils/Wynntils/issues/3946

Although I think we handle all cases where chat items can crash, weightings from external sources can sometimes include unexpected or outdated data and cause issues.

And also skip over non json objects when downloading weights in case one source or specific items have issues.