### PR TITLE
Improve performance of MinimapOverlay$renderPois

### DIFF
--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -4,6 +4,9 @@
  */
 package com.wynntils.features.map;
 
+import com.wynntils.core.components.Managers;
+import com.wynntils.core.components.Models;
+import com.wynntils.core.components.Services;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
@@ -14,10 +17,18 @@ import com.wynntils.core.keybinds.KeyBindDefinition;
 import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.persisted.config.ConfigProfile;
+import com.wynntils.mc.event.TickEvent;
 import com.wynntils.overlays.minimap.CoordinatesOverlay;
 import com.wynntils.overlays.minimap.MinimapOverlay;
 import com.wynntils.overlays.minimap.TerritoryOverlay;
+import com.wynntils.services.hades.type.PlayerRelation;
+import com.wynntils.services.map.pois.PlayerMiniMapPoi;
+import com.wynntils.services.map.pois.Poi;
 import com.wynntils.utils.type.RenderElementType;
+import net.neoforged.bus.api.SubscribeEvent;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 @ConfigCategory(Category.MAP)
 public class MinimapFeature extends Feature {
@@ -36,9 +47,30 @@ public class MinimapFeature extends Feature {
     @RegisterKeyBind
     public final KeyBind zoomOut = KeyBindDefinition.MINIMAP_ZOOM_OUT.create(() -> minimapOverlay.adjustZoomLevel(-2));
 
+    private List<? extends Poi> visiblePois = List.of();
+
     public MinimapFeature() {
         super(new ProfileDefault.Builder()
                 .enabledFor(ConfigProfile.DEFAULT, ConfigProfile.NEW_PLAYER, ConfigProfile.LITE)
                 .build());
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent event) {
+        Stream<? extends Poi> visiblePoiStream = Services.Poi.getServicePois();
+        visiblePoiStream = Stream.concat(visiblePoiStream, Services.Poi.getCombatPois());
+        visiblePoiStream = Stream.concat(
+                visiblePoiStream, Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get().stream());
+        visiblePoiStream = Stream.concat(visiblePoiStream, Services.Poi.getProvidedCustomPois().stream());
+        visiblePoiStream = Stream.concat(visiblePoiStream, Models.Marker.getAllPois());
+        visiblePoiStream = Stream.concat(visiblePoiStream, minimapOverlay.getMiniPlayerPois());
+        visiblePoiStream = Stream.concat(
+                visiblePoiStream, Services.Poi.getGatheringNodePois().filter(Services.Poi::isGatheringNodeTypeVisible));
+
+        this.visiblePois = visiblePoiStream.toList();
+    }
+
+    public List<? extends Poi> getVisiblePois() {
+        return visiblePois;
     }
 }

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -21,17 +21,13 @@ import com.wynntils.mc.event.TickEvent;
 import com.wynntils.overlays.minimap.CoordinatesOverlay;
 import com.wynntils.overlays.minimap.MinimapOverlay;
 import com.wynntils.overlays.minimap.TerritoryOverlay;
-import com.wynntils.services.hades.type.PlayerRelation;
-import com.wynntils.services.map.pois.PlayerMiniMapPoi;
 import com.wynntils.services.map.pois.Poi;
 import com.wynntils.utils.type.RenderElementType;
 import net.neoforged.bus.api.SubscribeEvent;
-import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 @ConfigCategory(Category.MAP)
 public class MinimapFeature extends Feature {
@@ -66,10 +62,7 @@ public class MinimapFeature extends Feature {
         Services.Poi.getCombatPois().forEach(result::add);
         Models.Marker.getAllPois().forEach(result::add);
         minimapOverlay.getMiniPlayerPois().forEach(result::add);
-        
-        Services.Poi.getGatheringNodePois()
-                .filter(Services.Poi::isGatheringNodeTypeVisible)
-                .forEach(result::add);
+        Services.Poi.getVisibleGatheringNodePois().forEach(result::add);
 
         result.addAll(Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get());
         result.addAll(Services.Poi.getProvidedCustomPois());

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -26,7 +26,10 @@ import com.wynntils.services.map.pois.PlayerMiniMapPoi;
 import com.wynntils.services.map.pois.Poi;
 import com.wynntils.utils.type.RenderElementType;
 import net.neoforged.bus.api.SubscribeEvent;
+import org.jetbrains.annotations.UnmodifiableView;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -57,17 +60,21 @@ public class MinimapFeature extends Feature {
 
     @SubscribeEvent
     public void onTick(TickEvent event) {
-        Stream<? extends Poi> visiblePoiStream = Services.Poi.getServicePois();
-        visiblePoiStream = Stream.concat(visiblePoiStream, Services.Poi.getCombatPois());
-        visiblePoiStream = Stream.concat(
-                visiblePoiStream, Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get().stream());
-        visiblePoiStream = Stream.concat(visiblePoiStream, Services.Poi.getProvidedCustomPois().stream());
-        visiblePoiStream = Stream.concat(visiblePoiStream, Models.Marker.getAllPois());
-        visiblePoiStream = Stream.concat(visiblePoiStream, minimapOverlay.getMiniPlayerPois());
-        visiblePoiStream = Stream.concat(
-                visiblePoiStream, Services.Poi.getGatheringNodePois().filter(Services.Poi::isGatheringNodeTypeVisible));
+        var result = new ArrayList<Poi>();
 
-        this.visiblePois = visiblePoiStream.toList();
+        Services.Poi.getServicePois().forEach(result::add);
+        Services.Poi.getCombatPois().forEach(result::add);
+        Models.Marker.getAllPois().forEach(result::add);
+        minimapOverlay.getMiniPlayerPois().forEach(result::add);
+        
+        Services.Poi.getGatheringNodePois()
+                .filter(Services.Poi::isGatheringNodeTypeVisible)
+                .forEach(result::add);
+
+        result.addAll(Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get());
+        result.addAll(Services.Poi.getProvidedCustomPois());
+
+        this.visiblePois = Collections.unmodifiableList(result);
     }
 
     public List<? extends Poi> getVisiblePois() {

--- a/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
+++ b/common/src/main/java/com/wynntils/features/map/MinimapFeature.java
@@ -23,11 +23,10 @@ import com.wynntils.overlays.minimap.MinimapOverlay;
 import com.wynntils.overlays.minimap.TerritoryOverlay;
 import com.wynntils.services.map.pois.Poi;
 import com.wynntils.utils.type.RenderElementType;
-import net.neoforged.bus.api.SubscribeEvent;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.MAP)
 public class MinimapFeature extends Feature {
@@ -64,7 +63,9 @@ public class MinimapFeature extends Feature {
         minimapOverlay.getMiniPlayerPois().forEach(result::add);
         Services.Poi.getVisibleGatheringNodePois().forEach(result::add);
 
-        result.addAll(Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get());
+        result.addAll(Managers.Feature.getFeatureInstance(MainMapFeature.class)
+                .customPois
+                .get());
         result.addAll(Services.Poi.getProvidedCustomPois());
 
         this.visiblePois = Collections.unmodifiableList(result);

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.features.map.MainMapFeature;
+import com.wynntils.features.map.MinimapFeature;
 import com.wynntils.services.hades.type.PlayerRelation;
 import com.wynntils.services.map.MapTexture;
 import com.wynntils.services.map.pois.PlayerMiniMapPoi;
@@ -37,6 +38,9 @@ import com.wynntils.utils.render.type.PointerType;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.BoundingBox;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
 import net.minecraft.client.DeltaTracker;
@@ -111,6 +115,14 @@ public class MinimapOverlay extends Overlay {
 
     public void adjustZoomLevel(int delta) {
         setZoomLevel(zoomLevel.get() + delta);
+    }
+
+    public Stream<PlayerMiniMapPoi> getMiniPlayerPois() {
+        return Services.Hades.getHadesUsers()
+                .filter(hadesUser -> (hadesUser.getRelation() == PlayerRelation.PARTY && renderRemotePartyPlayers.get())
+                        || (hadesUser.getRelation() == PlayerRelation.FRIEND && renderRemoteFriendPlayers.get())
+                        || (hadesUser.getRelation() == PlayerRelation.GUILD && renderRemoteGuildPlayers.get()))
+                .map(PlayerMiniMapPoi::new);
     }
 
     @Override
@@ -234,23 +246,9 @@ public class MinimapOverlay extends Overlay {
             float zoomRenderScale,
             float zoomLevel,
             BoundingBox visibleWorldBox) {
-        Stream<? extends Poi> poisToRender = Services.Poi.getServicePois();
-        poisToRender = Stream.concat(poisToRender, Services.Poi.getCombatPois());
-        poisToRender = Stream.concat(
-                poisToRender, Managers.Feature.getFeatureInstance(MainMapFeature.class).customPois.get().stream());
-        poisToRender = Stream.concat(poisToRender, Services.Poi.getProvidedCustomPois().stream());
-        poisToRender = Stream.concat(poisToRender, Models.Marker.getAllPois());
-        poisToRender = Stream.concat(
-                poisToRender,
-                getMiniPlayerPois(
-                        renderRemotePartyPlayers.get(),
-                        renderRemoteFriendPlayers.get(),
-                        renderRemoteGuildPlayers.get()));
-        poisToRender = Stream.concat(
-                poisToRender, Services.Poi.getGatheringNodePois().filter(Services.Poi::isGatheringNodeTypeVisible));
+        List<? extends Poi> poisToRender = Managers.Feature.getFeatureInstance(MinimapFeature.class).getVisiblePois();
 
-        Poi[] pois = poisToRender.toArray(Poi[]::new);
-        for (Poi poi : pois) {
+        for (Poi poi : poisToRender) {
             float poiWorldX = poi.getLocation().getX();
             float poiWorldZ = poi.getLocation().getZ();
 
@@ -402,15 +400,6 @@ public class MinimapOverlay extends Overlay {
 
             guiGraphics.pose().popMatrix();
         }
-    }
-
-    private Stream<PlayerMiniMapPoi> getMiniPlayerPois(
-            boolean renderRemotePartyPlayers, boolean renderRemoteFriendPlayers, boolean renderRemoteGuildPlayers) {
-        return Services.Hades.getHadesUsers()
-                .filter(hadesUser -> (hadesUser.getRelation() == PlayerRelation.PARTY && renderRemotePartyPlayers)
-                        || (hadesUser.getRelation() == PlayerRelation.FRIEND && renderRemoteFriendPlayers)
-                        || (hadesUser.getRelation() == PlayerRelation.GUILD && renderRemoteGuildPlayers))
-                .map(PlayerMiniMapPoi::new);
     }
 
     private void renderCardinalDirections(

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -14,7 +14,6 @@ import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.text.StyledText;
-import com.wynntils.features.map.MainMapFeature;
 import com.wynntils.features.map.MinimapFeature;
 import com.wynntils.services.hades.type.PlayerRelation;
 import com.wynntils.services.map.MapTexture;
@@ -38,8 +37,6 @@ import com.wynntils.utils.render.type.PointerType;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import com.wynntils.utils.type.BoundingBox;
-
-import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
@@ -258,7 +255,8 @@ public class MinimapOverlay extends Overlay {
             float zoomRenderScale,
             float zoomLevel,
             BoundingBox visibleWorldBox) {
-        List<? extends Poi> poisToRender = Managers.Feature.getFeatureInstance(MinimapFeature.class).getVisiblePois();
+        List<? extends Poi> poisToRender =
+                Managers.Feature.getFeatureInstance(MinimapFeature.class).getVisiblePois();
 
         for (Poi poi : poisToRender) {
             float poiWorldX = poi.getLocation().getX();

--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -118,10 +118,22 @@ public class MinimapOverlay extends Overlay {
     }
 
     public Stream<PlayerMiniMapPoi> getMiniPlayerPois() {
+        var isRelationVisible = EnumSet.noneOf(PlayerRelation.class);
+
+        if (renderRemotePartyPlayers.get()) {
+            isRelationVisible.add(PlayerRelation.PARTY);
+        }
+
+        if (renderRemoteFriendPlayers.get()) {
+            isRelationVisible.add(PlayerRelation.FRIEND);
+        }
+
+        if (renderRemoteGuildPlayers.get()) {
+            isRelationVisible.add(PlayerRelation.GUILD);
+        }
+
         return Services.Hades.getHadesUsers()
-                .filter(hadesUser -> (hadesUser.getRelation() == PlayerRelation.PARTY && renderRemotePartyPlayers.get())
-                        || (hadesUser.getRelation() == PlayerRelation.FRIEND && renderRemoteFriendPlayers.get())
-                        || (hadesUser.getRelation() == PlayerRelation.GUILD && renderRemoteGuildPlayers.get()))
+                .filter(hadesUser -> isRelationVisible.contains(hadesUser.getRelation()))
                 .map(PlayerMiniMapPoi::new);
     }
 

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -29,6 +29,9 @@ import com.wynntils.services.map.type.ServiceKind;
 import com.wynntils.utils.mc.type.Location;
 import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.Texture;
+import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
+
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -275,6 +278,23 @@ public class PoiService extends Service {
                 .filter(type -> type.materialType == materialType)
                 .map(GatheringNodeType::key)
                 .forEach(key -> visibleGatheringNodeTypes.get().put(key, visible));
+    }
+
+    public Stream<GatheringNodePoi> getVisibleGatheringNodePois() {
+        Object2BooleanMap<GatheringNodeType> visibility = new Object2BooleanOpenHashMap<>();
+
+        return getGatheringNodePois()
+                .filter((poi) -> {
+                    MaterialProfile.MaterialType materialType = poi.getMaterialType();
+                    MaterialProfile.SourceMaterial sourceMaterial = poi.getSourceMaterial();
+
+                    if (materialType == null || sourceMaterial == null) return true;
+
+                    return visibility.computeIfAbsent(
+                            new GatheringNodeType(materialType, sourceMaterial),
+                            (e) -> isGatheringNodeTypeVisible((GatheringNodeType) e)
+                    );
+                });
     }
 
     private static class PlacesProfile {

--- a/common/src/main/java/com/wynntils/services/map/PoiService.java
+++ b/common/src/main/java/com/wynntils/services/map/PoiService.java
@@ -31,7 +31,6 @@ import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.Texture;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
-
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -283,18 +282,16 @@ public class PoiService extends Service {
     public Stream<GatheringNodePoi> getVisibleGatheringNodePois() {
         Object2BooleanMap<GatheringNodeType> visibility = new Object2BooleanOpenHashMap<>();
 
-        return getGatheringNodePois()
-                .filter((poi) -> {
-                    MaterialProfile.MaterialType materialType = poi.getMaterialType();
-                    MaterialProfile.SourceMaterial sourceMaterial = poi.getSourceMaterial();
+        return getGatheringNodePois().filter((poi) -> {
+            MaterialProfile.MaterialType materialType = poi.getMaterialType();
+            MaterialProfile.SourceMaterial sourceMaterial = poi.getSourceMaterial();
 
-                    if (materialType == null || sourceMaterial == null) return true;
+            if (materialType == null || sourceMaterial == null) return true;
 
-                    return visibility.computeIfAbsent(
-                            new GatheringNodeType(materialType, sourceMaterial),
-                            (e) -> isGatheringNodeTypeVisible((GatheringNodeType) e)
-                    );
-                });
+            return visibility.computeIfAbsent(
+                    new GatheringNodeType(materialType, sourceMaterial),
+                    (e) -> isGatheringNodeTypeVisible((GatheringNodeType) e));
+        });
     }
 
     private static class PlacesProfile {


### PR DESCRIPTION
Prior to this renderPois collected poisToRender every frame, which took up a large chunk of the work done on the render thread. This PR moves the collection part to only happen per tick, and also optimizes some of the POI types.

MainMapScreen uses a similar structure so I might optimize that in the future (haven't checked if it needs it yet, though)

Before:
<img width="1038" height="420" alt="image" src="https://github.com/user-attachments/assets/70d65768-085c-43bd-85d1-d443a56e806a" />

After:

No screenshots for this but FPS on my main instance went from ~210 -> ~380 (not a scientific test but still)

