### PR TITLE
feat: Item Weights Visual Update

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -39,6 +39,7 @@ import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.TooltipUtils;
 import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.wynn.ColorScaleUtils;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -349,7 +350,7 @@ public class ItemStatInfoFeature extends Feature {
                 ItemWeighting weighting, IdentifiableItemProperty<?, ?> itemInfo) {
             float percentage = Services.ItemWeight.calculateWeighting(weighting, itemInfo);
             return List.of(GearItemWeightsComponent.buildRightAlignedWeightLine(
-                    Component.literal(" - " + weighting.weightName() + " Scale").withStyle(ChatFormatting.WHITE),
+                    Component.literal(weighting.weightName() + " Scale").withStyle(ChatFormatting.WHITE),
                     ColorScaleUtils.getPercentageTextComponent(
                             getColorMap(), percentage, colorLerp.get(), decimalPlaces.get())));
         }
@@ -368,7 +369,7 @@ public class ItemStatInfoFeature extends Feature {
             List<MutableComponent> lines = new ArrayList<>();
             float weightPercentage = Services.ItemWeight.calculateWeighting(weighting, itemInfo);
             lines.add(GearItemWeightsComponent.buildRightAlignedWeightLine(
-                    Component.literal(" - " + weighting.weightName() + " Scale").withStyle(ChatFormatting.WHITE),
+                    Component.literal(weighting.weightName() + " Scale").withStyle(ChatFormatting.WHITE),
                     ColorScaleUtils.getPercentageTextComponent(
                             getColorMap(), weightPercentage, colorLerp.get(), decimalPlaces.get())));
 
@@ -381,18 +382,17 @@ public class ItemStatInfoFeature extends Feature {
                     displayName += "Raw ";
                 }
 
-                String weightStr = String.format(Locale.ROOT, "(%.1f%%)", weight.a());
+                String weightStr = new DecimalFormat("#.#").format(weight.a()) + "%";
                 float percentage = distribution ? weight.b() : ((weight.a() / 100f) * weight.b());
 
                 lines.add(GearItemWeightsComponent.buildRightAlignedWeightLine(
-                        Component.literal("   - ")
-                                .withStyle(ChatFormatting.WHITE)
-                                .append(Component.literal(displayName).withStyle(ChatFormatting.WHITE))
-                                .append(Component.literal(weightStr).withStyle(ChatFormatting.WHITE)),
+                        Component.literal(weightStr)
+                                .withStyle(ChatFormatting.DARK_GRAY)
+                                .append(Component.literal(" "))
+                                .append(Component.literal(displayName).withStyle(ChatFormatting.GRAY)),
                         ColorScaleUtils.getPercentageTextComponent(
                                 getColorMap(), percentage, colorLerp.get(), decimalPlaces.get())));
             });
-            lines.add(GearItemWeightsComponent.withLanguageFont(Component.empty()));
 
             return lines;
         }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/components/gear/GearItemWeightsComponent.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/components/gear/GearItemWeightsComponent.java
@@ -73,32 +73,12 @@ public final class GearItemWeightsComponent {
             currentIndex++;
             currentIndex =
                     addWeightingLines(weightedHeader, noriWeightings, weightDecorator, itemProperty, currentIndex);
-            addedAny = true;
-
-            if (!weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
-                weightedHeader.add(currentIndex, Component.empty());
-                currentIndex++;
-            }
         }
 
         if (addWynnpool) {
             weightedHeader.add(currentIndex, buildWeightSourceHeader(ItemWeightSource.WYNNPOOL));
             currentIndex++;
-            currentIndex =
-                    addWeightingLines(weightedHeader, wynnpoolWeightings, weightDecorator, itemProperty, currentIndex);
-            addedAny = true;
-
-            if (!weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
-                weightedHeader.add(currentIndex, Component.empty());
-                currentIndex++;
-            }
-        }
-
-        if (addedAny
-                && currentIndex > 0
-                && currentIndex <= weightedHeader.size()
-                && !weightedHeader.get(currentIndex - 1).equals(Component.empty())) {
-            weightedHeader.add(currentIndex, Component.empty());
+            addWeightingLines(weightedHeader, wynnpoolWeightings, weightDecorator, itemProperty, currentIndex);
         }
 
         return weightedHeader;


### PR DESCRIPTION
Item weights have not been properly updated for Fruma tooltips, and currently feature odd looking whitespace after each pool type. This made sense before, but now that we are using the separator bar instead they are no longer necessary. This PR also seeks to generally improve screen real estate by shortening each line (hopefully addressing some cases of the id being pushed off to the side) as well as general visual clarity improvements.
<img width="314" height="443" alt="image" src="https://github.com/user-attachments/assets/1e3cf616-4f09-4dc6-820a-7d71feb6660e" /><img width="330" height="483" alt="image" src="https://github.com/user-attachments/assets/0aff1280-abd4-480f-bd84-62989f6e64a3" />
