### PR TITLE
fix: Fix held item cooldown not always returning a value

### DIFF
--- a/common/src/main/java/com/wynntils/functions/InventoryFunctions.java
+++ b/common/src/main/java/com/wynntils/functions/InventoryFunctions.java
@@ -357,7 +357,7 @@ public class InventoryFunctions {
     public static class HeldItemCooldownFunction extends Function<CappedValue> {
         @Override
         public CappedValue getValue(FunctionArguments arguments) {
-            return Models.CharacterStats.getItemCooldownTicks(InventoryUtils.getItemInHand());
+            return Models.CharacterStats.getItemCooldownTicks();
         }
 
         @Override

--- a/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
+++ b/common/src/main/java/com/wynntils/models/characterstats/CharacterStatsModel.java
@@ -47,11 +47,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemCooldowns;
-import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class CharacterStatsModel extends Model {
@@ -132,11 +132,23 @@ public final class CharacterStatsModel extends Model {
         return McUtils.player().position().y - endY;
     }
 
-    public CappedValue getItemCooldownTicks(ItemStack itemStack) {
+    public float getItemCooldown(DeltaTracker deltaTracker) {
+        ItemCooldowns.CooldownInstance cooldown = getActiveCooldown();
+        if (cooldown == null) return 0.0F;
+
         ItemCooldowns cooldowns = McUtils.player().getCooldowns();
-        Identifier identifier = cooldowns.getCooldownGroup(itemStack);
-        ItemCooldowns.CooldownInstance cooldown = cooldowns.cooldowns.get(identifier);
-        if (cooldown == null || cooldown.startTime >= cooldown.endTime) return CappedValue.EMPTY; // Sanity check
+
+        float total = cooldown.endTime() - cooldown.startTime();
+        float remaining = cooldown.endTime() - (cooldowns.tickCount + deltaTracker.getGameTimeDeltaPartialTick(true));
+
+        return Mth.clamp(remaining / total, 0.0F, 1.0F);
+    }
+
+    public CappedValue getItemCooldownTicks() {
+        ItemCooldowns.CooldownInstance cooldown = getActiveCooldown();
+        if (cooldown == null) return CappedValue.EMPTY;
+
+        ItemCooldowns cooldowns = McUtils.player().getCooldowns();
 
         int remaining = cooldown.endTime - cooldowns.tickCount;
         if (remaining <= 0) return CappedValue.EMPTY;
@@ -272,5 +284,19 @@ public final class CharacterStatsModel extends Model {
         // Profession experience segments are handled in ProfessionModel, from harvesting, as those values are far
         // more precise than the action bar segments.
         isProfessionExperience = true;
+    }
+
+    // Prior to 2.2 we would check the main hand item for the cooldown but for some reason
+    // the main hand item does not always have a cooldown anymore so we just use the first
+    // one in the cooldown map
+    private ItemCooldowns.CooldownInstance getActiveCooldown() {
+        if (InventoryUtils.getItemInHand().isEmpty()) return null;
+
+        ItemCooldowns cooldowns = McUtils.player().getCooldowns();
+        if (cooldowns.cooldowns.isEmpty()) return null;
+
+        ItemCooldowns.CooldownInstance cooldown =
+                cooldowns.cooldowns.values().iterator().next();
+        return cooldown.startTime() < cooldown.endTime() ? cooldown : null;
     }
 }

--- a/common/src/main/java/com/wynntils/models/spells/QueuedMeleeScheduler.java
+++ b/common/src/main/java/com/wynntils/models/spells/QueuedMeleeScheduler.java
@@ -29,8 +29,7 @@ public final class QueuedMeleeScheduler {
     }
 
     public static boolean isMeleeReady() {
-        CappedValue cooldown =
-                Models.CharacterStats.getItemCooldownTicks(McUtils.player().getItemInHand(InteractionHand.MAIN_HAND));
+        CappedValue cooldown = Models.CharacterStats.getItemCooldownTicks();
         return cooldown.current() <= 0;
     }
 

--- a/common/src/main/java/com/wynntils/overlays/HeldItemCooldownOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/HeldItemCooldownOverlay.java
@@ -5,19 +5,17 @@
 package com.wynntils.overlays;
 
 import com.mojang.blaze3d.platform.Window;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.overlays.Overlay;
 import com.wynntils.core.consumers.overlays.OverlayPosition;
 import com.wynntils.core.consumers.overlays.OverlaySize;
 import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
-import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.player.Player;
 
 public class HeldItemCooldownOverlay extends Overlay {
     public HeldItemCooldownOverlay() {
@@ -33,11 +31,7 @@ public class HeldItemCooldownOverlay extends Overlay {
 
     @Override
     public void render(GuiGraphics guiGraphics, DeltaTracker deltaTracker, Window window) {
-        Player player = McUtils.player();
-        float cooldownPercent = player.getCooldowns()
-                .getCooldownPercent(
-                        player.getItemInHand(InteractionHand.MAIN_HAND),
-                        deltaTracker.getGameTimeDeltaPartialTick(true));
+        float cooldownPercent = Models.CharacterStats.getItemCooldown(deltaTracker);
         if (cooldownPercent <= 0f) return;
         renderOverlay(guiGraphics, cooldownPercent);
     }


### PR DESCRIPTION
Some weapons/skins don't have the cooldown actually on them anymore, might be intentional might not but there's some phantom iron sword in the players cooldown map in the cases where the held item is missing the cooldown so just lookup the first cooldown in the map

