### PR TITLE
feat: Persist item annotation across pages

### DIFF
--- a/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/item/ItemHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2025.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.handlers.item;
@@ -9,7 +9,6 @@ import com.wynntils.core.components.Handler;
 import com.wynntils.core.mod.type.CrashType;
 import com.wynntils.core.text.StyledText;
 import com.wynntils.core.text.type.StyleType;
-import com.wynntils.handlers.item.event.ItemRenamedEvent;
 import com.wynntils.mc.event.ContainerSetContentEvent;
 import com.wynntils.mc.event.ContainerSetSlotEvent;
 import com.wynntils.mc.event.SetEntityDataEvent;
@@ -17,6 +16,7 @@ import com.wynntils.mc.event.SetSlotEvent;
 import com.wynntils.mc.extension.ItemStackExtension;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
+import com.wynntils.models.items.properties.PagedItemProperty;
 import com.wynntils.utils.mc.LoreUtils;
 import com.wynntils.utils.mc.McUtils;
 import java.util.ArrayList;
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.core.NonNullList;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.Display;
 import net.minecraft.world.entity.Entity;
@@ -43,17 +42,14 @@ import net.neoforged.bus.api.SubscribeEvent;
 public final class ItemHandler extends Handler {
     private static final List<Item> WILDCARD_ITEMS = List.of(Items.DIAMOND_SHOVEL, Items.DIAMOND_PICKAXE);
 
+    private static final Pattern TOOLTIP_PAGE_PATTERN = Pattern.compile("(§#ffea80ff)?\uE000");
+
     private final List<ItemAnnotator> annotators = new ArrayList<>();
     private final Map<Class<?>, Integer> profilingTimes = new HashMap<>();
     private final Map<Class<?>, Integer> profilingCounts = new HashMap<>();
     // Keep this as a field just of performance reasons to skip a new allocation in annotate()
     private final List<ItemAnnotator> crashedAnnotators = new ArrayList<>();
-    private final List<Pattern> knownMarkerNames = new ArrayList<>();
     private final List<Pattern> simplifiablePatterns = new ArrayList<>();
-
-    public void registerKnownMarkerNames(List<Pattern> markerPatterns) {
-        knownMarkerNames.addAll(markerPatterns);
-    }
 
     public void addSimplifiablePatterns(Pattern... patterns) {
         Collections.addAll(simplifiablePatterns, patterns);
@@ -181,7 +177,7 @@ public final class ItemHandler extends Handler {
 
         if (newName.equals(existingName)) {
             // The name is identical to the existing stack; now check the lore
-            if (isLoreSoftMatching(existingItem, newItem)) {
+            if (isLoreSoftMatching(existingItem, newItem, annotation)) {
                 // This is exactly the same item, so copy existing annotation
                 updateItem(newItem, annotation, originalName);
             } else {
@@ -190,40 +186,12 @@ public final class ItemHandler extends Handler {
                 // We need to reparse the lore since it has changed
                 annotate(newItem);
             }
-        } else if (isKnownMarkerName(newName)) {
-            // This object has gotten a known marker name, but it could also be
-            // that the lore has changed (e.g. durability/shiny stats)
-            boolean loreMatch = isLoreSoftMatching(existingItem, newItem);
-            if (!loreMatch) {
-                // We need to reparse the lore since it has changed
-                // Make sure to use the original name instead of the marker name
-                annotation = calculateAnnotation(newItem, originalName);
-            }
-            // Make sure to use the original name instead of the marker name
-            updateItem(newItem, annotation, originalName);
-
-            // Notify about the new name
-            ItemRenamedEvent event = new ItemRenamedEvent(newItem, existingName, newName);
-            WynntilsMod.postEvent(event);
-            if (event.isCanceled()) {
-                newItem.set(DataComponents.CUSTOM_NAME, existingItem.getHoverName());
-            }
         } else {
             // The name is different, and it is not a know special name. This means it could be a
             // completely new item, or it could be the same item slightly changed (e.g. durability
             // has decreased). In any case, we need to reparse the complete item.
             annotate(newItem);
         }
-    }
-
-    private boolean isKnownMarkerName(StyledText newName) {
-        String name = newName.getString();
-        for (Pattern markerPattern : knownMarkerNames) {
-            if (markerPattern.matcher(name).matches()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private boolean similarStack(ItemStack firstItem, ItemStack secondItem) {
@@ -249,9 +217,19 @@ public final class ItemHandler extends Handler {
      * This checks if the lore of the second item contains the entirety of the first item's lore, or vice versa.
      * It might have additional lines added, but these are not checked.
      */
-    private boolean isLoreSoftMatching(ItemStack firstItem, ItemStack secondItem) {
+    private boolean isLoreSoftMatching(ItemStack firstItem, ItemStack secondItem, ItemAnnotation firstItemAnnotation) {
         List<StyledText> firstLoreLines = LoreUtils.getLore(firstItem);
         List<StyledText> secondLoreLines = LoreUtils.getLore(secondItem);
+
+        if (firstItemAnnotation instanceof PagedItemProperty pagedItemProperty && secondLoreLines.size() > 2) {
+            int secondLinesLen = secondLoreLines.size();
+            int secondItemPage = parseTooltipPage(secondLoreLines.get(secondLinesLen - 2));
+
+            if (pagedItemProperty.currentPage() != secondItemPage) {
+                pagedItemProperty.updatePage(secondItemPage);
+                return true;
+            }
+        }
 
         // Tags implement equals, so we can use this to check if the lore is identical
         // This is the most common short-circuit case
@@ -342,6 +320,21 @@ public final class ItemHandler extends Handler {
         }
 
         return name;
+    }
+
+    private static int parseTooltipPage(StyledText styledText) {
+        Matcher matcher = styledText.getMatcher(TOOLTIP_PAGE_PATTERN);
+        int index = 0;
+
+        while (matcher.find()) {
+            if (matcher.group(1) != null) {
+                return index;
+            }
+
+            index++;
+        }
+
+        return 0;
     }
 
     private void annotate(ItemStack itemStack) {

--- a/common/src/main/java/com/wynntils/models/items/items/game/CharmItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CharmItem.java
@@ -32,7 +32,7 @@ public class CharmItem extends GameItem
                 PagedItemProperty {
     private final CharmInfo charmInfo;
     private final CharmInstance charmInstance;
-    private final int currentPage;
+    private int currentPage;
 
     public CharmItem(CharmInfo charmInfo, CharmInstance charmInstance, int currentPage) {
         this.charmInfo = charmInfo;
@@ -130,6 +130,11 @@ public class CharmItem extends GameItem
     @Override
     public int currentPage() {
         return currentPage;
+    }
+
+    @Override
+    public void updatePage(int newPage) {
+        this.currentPage = newPage;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
@@ -53,7 +53,7 @@ public class CraftedGearItem extends GameItem
     private final int powderSlots;
     private final boolean requirementsMet;
     private final CappedValue durability;
-    private final int currentPage;
+    private int currentPage;
 
     public CraftedGearItem(
             String name,
@@ -169,6 +169,11 @@ public class CraftedGearItem extends GameItem
     @Override
     public int currentPage() {
         return currentPage;
+    }
+
+    @Override
+    public void updatePage(int newPage) {
+        this.currentPage = newPage;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
@@ -46,7 +46,7 @@ public class GearItem extends GameItem
                 PagedItemProperty {
     private final GearInfo gearInfo;
     private final GearInstance gearInstance;
-    private final int currentPage;
+    private int currentPage;
     private final Optional<ShinyStat> parsedShinyStat;
 
     public GearItem(
@@ -189,6 +189,11 @@ public class GearItem extends GameItem
     @Override
     public int currentPage() {
         return currentPage;
+    }
+
+    @Override
+    public void updatePage(int newPage) {
+        this.currentPage = newPage;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/properties/PagedItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/PagedItemProperty.java
@@ -10,6 +10,9 @@ package com.wynntils.models.items.properties;
 public interface PagedItemProperty {
     int currentPage();
 
+    // This should only be updated from ItemHandler for now
+    void updatePage(int newPage);
+
     default boolean isStatPage() {
         return currentPage() == 0;
     }


### PR DESCRIPTION
Can see the high roll icon does not disappear after changing page


https://github.com/user-attachments/assets/eadf4e1a-7bb9-478c-adec-ffe912d5bffc

The overall % is not displayed on the other pages, that is something that should be fixed with the tooltip rework

Also removed the knownMarkerNames logic as it wasn't used anymore and needed some changes for this so opted to just drop it