### PR TITLE
feat: Reimplement circle minimap mask

### DIFF
--- a/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
+++ b/common/src/main/java/com/wynntils/overlays/minimap/MinimapOverlay.java
@@ -151,15 +151,16 @@ public class MinimapOverlay extends Overlay {
 
         if (hideWhenUnmapped.get() != UnmappedOption.NEITHER && maps.isEmpty()) return;
 
-        // FIXME: Reimplement circle mask
         // enable mask
-        switch (maskType.get()) {
-            case RECTANGULAR ->
-                RenderUtils.enableScissor(guiGraphics, (int) renderX, (int) renderY, (int) width, (int) height);
-        }
+        RenderUtils.enableScissor(guiGraphics, (int) renderX, (int) renderY, (int) width, (int) height);
 
         // Always draw a black background to cover transparent map areas
-        RenderUtils.drawRect(guiGraphics, CommonColors.BLACK, (int) renderX, (int) renderY, (int) width, (int) height);
+        if (maskType.get() == MapMaskType.RECTANGULAR) {
+            RenderUtils.drawRect(
+                    guiGraphics, CommonColors.BLACK, (int) renderX, (int) renderY, (int) width, (int) height);
+        } else {
+            MapRenderer.renderCircularBackground(guiGraphics, CommonColors.BLACK, renderX, renderY, width, height);
+        }
 
         // enable rotation if necessary
         if (followPlayerRotation.get()) {
@@ -172,15 +173,31 @@ public class MinimapOverlay extends Overlay {
         }
 
         for (MapTexture map : maps) {
-            MapRenderer.renderMapTile(
-                    guiGraphics,
-                    map,
-                    (float) playerX,
-                    (float) playerZ,
-                    centerX,
-                    centerZ,
-                    zoomRenderScale,
-                    visibleWorldBox);
+            if (maskType.get() == MapMaskType.RECTANGULAR) {
+                MapRenderer.renderMapTile(
+                        guiGraphics,
+                        map,
+                        (float) playerX,
+                        (float) playerZ,
+                        centerX,
+                        centerZ,
+                        zoomRenderScale,
+                        visibleWorldBox);
+            } else {
+                MapRenderer.renderCircularMapTile(
+                        guiGraphics,
+                        map,
+                        (float) playerX,
+                        (float) playerZ,
+                        centerX,
+                        centerZ,
+                        zoomRenderScale,
+                        visibleWorldBox,
+                        renderX,
+                        renderY,
+                        width,
+                        height);
+            }
         }
 
         // disable rotation if necessary
@@ -210,11 +227,8 @@ public class MinimapOverlay extends Overlay {
                 this.pointerType.get(),
                 followPlayerRotation.get());
 
-        // FIXME: Reimplement circle mask
         // disable mask & render border
-        switch (maskType.get()) {
-            case RECTANGULAR -> RenderUtils.disableScissor(guiGraphics);
-        }
+        RenderUtils.disableScissor(guiGraphics);
 
         // render border
         renderMapBorder(guiGraphics, renderX, renderY, width, height);
@@ -275,7 +289,17 @@ public class MinimapOverlay extends Overlay {
                 poiRenderZ = centerZ + rdZ;
             }
 
-            poi.renderAt(guiGraphics, poiRenderX, poiRenderZ, false, poiScale.get(), zoomRenderScale, zoomLevel, false);
+            renderPoi(
+                    guiGraphics,
+                    centerX,
+                    centerZ,
+                    width,
+                    height,
+                    poi,
+                    poiRenderX,
+                    poiRenderZ,
+                    zoomRenderScale,
+                    zoomLevel);
         }
 
         // Compass icon
@@ -327,12 +351,9 @@ public class MinimapOverlay extends Overlay {
 
             if (maskType.get() == MapMaskType.RECTANGULAR) {
                 toBorderScale = Math.min(scaledWidth / Math.abs(normX), scaledHeight / Math.abs(normZ)) / 2f;
+            } else if (maskType.get() == MapMaskType.CIRCLE) {
+                toBorderScale = scaledWidth / (MathUtils.magnitude(normX, normZ * scaledWidth / scaledHeight)) / 2f;
             }
-            // FIXME: Reimplement circle mask
-            //            } else if (maskType.get() == MapMaskType.CIRCLE) {
-            //                toBorderScale = scaledWidth / (MathUtils.magnitude(normX, normZ * scaledWidth /
-            // scaledHeight)) / 2f;
-            //            }
 
             float compassRenderX = poiRenderX;
             float compassRenderZ = poiRenderZ;
@@ -403,6 +424,44 @@ public class MinimapOverlay extends Overlay {
         }
     }
 
+    private void renderPoi(
+            GuiGraphics guiGraphics,
+            float centerX,
+            float centerZ,
+            float width,
+            float height,
+            Poi poi,
+            float renderX,
+            float renderZ,
+            float zoomRenderScale,
+            float zoomLevel) {
+        // Just render as normal
+        if (maskType.get() == MapMaskType.RECTANGULAR) {
+            poi.renderAt(guiGraphics, renderX, renderZ, false, poiScale.get(), zoomRenderScale, zoomLevel, false);
+            return;
+        }
+
+        float radiusX = width / 2f;
+        float radiusY = height / 2f;
+        if (radiusX <= 0f || radiusY <= 0f) return;
+
+        for (int i = 0; i < MapRenderer.CIRCLE_MASK_SEGMENTS; i++) {
+            float y1 = centerZ - radiusY + height * i / MapRenderer.CIRCLE_MASK_SEGMENTS;
+            float y2 = centerZ - radiusY + height * (i + 1) / MapRenderer.CIRCLE_MASK_SEGMENTS;
+            float normalizedY = ((y1 + y2) / 2f - centerZ) / radiusY;
+            float halfWidth = radiusX * (float) Math.sqrt(Math.max(0f, 1f - normalizedY * normalizedY));
+
+            RenderUtils.enableScissor(
+                    guiGraphics,
+                    (int) Math.floor(centerX - halfWidth),
+                    (int) Math.floor(y1),
+                    (int) Math.ceil(halfWidth * 2f),
+                    (int) Math.ceil(y2 - y1));
+            poi.renderAt(guiGraphics, renderX, renderZ, false, poiScale.get(), zoomRenderScale, zoomLevel, false);
+            RenderUtils.disableScissor(guiGraphics);
+        }
+    }
+
     private Stream<PlayerMiniMapPoi> getMiniPlayerPois(
             boolean renderRemotePartyPlayers, boolean renderRemoteFriendPlayers, boolean renderRemoteGuildPlayers) {
         return Services.Hades.getHadesUsers()
@@ -429,11 +488,9 @@ public class MinimapOverlay extends Overlay {
 
             if (maskType.get() == MapMaskType.RECTANGULAR) {
                 toBorderScaleNorth = Math.min(width / Math.abs(northDX), height / Math.abs(northDY)) / 2;
+            } else if (maskType.get() == MapMaskType.CIRCLE) {
+                toBorderScaleNorth = width / (MathUtils.magnitude(northDX, northDY * width / height)) / 2;
             }
-            // FIXME: Reimplement circle mask
-            //            } else if (maskType.get() == MapMaskType.CIRCLE) {
-            //                toBorderScaleNorth = width / (MathUtils.magnitude(northDX, northDY * width / height)) / 2;
-            //            }
 
             northDX *= toBorderScaleNorth;
             northDY *= toBorderScaleNorth;
@@ -464,11 +521,9 @@ public class MinimapOverlay extends Overlay {
 
             if (maskType.get() == MapMaskType.RECTANGULAR) {
                 toBorderScaleEast = Math.min(width / Math.abs(northDY), height / Math.abs(northDX)) / 2;
+            } else if (maskType.get() == MapMaskType.CIRCLE) {
+                toBorderScaleEast = width / (MathUtils.magnitude(eastDX, eastDY * width / height)) / 2;
             }
-            // FIXME: Reimplement circle mask
-            //            } else if (maskType.get() == MapMaskType.CIRCLE) {
-            //                toBorderScaleEast = width / (MathUtils.magnitude(eastDX, eastDY * width / height)) / 2;
-            //            }
 
             eastDX *= toBorderScaleEast;
             eastDY *= toBorderScaleEast;
@@ -500,11 +555,9 @@ public class MinimapOverlay extends Overlay {
     private void renderMapBorder(GuiGraphics guiGraphics, float renderX, float renderY, float width, float height) {
         Texture texture = borderType.get().texture();
         int grooves = borderType.get().groovesSize();
-        BorderInfo borderInfo = borderType.get().square();
-        // FIXME: Reimplement circle mask
-        //        BorderInfo borderInfo = maskType.get() == MapMaskType.CIRCLE
-        //                ? borderType.get().circle()
-        //                : borderType.get().square();
+        BorderInfo borderInfo = maskType.get() == MapMaskType.CIRCLE
+                ? borderType.get().circle()
+                : borderType.get().square();
         int tx1 = borderInfo.tx1();
         int ty1 = borderInfo.ty1();
         int tx2 = borderInfo.tx2();
@@ -551,8 +604,7 @@ public class MinimapOverlay extends Overlay {
 
     private enum MapMaskType {
         RECTANGULAR,
-        // FIXME: Reimplement circle mask
-        //        CIRCLE
+        CIRCLE
     }
 
     private enum MapBorderType {

--- a/common/src/main/java/com/wynntils/utils/render/MapRenderer.java
+++ b/common/src/main/java/com/wynntils/utils/render/MapRenderer.java
@@ -14,7 +14,9 @@ import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.render.pipelines.CustomRenderPipelines;
 import com.wynntils.utils.render.state.ColoredTrianglesRenderState;
+import com.wynntils.utils.render.state.TexturedPolygonRenderState;
 import com.wynntils.utils.render.type.PointerType;
+import com.wynntils.utils.render.type.Vertex;
 import com.wynntils.utils.type.BoundingBox;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +24,10 @@ import java.util.Set;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.render.TextureSetup;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.ChunkPos;
 import org.joml.Matrix3x2f;
 import org.joml.Vector2d;
@@ -50,6 +55,7 @@ public final class MapRenderer {
     private static final double MAX_ZOOM_LOG = Math.log(MAX_ZOOM);
 
     private static final float CHUNK_LINE_WIDTH = 1.0f;
+    public static final int CIRCLE_MASK_SEGMENTS = 64;
 
     // Zoom is calculated using exponential interpolation between MIN_ZOOM and MAX_ZOOM.
     // The result is that the zoom increases uniformly for all levels, no matter the current zoom.
@@ -116,6 +122,80 @@ public final class MapRenderer {
                 v2 - v1,
                 map.getTextureWidth(),
                 map.getTextureHeight());
+    }
+
+    public static void renderCircularBackground(
+            GuiGraphics guiGraphics, CustomColor color, float x, float y, float width, float height) {
+        Matrix3x2f pose = new Matrix3x2f(guiGraphics.pose());
+        CircleMask mask = CircleMask.fromBounds(x, y, width, height);
+        List<Vector2f> vertices = new ArrayList<>(CIRCLE_MASK_SEGMENTS * 3);
+        Vector2f center = new Vector2f(mask.centerX(), mask.centerY());
+
+        for (int i = 0; i < CIRCLE_MASK_SEGMENTS; i++) {
+            float startAngle = (float) (Math.PI * 2.0 * i / CIRCLE_MASK_SEGMENTS);
+            float endAngle = (float) (Math.PI * 2.0 * (i + 1) / CIRCLE_MASK_SEGMENTS);
+            vertices.add(center);
+            vertices.add(mask.point(startAngle));
+            vertices.add(mask.point(endAngle));
+        }
+
+        guiGraphics.guiRenderState.submitGuiElement(new ColoredTrianglesRenderState(
+                CustomRenderPipelines.POSITION_COLOR_QUAD_PIPELINE,
+                TextureSetup.noTexture(),
+                pose,
+                vertices,
+                color,
+                guiGraphics.scissorStack.peek()));
+    }
+
+    public static void renderCircularMapTile(
+            GuiGraphics guiGraphics,
+            MapTexture map,
+            float mapCenterX,
+            float mapCenterZ,
+            float centerX,
+            float centerZ,
+            float zoomRenderScale,
+            BoundingBox view,
+            float maskX,
+            float maskY,
+            float maskWidth,
+            float maskHeight) {
+        float mapMinX = map.getX1();
+        float mapMinZ = map.getZ1();
+        float mapMaxX = map.getX2() + 1f;
+        float mapMaxZ = map.getZ2() + 1f;
+
+        float clippedMinX = Math.max(view.x1(), mapMinX);
+        float clippedMinZ = Math.max(view.z1(), mapMinZ);
+        float clippedMaxX = Math.min(view.x2(), mapMaxX);
+        float clippedMaxZ = Math.min(view.z2(), mapMaxZ);
+
+        if (clippedMinX >= clippedMaxX || clippedMinZ >= clippedMaxZ) return;
+
+        float screenMinX = centerX + (clippedMinX - mapCenterX) * zoomRenderScale;
+        float screenMinY = centerZ + (clippedMinZ - mapCenterZ) * zoomRenderScale;
+        float screenMaxX = centerX + (clippedMaxX - mapCenterX) * zoomRenderScale;
+        float screenMaxY = centerZ + (clippedMaxZ - mapCenterZ) * zoomRenderScale;
+
+        float u1 = (clippedMinX - mapMinX) / map.getTextureWidth();
+        float v1 = (clippedMinZ - mapMinZ) / map.getTextureHeight();
+        float u2 = (clippedMaxX - mapMinX) / map.getTextureWidth();
+        float v2 = (clippedMaxZ - mapMinZ) / map.getTextureHeight();
+
+        renderCircleMaskedTexturedRect(
+                guiGraphics,
+                map.identifier(),
+                CommonColors.WHITE,
+                screenMinX,
+                screenMinY,
+                screenMaxX,
+                screenMaxY,
+                u1,
+                u2,
+                v1,
+                v2,
+                CircleMask.fromBounds(maskX, maskY, maskWidth, maskHeight));
     }
 
     public static void renderCursor(
@@ -465,5 +545,133 @@ public final class MapRenderer {
     public static float getRenderZ(int worldZ, float mapCenterZ, float centerZ, float currentZoom) {
         double distanceZ = worldZ - mapCenterZ;
         return (float) (centerZ + distanceZ * currentZoom);
+    }
+
+    private static void renderCircleMaskedTexturedRect(
+            GuiGraphics guiGraphics,
+            Identifier identifier,
+            CustomColor color,
+            float x1,
+            float y1,
+            float x2,
+            float y2,
+            float u1,
+            float u2,
+            float v1,
+            float v2,
+            CircleMask mask) {
+        AbstractTexture texture = McUtils.mc().getTextureManager().getTexture(identifier);
+        Matrix3x2f pose = new Matrix3x2f(guiGraphics.pose());
+        List<Vertex> vertices = clipTexturedRectToCircle(pose, x1, y1, x2, y2, u1, u2, v1, v2, mask);
+        if (vertices.isEmpty()) return;
+
+        guiGraphics.guiRenderState.submitGuiElement(new TexturedPolygonRenderState(
+                RenderPipelines.GUI_TEXTURED,
+                TextureSetup.singleTexture(texture.getTextureView(), texture.getSampler()),
+                pose,
+                vertices,
+                color,
+                guiGraphics.scissorStack.peek()));
+    }
+
+    private static List<Vertex> clipTexturedRectToCircle(
+            Matrix3x2f pose,
+            float x1,
+            float y1,
+            float x2,
+            float y2,
+            float u1,
+            float u2,
+            float v1,
+            float v2,
+            CircleMask mask) {
+        Matrix3x2f inversePose = new Matrix3x2f(pose).invert();
+        List<Vertex> vertices = new ArrayList<>(List.of(
+                new Vertex(transform(pose, x1, y1), new Vector2f(u1, v1)),
+                new Vertex(transform(pose, x1, y2), new Vector2f(u1, v2)),
+                new Vertex(transform(pose, x2, y2), new Vector2f(u2, v2)),
+                new Vertex(transform(pose, x2, y1), new Vector2f(u2, v1))));
+
+        for (int i = 0; i < CIRCLE_MASK_SEGMENTS && !vertices.isEmpty(); i++) {
+            float startAngleRadians = (float) (Math.PI * 2.0 * i / CIRCLE_MASK_SEGMENTS);
+            float endAngleRadians = (float) (Math.PI * 2.0 * (i + 1) / CIRCLE_MASK_SEGMENTS);
+
+            vertices = clipAgainstEdge(vertices, mask.point(startAngleRadians), mask.point(endAngleRadians));
+        }
+
+        List<Vertex> localVertices = new ArrayList<>(vertices.size());
+        for (Vertex vertex : vertices) {
+            localVertices.add(new Vertex(
+                    transform(
+                            inversePose,
+                            vertex.position().x(),
+                            vertex.position().y()),
+                    vertex.uv()));
+        }
+
+        return localVertices;
+    }
+
+    private static List<Vertex> clipAgainstEdge(List<Vertex> vertices, Vector2f edgeStart, Vector2f edgeEnd) {
+        List<Vertex> result = new ArrayList<>();
+        Vertex previous = vertices.getLast();
+        boolean previousInside = isInside(previous.position(), edgeStart, edgeEnd);
+
+        for (Vertex current : vertices) {
+            boolean currentInside = isInside(current.position(), edgeStart, edgeEnd);
+            if (currentInside != previousInside) {
+                result.add(intersection(previous, current, edgeStart, edgeEnd));
+            }
+
+            if (currentInside) {
+                result.add(current);
+            }
+
+            previous = current;
+            previousInside = currentInside;
+        }
+
+        return result;
+    }
+
+    private static boolean isInside(Vector2f point, Vector2f edgeStart, Vector2f edgeEnd) {
+        float edgeX = edgeEnd.x() - edgeStart.x();
+        float edgeY = edgeEnd.y() - edgeStart.y();
+        float pointX = point.x() - edgeStart.x();
+        float pointY = point.y() - edgeStart.y();
+
+        return edgeX * pointY - edgeY * pointX >= 0f;
+    }
+
+    private static Vertex intersection(Vertex start, Vertex end, Vector2f edgeStart, Vector2f edgeEnd) {
+        Vector2f line = new Vector2f(end.position()).sub(start.position());
+        Vector2f edge = new Vector2f(edgeEnd).sub(edgeStart);
+        float denominator = cross(line, edge);
+
+        if (Math.abs(denominator) < 0.00001f) {
+            return start;
+        }
+
+        float t = cross(new Vector2f(edgeStart).sub(start.position()), edge) / denominator;
+        return new Vertex(new Vector2f(start.position()).fma(t, line), new Vector2f(start.uv()).lerp(end.uv(), t));
+    }
+
+    private static float cross(Vector2f a, Vector2f b) {
+        return a.x() * b.y() - a.y() * b.x();
+    }
+
+    private static Vector2f transform(Matrix3x2f matrix, float x, float y) {
+        return matrix.transformPosition(new Vector2f(x, y));
+    }
+
+    private record CircleMask(float centerX, float centerY, float radiusX, float radiusY) {
+        private static CircleMask fromBounds(float x, float y, float width, float height) {
+            return new CircleMask(x + width / 2f, y + height / 2f, width / 2f, height / 2f);
+        }
+
+        private Vector2f point(float angle) {
+            return new Vector2f(
+                    centerX + (float) Math.cos(angle) * radiusX, centerY + (float) Math.sin(angle) * radiusY);
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/utils/render/state/TexturedPolygonRenderState.java
+++ b/common/src/main/java/com/wynntils/utils/render/state/TexturedPolygonRenderState.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.render.state;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.type.Vertex;
+import java.util.List;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.gui.render.TextureSetup;
+import net.minecraft.client.gui.render.state.GuiElementRenderState;
+import org.joml.Matrix3x2f;
+
+public record TexturedPolygonRenderState(
+        RenderPipeline pipeline,
+        TextureSetup textureSetup,
+        Matrix3x2f pose,
+        List<Vertex> vertices,
+        CustomColor color,
+        ScreenRectangle scissorArea,
+        ScreenRectangle bounds)
+        implements GuiElementRenderState {
+    public TexturedPolygonRenderState(
+            RenderPipeline pipeline,
+            TextureSetup textureSetup,
+            Matrix3x2f pose,
+            List<Vertex> vertices,
+            CustomColor color,
+            ScreenRectangle scissorArea) {
+        this(pipeline, textureSetup, pose, vertices, color, scissorArea, computeBounds(vertices, pose, scissorArea));
+    }
+
+    @Override
+    public void buildVertices(VertexConsumer consumer) {
+        if (vertices.size() < 3) return;
+
+        Vertex origin = vertices.getFirst();
+        for (int i = 1; i + 1 < vertices.size(); i++) {
+            writeVertex(consumer, origin);
+            writeVertex(consumer, vertices.get(i));
+            writeVertex(consumer, vertices.get(i + 1));
+            writeVertex(consumer, origin);
+        }
+    }
+
+    private void writeVertex(VertexConsumer consumer, Vertex vertex) {
+        consumer.addVertexWith2DPose(
+                        pose, vertex.position().x(), vertex.position().y())
+                .setUv(vertex.uv().x(), vertex.uv().y())
+                .setColor(color.r(), color.g(), color.b(), color.a());
+    }
+
+    private static ScreenRectangle computeBounds(List<Vertex> vertices, Matrix3x2f pose, ScreenRectangle scissorArea) {
+        if (vertices.isEmpty()) return scissorArea != null ? scissorArea : new ScreenRectangle(0, 0, 0, 0);
+
+        float minX = Float.MAX_VALUE;
+        float minY = Float.MAX_VALUE;
+        float maxX = -Float.MAX_VALUE;
+        float maxY = -Float.MAX_VALUE;
+
+        for (Vertex vertex : vertices) {
+            minX = Math.min(minX, vertex.position().x());
+            minY = Math.min(minY, vertex.position().y());
+            maxX = Math.max(maxX, vertex.position().x());
+            maxY = Math.max(maxY, vertex.position().y());
+        }
+
+        ScreenRectangle bounds = new ScreenRectangle(
+                        (int) minX, (int) minY, (int) Math.ceil(maxX - minX), (int) Math.ceil(maxY - minY))
+                .transformMaxBounds(pose);
+
+        return scissorArea != null ? scissorArea.intersection(bounds) : bounds;
+    }
+}

--- a/common/src/main/java/com/wynntils/utils/render/type/Vertex.java
+++ b/common/src/main/java/com/wynntils/utils/render/type/Vertex.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.utils.render.type;
+
+import org.joml.Vector2f;
+
+public record Vertex(Vector2f position, Vector2f uv) {}

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1175,7 +1175,7 @@
   "feature.wynntils.minimap.overlay.minimap.followPlayerRotation.name": "Follow Camera Rotation",
   "feature.wynntils.minimap.overlay.minimap.hideWhenUnmapped.description": "What should be hidden in unmapped areas, minimap & coordinates or just minimap?",
   "feature.wynntils.minimap.overlay.minimap.hideWhenUnmapped.name": "Hide in Unmapped Areas",
-  "feature.wynntils.minimap.overlay.minimap.maskType.description": "Should the minimap be a rectangle or a circle? (Circle is unsupported as of now)?",
+  "feature.wynntils.minimap.overlay.minimap.maskType.description": "Should the minimap be a rectangle or a circle?",
   "feature.wynntils.minimap.overlay.minimap.maskType.name": "Map Mask Type",
   "feature.wynntils.minimap.overlay.minimap.name": "Minimap",
   "feature.wynntils.minimap.overlay.minimap.poiScale.description": "How big should minimap POIs be?",


### PR DESCRIPTION
Closes https://github.com/Wynntils/Wynntils/issues/3678

Bit of a hacky approach but it works. And can confirm this works up to 26.2 so no major changes until then at least, maybe a future release will add proper support for us to do it the way we used to

<img width="1920" height="1080" alt="2026-06-23_18 51 47" src="https://github.com/user-attachments/assets/80f60350-caa6-47c7-b74c-8c852e82a1d0" />
