### PR TITLE
fix: Don't append font to StyledText string if same font

### DIFF
--- a/common/src/main/java/com/wynntils/core/text/PartStyle.java
+++ b/common/src/main/java/com/wynntils/core/text/PartStyle.java
@@ -521,7 +521,7 @@ public final class PartStyle {
         if (oldStyle.italic && !this.italic) return null;
         if (!oldStyle.italic && this.italic) add.append(ChatFormatting.ITALIC);
 
-        if (type.includeFonts() && !oldStyle.font.equals(this.font)) {
+        if (type.includeFonts() && !Objects.equals(oldStyle.font, this.font)) {
             if (oldStyle.font != null && this.font == null) return null;
             if (this.font != null) {
                 if (this.font instanceof FontDescription.Resource resource) {

--- a/common/src/main/java/com/wynntils/core/text/PartStyle.java
+++ b/common/src/main/java/com/wynntils/core/text/PartStyle.java
@@ -521,7 +521,7 @@ public final class PartStyle {
         if (oldStyle.italic && !this.italic) return null;
         if (!oldStyle.italic && this.italic) add.append(ChatFormatting.ITALIC);
 
-        if (type.includeFonts()) {
+        if (type.includeFonts() && !oldStyle.font.equals(this.font)) {
             if (oldStyle.font != null && this.font == null) return null;
             if (this.font != null) {
                 if (this.font instanceof FontDescription.Resource resource) {


### PR DESCRIPTION
Fixes https://github.com/Wynntils/Wynntils/issues/4003

Original
`§e§{fr:cp}󏿼󏿿󏿾§{fr:d} §oShadowCat§r§e: §fa ab abc abcd abcde abcdef abcdefg\n§e§{fr:cp}󏿼󐀆§{fr:d} §fabcdefgh`

Unwrapped
`§e§{fr:cp}§{fr:d} §oShadowCat§r§e: §fa ab abc abcd abcde abcdef abcdefg abcdefgh`