### PR TITLE
fix: Stop rounding Blood Pool to nearest 10

### DIFF
--- a/common/src/main/java/com/wynntils/models/abilities/bossbars/BloodPoolBar.java
+++ b/common/src/main/java/com/wynntils/models/abilities/bossbars/BloodPoolBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2024.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.abilities.bossbars;
@@ -30,14 +30,7 @@ public final class BloodPoolBar extends TrackedBar {
     @Override
     public void onUpdateProgress(float progress) {
         if (progress != 0f) {
-            // Round to nearest 10
-            int unroundedMax = (int) (current / progress);
-            int remainder = unroundedMax % 10;
-
-            int max = unroundedMax - remainder;
-            if (remainder > 5) {
-                max += 10;
-            }
+            int max = (int) (current / progress);
             updateValue(current, max);
         }
     }


### PR DESCRIPTION
I'd like to know other people's thoughts on this, but rounding to the nearest 10 is strictly wrong because of the aspect that gives a % increase to blood pool which can end up making it end with other numbers. The downside to this is that the maximum is typically off by 1-3 points while the blood pool isn't at maximum. This could be slightly addressed by saving the maximum value whenever it gets visited or alternatively calculating the value manually once ability tree & aspect parsing is reintroduced