### PR TITLE
fix: Fix log spam with unbound compare keybind

### DIFF
--- a/common/src/main/java/com/wynntils/features/tooltips/ItemCompareFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemCompareFeature.java
@@ -132,6 +132,7 @@ public class ItemCompareFeature extends Feature {
 
     @SubscribeEvent(priority = EventPriority.LOW)
     public void onItemTooltipRenderEvent(ItemTooltipRenderEvent.Pre event) {
+        if (holdToCompareKeyBind.getKeyMapping().isUnbound()) return;
         if (!KeyboardUtils.isKeyDown(holdToCompareKeyBind.getKeyMapping().key.getValue())) return;
         if (McUtils.screen() == null
                 || !(McUtils.screen() instanceof AbstractContainerScreen<?> abstractContainerScreen)) return;


### PR DESCRIPTION
Prevents this

```
[19:03:11] [Render thread/ERROR] (Minecraft) @ Render
[19:03:11] [Render thread/ERROR] (Minecraft) 65539: Invalid key -1
[19:03:11] [Render thread/ERROR] (Minecraft) ########## GL ERROR ##########
```