### PR TITLE
refactor: tooltip rework

### DIFF
--- a/common/src/main/java/com/wynntils/core/text/CommonStyles.java
+++ b/common/src/main/java/com/wynntils/core/text/CommonStyles.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.text;
+
+import com.wynntils.core.text.fonts.CommonFonts;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Style;
+
+public final class CommonStyles {
+    public static final Style LANGUAGE =
+            Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.WHITE);
+    public static final Style SPACE =
+            Style.EMPTY.withFont(CommonFonts.SPACE_FONT).withoutShadow();
+}

--- a/common/src/main/java/com/wynntils/core/text/fonts/CommonFonts.java
+++ b/common/src/main/java/com/wynntils/core/text/fonts/CommonFonts.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.text.fonts;
+
+import net.minecraft.network.chat.FontDescription;
+import net.minecraft.resources.Identifier;
+
+public final class CommonFonts {
+    public static final FontDescription LANGUAGE_FONT = font("language/wynncraft");
+    public static final FontDescription SPACE_FONT = font("space");
+    public static final FontDescription EMBLEM_FRAME_FONT = font("tooltip/emblem/frame");
+    public static final FontDescription EMBLEM_SPRITE_FONT = font("tooltip/emblem/sprite");
+    public static final FontDescription ATTRIBUTE_SPRITE_FONT = font("tooltip/attribute/sprite");
+    public static final FontDescription TOOLTIP_BANNER_FONT = font("tooltip/banner");
+    public static final FontDescription REQUIREMENT_FRAME_FONT = font("tooltip/requirement/frame");
+    public static final FontDescription REQUIREMENT_SPRITE_FONT = font("tooltip/requirement/sprite");
+    public static final FontDescription DIVIDER_FONT = font("tooltip/divider");
+    public static final FontDescription MAJOR_ID_FONT = font("tooltip/identification/major");
+    public static final FontDescription PAGE_FONT = font("tooltip/page");
+    public static final FontDescription CHAT_TILE_FONT = font("chat/tile");
+    public static final FontDescription COMMON_FONT = font("common");
+    public static final FontDescription QUAD_12 = font("offset/wynncraft_quad/12");
+
+    private static FontDescription font(String path) {
+        return new FontDescription.Resource(Identifier.withDefaultNamespace(path));
+    }
+}

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.features.tooltips;
 
+import com.wynntils.core.components.Handlers;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
 import com.wynntils.core.persisted.Persisted;
@@ -11,13 +12,18 @@ import com.wynntils.core.persisted.config.Category;
 import com.wynntils.core.persisted.config.Config;
 import com.wynntils.core.persisted.config.ConfigCategory;
 import com.wynntils.core.persisted.config.ConfigProfile;
+import com.wynntils.handlers.tooltip.type.TooltipOptions;
+import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.mc.event.ItemTooltipRenderEvent;
 import com.wynntils.models.gear.type.ItemWeightSource;
+import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.stats.type.StatListOrdering;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.TextColor;
+import net.neoforged.bus.api.SubscribeEvent;
 
 @ConfigCategory(Category.TOOLTIPS)
 public class ItemStatInfoFeature extends Feature {
@@ -94,6 +100,37 @@ public class ItemStatInfoFeature extends Feature {
 
     public NavigableMap<Float, TextColor> getColorMap() {
         return colorLerp.get() ? LERP_MAP : flatMap;
+    }
+
+    @SubscribeEvent
+    public void onTooltipPre(ItemTooltipRenderEvent.Pre event) {
+        if (event.getTooltips().isEmpty()) return;
+
+        Handlers.Item.getItemStackAnnotation(event.getItemStack()).ifPresent(annotation -> {
+            if (!(annotation instanceof IdentifiableItemProperty<?, ?> identifiableItem)) return;
+
+            event.setTooltips(
+                    Handlers.Tooltip.updateTooltip(event.getTooltips(), identifiableItem, getTooltipOptions()));
+        });
+    }
+
+    public TooltipOptions getTooltipOptions() {
+        return new TooltipOptions(
+                new TooltipStyle(
+                        identificationsOrdering.get(),
+                        groupIdentifications.get(),
+                        showBestValueLastAlways.get(),
+                        rainbowInternalRoll.get(),
+                        showRollWheel.get()),
+                perfect.get(),
+                defective.get(),
+                identificationDecorations.get(),
+                itemWeights.get(),
+                overallPercentageInName.get(),
+                overallPercentageInPerfectDefectiveName.get(),
+                getColorMap(),
+                colorLerp.get(),
+                decimalPlaces.get());
     }
 
     private NavigableMap<Float, TextColor> createFlatMap() {

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
@@ -5,8 +5,9 @@
 package com.wynntils.handlers.tooltip;
 
 import com.wynntils.core.text.StyledText;
-import com.wynntils.core.text.fonts.wynnfonts.BannerBoxFont;
+import com.wynntils.core.text.fonts.CommonFonts;
 import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
+import com.wynntils.handlers.tooltip.type.TooltipOptions;
 import com.wynntils.handlers.tooltip.type.TooltipStyle;
 import com.wynntils.handlers.tooltip.type.TooltipWeightDecorator;
 import com.wynntils.models.character.type.ClassType;
@@ -14,13 +15,14 @@ import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.ItemWeightSource;
 import com.wynntils.models.stats.type.StatListOrdering;
 import com.wynntils.models.wynnitem.parsing.WynnItemParser;
-import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.type.Pair;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.regex.Matcher;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 
 public abstract class TooltipBuilder {
     private static final TooltipStyle DEFAULT_TOOLTIP_STYLE =
@@ -41,6 +43,10 @@ public abstract class TooltipBuilder {
         return getTooltipLines(currentClass, DEFAULT_TOOLTIP_STYLE, null, ItemWeightSource.NONE, null);
     }
 
+    public List<Component> getTooltipLines(ClassType currentClass, TooltipOptions options) {
+        return getTooltipLines(currentClass, options.style(), null, options.itemWeightSource(), null);
+    }
+
     public List<Component> getTooltipLines(
             ClassType currentClass,
             TooltipStyle style,
@@ -48,28 +54,56 @@ public abstract class TooltipBuilder {
             ItemWeightSource weightSource,
             TooltipWeightDecorator weightDecorator) {
         if (tooltipLinesCache == null) {
-            List<Component> tooltip = new ArrayList<>();
-            if (!source.isEmpty()) {
-                tooltip.add(buildSourceLine());
-                tooltip.add(Component.empty());
+            List<Component> decoratedHeader = decorateHeader(header, identificationDecorator);
+            int targetWidth = 0;
+            for (Component line : decoratedHeader) {
+                targetWidth = Math.max(targetWidth, McUtils.mc().font.width(line));
+            }
+            for (Component line : footer) {
+                targetWidth = Math.max(targetWidth, McUtils.mc().font.width(line));
             }
 
-            tooltip.addAll(header);
-            tooltip.addAll(getIdentificationLines(currentClass, style, identificationDecorator, 0));
+            List<Component> tooltip = new ArrayList<>();
+            tooltip.addAll(decoratedHeader);
+            tooltip.addAll(getIdentificationLines(currentClass, style, identificationDecorator, targetWidth));
             tooltip.addAll(footer);
-            tooltipLinesCache = List.copyOf(tooltip);
+            tooltipLinesCache = prependSource(tooltip);
         }
 
         return tooltipLinesCache;
     }
 
     private Component buildSourceLine() {
-        return BannerBoxFont.buildMessage(source.toLowerCase(Locale.ROOT), CommonColors.WHITE, CommonColors.BLACK, "");
+        return Component.empty()
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).applyFormat(getSourceColor()))
+                .append(Component.literal("\uE000").withStyle(Style.EMPTY.withFont(CommonFonts.MAJOR_ID_FONT)))
+                .append(Component.literal("\uDB00\uDC02"))
+                .append(Component.literal(source)
+                        .withStyle(style ->
+                                style.withFont(CommonFonts.LANGUAGE_FONT).applyFormat(ChatFormatting.WHITE)));
+    }
+
+    protected ChatFormatting getSourceColor() {
+        return ChatFormatting.WHITE;
+    }
+
+    protected List<Component> prependSource(List<Component> lines) {
+        if (source.isEmpty()) return List.copyOf(lines);
+
+        List<Component> tooltip = new ArrayList<>(lines.size() + 1);
+        tooltip.add(buildSourceLine());
+        tooltip.addAll(lines);
+        return List.copyOf(tooltip);
     }
 
     protected List<Component> getIdentificationLines(
             ClassType currentClass, TooltipStyle style, TooltipIdentificationDecorator decorator, int targetWidth) {
         return List.of();
+    }
+
+    protected List<Component> decorateHeader(
+            List<Component> header, TooltipIdentificationDecorator identificationDecorator) {
+        return header;
     }
 
     protected static Pair<List<Component>, List<Component>> extractHeaderAndFooter(List<Component> lore) {

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
@@ -9,39 +9,49 @@ import com.wynntils.core.components.Models;
 import com.wynntils.handlers.tooltip.impl.crafted.CraftedTooltipBuilder;
 import com.wynntils.handlers.tooltip.impl.identifiable.IdentifiableTooltipBuilder;
 import com.wynntils.handlers.tooltip.type.TooltipOptions;
+import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.properties.CraftedItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
 public final class TooltipHandler extends Handler {
     public List<Component> updateTooltip(
-            List<Component> originalLines, IdentifiableItemProperty identifiableItem, TooltipOptions options) {
-        if (!(identifiableItem instanceof GearItem gearItem)) {
-            if (!identifiableItem.hasOverallValue()) return originalLines;
-
-            return IdentifiableTooltipBuilder.fromTooltipLines(originalLines, identifiableItem)
-                    .getTooltipLines(Models.Character.getClassType(), options);
+            List<Component> originalLines, IdentifiableItemProperty<?, ?> identifiableItem, TooltipOptions options) {
+        if (!(identifiableItem instanceof WynnItem wynnItem)) {
+            return calculateUpdatedTooltip(originalLines, identifiableItem, options);
         }
-        if (gearItem.getData().get(WynnItemData.TOOLTIP_KEY) != null) {
+
+        Object cachedTooltip = wynnItem.getData().get(WynnItemData.TOOLTIP_KEY);
+        if (cachedTooltip instanceof TooltipBuilder) {
             return originalLines;
         }
 
-        Map<UpdateKey, List<Component>> cache =
-                gearItem.getData().getOrCalculate(WynnItemData.UPDATED_TOOLTIP_KEY, HashMap::new);
+        UpdatedTooltipCache cache;
+        if (cachedTooltip instanceof UpdatedTooltipCache updatedTooltipCache) {
+            cache = updatedTooltipCache;
+        } else {
+            cache = new UpdatedTooltipCache();
+            wynnItem.getData().store(WynnItemData.TOOLTIP_KEY, cache);
+        }
+
         UpdateKey key = new UpdateKey(List.copyOf(originalLines), options);
-        return cache.computeIfAbsent(
-                key,
-                ignored -> gearItem.isStatPage()
-                        ? IdentifiableTooltipBuilder.buildNewItem(gearItem, "")
-                                .update(originalLines, Models.Character.getClassType(), options)
-                        : IdentifiableTooltipBuilder.fromTooltipLines(originalLines, gearItem)
-                                .getTooltipLines(Models.Character.getClassType(), options));
+        return cache.computeIfAbsent(key, ignored -> calculateUpdatedTooltip(originalLines, identifiableItem, options));
+    }
+
+    private List<Component> calculateUpdatedTooltip(
+            List<Component> originalLines, IdentifiableItemProperty<?, ?> identifiableItem, TooltipOptions options) {
+        if (identifiableItem instanceof GearItem gearItem && gearItem.isStatPage()) {
+            return IdentifiableTooltipBuilder.buildNewItem(gearItem, "")
+                    .update(originalLines, Models.Character.getClassType(), options);
+        }
+
+        return IdentifiableTooltipBuilder.fromTooltipLines(originalLines, identifiableItem)
+                .getTooltipLines(Models.Character.getClassType(), options);
     }
 
     public IdentifiableTooltipBuilder buildNew(
@@ -76,4 +86,6 @@ public final class TooltipHandler extends Handler {
     }
 
     private record UpdateKey(List<Component> originalLines, TooltipOptions options) {}
+
+    private static final class UpdatedTooltipCache extends HashMap<UpdateKey, List<Component>> {}
 }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
@@ -28,7 +28,7 @@ public final class TooltipHandler extends Handler {
             return IdentifiableTooltipBuilder.fromTooltipLines(originalLines, identifiableItem)
                     .getTooltipLines(Models.Character.getClassType(), options);
         }
-        if (!gearItem.isStatPage() || gearItem.getData().get(WynnItemData.TOOLTIP_KEY) != null) {
+        if (gearItem.getData().get(WynnItemData.TOOLTIP_KEY) != null) {
             return originalLines;
         }
 
@@ -37,8 +37,11 @@ public final class TooltipHandler extends Handler {
         UpdateKey key = new UpdateKey(List.copyOf(originalLines), options);
         return cache.computeIfAbsent(
                 key,
-                ignored -> IdentifiableTooltipBuilder.buildNewItem(gearItem, "")
-                        .update(originalLines, Models.Character.getClassType(), options));
+                ignored -> gearItem.isStatPage()
+                        ? IdentifiableTooltipBuilder.buildNewItem(gearItem, "")
+                                .update(originalLines, Models.Character.getClassType(), options)
+                        : IdentifiableTooltipBuilder.fromTooltipLines(originalLines, gearItem)
+                                .getTooltipLines(Models.Character.getClassType(), options));
     }
 
     public IdentifiableTooltipBuilder buildNew(

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipHandler.java
@@ -5,13 +5,42 @@
 package com.wynntils.handlers.tooltip;
 
 import com.wynntils.core.components.Handler;
+import com.wynntils.core.components.Models;
 import com.wynntils.handlers.tooltip.impl.crafted.CraftedTooltipBuilder;
 import com.wynntils.handlers.tooltip.impl.identifiable.IdentifiableTooltipBuilder;
+import com.wynntils.handlers.tooltip.type.TooltipOptions;
+import com.wynntils.models.items.WynnItemData;
+import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.properties.CraftedItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
 public final class TooltipHandler extends Handler {
+    public List<Component> updateTooltip(
+            List<Component> originalLines, IdentifiableItemProperty identifiableItem, TooltipOptions options) {
+        if (!(identifiableItem instanceof GearItem gearItem)) {
+            if (!identifiableItem.hasOverallValue()) return originalLines;
+
+            return IdentifiableTooltipBuilder.fromTooltipLines(originalLines, identifiableItem)
+                    .getTooltipLines(Models.Character.getClassType(), options);
+        }
+        if (!gearItem.isStatPage() || gearItem.getData().get(WynnItemData.TOOLTIP_KEY) != null) {
+            return originalLines;
+        }
+
+        Map<UpdateKey, List<Component>> cache =
+                gearItem.getData().getOrCalculate(WynnItemData.UPDATED_TOOLTIP_KEY, HashMap::new);
+        UpdateKey key = new UpdateKey(List.copyOf(originalLines), options);
+        return cache.computeIfAbsent(
+                key,
+                ignored -> IdentifiableTooltipBuilder.buildNewItem(gearItem, "")
+                        .update(originalLines, Models.Character.getClassType(), options));
+    }
+
     public IdentifiableTooltipBuilder buildNew(
             IdentifiableItemProperty identifiableItem, boolean hideUnidentified, boolean showItemType) {
         return buildNew(identifiableItem, hideUnidentified, showItemType, "");
@@ -42,4 +71,6 @@ public final class TooltipHandler extends Handler {
     public TooltipBuilder fromParsedItemStack(ItemStack itemStack, CraftedItemProperty craftedItemProperty) {
         return CraftedTooltipBuilder.fromParsedItemStack(itemStack, craftedItemProperty);
     }
+
+    private record UpdateKey(List<Component> originalLines, TooltipOptions options) {}
 }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipLayout.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipLayout.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.tooltip;
+
+import com.wynntils.core.components.Managers;
+import com.wynntils.core.text.fonts.CommonFonts;
+import com.wynntils.handlers.tooltip.type.TooltipLine;
+import com.wynntils.utils.mc.McUtils;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+
+public final class TooltipLayout {
+    private static final Style SPACING_STYLE =
+            Style.EMPTY.withFont(CommonFonts.SPACE_FONT).withoutShadow();
+    private static final Component DEFAULT_SPACING = Component.literal(" ");
+
+    private TooltipLayout() {}
+
+    public static List<Component> align(List<TooltipLine> lines) {
+        return align(lines, 0);
+    }
+
+    public static List<Component> align(List<TooltipLine> lines, int minimumWidth) {
+        int widestLine = Math.max(
+                minimumWidth,
+                lines.stream()
+                        .map(TooltipLine::unaligned)
+                        .mapToInt(line -> McUtils.mc().font.width(line))
+                        .max()
+                        .orElse(0));
+
+        while (true) {
+            LayoutResult result = alignOnce(lines, widestLine);
+            if (result.requiredWidth() <= widestLine) return List.copyOf(result.lines());
+
+            widestLine = result.requiredWidth();
+        }
+    }
+
+    private static LayoutResult alignOnce(List<TooltipLine> lines, int widestLine) {
+        List<Component> aligned = new ArrayList<>(lines.size());
+        int requiredWidth = widestLine;
+
+        for (TooltipLine line : lines) {
+            if (line instanceof TooltipLine.Fixed fixed) {
+                aligned.add(fixed.component());
+            } else if (line instanceof TooltipLine.Centered centered) {
+                aligned.add(center(centered.component(), widestLine));
+            } else if (line instanceof TooltipLine.Aligned pair) {
+                Component unaligned = pair.unaligned();
+                int currentWidth = McUtils.mc().font.width(unaligned);
+                String spacing = Managers.Font.calculateOffset(currentWidth, widestLine);
+                if (spacing.isEmpty()) {
+                    MutableComponent withDefaultSpacing = Component.empty()
+                            .append(pair.left().copy())
+                            .append(DEFAULT_SPACING.copy())
+                            .append(pair.right().copy());
+                    requiredWidth = Math.max(requiredWidth, McUtils.mc().font.width(withDefaultSpacing));
+                    aligned.add(withDefaultSpacing);
+                    continue;
+                }
+
+                aligned.add(Component.empty()
+                        .append(pair.left().copy())
+                        .append(Component.literal(spacing).withStyle(SPACING_STYLE))
+                        .append(pair.right().copy()));
+            }
+        }
+
+        return new LayoutResult(aligned, requiredWidth);
+    }
+
+    private static Component center(Component line, int widestLine) {
+        int currentWidth = McUtils.mc().font.width(line);
+        int target = currentWidth + ((widestLine - currentWidth) / 2);
+        String spacing = Managers.Font.calculateOffset(currentWidth, target);
+        return Component.empty()
+                .append(Component.literal(spacing).withStyle(SPACING_STYLE))
+                .append(line.copy());
+    }
+
+    private record LayoutResult(List<Component> lines, int requiredWidth) {}
+}

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipLayout.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipLayout.java
@@ -5,21 +5,16 @@
 package com.wynntils.handlers.tooltip;
 
 import com.wynntils.core.components.Managers;
-import com.wynntils.core.text.fonts.CommonFonts;
+import com.wynntils.core.text.CommonStyles;
 import com.wynntils.handlers.tooltip.type.TooltipLine;
 import com.wynntils.utils.mc.McUtils;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Style;
 
 public final class TooltipLayout {
-    private static final Style SPACING_STYLE =
-            Style.EMPTY.withFont(CommonFonts.SPACE_FONT).withoutShadow();
     private static final Component DEFAULT_SPACING = Component.literal(" ");
-
-    private TooltipLayout() {}
 
     public static List<Component> align(List<TooltipLine> lines) {
         return align(lines, 0);
@@ -67,7 +62,7 @@ public final class TooltipLayout {
 
                 aligned.add(Component.empty()
                         .append(pair.left().copy())
-                        .append(Component.literal(spacing).withStyle(SPACING_STYLE))
+                        .append(Component.literal(spacing).withStyle(CommonStyles.SPACE))
                         .append(pair.right().copy()));
             }
         }
@@ -80,7 +75,7 @@ public final class TooltipLayout {
         int target = currentWidth + ((widestLine - currentWidth) / 2);
         String spacing = Managers.Font.calculateOffset(currentWidth, target);
         return Component.empty()
-                .append(Component.literal(spacing).withStyle(SPACING_STYLE))
+                .append(Component.literal(spacing).withStyle(CommonStyles.SPACE))
                 .append(line.copy());
     }
 

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -6,6 +6,7 @@ package com.wynntils.handlers.tooltip.impl.identifiable;
 
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
+import com.wynntils.core.text.CommonStyles;
 import com.wynntils.core.text.fonts.CommonFonts;
 import com.wynntils.core.text.fonts.wynnfonts.BannerBoxFont;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
@@ -19,12 +20,20 @@ import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
+import com.wynntils.models.gear.type.GearRestrictions;
 import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.gear.type.GearType;
 import com.wynntils.models.gear.type.ItemWeightSource;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.properties.GearTierItemProperty;
+import com.wynntils.models.items.properties.GearTypeItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import com.wynntils.models.items.properties.LeveledItemProperty;
 import com.wynntils.models.items.properties.PagedItemProperty;
+import com.wynntils.models.items.properties.RerollableItemProperty;
+import com.wynntils.models.items.properties.ShinyItemProperty;
+import com.wynntils.models.rewards.type.CharmInfo;
+import com.wynntils.models.rewards.type.TomeInfo;
 import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.models.stats.type.ShinyStat;
 import com.wynntils.services.itemweight.type.ItemWeighting;
@@ -56,11 +65,7 @@ import net.minecraft.world.item.ItemStack;
  * @param <U> the type of the item instance
  */
 public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
-    private static final int MAJOR_ID_WRAP_WIDTH = 140;
-    private static final Style LANGUAGE_STYLE =
-            Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.WHITE);
-    private static final Style SPACE_STYLE =
-            Style.EMPTY.withFont(CommonFonts.SPACE_FONT).withoutShadow();
+    private static final int TOOLTIP_MIN_WIDTH = 140;
     private final IdentifiableItemProperty<T, U> itemInfo;
     private final boolean synthetic;
     private final Map<TooltipOptions, List<Component>> cache = new HashMap<>();
@@ -104,11 +109,8 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
     @Override
     public List<Component> getTooltipLines(ClassType currentClass, TooltipOptions options) {
-        if (synthetic && itemInfo instanceof GearItem gearItem) {
-            return cache.computeIfAbsent(
-                    options,
-                    ignored -> prependSource(assemble(
-                            gearItem, currentClass, options, buildHeader(gearItem, options), buildMajorId(gearItem))));
+        if (synthetic) {
+            return cache.computeIfAbsent(options, ignored -> buildSyntheticTooltip(currentClass, options));
         }
 
         return getTooltipLines(
@@ -117,6 +119,11 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                 new TooltipOptionDecorator(itemInfo, options),
                 ItemWeightSource.NONE,
                 null);
+    }
+
+    private List<Component> buildSyntheticTooltip(ClassType currentClass, TooltipOptions options) {
+        return prependSource(
+                assemble(itemInfo, currentClass, options, buildHeader(itemInfo, options), buildMajorId(itemInfo)));
     }
 
     @Override
@@ -169,37 +176,40 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
     }
 
     private List<Component> assemble(
-            GearItem item,
+            IdentifiableItemProperty<?, ?> item,
             ClassType currentClass,
             TooltipOptions options,
             List<TooltipLine> header,
             List<TooltipLine> majorId) {
+        GearTier tier = getGearTier(item);
         Sections sections = new Sections(
                 header,
                 buildWeights(item, options),
                 buildRequirements(item),
-                buildShiny(item),
-                buildReroll(item),
+                buildShiny(item, tier),
+                buildReroll(item, tier),
                 TooltipIdentifications.buildLines(
                         item, currentClass, new TooltipOptionDecorator(item, options), options.style()),
                 majorId,
-                buildPaginator(item.currentPage()));
+                buildPaginator(item));
 
-        return TooltipLayout.align(sections.lines(item.getItemInfo().tier()));
+        return TooltipLayout.align(sections.lines(tier), TOOLTIP_MIN_WIDTH);
     }
 
-    private List<TooltipLine> buildHeader(GearItem item, TooltipOptions options) {
-        GearInfo info = item.getItemInfo();
+    private List<TooltipLine> buildHeader(IdentifiableItemProperty<?, ?> item, TooltipOptions options) {
         List<TooltipLine> header = new ArrayList<>();
         header.add(new TooltipLine.Fixed(Component.empty()));
         header.add(new TooltipLine.Fixed(buildNameLine(item, options)));
-        header.add(new TooltipLine.Fixed(buildTypeLine(info)));
+        header.add(new TooltipLine.Fixed(buildTypeLine(item)));
 
-        Component tags = buildTagsLine(info);
-        if (!tags.getString().isBlank()) header.add(new TooltipLine.Fixed(tags));
+        if (item instanceof GearItem gearItem) {
+            GearInfo info = gearItem.getItemInfo();
+            Component tags = buildTagsLine(info);
+            if (!tags.getString().isBlank()) header.add(new TooltipLine.Fixed(tags));
 
-        header.add(new TooltipLine.Fixed(Component.empty()));
-        buildOverview(info).stream().map(TooltipLine.Fixed::new).forEach(header::add);
+            header.add(new TooltipLine.Fixed(Component.empty()));
+            buildOverview(info).stream().map(TooltipLine.Fixed::new).forEach(header::add);
+        }
         return header;
     }
 
@@ -212,7 +222,9 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
             if (i == 1) {
                 Component updatedTitle = line.copy();
                 if (!TooltipUtils.replaceTrailingTitleComponent(
-                        (MutableComponent) updatedTitle, item.getName(), buildDecoratedName(item, options))) {
+                        (MutableComponent) updatedTitle,
+                        item.getName(),
+                        buildDecoratedName(item, item.getGearTier(), options))) {
                     updatedTitle = buildNameLine(item, options);
                 }
                 line = updatedTitle;
@@ -237,26 +249,27 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
         return tail;
     }
 
-    private List<TooltipLine> buildWeights(GearItem item, TooltipOptions options) {
+    private List<TooltipLine> buildWeights(IdentifiableItemProperty<?, ?> identifiableItem, TooltipOptions options) {
+        if (!(identifiableItem instanceof GearItem item)) return List.of();
         if (item.getItemInstance().isEmpty() || options.itemWeightSource() == ItemWeightSource.NONE) {
             return List.of();
         }
 
         List<TooltipLine> lines = new ArrayList<>();
-        appendWeightSource(lines, item, options, ItemWeightSource.NORI, 0x67ccf5);
-        appendWeightSource(lines, item, options, ItemWeightSource.WYNNPOOL, 0xffc457);
+        appendWeightSource(lines, item, options, ItemWeightSource.NORI);
+        appendWeightSource(lines, item, options, ItemWeightSource.WYNNPOOL);
         return lines;
     }
 
     private void appendWeightSource(
-            List<TooltipLine> lines, GearItem item, TooltipOptions options, ItemWeightSource source, int color) {
+            List<TooltipLine> lines, GearItem item, TooltipOptions options, ItemWeightSource source) {
         if (options.itemWeightSource() != ItemWeightSource.ALL && options.itemWeightSource() != source) return;
 
         List<ItemWeighting> weightings = Services.ItemWeight.getItemWeighting(item.getName(), source);
         if (weightings.isEmpty()) return;
 
-        lines.add(new TooltipLine.Fixed(BannerBoxFont.buildMessage(
-                source.name().toLowerCase(), CustomColor.fromInt(color), CommonColors.BLACK, "")));
+        lines.add(new TooltipLine.Fixed(
+                BannerBoxFont.buildMessage(source.name().toLowerCase(), source.getColor(), CommonColors.BLACK, "")));
         for (ItemWeighting weighting : weightings) {
             float percentage = Services.ItemWeight.calculateWeighting(weighting, item);
             Component percentageComponent = ColorScaleUtils.getPercentageTextComponent(
@@ -264,12 +277,22 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                     .withStyle(style -> style.withFont(CommonFonts.LANGUAGE_FONT));
 
             lines.add(new TooltipLine.Aligned(
-                    Component.literal(weighting.weightName() + " Scale").withStyle(LANGUAGE_STYLE),
+                    Component.literal(weighting.weightName() + " Scale").withStyle(CommonStyles.LANGUAGE),
                     percentageComponent));
         }
     }
 
-    private List<TooltipLine> buildRequirements(GearItem item) {
+    private List<TooltipLine> buildRequirements(IdentifiableItemProperty<?, ?> item) {
+        if (item instanceof GearItem gearItem) return buildGearRequirements(gearItem);
+        if (!(item instanceof LeveledItemProperty leveledItem) || leveledItem.getLevel() <= 0) return List.of();
+
+        return List.of(requirementLine(
+                " Combat Level",
+                String.valueOf(leveledItem.getLevel()),
+                Models.CharacterStats.getLevel() >= leveledItem.getLevel()));
+    }
+
+    private List<TooltipLine> buildGearRequirements(GearItem item) {
         GearInfo info = item.getItemInfo();
         List<TooltipLine> requirements = new ArrayList<>();
 
@@ -301,7 +324,7 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
     private TooltipLine requirementLine(String label, String value, boolean fulfilled) {
         MutableComponent left =
-                requirementIcon(fulfilled).append(Component.literal(label).withStyle(LANGUAGE_STYLE));
+                requirementIcon(fulfilled).append(Component.literal(label).withStyle(CommonStyles.LANGUAGE));
         Component right = Component.literal(value)
                 .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.GRAY));
         return new TooltipLine.Aligned(left, right);
@@ -318,7 +341,7 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                     .append(Component.literal("\uDAFF\uDFE7"))
                     .append(Component.literal(sprite)
                             .withStyle(Style.EMPTY.withFont(CommonFonts.REQUIREMENT_SPRITE_FONT)))));
-            line.append(Component.literal("\uDB00\uDC02").withStyle(SPACE_STYLE));
+            line.append(Component.literal("\uDB00\uDC02").withStyle(CommonStyles.SPACE));
         }
         return line;
     }
@@ -333,18 +356,21 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
             String icon = count == 0 ? "\uE005" : fulfilled ? "\uE006" : "\uE007";
             line.append(withWhiteShadow(Component.literal(icon + "\uDAFF\uDFFF")
                     .withStyle(Style.EMPTY.withFont(CommonFonts.REQUIREMENT_SPRITE_FONT))));
-            line.append(Component.literal("\uDB00\uDC03").withStyle(SPACE_STYLE));
+            line.append(Component.literal("\uDB00\uDC03").withStyle(CommonStyles.SPACE));
             line.append(Component.literal(String.valueOf(count))
                     .withStyle(Style.EMPTY
                             .withFont(CommonFonts.LANGUAGE_FONT)
                             .withColor(count == 0 ? 0x555555 : fulfilled ? 0xacfac6 : 0xfaacac)));
-            line.append(Component.literal("\uDB00\uDC04").withStyle(SPACE_STYLE));
+            line.append(Component.literal("\uDB00\uDC04").withStyle(CommonStyles.SPACE));
         }
         return line;
     }
 
-    private List<TooltipLine> buildShiny(GearItem item) {
-        return item.getShinyStat()
+    private List<TooltipLine> buildShiny(IdentifiableItemProperty<?, ?> item, GearTier tier) {
+        if (!(item instanceof ShinyItemProperty shinyItem)) return List.of();
+
+        return shinyItem
+                .getShinyStat()
                 .<List<TooltipLine>>map(shiny -> List.of(new TooltipLine.Aligned(
                         Component.empty()
                                 .append(withWhiteShadow(Component.literal("\uE04F")
@@ -352,20 +378,22 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                                 .append(Component.literal(" " + shiny.statType().displayName())
                                         .withStyle(Style.EMPTY
                                                 .withFont(CommonFonts.LANGUAGE_FONT)
-                                                .withColor(dividerColor(item.getGearTier())))),
-                        buildShinyValue(shiny, item.getGearTier()))))
+                                                .withColor(dividerColor(tier)))),
+                        buildShinyValue(shiny, tier))))
                 .orElseGet(List::of);
     }
 
-    private List<TooltipLine> buildReroll(GearItem item) {
-        int rerolls = item.getRerollCount();
+    private List<TooltipLine> buildReroll(IdentifiableItemProperty<?, ?> item, GearTier tier) {
+        if (!(item instanceof RerollableItemProperty rerollableItem)) return List.of();
+
+        int rerolls = rerollableItem.getRerollCount();
         if (rerolls <= 0) return List.of();
 
-        int color = dividerColor(item.getGearTier());
+        int color = dividerColor(tier);
         MutableComponent line = Component.empty()
                 .append(BannerBoxFont.buildMessage(
                         String.valueOf(rerolls), CustomColor.fromInt(color), CommonColors.BLACK, "\uDB00\uDC02"))
-                .append(Component.literal("\uDAFF\uDFFF").withStyle(SPACE_STYLE))
+                .append(Component.literal("\uDAFF\uDFFF").withStyle(CommonStyles.SPACE))
                 .append(Component.literal("\uE005")
                         .withStyle(Style.EMPTY
                                 .withFont(CommonFonts.TOOLTIP_BANNER_FONT)
@@ -378,7 +406,7 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
     private Component buildShinyValue(ShinyStat shiny, GearTier tier) {
         MutableComponent value =
-                Component.literal(String.valueOf(shiny.value())).withStyle(LANGUAGE_STYLE);
+                Component.literal(String.valueOf(shiny.value())).withStyle(CommonStyles.LANGUAGE);
         if (shiny.shinyRerolls() > 0) {
             value.append(" ")
                     .append(BannerBoxFont.buildMessage(
@@ -390,7 +418,9 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
         return value;
     }
 
-    private List<TooltipLine> buildMajorId(GearItem item) {
+    private List<TooltipLine> buildMajorId(IdentifiableItemProperty<?, ?> identifiableItem) {
+        if (!(identifiableItem instanceof GearItem item)) return List.of();
+
         return item.getItemInfo()
                 .fixedStats()
                 .majorIds()
@@ -408,7 +438,7 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                             .append(major.lore()
                                     .map(part -> part.withStyle(style -> style.withFont(CommonFonts.LANGUAGE_FONT)))
                                     .getComponent());
-                    ComponentUtils.splitComponent(text, MAJOR_ID_WRAP_WIDTH).stream()
+                    ComponentUtils.splitComponent(text, TOOLTIP_MIN_WIDTH).stream()
                             .map(TooltipLine.Fixed::new)
                             .forEach(lines::add);
                     return lines;
@@ -416,61 +446,80 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                 .orElseGet(List::of);
     }
 
-    private List<TooltipLine> buildPaginator(int currentPage) {
+    private List<TooltipLine> buildPaginator(IdentifiableItemProperty<?, ?> item) {
+        if (!(item instanceof GearItem gearItem)) return List.of();
+
+        int currentPage = gearItem.currentPage();
         MutableComponent paginator = Component.literal("\uF002")
                 .withStyle(Style.EMPTY.withFont(CommonFonts.CHAT_TILE_FONT))
-                .append(Component.literal("\uDAFF\uDF98\uDB00\uDC3F").withStyle(LANGUAGE_STYLE));
+                .append(Component.literal("\uDAFF\uDF98\uDB00\uDC3F").withStyle(CommonStyles.LANGUAGE));
         for (int page = 0; page < 3; page++) {
             paginator.append(Component.literal("\uE000")
                     .withStyle(Style.EMPTY
                             .withFont(CommonFonts.PAGE_FONT)
                             .withColor(page == currentPage ? 0xffea80 : 0x455449)
                             .withShadowColor(0xffffff)));
-            if (page < 2) paginator.append(Component.literal("\uDB00\uDC04").withStyle(LANGUAGE_STYLE));
+            if (page < 2) paginator.append(Component.literal("\uDB00\uDC04").withStyle(CommonStyles.LANGUAGE));
         }
         return List.of(new TooltipLine.Centered(paginator), new TooltipLine.Fixed(Component.empty()));
     }
 
-    private Component buildNameLine(GearItem item, TooltipOptions options) {
-        GearInfo info = item.getItemInfo();
+    private Component buildNameLine(IdentifiableItemProperty<?, ?> item, TooltipOptions options) {
+        GearType type = getGearType(item);
+        String emblemFrame = item instanceof GearItem gearItem
+                ? gearItem.getItemInfo().getEmblemFrameCode()
+                : rewardEmblemFrame(type);
+        String emblemSprite = item instanceof GearItem gearItem
+                ? gearItem.getItemInfo().getEmblemSpriteCode()
+                : rewardEmblemSprite(type);
+        return buildNameLine(emblemFrame, emblemSprite, buildDecoratedName(item, getGearTier(item), options));
+    }
+
+    private Component buildNameLine(String emblemFrame, String emblemSprite, Component title) {
         MutableComponent line = Component.literal("\uDAFF\uDFF0")
                 .withStyle(style -> style.withFont(CommonFonts.LANGUAGE_FONT).withShadowColor(0xffffff));
-        line.append(Component.literal(info.getEmblemFrameCode())
-                .withStyle(Style.EMPTY.withFont(CommonFonts.EMBLEM_FRAME_FONT)));
+        line.append(Component.literal(emblemFrame).withStyle(Style.EMPTY.withFont(CommonFonts.EMBLEM_FRAME_FONT)));
         line.append("\uDAFF\uDFCF");
-        line.append(Component.literal(info.getEmblemSpriteCode())
+        line.append(Component.literal(emblemSprite)
                 .withStyle(Style.EMPTY.withFont(CommonFonts.EMBLEM_SPRITE_FONT).withColor(0x00eb1c)));
-        line.append(Component.literal("\uDB00\uDC05").withStyle(SPACE_STYLE));
-        line.append(buildDecoratedName(item, options));
+        line.append(Component.literal("\uDB00\uDC05").withStyle(CommonStyles.SPACE));
+        line.append(title);
         return line;
     }
 
-    private MutableComponent buildDecoratedName(GearItem item, TooltipOptions options) {
-        String name = item.getShinyStat().isPresent() ? "Shiny " + item.getName() : item.getName();
+    private MutableComponent buildDecoratedName(
+            IdentifiableItemProperty<?, ?> item, GearTier tier, TooltipOptions options) {
+        boolean shiny = item instanceof ShinyItemProperty shinyItem
+                && shinyItem.getShinyStat().isPresent();
+        String name = shiny ? "Shiny " + item.getName() : item.getName();
         Component title = Component.literal(name)
-                .withStyle(Style.EMPTY
-                        .withFont(CommonFonts.LANGUAGE_FONT)
-                        .withColor(item.getGearTier().getChatFormatting()));
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(tier.getChatFormatting()));
         return new TooltipOptionDecorator(item, options).getTitle(title);
     }
 
-    private Component buildTypeLine(GearInfo info) {
+    private Component buildTypeLine(IdentifiableItemProperty<?, ?> item) {
+        GearType type = getGearType(item);
+        String typeName = type.isReward() ? rewardTypeName(type) : type.name();
+        return buildTypeLine(getGearTier(item), typeName, getRestrictions(item));
+    }
+
+    private Component buildTypeLine(GearTier tier, String typeName, GearRestrictions restrictions) {
         Pair<String, String> restrictionIcon =
-                switch (info.metaInfo().restrictions()) {
+                switch (restrictions) {
                     case UNTRADABLE -> Pair.of("\uE002", "\uF002");
                     case QUEST_ITEM -> Pair.of("\uE003", "\uF003");
                     default -> null;
                 };
-        MutableComponent line = Component.literal("\uDB00\uDC26").withStyle(SPACE_STYLE);
+        MutableComponent line = Component.literal("\uDB00\uDC26").withStyle(CommonStyles.SPACE);
         line.append(BannerBoxFont.buildMessage(
-                info.tier().getName(),
-                CustomColor.fromChatFormatting(info.tier().getChatFormatting()),
+                tier.getName(),
+                CustomColor.fromChatFormatting(tier.getChatFormatting()),
                 CommonColors.BLACK,
                 "\uDB00\uDC02"));
-        line.append(Component.literal("\uDB00\uDC01").withStyle(SPACE_STYLE));
+        line.append(Component.literal("\uDB00\uDC01").withStyle(CommonStyles.SPACE));
         line.append(BannerBoxFont.buildMessage(
-                info.type().name(),
-                CustomColor.fromInt(dividerColor(info.tier())),
+                typeName,
+                CustomColor.fromInt(dividerColor(tier)),
                 CommonColors.BLACK,
                 restrictionIcon != null ? "\uDB00\uDC02" : ""));
         if (restrictionIcon != null) {
@@ -483,6 +532,53 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                     .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_BANNER_FONT))));
         }
         return line;
+    }
+
+    private GearRestrictions getRestrictions(IdentifiableItemProperty<?, ?> item) {
+        return switch (item.getItemInfo()) {
+            case GearInfo info -> info.metaInfo().restrictions();
+            case CharmInfo info -> info.metaInfo().restrictions();
+            case TomeInfo info -> info.metaInfo().restrictions();
+            default -> GearRestrictions.NONE;
+        };
+    }
+
+    private GearTier getGearTier(IdentifiableItemProperty<?, ?> item) {
+        if (item instanceof GearTierItemProperty tierItem) return tierItem.getGearTier();
+
+        throw new IllegalArgumentException(
+                "Identifiable item has no gear tier: " + item.getClass().getName());
+    }
+
+    private GearType getGearType(IdentifiableItemProperty<?, ?> item) {
+        if (item instanceof GearTypeItemProperty typeItem) return typeItem.getGearType();
+
+        throw new IllegalArgumentException(
+                "Identifiable item has no gear type: " + item.getClass().getName());
+    }
+
+    private String rewardTypeName(GearType type) {
+        return switch (type) {
+            case CHARM -> "Charm";
+            case MASTERY_TOME -> "Tome";
+            default -> type.name();
+        };
+    }
+
+    private String rewardEmblemFrame(GearType type) {
+        return switch (type) {
+            case CHARM -> "\uE035";
+            case MASTERY_TOME -> "\uE041";
+            default -> type.getFrameCode();
+        };
+    }
+
+    private String rewardEmblemSprite(GearType type) {
+        return switch (type) {
+            case CHARM -> "\uE031";
+            case MASTERY_TOME -> "\uE028";
+            default -> type.getFrameSpriteCode();
+        };
     }
 
     private Component buildTagsLine(GearInfo info) {
@@ -559,12 +655,12 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
             overview.add(
                     Component.literal(String.format("%,d", info.fixedStats().averageDps()))
                             .withStyle(Style.EMPTY.withFont(CommonFonts.QUAD_12).withColor(dividerColor(info.tier())))
-                            .append(Component.literal(" DPS").withStyle(LANGUAGE_STYLE)));
+                            .append(Component.literal(" DPS").withStyle(CommonStyles.LANGUAGE)));
         } else if (info.type().isArmor() || info.type().isAccessory()) {
             overview.add(Component.literal(
                             StringUtils.toSignedCommaString(info.fixedStats().healthBuff()))
                     .withStyle(Style.EMPTY.withFont(CommonFonts.QUAD_12).withColor(dividerColor(info.tier())))
-                    .append(Component.literal(" Health").withStyle(LANGUAGE_STYLE)));
+                    .append(Component.literal(" Health").withStyle(CommonStyles.LANGUAGE)));
         }
 
         info.fixedStats()

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -4,35 +4,696 @@
  */
 package com.wynntils.handlers.tooltip.impl.identifiable;
 
+import com.wynntils.core.components.Models;
+import com.wynntils.core.components.Services;
+import com.wynntils.core.text.fonts.CommonFonts;
+import com.wynntils.core.text.fonts.wynnfonts.BannerBoxFont;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
+import com.wynntils.handlers.tooltip.TooltipLayout;
+import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
+import com.wynntils.handlers.tooltip.type.TooltipLine;
+import com.wynntils.handlers.tooltip.type.TooltipOptions;
+import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.models.character.type.ClassType;
+import com.wynntils.models.elements.type.Element;
+import com.wynntils.models.elements.type.Skill;
+import com.wynntils.models.gear.type.GearInfo;
+import com.wynntils.models.gear.type.GearInstance;
+import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.gear.type.ItemWeightSource;
+import com.wynntils.models.items.items.game.GearItem;
+import com.wynntils.models.items.properties.GearTierItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import com.wynntils.models.items.properties.PagedItemProperty;
+import com.wynntils.models.stats.type.DamageType;
+import com.wynntils.models.stats.type.ShinyStat;
+import com.wynntils.services.itemweight.type.ItemWeighting;
+import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.LoreUtils;
+import com.wynntils.utils.mc.TooltipUtils;
 import com.wynntils.utils.type.Pair;
+import com.wynntils.utils.type.RangedValue;
+import com.wynntils.utils.wynn.ColorScaleUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FontDescription;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.world.item.ItemStack;
 
+/**
+ * A builder for identifiable item tooltips.
+ * @param <T> the type of the item info
+ * @param <U> the type of the item instance
+ */
 public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
-    private IdentifiableTooltipBuilder(List<Component> header, List<Component> footer, String source) {
+    private static final int MAJOR_ID_WRAP_WIDTH = 140;
+    private static final Style LANGUAGE_STYLE =
+            Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.WHITE);
+    private static final Style SPACE_STYLE =
+            Style.EMPTY.withFont(CommonFonts.SPACE_FONT).withoutShadow();
+    private final IdentifiableItemProperty<T, U> itemInfo;
+    private final boolean synthetic;
+    private final Map<TooltipOptions, List<Component>> cache = new HashMap<>();
+
+    private IdentifiableTooltipBuilder(
+            IdentifiableItemProperty<T, U> itemInfo,
+            List<Component> header,
+            List<Component> footer,
+            String source,
+            boolean synthetic) {
         super(header, footer, source);
+        this.itemInfo = itemInfo;
+        this.synthetic = synthetic;
     }
 
     public static <T, U> IdentifiableTooltipBuilder<T, U> buildNewItem(
             IdentifiableItemProperty<T, U> identifiableItem, String source) {
-        return new IdentifiableTooltipBuilder<>(List.of(), List.of(), source);
+        return new IdentifiableTooltipBuilder<>(identifiableItem, List.of(), List.of(), source, true);
     }
 
     public static <T, U> IdentifiableTooltipBuilder<T, U> buildFromItemStack(
             ItemStack itemStack, IdentifiableItemProperty<T, U> identifiableItem, String source) {
-        List<Component> tooltips = LoreUtils.getTooltipLines(itemStack);
-        Pair<List<Component>, List<Component>> splitLore = extractHeaderAndFooter(tooltips);
-        return new IdentifiableTooltipBuilder<>(splitLore.a(), splitLore.b(), source);
+        return fromTooltipLines(LoreUtils.getTooltipLines(itemStack), identifiableItem, source);
+    }
+
+    public static <T, U> IdentifiableTooltipBuilder<T, U> fromTooltipLines(
+            List<Component> tooltipLines, IdentifiableItemProperty<T, U> identifiableItem) {
+        return fromTooltipLines(tooltipLines, identifiableItem, "");
+    }
+
+    private static <T, U> IdentifiableTooltipBuilder<T, U> fromTooltipLines(
+            List<Component> tooltipLines, IdentifiableItemProperty<T, U> identifiableItem, String source) {
+        Pair<List<Component>, List<Component>> splitLore = extractHeaderAndFooter(tooltipLines);
+        return new IdentifiableTooltipBuilder<>(identifiableItem, splitLore.a(), splitLore.b(), source, false);
     }
 
     public static IdentifiableTooltipBuilder fromParsedItemStack(
             ItemStack itemStack, IdentifiableItemProperty itemInfo) {
-        List<Component> tooltips = LoreUtils.getTooltipLines(itemStack);
-        Pair<List<Component>, List<Component>> splitLore = extractHeaderAndFooter(tooltips);
-        return new IdentifiableTooltipBuilder(splitLore.a(), splitLore.b(), "");
+        return fromTooltipLines(LoreUtils.getTooltipLines(itemStack), itemInfo);
+    }
+
+    @Override
+    public List<Component> getTooltipLines(ClassType currentClass, TooltipOptions options) {
+        if (synthetic && itemInfo instanceof GearItem gearItem) {
+            return cache.computeIfAbsent(
+                    options,
+                    ignored -> prependSource(assemble(
+                            gearItem, currentClass, options, buildHeader(gearItem, options), buildMajorId(gearItem))));
+        }
+
+        return getTooltipLines(
+                currentClass,
+                options.style(),
+                new TooltipOptionDecorator(itemInfo, options),
+                ItemWeightSource.NONE,
+                null);
+    }
+
+    @Override
+    protected ChatFormatting getSourceColor() {
+        return itemInfo instanceof GearTierItemProperty tierItem
+                ? tierItem.getGearTier().getChatFormatting()
+                : ChatFormatting.WHITE;
+    }
+
+    public List<Component> update(List<Component> originalLines, ClassType currentClass, TooltipOptions options) {
+        if (!(itemInfo instanceof GearItem gearItem)) return originalLines;
+
+        List<TooltipLine> header = extractHeader(originalLines, gearItem, options);
+        List<TooltipLine> majorId = extractMajorId(originalLines);
+        return assemble(gearItem, currentClass, options, header, majorId);
+    }
+
+    @Override
+    protected List<Component> decorateHeader(
+            List<Component> header, TooltipIdentificationDecorator identificationDecorator) {
+        if (identificationDecorator == null) return header;
+
+        List<Component> decoratedHeader = new ArrayList<>(header);
+
+        for (int i = 0; i < decoratedHeader.size(); i++) {
+            MutableComponent line = decoratedHeader.get(i).copy();
+            List<Component> siblings = line.getSiblings();
+            for (int j = siblings.size() - 1; j >= 0; j--) {
+                Component sibling = siblings.get(j);
+                String text = sibling.getString().trim();
+                if (!text.equals(itemInfo.getName()) && !text.endsWith(itemInfo.getName())) continue;
+
+                siblings.set(j, identificationDecorator.getTitle(sibling));
+                decoratedHeader.set(i, line);
+                return List.copyOf(decoratedHeader);
+            }
+        }
+
+        return List.copyOf(decoratedHeader);
+    }
+
+    @Override
+    protected List<Component> getIdentificationLines(
+            ClassType currentClass, TooltipStyle style, TooltipIdentificationDecorator decorator, int targetWidth) {
+        if (itemInfo instanceof PagedItemProperty pagedItem && !pagedItem.isStatPage()) {
+            return List.of();
+        }
+
+        return TooltipIdentifications.buildTooltip(itemInfo, currentClass, decorator, style, targetWidth);
+    }
+
+    private List<Component> assemble(
+            GearItem item,
+            ClassType currentClass,
+            TooltipOptions options,
+            List<TooltipLine> header,
+            List<TooltipLine> majorId) {
+        Sections sections = new Sections(
+                header,
+                buildWeights(item, options),
+                buildRequirements(item),
+                buildShiny(item),
+                buildReroll(item),
+                TooltipIdentifications.buildLines(
+                        item, currentClass, new TooltipOptionDecorator(item, options), options.style()),
+                majorId,
+                buildPaginator(item.currentPage()));
+
+        return TooltipLayout.align(sections.lines(item.getItemInfo().tier()));
+    }
+
+    private List<TooltipLine> buildHeader(GearItem item, TooltipOptions options) {
+        GearInfo info = item.getItemInfo();
+        List<TooltipLine> header = new ArrayList<>();
+        header.add(new TooltipLine.Fixed(Component.empty()));
+        header.add(new TooltipLine.Fixed(buildNameLine(item, options)));
+        header.add(new TooltipLine.Fixed(buildTypeLine(info)));
+
+        Component tags = buildTagsLine(info);
+        if (!tags.getString().isBlank()) header.add(new TooltipLine.Fixed(tags));
+
+        header.add(new TooltipLine.Fixed(Component.empty()));
+        buildOverview(info).stream().map(TooltipLine.Fixed::new).forEach(header::add);
+        return header;
+    }
+
+    private List<TooltipLine> extractHeader(List<Component> original, GearItem item, TooltipOptions options) {
+        int firstDivider = findFirstLineWithFont(original, CommonFonts.DIVIDER_FONT);
+        int end = firstDivider < 0 ? original.size() : firstDivider;
+        List<TooltipLine> header = new ArrayList<>(end);
+        for (int i = 0; i < end; i++) {
+            Component line = original.get(i);
+            if (i == 1) {
+                Component updatedTitle = line.copy();
+                if (!TooltipUtils.replaceTrailingTitleComponent(
+                        (MutableComponent) updatedTitle, item.getName(), buildDecoratedName(item, options))) {
+                    updatedTitle = buildNameLine(item, options);
+                }
+                line = updatedTitle;
+            }
+            header.add(new TooltipLine.Fixed(line));
+        }
+        return header;
+    }
+
+    private List<TooltipLine> extractMajorId(List<Component> original) {
+        int majorId = findFirstLineWithFont(original, CommonFonts.MAJOR_ID_FONT);
+        int paginator = findFirstLineWithFont(original, CommonFonts.PAGE_FONT);
+        if (majorId < 0) return List.of();
+
+        int start = majorId;
+        while (start > 0 && original.get(start - 1).getString().isBlank()) start--;
+        List<TooltipLine> tail = new ArrayList<>();
+        int end = paginator >= 0 ? paginator : original.size();
+        for (int i = start; i < end; i++) {
+            tail.add(new TooltipLine.Fixed(original.get(i)));
+        }
+        return tail;
+    }
+
+    private List<TooltipLine> buildWeights(GearItem item, TooltipOptions options) {
+        if (item.getItemInstance().isEmpty() || options.itemWeightSource() == ItemWeightSource.NONE) {
+            return List.of();
+        }
+
+        List<TooltipLine> lines = new ArrayList<>();
+        appendWeightSource(lines, item, options, ItemWeightSource.NORI, 0x67ccf5);
+        appendWeightSource(lines, item, options, ItemWeightSource.WYNNPOOL, 0xffc457);
+        return lines;
+    }
+
+    private void appendWeightSource(
+            List<TooltipLine> lines, GearItem item, TooltipOptions options, ItemWeightSource source, int color) {
+        if (options.itemWeightSource() != ItemWeightSource.ALL && options.itemWeightSource() != source) return;
+
+        List<ItemWeighting> weightings = Services.ItemWeight.getItemWeighting(item.getName(), source);
+        if (weightings.isEmpty()) return;
+
+        lines.add(new TooltipLine.Fixed(BannerBoxFont.buildMessage(
+                source.name().toLowerCase(), CustomColor.fromInt(color), CommonColors.BLACK, "")));
+        for (ItemWeighting weighting : weightings) {
+            float percentage = Services.ItemWeight.calculateWeighting(weighting, item);
+            Component percentageComponent = ColorScaleUtils.getPercentageTextComponent(
+                            options.colorMap(), percentage, options.colorLerp(), options.decimalPlaces())
+                    .withStyle(style -> style.withFont(CommonFonts.LANGUAGE_FONT));
+
+            lines.add(new TooltipLine.Aligned(
+                    Component.literal(weighting.weightName() + " Scale").withStyle(LANGUAGE_STYLE),
+                    percentageComponent));
+        }
+    }
+
+    private List<TooltipLine> buildRequirements(GearItem item) {
+        GearInfo info = item.getItemInfo();
+        List<TooltipLine> requirements = new ArrayList<>();
+
+        if (!info.requirements().skills().isEmpty()) {
+            requirements.add(new TooltipLine.Fixed(Component.empty()));
+            requirements.add(new TooltipLine.Centered(buildSkillIcons(info)));
+            requirements.add(new TooltipLine.Fixed(Component.empty()));
+            requirements.add(new TooltipLine.Centered(
+                    buildSkillValues(info, item.getItemInstance().orElse(null))));
+            requirements.add(new TooltipLine.Fixed(Component.empty()));
+        }
+
+        info.requirements()
+                .quest()
+                .ifPresent(quest -> requirements.add(
+                        requirementLine(" Quest", StringUtils.shorten(quest, 10), item.meetsActualRequirements())));
+        info.requirements()
+                .classType()
+                .ifPresent(classType -> requirements.add(requirementLine(
+                        " Class Type", classType.getFullName(), Models.Character.getClassType() == classType)));
+        if (info.requirements().level() > 0) {
+            requirements.add(requirementLine(
+                    " Combat Level",
+                    String.valueOf(info.requirements().level()),
+                    Models.CharacterStats.getLevel() >= info.requirements().level()));
+        }
+        return requirements;
+    }
+
+    private TooltipLine requirementLine(String label, String value, boolean fulfilled) {
+        MutableComponent left =
+                requirementIcon(fulfilled).append(Component.literal(label).withStyle(LANGUAGE_STYLE));
+        Component right = Component.literal(value)
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.GRAY));
+        return new TooltipLine.Aligned(left, right);
+    }
+
+    private Component buildSkillIcons(GearInfo info) {
+        MutableComponent line = Component.empty();
+        for (Skill skill : Skill.values()) {
+            int count = skillRequirement(info, skill);
+            String frame = count == 0 ? "\uE007" : skillFrame(info.tier());
+            String sprite = String.valueOf((char) ((count == 0 ? '\uE010' : '\uE000') + skill.ordinal()));
+            line.append(withWhiteShadow(Component.literal(frame)
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.REQUIREMENT_FRAME_FONT))
+                    .append(Component.literal("\uDAFF\uDFE7"))
+                    .append(Component.literal(sprite)
+                            .withStyle(Style.EMPTY.withFont(CommonFonts.REQUIREMENT_SPRITE_FONT)))));
+            line.append(Component.literal("\uDB00\uDC02").withStyle(SPACE_STYLE));
+        }
+        return line;
+    }
+
+    private Component buildSkillValues(GearInfo info, GearInstance instance) {
+        MutableComponent line = Component.empty();
+        for (Skill skill : Skill.values()) {
+            int count = skillRequirement(info, skill);
+            boolean fulfilled = count == 0
+                    || instance != null && instance.meetsRequirements()
+                    || Models.SkillPoint.getTotalSkillPoints(skill) >= count;
+            String icon = count == 0 ? "\uE005" : fulfilled ? "\uE006" : "\uE007";
+            line.append(withWhiteShadow(Component.literal(icon + "\uDAFF\uDFFF")
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.REQUIREMENT_SPRITE_FONT))));
+            line.append(Component.literal("\uDB00\uDC03").withStyle(SPACE_STYLE));
+            line.append(Component.literal(String.valueOf(count))
+                    .withStyle(Style.EMPTY
+                            .withFont(CommonFonts.LANGUAGE_FONT)
+                            .withColor(count == 0 ? 0x555555 : fulfilled ? 0xacfac6 : 0xfaacac)));
+            line.append(Component.literal("\uDB00\uDC04").withStyle(SPACE_STYLE));
+        }
+        return line;
+    }
+
+    private List<TooltipLine> buildShiny(GearItem item) {
+        return item.getShinyStat()
+                .<List<TooltipLine>>map(shiny -> List.of(new TooltipLine.Aligned(
+                        Component.empty()
+                                .append(withWhiteShadow(Component.literal("\uE04F")
+                                        .withStyle(Style.EMPTY.withFont(CommonFonts.COMMON_FONT))))
+                                .append(Component.literal(" " + shiny.statType().displayName())
+                                        .withStyle(Style.EMPTY
+                                                .withFont(CommonFonts.LANGUAGE_FONT)
+                                                .withColor(dividerColor(item.getGearTier())))),
+                        buildShinyValue(shiny, item.getGearTier()))))
+                .orElseGet(List::of);
+    }
+
+    private List<TooltipLine> buildReroll(GearItem item) {
+        int rerolls = item.getRerollCount();
+        if (rerolls <= 0) return List.of();
+
+        int color = dividerColor(item.getGearTier());
+        MutableComponent line = Component.empty()
+                .append(BannerBoxFont.buildMessage(
+                        String.valueOf(rerolls), CustomColor.fromInt(color), CommonColors.BLACK, "\uDB00\uDC02"))
+                .append(Component.literal("\uDAFF\uDFFF").withStyle(SPACE_STYLE))
+                .append(Component.literal("\uE005")
+                        .withStyle(Style.EMPTY
+                                .withFont(CommonFonts.TOOLTIP_BANNER_FONT)
+                                .withColor(color)
+                                .withShadowColor(0xffffff)))
+                .append(withWhiteShadow(Component.literal("\uDAFF\uDFF6\uF005")
+                        .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_BANNER_FONT))));
+        return List.of(new TooltipLine.Aligned(Component.empty(), line));
+    }
+
+    private Component buildShinyValue(ShinyStat shiny, GearTier tier) {
+        MutableComponent value =
+                Component.literal(String.valueOf(shiny.value())).withStyle(LANGUAGE_STYLE);
+        if (shiny.shinyRerolls() > 0) {
+            value.append(" ")
+                    .append(BannerBoxFont.buildMessage(
+                            String.valueOf(shiny.shinyRerolls()),
+                            CustomColor.fromInt(dividerColor(tier)),
+                            CommonColors.BLACK,
+                            "\uDB00\uDC02"));
+        }
+        return value;
+    }
+
+    private List<TooltipLine> buildMajorId(GearItem item) {
+        return item.getItemInfo()
+                .fixedStats()
+                .majorIds()
+                .<List<TooltipLine>>map(major -> {
+                    List<TooltipLine> lines = new ArrayList<>();
+                    lines.add(new TooltipLine.Fixed(Component.empty()));
+                    MutableComponent text = Component.empty()
+                            .withStyle(Style.EMPTY
+                                    .withFont(CommonFonts.LANGUAGE_FONT)
+                                    .withColor(dividerColor(item.getGearTier())))
+                            .append(Component.literal("\uE000")
+                                    .withStyle(Style.EMPTY.withFont(CommonFonts.MAJOR_ID_FONT)))
+                            .append(Component.literal("\uDB00\uDC02"))
+                            .append(Component.literal(major.name() + ": "))
+                            .append(major.lore()
+                                    .map(part -> part.withStyle(style -> style.withFont(CommonFonts.LANGUAGE_FONT)))
+                                    .getComponent());
+                    ComponentUtils.splitComponent(text, MAJOR_ID_WRAP_WIDTH).stream()
+                            .map(TooltipLine.Fixed::new)
+                            .forEach(lines::add);
+                    return lines;
+                })
+                .orElseGet(List::of);
+    }
+
+    private List<TooltipLine> buildPaginator(int currentPage) {
+        MutableComponent paginator = Component.literal("\uF002")
+                .withStyle(Style.EMPTY.withFont(CommonFonts.CHAT_TILE_FONT))
+                .append(Component.literal("\uDAFF\uDF98\uDB00\uDC3F").withStyle(LANGUAGE_STYLE));
+        for (int page = 0; page < 3; page++) {
+            paginator.append(Component.literal("\uE000")
+                    .withStyle(Style.EMPTY
+                            .withFont(CommonFonts.PAGE_FONT)
+                            .withColor(page == currentPage ? 0xffea80 : 0x455449)
+                            .withShadowColor(0xffffff)));
+            if (page < 2) paginator.append(Component.literal("\uDB00\uDC04").withStyle(LANGUAGE_STYLE));
+        }
+        return List.of(new TooltipLine.Centered(paginator), new TooltipLine.Fixed(Component.empty()));
+    }
+
+    private Component buildNameLine(GearItem item, TooltipOptions options) {
+        GearInfo info = item.getItemInfo();
+        MutableComponent line = Component.literal("\uDAFF\uDFF0")
+                .withStyle(style -> style.withFont(CommonFonts.LANGUAGE_FONT).withShadowColor(0xffffff));
+        line.append(Component.literal(info.getEmblemFrameCode())
+                .withStyle(Style.EMPTY.withFont(CommonFonts.EMBLEM_FRAME_FONT)));
+        line.append("\uDAFF\uDFCF");
+        line.append(Component.literal(info.getEmblemSpriteCode())
+                .withStyle(Style.EMPTY.withFont(CommonFonts.EMBLEM_SPRITE_FONT).withColor(0x00eb1c)));
+        line.append(Component.literal("\uDB00\uDC05").withStyle(SPACE_STYLE));
+        line.append(buildDecoratedName(item, options));
+        return line;
+    }
+
+    private MutableComponent buildDecoratedName(GearItem item, TooltipOptions options) {
+        String name = item.getShinyStat().isPresent() ? "Shiny " + item.getName() : item.getName();
+        Component title = Component.literal(name)
+                .withStyle(Style.EMPTY
+                        .withFont(CommonFonts.LANGUAGE_FONT)
+                        .withColor(item.getGearTier().getChatFormatting()));
+        return new TooltipOptionDecorator(item, options).getTitle(title);
+    }
+
+    private Component buildTypeLine(GearInfo info) {
+        Pair<String, String> restrictionIcon =
+                switch (info.metaInfo().restrictions()) {
+                    case UNTRADABLE -> Pair.of("\uE002", "\uF002");
+                    case QUEST_ITEM -> Pair.of("\uE003", "\uF003");
+                    default -> null;
+                };
+        MutableComponent line = Component.literal("\uDB00\uDC26").withStyle(SPACE_STYLE);
+        line.append(BannerBoxFont.buildMessage(
+                info.tier().getName(),
+                CustomColor.fromChatFormatting(info.tier().getChatFormatting()),
+                CommonColors.BLACK,
+                "\uDB00\uDC02"));
+        line.append(Component.literal("\uDB00\uDC01").withStyle(SPACE_STYLE));
+        line.append(BannerBoxFont.buildMessage(
+                info.type().name(),
+                CustomColor.fromInt(dividerColor(info.tier())),
+                CommonColors.BLACK,
+                restrictionIcon != null ? "\uDB00\uDC02" : ""));
+        if (restrictionIcon != null) {
+            line.append(Component.literal(restrictionIcon.a())
+                    .withStyle(Style.EMPTY
+                            .withFont(CommonFonts.TOOLTIP_BANNER_FONT)
+                            .withColor(0xff4242)
+                            .withShadowColor(0xffffff)));
+            line.append(withWhiteShadow(Component.literal("\uDAFF\uDFF6" + restrictionIcon.b())
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_BANNER_FONT))));
+        }
+        return line;
+    }
+
+    private Component buildTagsLine(GearInfo info) {
+        Set<Element> elements = new LinkedHashSet<>();
+        info.fixedStats().damages().forEach(damage -> damage.a().getElement().ifPresent(elements::add));
+        info.fixedStats().defences().forEach(defence -> elements.add(defence.a()));
+        List<Element> sortedElements = elements.stream()
+                .sorted((left, right) -> Integer.compare(left.getEncodingId(), right.getEncodingId()))
+                .toList();
+        CustomColor tierColor = CustomColor.fromInt(dividerColor(info.tier()));
+        MutableComponent line = Component.empty()
+                .withStyle(Style.EMPTY
+                        .withFont(CommonFonts.LANGUAGE_FONT)
+                        .withColor(tierColor.asInt())
+                        .withShadowColor(0xffffff));
+        boolean hasSet = info.setInfo().isPresent();
+
+        info.setInfo()
+                .ifPresent(set -> line.append(Component.literal("\uDB00\uDC26"))
+                        .append(BannerBoxFont.buildMessage(set.name() + " set", tierColor, CommonColors.BLACK, "")));
+        if (sortedElements.isEmpty()) return line;
+
+        if (hasSet) {
+            line.append(" ");
+        } else {
+            line.append("\uDB00\uDC26");
+        }
+        appendElementStrip(line, sortedElements);
+
+        if (!hasSet && sortedElements.size() == 1) {
+            line.append("\uDAFF\uDFFF");
+            line.append(BannerBoxFont.buildMessage(
+                    sortedElements.getFirst().getDisplayName(), tierColor, CommonColors.BLACK, ""));
+        }
+        return line;
+    }
+
+    private void appendElementStrip(MutableComponent line, List<Element> elements) {
+        for (int i = 0; i < elements.size(); i++) {
+            Element element = elements.get(i);
+            line.append(Component.literal(elementBannerGlyph(element))
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_BANNER_FONT)));
+            line.append(Component.literal("\uDAFF\uDFF6" + elementBannerOverlayGlyph(element))
+                    .withStyle(Style.EMPTY
+                            .withFont(CommonFonts.TOOLTIP_BANNER_FONT)
+                            .withColor(ChatFormatting.WHITE)));
+            if (i < elements.size() - 1) line.append("\uDAFF\uDFFF");
+        }
+    }
+
+    private String elementBannerGlyph(Element element) {
+        return switch (element) {
+            case EARTH -> "\uE006";
+            case THUNDER -> "\uE007";
+            case WATER -> "\uE008";
+            case FIRE -> "\uE009";
+            case AIR -> "\uE00A";
+        };
+    }
+
+    private String elementBannerOverlayGlyph(Element element) {
+        return switch (element) {
+            case EARTH -> "\uF006";
+            case THUNDER -> "\uF007";
+            case WATER -> "\uF008";
+            case FIRE -> "\uF009";
+            case AIR -> "\uF00A";
+        };
+    }
+
+    private List<Component> buildOverview(GearInfo info) {
+        List<Component> overview = new ArrayList<>();
+        if (info.type().isWeapon()) {
+            overview.add(
+                    Component.literal(String.format("%,d", info.fixedStats().averageDps()))
+                            .withStyle(Style.EMPTY.withFont(CommonFonts.QUAD_12).withColor(dividerColor(info.tier())))
+                            .append(Component.literal(" DPS").withStyle(LANGUAGE_STYLE)));
+        } else if (info.type().isArmor() || info.type().isAccessory()) {
+            overview.add(Component.literal(
+                            StringUtils.toSignedCommaString(info.fixedStats().healthBuff()))
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.QUAD_12).withColor(dividerColor(info.tier())))
+                    .append(Component.literal(" Health").withStyle(LANGUAGE_STYLE)));
+        }
+
+        info.fixedStats()
+                .attackSpeed()
+                .ifPresent(speed -> overview.add(withWhiteShadow(Component.literal("\uE007")
+                                .withStyle(Style.EMPTY.withFont(CommonFonts.ATTRIBUTE_SPRITE_FONT)))
+                        .append(Component.literal(" " + speed.getName() + " ")
+                                .withStyle(Style.EMPTY
+                                        .withFont(CommonFonts.LANGUAGE_FONT)
+                                        .withColor(ChatFormatting.GRAY)))
+                        .append(Component.literal("(" + speed.getHitsPerSecond() + " hits/s)")
+                                .withStyle(Style.EMPTY
+                                        .withFont(CommonFonts.LANGUAGE_FONT)
+                                        .withColor(ChatFormatting.DARK_GRAY)))));
+
+        if (!info.fixedStats().damages().isEmpty())
+            overview.add(buildDamageLine(info.fixedStats().damages()));
+        if (!info.fixedStats().defences().isEmpty())
+            overview.add(buildDefenceLine(info.fixedStats().defences()));
+        return overview;
+    }
+
+    private Component buildDamageLine(List<Pair<DamageType, RangedValue>> damages) {
+        MutableComponent line = Component.empty();
+        for (Pair<DamageType, RangedValue> damage : damages) {
+            line.append(withWhiteShadow(Component.literal(damage.a().getTooltipSprite())
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.ATTRIBUTE_SPRITE_FONT))));
+            line.append(Component.literal(
+                            " " + damage.b().low() + "-" + damage.b().high() + " ")
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.GRAY)));
+        }
+        return line;
+    }
+
+    private Component buildDefenceLine(List<Pair<Element, Integer>> defences) {
+        MutableComponent line = Component.empty();
+        for (Pair<Element, Integer> defence : defences) {
+            line.append(withWhiteShadow(Component.literal(defence.a().getTooltipSprite())
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.ATTRIBUTE_SPRITE_FONT))));
+            line.append(Component.literal(" " + StringUtils.toSignedCommaString(defence.b()) + " ")
+                    .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.GRAY)));
+        }
+        return line;
+    }
+
+    private MutableComponent requirementIcon(boolean fulfilled) {
+        return withWhiteShadow(Component.literal((fulfilled ? "\uE006" : "\uE007") + "\uDAFF\uDFFF")
+                .withStyle(Style.EMPTY.withFont(CommonFonts.REQUIREMENT_SPRITE_FONT)));
+    }
+
+    private static MutableComponent withWhiteShadow(Component component) {
+        return Component.empty()
+                .withStyle(style -> style.withShadowColor(0xffffff))
+                .append(component.copy());
+    }
+
+    private int skillRequirement(GearInfo info, Skill skill) {
+        return info.requirements().skills().stream()
+                .filter(requirement -> requirement.a() == skill)
+                .map(Pair::b)
+                .findFirst()
+                .orElse(0);
+    }
+
+    private String skillFrame(GearTier tier) {
+        GearTier[] tiers = GearTier.validValues();
+        for (int i = 0; i < tiers.length; i++) {
+            if (tiers[i] == tier) return String.valueOf((char) ('\uE000' + i));
+        }
+        return "\uE007";
+    }
+
+    private static Component divider(GearTier tier) {
+        return withWhiteShadow(Component.literal("\uE000")
+                .withStyle(Style.EMPTY.withFont(CommonFonts.DIVIDER_FONT).withColor(dividerColor(tier))));
+    }
+
+    private static int dividerColor(GearTier tier) {
+        return switch (tier) {
+            case NORMAL -> 0xe0e0e0;
+            case UNIQUE -> 0xfff2b3;
+            case RARE -> 0xf2c2f2;
+            case LEGENDARY -> 0xc2f2f2;
+            case FABLED -> 0xf2c2c2;
+            case MYTHIC -> 0xe0b3e6;
+            default -> 0xffffff;
+        };
+    }
+
+    private int findFirstLineWithFont(List<Component> lines, FontDescription font) {
+        for (int i = 0; i < lines.size(); i++) {
+            if (TooltipUtils.containsFont(lines.get(i), font)) return i;
+        }
+        return -1;
+    }
+
+    private record Sections(
+            List<TooltipLine> header,
+            List<TooltipLine> weights,
+            List<TooltipLine> requirements,
+            List<TooltipLine> shiny,
+            List<TooltipLine> reroll,
+            List<TooltipLine> stats,
+            List<TooltipLine> majorId,
+            List<TooltipLine> paginator) {
+        private List<TooltipLine> lines(GearTier tier) {
+            List<TooltipLine> lines = new ArrayList<>();
+            lines.addAll(header);
+            if (!weights.isEmpty()) {
+                lines.add(new TooltipLine.Centered(divider(tier)));
+                lines.addAll(weights);
+            }
+            lines.add(new TooltipLine.Centered(divider(tier)));
+            lines.addAll(requirements);
+            if (!shiny.isEmpty()) {
+                lines.add(new TooltipLine.Centered(divider(tier)));
+                lines.addAll(shiny);
+            }
+            if (!reroll.isEmpty()) {
+                lines.add(new TooltipLine.Centered(divider(tier)));
+                lines.addAll(reroll);
+            }
+            if (reroll.isEmpty()) {
+                lines.add(new TooltipLine.Centered(divider(tier)));
+            }
+            lines.addAll(stats);
+            lines.addAll(majorId);
+            lines.addAll(paginator);
+            return lines;
+        }
     }
 }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -466,12 +466,11 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
     private Component buildNameLine(IdentifiableItemProperty<?, ?> item, TooltipOptions options) {
         GearType type = getGearType(item);
-        String emblemFrame = item instanceof GearItem gearItem
-                ? gearItem.getItemInfo().getEmblemFrameCode()
-                : rewardEmblemFrame(type);
+        String emblemFrame =
+                item instanceof GearItem gearItem ? gearItem.getItemInfo().getEmblemFrameCode() : type.getFrameCode();
         String emblemSprite = item instanceof GearItem gearItem
                 ? gearItem.getItemInfo().getEmblemSpriteCode()
-                : rewardEmblemSprite(type);
+                : type.getFrameSpriteCode();
         return buildNameLine(emblemFrame, emblemSprite, buildDecoratedName(item, getGearTier(item), options));
     }
 
@@ -499,7 +498,7 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
     private Component buildTypeLine(IdentifiableItemProperty<?, ?> item) {
         GearType type = getGearType(item);
-        String typeName = type.isReward() ? rewardTypeName(type) : type.name();
+        String typeName = type.isReward() ? StringUtils.capitalizeFirst(type.getModelKey()) : type.name();
         return buildTypeLine(getGearTier(item), typeName, getRestrictions(item));
     }
 
@@ -555,30 +554,6 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
         throw new IllegalArgumentException(
                 "Identifiable item has no gear type: " + item.getClass().getName());
-    }
-
-    private String rewardTypeName(GearType type) {
-        return switch (type) {
-            case CHARM -> "Charm";
-            case MASTERY_TOME -> "Tome";
-            default -> type.name();
-        };
-    }
-
-    private String rewardEmblemFrame(GearType type) {
-        return switch (type) {
-            case CHARM -> "\uE035";
-            case MASTERY_TOME -> "\uE041";
-            default -> type.getFrameCode();
-        };
-    }
-
-    private String rewardEmblemSprite(GearType type) {
-        return switch (type) {
-            case CHARM -> "\uE031";
-            case MASTERY_TOME -> "\uE028";
-            default -> type.getFrameSpriteCode();
-        };
     }
 
     private Component buildTagsLine(GearInfo info) {

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/TooltipIdentifications.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/TooltipIdentifications.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © Wynntils 2023-2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.tooltip.impl.identifiable;
+
+import com.wynntils.core.WynntilsMod;
+import com.wynntils.core.components.Models;
+import com.wynntils.core.text.fonts.CommonFonts;
+import com.wynntils.handlers.tooltip.TooltipLayout;
+import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
+import com.wynntils.handlers.tooltip.type.TooltipLine;
+import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.models.character.type.ClassType;
+import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import com.wynntils.models.stats.StatCalculator;
+import com.wynntils.models.stats.type.SkillStatType;
+import com.wynntils.models.stats.type.StatActualValue;
+import com.wynntils.models.stats.type.StatListDelimiter;
+import com.wynntils.models.stats.type.StatPossibleValues;
+import com.wynntils.models.stats.type.StatType;
+import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.type.Pair;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+
+public final class TooltipIdentifications {
+    private TooltipIdentifications() {}
+
+    public static List<Component> buildTooltip(
+            IdentifiableItemProperty<?, ?> itemInfo,
+            ClassType currentClass,
+            TooltipIdentificationDecorator decorator,
+            TooltipStyle style,
+            int targetWidth) {
+        return TooltipLayout.align(buildLines(itemInfo, currentClass, decorator, style), targetWidth);
+    }
+
+    public static List<TooltipLine> buildLines(
+            IdentifiableItemProperty<?, ?> itemInfo,
+            ClassType currentClass,
+            TooltipIdentificationDecorator decorator,
+            TooltipStyle style) {
+        List<TooltipLine> lines = new ArrayList<>();
+        List<StatType> ordering = Models.Stat.getOrderingList(style.ordering());
+        List<StatType> allStats = new ArrayList<>(itemInfo.getVariableStats());
+
+        itemInfo.getIdentifications().stream()
+                .map(StatActualValue::statType)
+                .filter(stat -> !allStats.contains(stat))
+                .forEach(allStats::add);
+
+        boolean delimiterNeeded = false;
+        for (StatType statType : ordering) {
+            if (style.groupIdentifications() && statType instanceof StatListDelimiter) {
+                if (delimiterNeeded) {
+                    lines.add(new TooltipLine.Fixed(Component.empty()));
+                    delimiterNeeded = false;
+                }
+            }
+            if (!allStats.contains(statType)) continue;
+
+            Pair<MutableComponent, MutableComponent> line =
+                    getStatLineParts(statType, itemInfo, currentClass, decorator, style);
+            if (line == null) continue;
+
+            lines.add(new TooltipLine.Aligned(line.a(), line.b()));
+            delimiterNeeded = true;
+        }
+
+        if (!lines.isEmpty() && lines.getLast().unaligned().getString().isEmpty()) {
+            lines.removeLast();
+        }
+        return lines;
+    }
+
+    private static Pair<MutableComponent, MutableComponent> getStatLineParts(
+            StatType statType,
+            IdentifiableItemProperty<?, ?> itemInfo,
+            ClassType currentClass,
+            TooltipIdentificationDecorator decorator,
+            TooltipStyle style) {
+        if (itemInfo.getIdentifications().isEmpty()) {
+            StatPossibleValues possibleValues = findPossibleValues(itemInfo, statType);
+            if (possibleValues == null) {
+                WynntilsMod.warn("Missing possible values in item " + itemInfo.getName() + " for stat: " + statType);
+                return null;
+            }
+            return buildUnidentifiedLineParts(itemInfo, style, possibleValues);
+        }
+
+        StatActualValue actualValue = itemInfo.getIdentifications().stream()
+                .filter(stat -> stat.statType() == statType)
+                .findFirst()
+                .orElse(null);
+        if (actualValue == null) {
+            WynntilsMod.warn("Missing value in item " + itemInfo.getName() + " for stat: " + statType);
+            return null;
+        }
+
+        MutableComponent suffix = null;
+        StatPossibleValues possibleValues = findPossibleValues(itemInfo, statType);
+        if (possibleValues == null) {
+            WynntilsMod.warn("Missing stat type in item " + itemInfo.getName() + " for stat: " + statType
+                    + " which has value: " + actualValue.value());
+        } else if (!possibleValues.range().isFixed() && decorator != null) {
+            suffix = decorator.getSuffix(actualValue, possibleValues, style);
+        }
+        return buildIdentifiedLineParts(itemInfo, actualValue, currentClass, suffix);
+    }
+
+    private static StatPossibleValues findPossibleValues(IdentifiableItemProperty<?, ?> itemInfo, StatType statType) {
+        return itemInfo.getPossibleValues().stream()
+                .filter(stat -> stat.statType() == statType)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static Pair<MutableComponent, MutableComponent> buildIdentifiedLineParts(
+            IdentifiableItemProperty<?, ?> itemInfo,
+            StatActualValue actualValue,
+            ClassType currentClass,
+            MutableComponent suffix) {
+        StatType statType = actualValue.statType();
+        int value = statType.calculateAsInverted() ? -actualValue.value() : actualValue.value();
+        boolean positive = value > 0 ^ statType.displayAsInverted();
+        String displayName = Models.Stat.getDisplayName(
+                statType, itemInfo.getRequiredClass(), currentClass, itemInfo.getIdentificationLevelRange());
+
+        MutableComponent left = Component.empty();
+        appendIconPrefix(left, statType, actualValue.hasIconPrefix());
+        left.append(Component.literal(displayName + " ")
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.WHITE)));
+
+        MutableComponent right = Component.literal(
+                        StringUtils.toSignedString(value) + statType.getUnit().getDisplayName())
+                .withStyle(Style.EMPTY
+                        .withFont(CommonFonts.LANGUAGE_FONT)
+                        .withColor(positive ? ChatFormatting.GREEN : ChatFormatting.RED));
+        if (suffix != null) right.append(suffix);
+        return Pair.of(left, right);
+    }
+
+    private static Pair<MutableComponent, MutableComponent> buildUnidentifiedLineParts(
+            IdentifiableItemProperty<?, ?> itemInfo, TooltipStyle style, StatPossibleValues possibleValues) {
+        StatType statType = possibleValues.statType();
+        Pair<Integer, Integer> range = StatCalculator.getDisplayRange(possibleValues, style.showBestValueLastAlways());
+        boolean positive = range.a() > 0 ^ statType.displayAsInverted();
+        ChatFormatting color = positive ? ChatFormatting.GREEN : ChatFormatting.RED;
+        ChatFormatting darkColor = positive ? ChatFormatting.DARK_GREEN : ChatFormatting.DARK_RED;
+        String displayName = Models.Stat.getDisplayName(
+                statType,
+                itemInfo.getRequiredClass(),
+                Models.Character.getClassType(),
+                itemInfo.getIdentificationLevelRange());
+
+        MutableComponent left = Component.literal(displayName + " ")
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(ChatFormatting.WHITE));
+        MutableComponent right = Component.literal(StringUtils.toSignedString(range.a()))
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(color));
+        right.append(Component.literal(" to ")
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(darkColor)));
+        right.append(Component.literal(range.b() + statType.getUnit().getDisplayName())
+                .withStyle(Style.EMPTY.withFont(CommonFonts.LANGUAGE_FONT).withColor(color)));
+        return Pair.of(left, right);
+    }
+
+    private static void appendIconPrefix(MutableComponent line, StatType statType, boolean showIconPrefix) {
+        if (!showIconPrefix || !(statType instanceof SkillStatType skillStatType)) return;
+
+        String icon =
+                switch (skillStatType.getSkill()) {
+                    case STRENGTH -> "\uDAFF\uDFFF\uE010\uDB00\uDC02 ";
+                    case DEXTERITY -> "\uE011\uDB00\uDC02 ";
+                    case INTELLIGENCE -> "\uDAFF\uDFFF\uE012\uDB00\uDC02 ";
+                    case DEFENCE -> "\uDAFF\uDFFF\uE013\uDB00\uDC01\uDB00\uDC02 ";
+                    case AGILITY -> "\uE014\uDB00\uDC02 ";
+                };
+        line.append(Component.literal(icon)
+                .withStyle(Style.EMPTY
+                        .withFont(CommonFonts.ATTRIBUTE_SPRITE_FONT)
+                        .withColor(ChatFormatting.WHITE)
+                        .withShadowColor(0xFFFFFF)));
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/TooltipIdentifications.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/TooltipIdentifications.java
@@ -29,8 +29,6 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 
 public final class TooltipIdentifications {
-    private TooltipIdentifications() {}
-
     public static List<Component> buildTooltip(
             IdentifiableItemProperty<?, ?> itemInfo,
             ClassType currentClass,

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/TooltipOptionDecorator.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/TooltipOptionDecorator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.tooltip.impl.identifiable;
+
+import com.wynntils.core.text.fonts.CommonFonts;
+import com.wynntils.handlers.tooltip.type.TooltipIdentificationDecorator;
+import com.wynntils.handlers.tooltip.type.TooltipOptions;
+import com.wynntils.handlers.tooltip.type.TooltipStyle;
+import com.wynntils.models.items.properties.IdentifiableItemProperty;
+import com.wynntils.models.stats.StatCalculator;
+import com.wynntils.models.stats.type.StatActualValue;
+import com.wynntils.models.stats.type.StatPossibleValues;
+import com.wynntils.utils.colors.WynncraftShaderColor;
+import com.wynntils.utils.mc.ComponentUtils;
+import com.wynntils.utils.wynn.ColorScaleUtils;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+
+public final class TooltipOptionDecorator implements TooltipIdentificationDecorator {
+    private final IdentifiableItemProperty<?, ?> item;
+    private final TooltipOptions options;
+
+    public TooltipOptionDecorator(IdentifiableItemProperty<?, ?> item, TooltipOptions options) {
+        this.item = item;
+        this.options = options;
+    }
+
+    @Override
+    public MutableComponent getTitle(Component title) {
+        boolean perfect = options.perfectTitle() && item.isPerfect();
+        boolean defective = options.defectiveTitle() && item.isDefective();
+        MutableComponent decorated;
+        if (perfect) {
+            decorated = ComponentUtils.makeRainbowStyle("Perfect " + title.getString(), true);
+        } else if (defective) {
+            decorated = ComponentUtils.makeCrimsonStyle("Defective " + title.getString(), true);
+        } else {
+            decorated = title.copy();
+        }
+
+        boolean showPercentage = item.hasOverallValue()
+                && (perfect || defective
+                        ? options.overallPercentageInSpecialName()
+                        : options.overallPercentageInName());
+        if (showPercentage) {
+            decorated.append(ColorScaleUtils.getPercentageTextComponent(
+                    options.colorMap(), item.getOverallPercentage(), options.colorLerp(), options.decimalPlaces()));
+        }
+        return decorated;
+    }
+
+    @Override
+    public MutableComponent getSuffix(
+            StatActualValue actualValue, StatPossibleValues possibleValues, TooltipStyle style) {
+        if (!options.identificationDecorations()) return Component.empty();
+
+        MutableComponent percentage = ColorScaleUtils.getPercentageTextComponent(
+                        options.colorMap(),
+                        StatCalculator.getPercentage(actualValue, possibleValues),
+                        options.colorLerp(),
+                        options.decimalPlaces())
+                .withStyle(componentStyle -> componentStyle.withFont(CommonFonts.LANGUAGE_FONT));
+        if (style.rainbowInternalRoll() && actualValue.stars() == 3) {
+            percentage.withColor(WynncraftShaderColor.RAINBOW.color.asInt());
+        }
+        return percentage;
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipIdentificationDecorator.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipIdentificationDecorator.java
@@ -4,4 +4,16 @@
  */
 package com.wynntils.handlers.tooltip.type;
 
-public interface TooltipIdentificationDecorator {}
+import com.wynntils.models.stats.type.StatActualValue;
+import com.wynntils.models.stats.type.StatPossibleValues;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+
+@FunctionalInterface
+public interface TooltipIdentificationDecorator {
+    default MutableComponent getTitle(Component title) {
+        return title.copy();
+    }
+
+    MutableComponent getSuffix(StatActualValue actualValue, StatPossibleValues possibleValues, TooltipStyle style);
+}

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipLine.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipLine.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.tooltip.type;
+
+import net.minecraft.network.chat.Component;
+
+public sealed interface TooltipLine permits TooltipLine.Fixed, TooltipLine.Aligned, TooltipLine.Centered {
+    Component unaligned();
+
+    record Fixed(Component component) implements TooltipLine {
+        @Override
+        public Component unaligned() {
+            return component;
+        }
+    }
+
+    record Aligned(Component left, Component right) implements TooltipLine {
+        @Override
+        public Component unaligned() {
+            return Component.empty().append(left.copy()).append(right.copy());
+        }
+    }
+
+    record Centered(Component component) implements TooltipLine {
+        @Override
+        public Component unaligned() {
+            return component;
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipOptions.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.handlers.tooltip.type;
+
+import com.wynntils.models.gear.type.ItemWeightSource;
+import com.wynntils.models.stats.type.StatListOrdering;
+import java.util.Collections;
+import java.util.NavigableMap;
+import net.minecraft.network.chat.TextColor;
+
+public record TooltipOptions(
+        TooltipStyle style,
+        boolean perfectTitle,
+        boolean defectiveTitle,
+        boolean identificationDecorations,
+        ItemWeightSource itemWeightSource,
+        boolean overallPercentageInName,
+        boolean overallPercentageInSpecialName,
+        NavigableMap<Float, TextColor> colorMap,
+        boolean colorLerp,
+        int decimalPlaces) {
+    public static final TooltipOptions DEFAULT = new TooltipOptions(
+            new TooltipStyle(StatListOrdering.WYNNCRAFT, false, false, true, true),
+            false,
+            false,
+            false,
+            ItemWeightSource.NONE,
+            false,
+            false,
+            Collections.emptyNavigableMap(),
+            false,
+            0);
+}

--- a/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearInfoRegistry.java
@@ -15,6 +15,7 @@ import com.wynntils.core.components.Services;
 import com.wynntils.core.net.Dependency;
 import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.net.UrlId;
+import com.wynntils.models.gear.type.GearEmblem;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearMetaInfo;
 import com.wynntils.models.gear.type.GearRequirements;
@@ -123,6 +124,8 @@ public class GearInfoRegistry {
                 throw new RuntimeException("Invalid Wynncraft data: item has no gear tier");
             }
 
+            GearEmblem emblem = GearEmblem.fromString(json.get("emblem").getAsString());
+
             int powderSlots = JsonUtils.getNullableJsonInt(json, "powderSlots");
 
             GearMetaInfo metaInfo = parseMetaInfo(json, internalName, type);
@@ -134,6 +137,7 @@ public class GearInfoRegistry {
                     displayName,
                     type,
                     tier,
+                    emblem,
                     powderSlots,
                     metaInfo,
                     requirements,

--- a/common/src/main/java/com/wynntils/models/gear/type/GearEmblem.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearEmblem.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.gear.type;
+
+import java.util.Locale;
+
+public record GearEmblem(GearEmblemShape gearEmblemShape, int variant) {
+    private static final int VARIANT_COUNT = 6;
+
+    public GearEmblem {
+        if (variant < 1 || variant > VARIANT_COUNT) {
+            throw new IllegalArgumentException("Unknown gear emblem variant: " + variant);
+        }
+    }
+
+    public static GearEmblem fromString(String emblem) {
+        String[] parts = emblem.split("_");
+        GearEmblemShape gearEmblemShape = GearEmblemShape.valueOf(parts[0].toUpperCase(Locale.ROOT));
+        int variant = parts.length == 1 ? 1 : Integer.parseInt(parts[1]);
+        return new GearEmblem(gearEmblemShape, variant);
+    }
+
+    public String getFrameCode() {
+        return String.valueOf((char) ('\uE000' + (variant - 1) * 0x10 + gearEmblemShape.offset()));
+    }
+
+    public enum GearEmblemShape {
+        DIAMOND(0),
+        SQUARE(1),
+        HEXAGON(2),
+        SHIELD(3),
+        CIRCLE(4),
+        STICKER(5);
+
+        private final int offset;
+
+        GearEmblemShape(int offset) {
+            this.offset = offset;
+        }
+
+        public int offset() {
+            return offset;
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/models/gear/type/GearInfo.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;
@@ -17,12 +17,21 @@ public record GearInfo(
         String name,
         GearType type,
         GearTier tier,
+        GearEmblem emblem,
         int powderSlots,
         GearMetaInfo metaInfo,
         GearRequirements requirements,
         FixedStats fixedStats,
         List<Pair<StatType, StatPossibleValues>> variableStats,
         Optional<SetInfo> setInfo) {
+    public String getEmblemFrameCode() {
+        return emblem.getFrameCode();
+    }
+
+    public String getEmblemSpriteCode() {
+        return type.getFrameSpriteCode();
+    }
+
     public StatPossibleValues getPossibleValues(StatType statType) {
         return this.variableStats().stream()
                 .filter(p -> p.key().equals(statType))

--- a/common/src/main/java/com/wynntils/models/gear/type/GearTier.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearTier.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 
 public enum GearTier {
     NORMAL(ChatFormatting.WHITE, 0, 0.0f),
@@ -84,6 +85,10 @@ public enum GearTier {
 
     public String getName() {
         return StringUtils.capitalizeFirst(name().toLowerCase(Locale.ROOT));
+    }
+
+    public Identifier getTooltipStyle(boolean shiny) {
+        return Identifier.withDefaultNamespace(apiName + (shiny ? "_shiny" : ""));
     }
 
     // This should be used instead of values() in almost all places as to not include the SET tier

--- a/common/src/main/java/com/wynntils/models/gear/type/GearType.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearType.java
@@ -84,8 +84,8 @@ public enum GearType {
                     Items.DIAMOND_BOOTS,
                     Items.NETHERITE_BOOTS),
             11),
-    MASTERY_TOME(null, "\uE028", "tome", -1),
-    CHARM(null, "\uE029", "charm", -1);
+    MASTERY_TOME(null, "\uE028", "tome", -1, "\uE041"),
+    CHARM(null, "\uE031", "charm", -1, "\uE035");
 
     private final ClassType classReq;
     private final Item defaultItem;
@@ -94,6 +94,7 @@ public enum GearType {
     private final String skinModelKey;
     private final List<Item> otherItems;
     private final int encodingId;
+    private final String frameCode;
 
     private List<Float> modelList = new ArrayList<>();
 
@@ -104,7 +105,8 @@ public enum GearType {
             String modelKey,
             String skinModelKey,
             List<Item> otherItems,
-            int encodingId) {
+            int encodingId,
+            String frameCode) {
         this.classReq = classReq;
         this.defaultItem = defaultItem;
         this.frameSpriteCode = frameSpriteCode;
@@ -112,6 +114,18 @@ public enum GearType {
         this.skinModelKey = skinModelKey;
         this.otherItems = otherItems;
         this.encodingId = encodingId;
+        this.frameCode = frameCode;
+    }
+
+    GearType(
+            ClassType classReq,
+            Item defaultItem,
+            String frameSpriteCode,
+            String modelKey,
+            String skinModelKey,
+            List<Item> otherItems,
+            int encodingId) {
+        this(classReq, defaultItem, frameSpriteCode, modelKey, skinModelKey, otherItems, encodingId, null);
     }
 
     GearType(
@@ -121,7 +135,7 @@ public enum GearType {
             String modelKey,
             List<Item> otherItems,
             int encodingId) {
-        this(classReq, defaultItem, frameSpriteCode, modelKey, null, otherItems, encodingId);
+        this(classReq, defaultItem, frameSpriteCode, modelKey, null, otherItems, encodingId, null);
     }
 
     GearType(ClassType classReq, String frameSpriteCode, String modelKey, Item craftedItem, int encodingId) {
@@ -130,6 +144,10 @@ public enum GearType {
 
     GearType(ClassType classReq, String frameSpriteCode, String modelKey, int encodingId) {
         this(classReq, Items.POTION, frameSpriteCode, modelKey, List.of(), encodingId);
+    }
+
+    GearType(ClassType classReq, String frameSpriteCode, String modelKey, int encodingId, String frameCode) {
+        this(classReq, Items.POTION, frameSpriteCode, modelKey, null, List.of(), encodingId, frameCode);
     }
 
     public static GearType fromString(String typeStr) {
@@ -207,13 +225,17 @@ public enum GearType {
         return frameSpriteCode;
     }
 
+    public String getModelKey() {
+        return modelKey;
+    }
+
     public String getFrameCode() {
+        if (frameCode != null) return frameCode;
+
         if (this.isArmor()) {
             return "\uE003";
-        } else if (this.isAccessory() || this == CHARM) {
+        } else if (this.isAccessory()) {
             return "\uE005";
-        } else if (this == MASTERY_TOME) {
-            return "\uE001";
         }
 
         // Weapon

--- a/common/src/main/java/com/wynntils/models/gear/type/ItemWeightSource.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/ItemWeightSource.java
@@ -4,14 +4,13 @@
  */
 package com.wynntils.models.gear.type;
 
-import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 
 public enum ItemWeightSource {
-    NONE(CommonColors.WHITE),
+    NONE(CustomColor.NONE),
     WYNNPOOL(CustomColor.fromInt(0xffc457)),
     NORI(CustomColor.fromInt(0x67ccf5)),
-    ALL(CommonColors.WHITE);
+    ALL(CustomColor.NONE);
 
     private final CustomColor color;
 

--- a/common/src/main/java/com/wynntils/models/gear/type/ItemWeightSource.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/ItemWeightSource.java
@@ -1,16 +1,29 @@
 /*
- * Copyright © Wynntils 2025.
+ * Copyright © Wynntils 2025-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;
 
+import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
+
 public enum ItemWeightSource {
-    NONE,
-    WYNNPOOL,
-    NORI,
-    ALL;
+    NONE(CommonColors.WHITE),
+    WYNNPOOL(CustomColor.fromInt(0xffc457)),
+    NORI(CustomColor.fromInt(0x67ccf5)),
+    ALL(CommonColors.WHITE);
+
+    private final CustomColor color;
+
+    ItemWeightSource(CustomColor color) {
+        this.color = color;
+    }
 
     public boolean isSingleSource() {
         return this == WYNNPOOL || this == NORI;
+    }
+
+    public CustomColor getColor() {
+        return color;
     }
 }

--- a/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
+++ b/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
@@ -15,6 +15,7 @@ import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.items.properties.NamedItemProperty;
 import com.wynntils.utils.mc.TooltipUtils;
 import java.util.List;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -38,6 +39,12 @@ public class FakeItemStack extends ItemStack {
 
         if (wynnItem instanceof NamedItemProperty namedItemProperty) {
             Handlers.Item.updateItem(this, wynnItem, StyledText.fromString(namedItemProperty.getName()));
+        }
+        if (!useBackingTooltip && wynnItem instanceof GearItem gearItem) {
+            this.set(
+                    DataComponents.TOOLTIP_STYLE,
+                    gearItem.getGearTier()
+                            .getTooltipStyle(gearItem.getShinyStat().isPresent()));
         }
 
         this.wynnItem = wynnItem;

--- a/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
+++ b/common/src/main/java/com/wynntils/models/items/FakeItemStack.java
@@ -11,8 +11,10 @@ import com.wynntils.core.text.StyledText;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.models.items.properties.CraftedItemProperty;
+import com.wynntils.models.items.properties.GearTierItemProperty;
 import com.wynntils.models.items.properties.IdentifiableItemProperty;
 import com.wynntils.models.items.properties.NamedItemProperty;
+import com.wynntils.models.items.properties.ShinyItemProperty;
 import com.wynntils.utils.mc.TooltipUtils;
 import java.util.List;
 import net.minecraft.core.component.DataComponents;
@@ -40,11 +42,10 @@ public class FakeItemStack extends ItemStack {
         if (wynnItem instanceof NamedItemProperty namedItemProperty) {
             Handlers.Item.updateItem(this, wynnItem, StyledText.fromString(namedItemProperty.getName()));
         }
-        if (!useBackingTooltip && wynnItem instanceof GearItem gearItem) {
-            this.set(
-                    DataComponents.TOOLTIP_STYLE,
-                    gearItem.getGearTier()
-                            .getTooltipStyle(gearItem.getShinyStat().isPresent()));
+        if (!useBackingTooltip && wynnItem instanceof GearTierItemProperty tierItem) {
+            boolean shiny = wynnItem instanceof ShinyItemProperty shinyItem
+                    && shinyItem.getShinyStat().isPresent();
+            this.set(DataComponents.TOOLTIP_STYLE, tierItem.getGearTier().getTooltipStyle(shiny));
         }
 
         this.wynnItem = wynnItem;

--- a/common/src/main/java/com/wynntils/models/items/WynnItemData.java
+++ b/common/src/main/java/com/wynntils/models/items/WynnItemData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2022-2023.
+ * Copyright © Wynntils 2022-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items;
@@ -13,6 +13,7 @@ public class WynnItemData {
     public static final String HIGHLIGHT_KEY = "highlight";
     public static final String OVERLAY_KEY = "overlay";
     public static final String TOOLTIP_KEY = "tooltip";
+    public static final String UPDATED_TOOLTIP_KEY = "updatedTooltip";
     public static final String SEARCHED_KEY = "searched";
     public static final String FAVORITE_KEY = "favorite";
     public static final String EMERALD_PRICE_KEY = "price";

--- a/common/src/main/java/com/wynntils/models/items/WynnItemData.java
+++ b/common/src/main/java/com/wynntils/models/items/WynnItemData.java
@@ -13,7 +13,6 @@ public class WynnItemData {
     public static final String HIGHLIGHT_KEY = "highlight";
     public static final String OVERLAY_KEY = "overlay";
     public static final String TOOLTIP_KEY = "tooltip";
-    public static final String UPDATED_TOOLTIP_KEY = "updatedTooltip";
     public static final String SEARCHED_KEY = "searched";
     public static final String FAVORITE_KEY = "favorite";
     public static final String EMERALD_PRICE_KEY = "price";

--- a/common/src/main/java/com/wynntils/screens/guides/charm/GuideCharmItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/charm/GuideCharmItemStack.java
@@ -6,7 +6,7 @@ package com.wynntils.screens.guides.charm;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Models;
-import com.wynntils.handlers.tooltip.impl.identifiable.IdentifiableTooltipBuilder;
+import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.CharmItem;
 import com.wynntils.models.rewards.type.CharmInfo;
@@ -55,8 +55,7 @@ public class GuideCharmItemStack extends GuideItemStack {
     }
 
     public void buildTooltip() {
-        IdentifiableTooltipBuilder tooltipBuilder =
-                Handlers.Tooltip.buildNew(new CharmItem(charmInfo, null), true, false);
+        TooltipBuilder tooltipBuilder = Handlers.Tooltip.buildNew(new CharmItem(charmInfo, null), true, false);
         this.generatedTooltip = tooltipBuilder.getTooltipLines(Models.Character.getClassType());
 
         // Force ItemStatInfoFeature to recreate its cache

--- a/common/src/main/java/com/wynntils/screens/guides/charm/GuideCharmItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/charm/GuideCharmItemStack.java
@@ -6,14 +6,15 @@ package com.wynntils.screens.guides.charm;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Models;
-import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.CharmItem;
 import com.wynntils.models.rewards.type.CharmInfo;
 import com.wynntils.screens.guides.GuideItemStack;
+import com.wynntils.utils.mc.TooltipUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
@@ -32,6 +33,7 @@ public class GuideCharmItemStack extends GuideItemStack {
         this.name =
                 Component.literal(charmInfo.name()).withStyle(charmInfo.tier().getChatFormatting());
         this.generatedTooltip = List.of();
+        this.set(DataComponents.TOOLTIP_STYLE, charmInfo.tier().getTooltipStyle(false));
     }
 
     @Override
@@ -55,12 +57,12 @@ public class GuideCharmItemStack extends GuideItemStack {
     }
 
     public void buildTooltip() {
-        TooltipBuilder tooltipBuilder = Handlers.Tooltip.buildNew(new CharmItem(charmInfo, null), true, false);
-        this.generatedTooltip = tooltipBuilder.getTooltipLines(Models.Character.getClassType());
-
-        // Force ItemStatInfoFeature to recreate its cache
         Optional<CharmItem> charmItemOpt = Models.Item.asWynnItem(this, CharmItem.class);
         if (charmItemOpt.isEmpty()) return;
-        charmItemOpt.get().getData().clear(WynnItemData.TOOLTIP_KEY);
+        CharmItem charmItem = charmItemOpt.get();
+        charmItem
+                .getData()
+                .getOrCalculate(WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(charmItem, true, false));
+        this.generatedTooltip = TooltipUtils.getWynnItemTooltip(this, charmItem);
     }
 }

--- a/common/src/main/java/com/wynntils/screens/guides/gear/GuideGearItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/gear/GuideGearItemStack.java
@@ -6,14 +6,15 @@ package com.wynntils.screens.guides.gear;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Models;
-import com.wynntils.handlers.tooltip.impl.identifiable.IdentifiableTooltipBuilder;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.GearItem;
 import com.wynntils.screens.guides.GuideItemStack;
+import com.wynntils.utils.mc.TooltipUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
@@ -31,6 +32,7 @@ public final class GuideGearItemStack extends GuideItemStack {
         this.gearInfo = gearInfo;
         this.name = Component.literal(gearInfo.name()).withStyle(gearInfo.tier().getChatFormatting());
         this.generatedTooltip = List.of();
+        this.set(DataComponents.TOOLTIP_STYLE, gearInfo.tier().getTooltipStyle(false));
     }
 
     @Override
@@ -55,13 +57,11 @@ public final class GuideGearItemStack extends GuideItemStack {
     }
 
     public void buildTooltip() {
-        IdentifiableTooltipBuilder tooltipBuilder =
-                Handlers.Tooltip.buildNew(new GearItem(gearInfo, null), true, false);
-        this.generatedTooltip = tooltipBuilder.getTooltipLines(Models.Character.getClassType());
-
-        // Force ItemStatInfoFeature to recreate its cache
         Optional<GearItem> gearItemOpt = Models.Item.asWynnItem(this, GearItem.class);
         if (gearItemOpt.isEmpty()) return;
-        gearItemOpt.get().getData().clear(WynnItemData.TOOLTIP_KEY);
+        GearItem gearItem = gearItemOpt.get();
+        gearItem.getData()
+                .getOrCalculate(WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(gearItem, true, false));
+        this.generatedTooltip = TooltipUtils.getWynnItemTooltip(this, gearItem);
     }
 }

--- a/common/src/main/java/com/wynntils/screens/guides/tome/GuideTomeItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/tome/GuideTomeItemStack.java
@@ -6,14 +6,15 @@ package com.wynntils.screens.guides.tome;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Models;
-import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.TomeItem;
 import com.wynntils.models.rewards.type.TomeInfo;
 import com.wynntils.screens.guides.GuideItemStack;
+import com.wynntils.utils.mc.TooltipUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
@@ -31,6 +32,7 @@ public class GuideTomeItemStack extends GuideItemStack {
         this.tomeInfo = tomeInfo;
         this.name = Component.literal(tomeInfo.name()).withStyle(tomeInfo.tier().getChatFormatting());
         this.generatedTooltip = List.of();
+        this.set(DataComponents.TOOLTIP_STYLE, tomeInfo.tier().getTooltipStyle(false));
     }
 
     @Override
@@ -54,12 +56,11 @@ public class GuideTomeItemStack extends GuideItemStack {
     }
 
     public void buildTooltip() {
-        TooltipBuilder tooltipBuilder = Handlers.Tooltip.buildNew(new TomeItem(tomeInfo, null), true, false);
-        this.generatedTooltip = tooltipBuilder.getTooltipLines(Models.Character.getClassType());
-
-        // Force ItemStatInfoFeature to recreate its cache
         Optional<TomeItem> tomeItemOpt = Models.Item.asWynnItem(this, TomeItem.class);
         if (tomeItemOpt.isEmpty()) return;
-        tomeItemOpt.get().getData().clear(WynnItemData.TOOLTIP_KEY);
+        TomeItem tomeItem = tomeItemOpt.get();
+        tomeItem.getData()
+                .getOrCalculate(WynnItemData.TOOLTIP_KEY, () -> Handlers.Tooltip.buildNew(tomeItem, true, false));
+        this.generatedTooltip = TooltipUtils.getWynnItemTooltip(this, tomeItem);
     }
 }

--- a/common/src/main/java/com/wynntils/screens/guides/tome/GuideTomeItemStack.java
+++ b/common/src/main/java/com/wynntils/screens/guides/tome/GuideTomeItemStack.java
@@ -6,7 +6,7 @@ package com.wynntils.screens.guides.tome;
 
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Models;
-import com.wynntils.handlers.tooltip.impl.identifiable.IdentifiableTooltipBuilder;
+import com.wynntils.handlers.tooltip.TooltipBuilder;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.TomeItem;
 import com.wynntils.models.rewards.type.TomeInfo;
@@ -54,8 +54,7 @@ public class GuideTomeItemStack extends GuideItemStack {
     }
 
     public void buildTooltip() {
-        IdentifiableTooltipBuilder tooltipBuilder =
-                Handlers.Tooltip.buildNew(new TomeItem(tomeInfo, null), true, false);
+        TooltipBuilder tooltipBuilder = Handlers.Tooltip.buildNew(new TomeItem(tomeInfo, null), true, false);
         this.generatedTooltip = tooltipBuilder.getTooltipLines(Models.Character.getClassType());
 
         // Force ItemStatInfoFeature to recreate its cache

--- a/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
+++ b/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
@@ -28,28 +28,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.FontDescription;
-import net.minecraft.network.chat.Style;
-import net.minecraft.resources.Identifier;
 
 public class ItemWeightService extends Service {
-    private static final FontDescription PILL_FONT =
-            new FontDescription.Resource(Identifier.withDefaultNamespace("banner/pill"));
-    private static final Style NORI_STYLE = Style.EMPTY
-            .withFont(PILL_FONT)
-            .withColor(ItemWeightSource.NORI.getColor().asInt());
-    private static final Style WYNNPOOL_STYLE = Style.EMPTY
-            .withFont(PILL_FONT)
-            .withColor(ItemWeightSource.WYNNPOOL.getColor().asInt());
-
-    public static final Component NORI_HEADER = Component.literal(
-                    "\uE060\uDAFF\uDFFF\uE03D\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE038\uDAFF\uDFFF\uE062")
-            .withStyle(NORI_STYLE);
-    public static final Component WYNNPOOL_HEADER = Component.literal(
-                    "\uE060\uDAFF\uDFFF\uE046\uDAFF\uDFFF\uE048\uDAFF\uDFFF\uE03D\uDAFF\uDFFF\uE03D\uDAFF\uDFFF\uE03F\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE03B\uDAFF\uDFFF\uE062")
-            .withStyle(WYNNPOOL_STYLE);
-
     private Map<ItemWeightSource, Map<String, List<ItemWeighting>>> weightings = new HashMap<>();
 
     public ItemWeightService() {

--- a/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
+++ b/common/src/main/java/com/wynntils/services/itemweight/ItemWeightService.java
@@ -18,7 +18,6 @@ import com.wynntils.models.stats.type.StatActualValue;
 import com.wynntils.models.stats.type.StatPossibleValues;
 import com.wynntils.models.stats.type.StatType;
 import com.wynntils.services.itemweight.type.ItemWeighting;
-import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.type.Pair;
 import java.io.Reader;
 import java.util.ArrayList;
@@ -37,10 +36,12 @@ import net.minecraft.resources.Identifier;
 public class ItemWeightService extends Service {
     private static final FontDescription PILL_FONT =
             new FontDescription.Resource(Identifier.withDefaultNamespace("banner/pill"));
-    private static final CustomColor NORI_COLOR = CustomColor.fromInt(0x1cb5fc);
-    private static final CustomColor WYNNPOOL_COLOR = CustomColor.fromInt(0xfc9700);
-    private static final Style NORI_STYLE = Style.EMPTY.withFont(PILL_FONT).withColor(NORI_COLOR.asInt());
-    private static final Style WYNNPOOL_STYLE = Style.EMPTY.withFont(PILL_FONT).withColor(WYNNPOOL_COLOR.asInt());
+    private static final Style NORI_STYLE = Style.EMPTY
+            .withFont(PILL_FONT)
+            .withColor(ItemWeightSource.NORI.getColor().asInt());
+    private static final Style WYNNPOOL_STYLE = Style.EMPTY
+            .withFont(PILL_FONT)
+            .withColor(ItemWeightSource.WYNNPOOL.getColor().asInt());
 
     public static final Component NORI_HEADER = Component.literal(
                     "\uE060\uDAFF\uDFFF\uE03D\uDAFF\uDFFF\uE03E\uDAFF\uDFFF\uE041\uDAFF\uDFFF\uE038\uDAFF\uDFFF\uE062")

--- a/common/src/main/java/com/wynntils/utils/mc/TooltipUtils.java
+++ b/common/src/main/java/com/wynntils/utils/mc/TooltipUtils.java
@@ -4,8 +4,11 @@
  */
 package com.wynntils.utils.mc;
 
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
+import com.wynntils.features.tooltips.ItemStatInfoFeature;
 import com.wynntils.handlers.tooltip.TooltipBuilder;
+import com.wynntils.handlers.tooltip.type.TooltipOptions;
 import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.utils.render.FontRenderer;
@@ -43,7 +46,10 @@ public final class TooltipUtils {
     public static List<Component> getWynnItemTooltip(ItemStack itemStack, WynnItem wynnItem) {
         TooltipBuilder tooltipBuilder = wynnItem.getData().get(WynnItemData.TOOLTIP_KEY);
         if (tooltipBuilder != null) {
-            return tooltipBuilder.getTooltipLines(Models.Character.getClassType());
+            ItemStatInfoFeature feature = Managers.Feature.getFeatureInstance(ItemStatInfoFeature.class);
+            return tooltipBuilder.getTooltipLines(
+                    Models.Character.getClassType(),
+                    feature.isEnabled() ? feature.getTooltipOptions() : TooltipOptions.DEFAULT);
         }
 
         return LoreUtils.getTooltipLines(itemStack);


### PR DESCRIPTION
Refactoring the tooltip code to be cleaner and hopefully better

**Known issues:**
- Unidentified tomes have duplicated identification ranges shown
- Alignments in guide tooltips do not work yet
- Pagination element isn't centered correctly
- Item compare tooltips not being built correctly (not handled with this system yet)
- some font fallbacks are missing

**Still to implement**:
- Shiny tracker reroll
- Pressing shift/ctrl to see more details
- Change the identification colors to match Wynncraft tooltips

**Screenshots**:
<img width="337" height="441" alt="image" src="https://github.com/user-attachments/assets/0c64b1eb-2e2a-43e6-a94f-fcf0ebcadcfa" />
<img width="374" height="920" alt="image" src="https://github.com/user-attachments/assets/0c9c65e7-8863-42e7-b8ea-c7ca9e218f26" />
<img width="914" height="815" alt="image" src="https://github.com/user-attachments/assets/b18e1c4e-4bc7-4e57-8533-410d33a2803f" />
<img width="570" height="200" alt="image" src="https://github.com/user-attachments/assets/8bf03c68-aeb7-4a10-8c53-01dd4ba2a737" />
<img width="527" height="818" alt="image" src="https://github.com/user-attachments/assets/ee1348ea-5b14-4211-ac29-edde32b85c9a" />
<img width="420" height="260" alt="image" src="https://github.com/user-attachments/assets/d61524c9-5789-44b5-a0ac-d391d3315c34" />
<img width="388" height="640" alt="image" src="https://github.com/user-attachments/assets/95c8ddcd-26d8-490c-9f15-94a4e774ce7c" />

