### PR TITLE
ci: Workflow fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,22 +2,19 @@ name: Spotless, Build and Test
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     branches: [main, development]
 
 jobs:
   format-and-build:
-    if: '! github.event.pull_request.draft'
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.PRIVATE_TOKEN }}
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Set up JDK 21
@@ -45,20 +42,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Format with spotless
-        run: ./gradlew spotlessApply
-
-      - name: Delete empty files
-        run: find $(git ls-files -m) -size 0 -delete
-
-      - name: Run remove_unused_i18n.sh
-        run: bash utils/remove_unused_i18n.sh
-
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_user_name: 'WynntilsBot'
-          commit_user_email: 'admin@wynntils.com'
-          commit_message: 'ci: spotless formatting'
+      - name: Check formatting with Spotless
+        run: ./gradlew spotlessCheck
 
       - name: Build with Gradle
         run: ./gradlew buildDependents -x spotlessCheck -x test

--- a/.github/workflows/cleanup-i18n.yml
+++ b/.github/workflows/cleanup-i18n.yml
@@ -1,0 +1,39 @@
+# Github actions runner will run this script on a schedule
+
+name: Clean up i18n files
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily
+
+jobs:
+  cleanup-i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Run remove_unused_i18n.sh
+        run: bash utils/remove_unused_i18n.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PRIVATE_TOKEN }}
+          labels: auto-generated
+          committer: WynntilsBot <admin@wynntils.com>
+          commit-message: "chore: [auto-generated] Remove unused i18n entries [ci skip]"
+          title: "chore: [auto-generated] Remove unused i18n entries [ci skip]"
+          body: |
+            Removes translation keys that no longer exist in `en_us.json`.
+
+            This PR has been automatically generated.
+          branch: auto-cleanup-i18n


### PR DESCRIPTION
Spotless is no longer applied to pull requests, instead the action will just fail and the remove outdated i18n step has also been removed however a new action that runs daily will execute that task and create a pr similar to auto update urls.

This has been done due to https://github.com/Wynntils/Wynntils/actions/runs/29934159544/job/88971255015

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

We may be able to bypass this, without including a security risk, but for now this will do