### PR TITLE
fix: LoadoutMigrationUpfixer and crash when saving wrong class

### DIFF
--- a/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
+++ b/common/src/main/java/com/wynntils/commands/WynntilsCommand.java
@@ -435,18 +435,22 @@ public class WynntilsCommand extends Command {
         McUtils.sendWynntilsPrefixMessage(
                 Component.translatable("command.wynntils.rescan.startText").withColor(CommonColors.YELLOW.asInt()));
 
+        McUtils.player().closeContainer();
+
         // This should probably be changed to a function interface if more were to be added to it.
-        Models.Character.scanCharacterInfo(() -> {
-            Models.Account.scanRankInfo(true, () -> {
-                Models.Aspect.clearEquippedAspectsAndRescan(
-                        onStatus -> {},
-                        McUtils::sendErrorToClient,
-                        aspectComplete -> Models.AbilityTree.clearUnlockedAbilitesAndRescan(
-                                onStatus -> {},
-                                McUtils::sendErrorToClient,
-                                onComplete -> McUtils.sendWynntilsPrefixMessage(
-                                        Component.translatable("command.wynntils.rescan.endText")
-                                                .withColor(CommonColors.GREEN.asInt()))));
+        Managers.TickScheduler.scheduleNextTick(() -> {
+            Models.Character.scanCharacterInfo(() -> {
+                Models.Account.scanRankInfo(true, () -> {
+                    Models.Aspect.clearEquippedAspectsAndRescan(
+                            onStatus -> {},
+                            McUtils::sendErrorToClient,
+                            aspectComplete -> Models.AbilityTree.clearUnlockedAbilitesAndRescan(
+                                    onStatus -> {},
+                                    McUtils::sendErrorToClient,
+                                    onComplete -> McUtils.sendWynntilsPrefixMessage(
+                                            Component.translatable("command.wynntils.rescan.endText")
+                                                    .withColor(CommonColors.GREEN.asInt()))));
+                });
             });
         });
         return 1;

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
@@ -254,7 +254,7 @@ public class LoadoutMigrationUpfixer implements Upfixer {
     }
 
     private static Optional<GearInfo> resolveGearInfo(String rawName) {
-        String removeFormatting = rawName.replaceFirst("§.", "");
+        String removeFormatting = rawName.replaceAll("§.", "");
         String cleanName = SANITIZE_PATTERN.matcher(removeFormatting).replaceAll("");
         GearInfo gearInfo = Models.Gear.getGearInfoFromDisplayName(cleanName);
         if (gearInfo == null) {

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
@@ -25,6 +25,7 @@ import com.wynntils.models.stats.type.StatType;
 import com.wynntils.utils.EncodedByteBuffer;
 import com.wynntils.utils.type.ErrorOr;
 import com.wynntils.utils.type.RangedValue;
+import com.wynntils.utils.wynn.WynnUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,10 +33,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Pattern;
 
 public class LoadoutMigrationUpfixer implements Upfixer {
-    private static final Pattern SANITIZE_PATTERN = Pattern.compile("[^a-zA-Z0-9'\\-.,!?\\s]");
     private static final String OLD_ABILITY_TREE_KEY = "model.abilityTree.abilityTreeLoadouts";
     private static final String OLD_ASPECT_KEY = "model.aspect.aspectLoadouts";
     private static final String OLD_SKILL_POINT_KEY = "model.skillPoint.skillPointLoadouts";
@@ -255,7 +254,7 @@ public class LoadoutMigrationUpfixer implements Upfixer {
 
     private static Optional<GearInfo> resolveGearInfo(String rawName) {
         String removeFormatting = rawName.replaceAll("§.", "");
-        String cleanName = SANITIZE_PATTERN.matcher(removeFormatting).replaceAll("");
+        String cleanName = WynnUtils.stripItemNameMarkers(removeFormatting);
         GearInfo gearInfo = Models.Gear.getGearInfoFromDisplayName(cleanName);
         if (gearInfo == null) {
             WynntilsMod.warn("Upfixer: no gear info found for " + cleanName);

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
@@ -124,23 +124,34 @@ public class LoadoutMigrationUpfixer implements Upfixer {
 
         skillPointObject.addProperty(
                 "strength",
-                oldSkillPointObject.has("strength") ? oldSkillPointObject.get("strength").getAsInt() : 0);
+                oldSkillPointObject.has("strength")
+                        ? oldSkillPointObject.get("strength").getAsInt()
+                        : 0);
         skillPointObject.addProperty(
                 "dexterity",
-                oldSkillPointObject.has("dexterity") ? oldSkillPointObject.get("dexterity").getAsInt() : 0);
+                oldSkillPointObject.has("dexterity")
+                        ? oldSkillPointObject.get("dexterity").getAsInt()
+                        : 0);
         skillPointObject.addProperty(
                 "intelligence",
-                oldSkillPointObject.has("intelligence") ? oldSkillPointObject.get("intelligence").getAsInt() : 0);
+                oldSkillPointObject.has("intelligence")
+                        ? oldSkillPointObject.get("intelligence").getAsInt()
+                        : 0);
         skillPointObject.addProperty(
                 "defence",
-                oldSkillPointObject.has("defence") ? oldSkillPointObject.get("defence").getAsInt() : 0);
+                oldSkillPointObject.has("defence")
+                        ? oldSkillPointObject.get("defence").getAsInt()
+                        : 0);
         skillPointObject.addProperty(
                 "agility",
-                oldSkillPointObject.has("agility") ? oldSkillPointObject.get("agility").getAsInt() : 0);
+                oldSkillPointObject.has("agility")
+                        ? oldSkillPointObject.get("agility").getAsInt()
+                        : 0);
 
         skillPointObject.add("weapon", JsonNull.INSTANCE);
 
-        if (oldSkillPointObject.has("weapon") && !oldSkillPointObject.get("weapon").isJsonNull()) {
+        if (oldSkillPointObject.has("weapon")
+                && !oldSkillPointObject.get("weapon").isJsonNull()) {
             String weaponName = oldSkillPointObject.get("weapon").getAsString();
             encodeDefaultGearItem(weaponName)
                     .ifPresentOrElse(
@@ -158,7 +169,8 @@ public class LoadoutMigrationUpfixer implements Upfixer {
     }
 
     private JsonArray migrateArmourNameArray(JsonObject oldSkillPointObject) {
-        if (!oldSkillPointObject.has("armourNames") || !oldSkillPointObject.get("armourNames").isJsonArray()) return null;
+        if (!oldSkillPointObject.has("armourNames")
+                || !oldSkillPointObject.get("armourNames").isJsonArray()) return null;
 
         JsonArray oldNames = oldSkillPointObject.getAsJsonArray("armourNames");
         // 0=helmet, 1=chestplate, 2=leggings, 3=boots
@@ -198,7 +210,8 @@ public class LoadoutMigrationUpfixer implements Upfixer {
     }
 
     private JsonArray migrateAccessoryNameArray(JsonObject oldSkillPointObject) {
-        if (!oldSkillPointObject.has("accessoryNames") || !oldSkillPointObject.get("accessoryNames").isJsonArray()) return null;
+        if (!oldSkillPointObject.has("accessoryNames")
+                || !oldSkillPointObject.get("accessoryNames").isJsonArray()) return null;
 
         JsonArray oldNames = oldSkillPointObject.getAsJsonArray("accessoryNames");
         // 0=ring1, 1=ring2, 2=bracelet, 3=necklace

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
@@ -6,6 +6,7 @@ package com.wynntils.core.persisted.upfixers.storage;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
@@ -27,11 +28,14 @@ import com.wynntils.utils.type.RangedValue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 public class LoadoutMigrationUpfixer implements Upfixer {
+    private static final Pattern SANITIZE_PATTERN = Pattern.compile("[^a-zA-Z0-9'\\-.,!?\\s]");
     private static final String OLD_ABILITY_TREE_KEY = "model.abilityTree.abilityTreeLoadouts";
     private static final String OLD_ASPECT_KEY = "model.aspect.aspectLoadouts";
     private static final String OLD_SKILL_POINT_KEY = "model.skillPoint.skillPointLoadouts";
@@ -115,26 +119,48 @@ public class LoadoutMigrationUpfixer implements Upfixer {
     private JsonElement migrateSkillPointGearNames(JsonElement skillPointElement) {
         if (skillPointElement == null || !skillPointElement.isJsonObject()) return skillPointElement;
 
-        JsonObject skillPointObject = skillPointElement.getAsJsonObject();
+        JsonObject oldSkillPointObject = skillPointElement.getAsJsonObject();
+        JsonObject skillPointObject = new JsonObject();
 
-        if (skillPointObject.has("weapon") && !skillPointObject.get("weapon").isJsonNull()) {
-            String weaponName = skillPointObject.get("weapon").getAsString();
+        skillPointObject.addProperty(
+                "strength",
+                oldSkillPointObject.has("strength") ? oldSkillPointObject.get("strength").getAsInt() : 0);
+        skillPointObject.addProperty(
+                "dexterity",
+                oldSkillPointObject.has("dexterity") ? oldSkillPointObject.get("dexterity").getAsInt() : 0);
+        skillPointObject.addProperty(
+                "intelligence",
+                oldSkillPointObject.has("intelligence") ? oldSkillPointObject.get("intelligence").getAsInt() : 0);
+        skillPointObject.addProperty(
+                "defence",
+                oldSkillPointObject.has("defence") ? oldSkillPointObject.get("defence").getAsInt() : 0);
+        skillPointObject.addProperty(
+                "agility",
+                oldSkillPointObject.has("agility") ? oldSkillPointObject.get("agility").getAsInt() : 0);
+
+        skillPointObject.add("weapon", JsonNull.INSTANCE);
+
+        if (oldSkillPointObject.has("weapon") && !oldSkillPointObject.get("weapon").isJsonNull()) {
+            String weaponName = oldSkillPointObject.get("weapon").getAsString();
             encodeDefaultGearItem(weaponName)
                     .ifPresentOrElse(
                             savableGear -> skillPointObject.add("weapon", savableItemToJson(savableGear)),
                             () -> WynntilsMod.warn("Upfixer: could not encode weapon " + weaponName));
         }
 
-        migrateArmourNameArray(skillPointObject, "armourNames");
-        migrateAccessoryNameArray(skillPointObject, "accessoryNames");
+        JsonArray armourArray = migrateArmourNameArray(oldSkillPointObject);
+        JsonArray accessoryArray = migrateAccessoryNameArray(oldSkillPointObject);
+
+        skillPointObject.add("armourNames", Objects.requireNonNullElseGet(armourArray, JsonArray::new));
+        skillPointObject.add("accessoryNames", Objects.requireNonNullElseGet(accessoryArray, JsonArray::new));
 
         return skillPointObject;
     }
 
-    private void migrateArmourNameArray(JsonObject skillPointObject, String key) {
-        if (!skillPointObject.has(key) || !skillPointObject.get(key).isJsonArray()) return;
+    private JsonArray migrateArmourNameArray(JsonObject oldSkillPointObject) {
+        if (!oldSkillPointObject.has("armourNames") || !oldSkillPointObject.get("armourNames").isJsonArray()) return null;
 
-        JsonArray oldNames = skillPointObject.getAsJsonArray(key);
+        JsonArray oldNames = oldSkillPointObject.getAsJsonArray("armourNames");
         // 0=helmet, 1=chestplate, 2=leggings, 3=boots
         SavableGear[] slots = {new SavableGear(), new SavableGear(), new SavableGear(), new SavableGear()};
 
@@ -168,13 +194,13 @@ public class LoadoutMigrationUpfixer implements Upfixer {
         for (SavableGear slot : slots) {
             newNames.add(savableItemToJson(slot));
         }
-        skillPointObject.add(key, newNames);
+        return newNames;
     }
 
-    private void migrateAccessoryNameArray(JsonObject skillPointObject, String key) {
-        if (!skillPointObject.has(key) || !skillPointObject.get(key).isJsonArray()) return;
+    private JsonArray migrateAccessoryNameArray(JsonObject oldSkillPointObject) {
+        if (!oldSkillPointObject.has("accessoryNames") || !oldSkillPointObject.get("accessoryNames").isJsonArray()) return null;
 
-        JsonArray oldNames = skillPointObject.getAsJsonArray(key);
+        JsonArray oldNames = oldSkillPointObject.getAsJsonArray("accessoryNames");
         // 0=ring1, 1=ring2, 2=bracelet, 3=necklace
         SavableGear[] slots = {new SavableGear(), new SavableGear(), new SavableGear(), new SavableGear()};
 
@@ -211,11 +237,12 @@ public class LoadoutMigrationUpfixer implements Upfixer {
         for (SavableGear slot : slots) {
             newNames.add(savableItemToJson(slot));
         }
-        skillPointObject.add(key, newNames);
+        return newNames;
     }
 
     private static Optional<GearInfo> resolveGearInfo(String rawName) {
-        String cleanName = rawName.replaceFirst("§.", "");
+        String removeFormatting = rawName.replaceFirst("§.", "");
+        String cleanName = SANITIZE_PATTERN.matcher(removeFormatting).replaceAll("");
         GearInfo gearInfo = Models.Gear.getGearInfoFromDisplayName(cleanName);
         if (gearInfo == null) {
             WynntilsMod.warn("Upfixer: no gear info found for " + cleanName);

--- a/common/src/main/java/com/wynntils/features/wynntils/CharacterInfoIndicatorFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/CharacterInfoIndicatorFeature.java
@@ -167,8 +167,6 @@ public class CharacterInfoIndicatorFeature extends Feature {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onWorldStateChanged(WorldStateEvent e) {
-        if (!rescanMessage.get()) return;
-
         compassScanPending = e.getNewState() == WorldState.WORLD;
     }
 
@@ -234,6 +232,7 @@ public class CharacterInfoIndicatorFeature extends Feature {
                 isMismatch ? " Mismatch detected, tracked ability tree state is out of sync." : ""));
 
         if (!isMismatch) return;
+        if (!rescanMessage.get()) return;
 
         Component clickableHere = Component.translatable(
                         "feature.wynntils.characterInfoIndicator.rescanMessage.message.clickHere")

--- a/common/src/main/java/com/wynntils/features/wynntils/CharacterInfoIndicatorFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/CharacterInfoIndicatorFeature.java
@@ -7,7 +7,6 @@ package com.wynntils.features.wynntils;
 import com.google.common.collect.Lists;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
-import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.features.Feature;
 import com.wynntils.core.consumers.features.ProfileDefault;
@@ -21,6 +20,8 @@ import com.wynntils.core.text.fonts.CommonFonts;
 import com.wynntils.core.text.fonts.WynnFont;
 import com.wynntils.core.text.fonts.wynnfonts.WynncraftKeybindsFont;
 import com.wynntils.mc.event.ScreenOpenedEvent;
+import com.wynntils.mc.event.SetSlotEvent;
+import com.wynntils.mc.event.TickEvent;
 import com.wynntils.models.abilitytree.type.AbilityPointProgression;
 import com.wynntils.models.abilitytree.type.AbilityTreeSkillNode;
 import com.wynntils.models.character.type.ClassType;
@@ -35,9 +36,11 @@ import com.wynntils.utils.render.FontRenderer;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
+import com.wynntils.utils.wynn.InventoryUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.ChatFormatting;
@@ -57,9 +60,10 @@ import org.lwjgl.glfw.GLFW;
 
 @ConfigCategory(Category.WYNNTILS)
 public class CharacterInfoIndicatorFeature extends Feature {
-    // It takes a while for the compass to actually have the correct ability points,
-    // otherwise it is max and then the calculation fails and an error shows up in the chat.
-    private static final int DELAY_TICKS = 20 * 30;
+    private boolean compassScanPending = false;
+    private int compassSettleTicks = -1;
+
+    private static final int COMPASS_SETTLE_DELAY = 20 * 20; // 20s
 
     private static final Pattern UNUSED_ABILITY_POINTS_PATTERN = Pattern.compile("§3✦ Unused Ability Points: §f(\\d+)");
 
@@ -165,13 +169,34 @@ public class CharacterInfoIndicatorFeature extends Feature {
     public void onWorldStateChanged(WorldStateEvent e) {
         if (!rescanMessage.get()) return;
 
-        if (e.getNewState() == WorldState.WORLD) {
-            Managers.TickScheduler.scheduleLater(this::handleAbilityPointsFromCompass, DELAY_TICKS);
+        compassScanPending = e.getNewState() == WorldState.WORLD;
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onSetSlot(SetSlotEvent.Post event) {
+        if (!compassScanPending) return;
+        if (!Objects.equals(event.getContainer(), McUtils.inventory())) return;
+        if (event.getSlot() != InventoryUtils.COMPASS_SLOT_NUM) return;
+
+        compassSettleTicks = COMPASS_SETTLE_DELAY;
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent e) {
+        if (compassSettleTicks < 0) return;
+
+        if (compassSettleTicks == 0) {
+            compassSettleTicks = -1;
+            compassScanPending = false;
+            handleAbilityPointsFromCompass();
+            return;
         }
+
+        compassSettleTicks--;
     }
 
     private void handleAbilityPointsFromCompass() {
-        ItemStack compassItem = McUtils.inventory().items.get(Models.Character.CHARACTER_INFO_SLOT);
+        ItemStack compassItem = McUtils.inventory().items.get(InventoryUtils.COMPASS_SLOT_NUM);
         Matcher matcher = LoreUtils.matchLoreLine(compassItem, 6, UNUSED_ABILITY_POINTS_PATTERN);
 
         if (!matcher.matches()) {

--- a/common/src/main/java/com/wynntils/features/wynntils/CharacterInfoIndicatorFeature.java
+++ b/common/src/main/java/com/wynntils/features/wynntils/CharacterInfoIndicatorFeature.java
@@ -59,7 +59,7 @@ import org.lwjgl.glfw.GLFW;
 public class CharacterInfoIndicatorFeature extends Feature {
     // It takes a while for the compass to actually have the correct ability points,
     // otherwise it is max and then the calculation fails and an error shows up in the chat.
-    private static final int DELAY_TICKS = 200;
+    private static final int DELAY_TICKS = 20 * 30;
 
     private static final Pattern UNUSED_ABILITY_POINTS_PATTERN = Pattern.compile("§3✦ Unused Ability Points: §f(\\d+)");
 

--- a/common/src/main/java/com/wynntils/screens/buildloadouts/widgets/LoadoutMenuScrollListAbilityWidget.java
+++ b/common/src/main/java/com/wynntils/screens/buildloadouts/widgets/LoadoutMenuScrollListAbilityWidget.java
@@ -41,12 +41,14 @@ public class LoadoutMenuScrollListAbilityWidget extends AbstractWidget implement
 
         AbilityTreeSkillNode abilityTreeSkillNode = Models.AbilityTree.getNodeFromNameAndClass(
                 this.text.getString(), parent.getSelectedLoadout().getClassType());
-        abilityItemStack = new AbilityTreeNodeItemStack(
+
+        abilityItemStack = parent.getSelectedLoadout().hasAbilityTree() && abilityTreeSkillNode != null
+                ? new AbilityTreeNodeItemStack(
                 abilityTreeSkillNode,
-                parent.getSelectedLoadout().hasAbilityTree()
-                        ? parent.getSelectedLoadout().abilityTree()
-                        : null);
-        ultimateAbility = abilityTreeSkillNode.abilityTreeNodeType().isUltimate();
+                parent.getSelectedLoadout().abilityTree())
+                : ItemStack.EMPTY;
+
+        ultimateAbility = abilityTreeSkillNode != null && abilityTreeSkillNode.abilityTreeNodeType().isUltimate();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/screens/buildloadouts/widgets/LoadoutMenuScrollListAbilityWidget.java
+++ b/common/src/main/java/com/wynntils/screens/buildloadouts/widgets/LoadoutMenuScrollListAbilityWidget.java
@@ -44,11 +44,11 @@ public class LoadoutMenuScrollListAbilityWidget extends AbstractWidget implement
 
         abilityItemStack = parent.getSelectedLoadout().hasAbilityTree() && abilityTreeSkillNode != null
                 ? new AbilityTreeNodeItemStack(
-                abilityTreeSkillNode,
-                parent.getSelectedLoadout().abilityTree())
+                        abilityTreeSkillNode, parent.getSelectedLoadout().abilityTree())
                 : ItemStack.EMPTY;
 
-        ultimateAbility = abilityTreeSkillNode != null && abilityTreeSkillNode.abilityTreeNodeType().isUltimate();
+        ultimateAbility = abilityTreeSkillNode != null
+                && abilityTreeSkillNode.abilityTreeNodeType().isUltimate();
     }
 
     @Override

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -256,7 +256,7 @@
   "feature.wynntils.characterInfoIndicator.name": "Character Info Indicator",
   "feature.wynntils.characterInfoIndicator.rescanMessage.description": "Should the rescan message appear in chat?",
   "feature.wynntils.characterInfoIndicator.rescanMessage.message.clickHere": "here",
-  "feature.wynntils.characterInfoIndicator.rescanMessage.message.prefix": "Your ability tree is outdated click ",
+  "feature.wynntils.characterInfoIndicator.rescanMessage.message.prefix": "Your ability tree is outdated, click ",
   "feature.wynntils.characterInfoIndicator.rescanMessage.message.suffix": " to update.",
   "feature.wynntils.characterInfoIndicator.rescanMessage.name": "Rescan Message",
   "feature.wynntils.characterInfoIndicator.tooltip.leftClick": "Left-Click to update",


### PR DESCRIPTION
Fixes the LoadoutMigrationUpfixer. The bug happened when saving a weapon that was either crafted or had the name sanitization fail causing there to be still a string in the json object instead of the json object is actually expected.

Fixes the crash when character model somehow provides the wrong class during saving.

Hopefully fixes this issue: https://discord.com/channels/394189072635133952/1257255311589511189/1533846607236169980