### PR TITLE
fix: Fix Exchange Merchant markers not showing on the map

### DIFF
--- a/common/src/main/java/com/wynntils/services/map/type/ServiceKind.java
+++ b/common/src/main/java/com/wynntils/services/map/type/ServiceKind.java
@@ -17,7 +17,7 @@ public enum ServiceKind {
     DUNGEON_MERCHANT("Dungeon Merchant", Texture.DUNGEON_MERCHANT, "merchant:dungeon"),
     DUNGEON_SCROLL_MERCHANT("Dungeon Scroll Merchant", Texture.DUNGEON_SCROLL_MERCHANT, "merchant:dungeon-scroll"),
     EMERALD_MERCHANT("Emerald Merchant", Texture.EMERALD_MERCHANT, "merchant:emerald"),
-    EXCHANGE_MERCHANT("Emerald Merchant", Texture.EXCHANGE_MERCHANT, "merchant:exchange"),
+    EXCHANGE_MERCHANT("Exchange Merchant", Texture.EXCHANGE_MERCHANT, "merchant:exchange"),
     FAST_TRAVEL("Fast Travel", Texture.FAST_TRAVEL, "fast-travel"),
     HOUSING_BALLOON("Housing Balloon", Texture.HOUSING_BALLOON, "housing-balloon"),
     ITEM_IDENTIFIER("Item Identifier", Texture.ITEM_IDENTIFIER, "identifier"),


### PR DESCRIPTION
`ServiceKind.EXCHANGE_MERCHANT` has `"Emerald Merchant"` as its display name, the same as `EMERALD_MERCHANT` on the line above it.

`ServiceKind.fromString` matches on that name and takes the first hit, so `"Exchange Merchant"` never resolves. `PoiService` then drops those locations and logs `Unknown service type in services.json: Exchange Merchant`.

`services_crowdsourced.json` currently has an Exchange Merchant entry with 10 locations, so those 10 markers are missing from the map.

Emerald Merchant itself is fine, `EMERALD_MERCHANT` is declared first and still matches its own name, so only Exchange Merchant is affected.
