### PR TITLE
fix: Fix tests failing outside English locales

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -61,6 +61,11 @@ dependencies {
 
 test {
     useJUnitPlatform()
+
+    // Some tests compare formatted numbers against strings written with a decimal point, so on
+    // a machine whose locale uses a decimal comma they fail for no reason to do with the code.
+    systemProperty "user.language", "en"
+    systemProperty "user.country", "US"
 }
 
 processResources {


### PR DESCRIPTION
A few tests compare formatted numbers against strings written with a decimal point, for example

```java
assertTemplateResult("{abs(-12.5):1}", "12.5");
assertTemplateResult("{if(equals(3;3);add(1;1);add(2;2))}", "2.00");
```

On a machine whose locale uses a decimal comma those come out as `12,5` and `2,00`, so the tests fail and `gradlew build` does not pass locally. CI never sees it because the runners are en_US.

Three fail here on a Turkish locale, `testMathFunctions` and `testConditions` in `TestGenericFunctions` plus `MountAnnotator_STAT_PATTERN` in `TestRegex`, since that pattern matches numbers too.

Pinning the locale for the test task keeps the result the same wherever the build runs. With it the full 290 tests pass here.
