### PR TITLE
chore: Make DevAuth use global settings and accounts

### DIFF
--- a/.devauth/config.toml
+++ b/.devauth/config.toml
@@ -1,8 +1,0 @@
-defaultEnabled = true
-defaultAccount = "main"
-
-[accounts.main]
-type = "microsoft"
-
-[accounts.alt]
-type = "microsoft"

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ classes/
 
 # Data generated while running Minecraft or tests
 run/
+.devauth/
 */logs/*
 
 # IDEs

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ classes/
 
 # Data generated while running Minecraft or tests
 run/
-.devauth/microsoft_accounts.json
 */logs/*
 
 # IDEs

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ subprojects {
 
         runs {
             client {
-                property("devauth.configDir", getRootProject().file(".devauth").absolutePath)
                 if (usingHotswapAgent) {
                     vmArgs "-XX:+AllowEnhancedClassRedefinition"
                     // https://youtrack.jetbrains.com/issue/JBR-7351/JVM-CodeCache-will-not-be-cleaned-using-G1GC-if-Hotswap-Agent-is-enabled-since-JBR-6419-jbr21.351
@@ -40,6 +39,7 @@ subprojects {
                     vmArgs "-XX:HotswapAgent=fatjar"
                 }
                 vmArgs "-ea" // run dev builds with asserts
+                vmArgs "-devauth.enabled=true" // enable devauth
                 client()
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ subprojects {
                     vmArgs "-XX:HotswapAgent=fatjar"
                 }
                 vmArgs "-ea" // run dev builds with asserts
-                vmArgs "-devauth.enabled=true" // enable devauth
+                vmArgs "-Ddevauth.enabled=true" // enable devauth
+                vmArgs "-Ddevauth.account=main"
                 client()
             }
         }


### PR DESCRIPTION
By default, DevAuth uses global stuff that is stored in users home directory, but Wynntils is set up to have its own dedicated local store, I believe there is not much use in that, seeing that the config file changed only one field too, and it only makes a minor annoyance when you get logged out because you weren't using that Wynntils specific session because you were working on other projects. 

This PR simply removes the local store, making DevAuth use its default global counterpart and enables it by default using jvm arguments instead, because that's the only thing in the config file that was changed.