### PR TITLE
fix(map): remove user waypoints on click, fix focus cycling for them

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -364,8 +364,15 @@ public final class MainMapScreen extends AbstractMapScreen {
             if (hoveredFeature instanceof MapLocation hoveredLocation) {
                 McUtils.playSoundUI(SoundEvents.EXPERIENCE_ORB_PICKUP);
 
+                // Check if this is an user marked feature
                 if (Services.UserMarker.isUserMarkedFeature(hoveredLocation)) {
                     Services.UserMarker.removeUserMarkedFeature(hoveredLocation);
+                    return true;
+                }
+
+                // Check if this is a user waypoint
+                if (Services.UserMarker.isMarkerAtLocation(hoveredLocation.getLocation())) {
+                    Services.UserMarker.removeMarkerAtLocation(hoveredLocation.getLocation());
                     return true;
                 }
 
@@ -438,7 +445,10 @@ public final class MainMapScreen extends AbstractMapScreen {
         if (markedLocations.isEmpty()) return;
 
         // Invalidate the focused marker if it's not marked anymore
-        if (!Services.UserMarker.isUserMarkedFeature(focusedMarker)) {
+        boolean stillMarked = focusedMarker != null
+                && (Services.UserMarker.isUserMarkedFeature(focusedMarker)
+                        || Services.UserMarker.isMarkerAtLocation(focusedMarker.getLocation()));
+        if (!stillMarked) {
             focusedMarker = null;
         }
 


### PR DESCRIPTION
Left-clicking a MapLocation waypoint placed via middle-click never called removeMarkerAtLocation - only isUserMarkedFeature (existing map features overridden by the user) was checked, so the click fell through to the generic "clear all + re-add" branch instead of actually removing it, leaving a stale marker with no icon that the focus button could still jump to. Add the missing isMarkerAtLocation check, mirroring the existing MapArea handling just below.

Also fix focusNextMarkedLocation's "still marked" check, which only considered isUserMarkedFeature - a focused user-placed waypoint was never recognized as still marked, so focusedMarker was reset to null every call and cycling always restarted at index 0 instead of advancing.

Closes https://github.com/Wynntils/Wynntils/issues/3342