### PR TITLE
feat: Add back gathering nodes to mapdata

### DIFF
--- a/common/src/main/java/com/wynntils/core/net/UrlId.java
+++ b/common/src/main/java/com/wynntils/core/net/UrlId.java
@@ -36,6 +36,7 @@ public enum UrlId {
     DATA_STATIC_COMBAT_LOCATIONS("dataStaticCombatLocations"),
     DATA_STATIC_COMBAT_MAPFEATURES("dataStaticCombatMapFeatures"),
     DATA_STATIC_DESTINATIONS("dataStaticDestinations"),
+    DATA_STATIC_GATHERING_NODE_MAPFEATURES("dataStaticGatheringNodeMapFeatures"),
     DATA_STATIC_GATHERING_NODES("dataStaticGatheringNodes"),
     DATA_STATIC_GEAR("dataStaticGear"),
     DATA_STATIC_HINTS("dataStaticHints"),

--- a/common/src/main/java/com/wynntils/models/profession/GatheringNodeRegistry.java
+++ b/common/src/main/java/com/wynntils/models/profession/GatheringNodeRegistry.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.profession;
+
+import com.google.gson.reflect.TypeToken;
+import com.wynntils.core.components.Managers;
+import com.wynntils.core.components.Models;
+import com.wynntils.core.net.Dependency;
+import com.wynntils.core.net.DownloadRegistry;
+import com.wynntils.core.net.UrlId;
+import com.wynntils.models.profession.providers.GatheringNodeProvider;
+import com.wynntils.models.profession.providers.GatheringNodeProvider.GatheringNodeLocation;
+import java.io.Reader;
+import java.util.List;
+
+public class GatheringNodeRegistry {
+    private final GatheringNodeProvider gatheringNodeProvider;
+
+    public GatheringNodeRegistry(GatheringNodeProvider gatheringNodeProvider) {
+        this.gatheringNodeProvider = gatheringNodeProvider;
+    }
+
+    public void registerDownloads(DownloadRegistry registry) {
+        // The nodes are grouped into categories per source material, which can only be resolved
+        // once the material registry is downloaded.
+        registry.registerDownload(
+                        UrlId.DATA_STATIC_GATHERING_NODE_MAPFEATURES,
+                        Dependency.simple(Models.Profession, UrlId.DATA_STATIC_MATERIALS))
+                .handleReader(this::handleGatheringNodes);
+    }
+
+    private void handleGatheringNodes(Reader reader) {
+        TypeToken<List<GatheringNodeLocation>> type = new TypeToken<>() {};
+        List<GatheringNodeLocation> nodes = Managers.Json.GSON.fromJson(reader, type.getType());
+
+        gatheringNodeProvider.updateNodes(nodes);
+    }
+}

--- a/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
+++ b/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -94,7 +95,7 @@ public final class ProfessionModel extends Model {
 
     // Keyed by map data category id. Gathering nodes are hidden until the user asks for them.
     @Persisted
-    private final Storage<Map<String, Boolean>> visibleGatheringNodeTypes = new Storage<>(new ConcurrentHashMap<>());
+    private final Storage<Map<String, Boolean>> visibleGatheringNodeTypes = new Storage<>(new TreeMap<>());
 
     private long lastGatherTime = 0L;
     private HarvestInfo lastHarvest;

--- a/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
+++ b/common/src/main/java/com/wynntils/models/profession/ProfessionModel.java
@@ -7,6 +7,8 @@ package com.wynntils.models.profession;
 import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Handlers;
 import com.wynntils.core.components.Model;
+import com.wynntils.core.components.Services;
+import com.wynntils.core.mod.event.WynntilsInitEvent;
 import com.wynntils.core.net.DownloadRegistry;
 import com.wynntils.core.persisted.Persisted;
 import com.wynntils.core.persisted.storage.Storage;
@@ -20,6 +22,8 @@ import com.wynntils.models.profession.label.GatheringNodeHarvestLabelInfo;
 import com.wynntils.models.profession.label.GatheringNodeHarvestLabelParser;
 import com.wynntils.models.profession.label.GatheringNodeLabelParser;
 import com.wynntils.models.profession.label.ProfessionGatheringNodeLabelInfo;
+import com.wynntils.models.profession.providers.GatheringNodeProvider;
+import com.wynntils.models.profession.type.GatheringNodeType;
 import com.wynntils.models.profession.type.GatheringToolInfo;
 import com.wynntils.models.profession.type.HarvestInfo;
 import com.wynntils.models.profession.type.MaterialInfo;
@@ -50,8 +54,11 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 
 public final class ProfessionModel extends Model {
+    private static final GatheringNodeProvider GATHERING_NODE_PROVIDER = new GatheringNodeProvider();
+
     private final GatheringToolInfoRegistry gatheringToolInfoRegistry = new GatheringToolInfoRegistry();
     private final MaterialInfoRegistry materialInfoRegistry = new MaterialInfoRegistry();
+    private final GatheringNodeRegistry gatheringNodeRegistry = new GatheringNodeRegistry(GATHERING_NODE_PROVIDER);
 
     // §dx2.0 §7[+§d28 §fⒺ §7Scribing XP] §6[56%]
     private static final Pattern PROFESSION_CRAFT_PATTERN = Pattern.compile(
@@ -85,6 +92,10 @@ public final class ProfessionModel extends Model {
     @Persisted
     private final Storage<Integer> professionDryStreak = new Storage<>(0);
 
+    // Keyed by map data category id. Gathering nodes are hidden until the user asks for them.
+    @Persisted
+    private final Storage<Map<String, Boolean>> visibleGatheringNodeTypes = new Storage<>(new ConcurrentHashMap<>());
+
     private long lastGatherTime = 0L;
     private HarvestInfo lastHarvest;
 
@@ -110,6 +121,19 @@ public final class ProfessionModel extends Model {
     public void registerDownloads(DownloadRegistry registry) {
         gatheringToolInfoRegistry.registerDownloads(registry);
         materialInfoRegistry.registerDownloads(registry);
+        gatheringNodeRegistry.registerDownloads(registry);
+    }
+
+    @SubscribeEvent
+    public void onModInitFinished(WynntilsInitEvent.ModInitFinished event) {
+        Services.MapData.registerBuiltInProvider(GATHERING_NODE_PROVIDER);
+    }
+
+    @Override
+    public void onStorageLoad(Storage<?> storage) {
+        if (storage == visibleGatheringNodeTypes) {
+            GATHERING_NODE_PROVIDER.applyFilter();
+        }
     }
 
     @SubscribeEvent
@@ -331,6 +355,40 @@ public final class ProfessionModel extends Model {
 
     public Set<ProfessionGatheringNodeLabelInfo> getNodesSet() {
         return Collections.unmodifiableSet(nodesSet);
+    }
+
+    public List<GatheringNodeType> getGatheringNodeTypes() {
+        return GATHERING_NODE_PROVIDER.getNodeTypes();
+    }
+
+    public boolean isGatheringNodeTypeVisible(GatheringNodeType gatheringNodeType) {
+        return visibleGatheringNodeTypes.get().getOrDefault(gatheringNodeType.categoryId(), false);
+    }
+
+    public void setGatheringNodeTypeVisible(GatheringNodeType gatheringNodeType, boolean visible) {
+        visibleGatheringNodeTypes.get().put(gatheringNodeType.categoryId(), visible);
+        visibleGatheringNodeTypes.touched();
+
+        GATHERING_NODE_PROVIDER.applyFilter();
+    }
+
+    public void setAllGatheringNodeTypesVisible(boolean visible) {
+        setGatheringNodeTypesVisible(getGatheringNodeTypes(), visible);
+    }
+
+    public void setAllGatheringNodeTypesVisible(MaterialType materialType, boolean visible) {
+        setGatheringNodeTypesVisible(
+                getGatheringNodeTypes().stream()
+                        .filter(nodeType -> nodeType.materialType() == materialType)
+                        .toList(),
+                visible);
+    }
+
+    private void setGatheringNodeTypesVisible(List<GatheringNodeType> gatheringNodeTypes, boolean visible) {
+        gatheringNodeTypes.forEach(nodeType -> visibleGatheringNodeTypes.get().put(nodeType.categoryId(), visible));
+        visibleGatheringNodeTypes.touched();
+
+        GATHERING_NODE_PROVIDER.applyFilter();
     }
 
     public List<ProfessionType> getIngredientProfessionOrder() {

--- a/common/src/main/java/com/wynntils/models/profession/providers/GatheringNodeProvider.java
+++ b/common/src/main/java/com/wynntils/models/profession/providers/GatheringNodeProvider.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.profession.providers;
+
+import com.wynntils.core.components.Models;
+import com.wynntils.models.profession.type.GatheringNodeType;
+import com.wynntils.models.profession.type.MaterialType;
+import com.wynntils.models.profession.type.SourceMaterial;
+import com.wynntils.services.mapdata.attributes.impl.AbstractMapAttributes;
+import com.wynntils.services.mapdata.attributes.impl.MapLocationAttributesImpl;
+import com.wynntils.services.mapdata.attributes.type.MapAttributes;
+import com.wynntils.services.mapdata.features.impl.MapLocationImpl;
+import com.wynntils.services.mapdata.features.type.MapFeature;
+import com.wynntils.services.mapdata.providers.builtin.BuiltInProvider;
+import com.wynntils.services.mapdata.type.MapCategory;
+import com.wynntils.utils.StringUtils;
+import com.wynntils.utils.mc.type.Location;
+import com.wynntils.utils.type.Pair;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Provides the gathering nodes downloaded by {@link com.wynntils.models.profession.GatheringNodeRegistry}.
+ * <p>
+ * The per-resource categories are not hardcoded; they are built from the categories present in the
+ * downloaded data and resolved against the material registry, so a resource Wynncraft adds later
+ * needs no code change here.
+ */
+public class GatheringNodeProvider extends BuiltInProvider {
+    public static final String GATHERING_CATEGORY_ID = "wynntils:gathering";
+    public static final String UNKNOWN_GATHERING_CATEGORY_ID = GATHERING_CATEGORY_ID + ":unknown";
+
+    private static final List<MapFeature> ALL_FEATURES = new ArrayList<>();
+    private static final List<MapFeature> VISIBLE_FEATURES = new ArrayList<>();
+    private static final List<MapCategory> RESOURCE_CATEGORIES = new ArrayList<>();
+    private static final Map<String, GatheringNodeType> NODE_TYPES = new HashMap<>();
+
+    @Override
+    public String getProviderId() {
+        return "gathering-nodes";
+    }
+
+    @Override
+    public Stream<MapFeature> getFeatures() {
+        return VISIBLE_FEATURES.stream();
+    }
+
+    @Override
+    public Stream<MapCategory> getCategories() {
+        return RESOURCE_CATEGORIES.stream();
+    }
+
+    @Override
+    public void reloadData() {
+        // The data is downloaded by GatheringNodeRegistry, which needs the material registry to be
+        // downloaded first, a dependency that can only be expressed through the download registry.
+    }
+
+    public void updateNodes(List<GatheringNodeLocation> nodes) {
+        ALL_FEATURES.forEach(this::notifyCallbacks);
+        ALL_FEATURES.clear();
+        ALL_FEATURES.addAll(nodes);
+
+        rebuildNodeTypes();
+        applyFilter();
+    }
+
+    public List<GatheringNodeType> getNodeTypes() {
+        return NODE_TYPES.values().stream().sorted().toList();
+    }
+
+    /**
+     * Recomputes which nodes are shown on the map. Nodes of a resource that could not be resolved
+     * against the material registry are always shown, as they cannot be filtered.
+     */
+    public void applyFilter() {
+        // No callbacks here on purpose. Only the set of shown features changes, not the attributes
+        // of any of them, so there is nothing cached to invalidate.
+        VISIBLE_FEATURES.clear();
+
+        for (MapFeature feature : ALL_FEATURES) {
+            GatheringNodeType nodeType = NODE_TYPES.get(feature.getCategoryId());
+            if (nodeType == null || Models.Profession.isGatheringNodeTypeVisible(nodeType)) {
+                VISIBLE_FEATURES.add(feature);
+            }
+        }
+    }
+
+    private void rebuildNodeTypes() {
+        RESOURCE_CATEGORIES.forEach(this::notifyCallbacks);
+        RESOURCE_CATEGORIES.clear();
+        NODE_TYPES.clear();
+
+        for (String categoryId :
+                ALL_FEATURES.stream().map(MapFeature::getCategoryId).distinct().toList()) {
+            Optional<Pair<MaterialType, SourceMaterial>> material =
+                    Models.Profession.findMaterialBySourceName(getResourceName(categoryId));
+            if (material.isEmpty()) continue;
+
+            GatheringNodeType nodeType = new GatheringNodeType(
+                    categoryId, material.get().key(), material.get().value());
+
+            NODE_TYPES.put(categoryId, nodeType);
+            RESOURCE_CATEGORIES.add(new GatheringResourceCategory(nodeType));
+        }
+    }
+
+    public static String getProfessionCategoryId(MaterialType materialType) {
+        return GATHERING_CATEGORY_ID + ":"
+                + materialType.getProfessionType().name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Turns the resource segment of a category id back into a source material name,
+     * e.g. {@code wynntils:gathering:woodcutting:red-alder} into {@code Red Alder}.
+     */
+    private static String getResourceName(String categoryId) {
+        String slug = categoryId.substring(categoryId.lastIndexOf(':') + 1);
+
+        return Arrays.stream(slug.split("-")).map(StringUtils::capitalized).collect(Collectors.joining(" "));
+    }
+
+    public static final class GatheringNodeLocation extends MapLocationImpl {
+        public GatheringNodeLocation(
+                String featureId, String categoryId, MapLocationAttributesImpl attributes, Location location) {
+            super(featureId, categoryId, attributes, location);
+        }
+    }
+
+    private static final class GatheringResourceCategory implements MapCategory {
+        private final GatheringNodeType nodeType;
+
+        private GatheringResourceCategory(GatheringNodeType nodeType) {
+            this.nodeType = nodeType;
+        }
+
+        @Override
+        public String getCategoryId() {
+            return nodeType.categoryId();
+        }
+
+        @Override
+        public Optional<String> getName() {
+            return Optional.of(nodeType.getDisplayName());
+        }
+
+        @Override
+        public Optional<MapAttributes> getAttributes() {
+            return Optional.of(new AbstractMapAttributes() {
+                @Override
+                public Optional<String> getLabel() {
+                    return Optional.of(nodeType.getDisplayName());
+                }
+
+                @Override
+                public Optional<Integer> getLevel() {
+                    return Optional.of(nodeType.sourceMaterial().level());
+                }
+            });
+        }
+    }
+}

--- a/common/src/main/java/com/wynntils/models/profession/providers/GatheringNodeProvider.java
+++ b/common/src/main/java/com/wynntils/models/profession/providers/GatheringNodeProvider.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.models.profession.providers;
 
+import com.wynntils.core.WynntilsMod;
 import com.wynntils.core.components.Models;
 import com.wynntils.models.profession.type.GatheringNodeType;
 import com.wynntils.models.profession.type.MaterialType;
@@ -34,15 +35,18 @@ import java.util.stream.Stream;
  * The per-resource categories are not hardcoded; they are built from the categories present in the
  * downloaded data and resolved against the material registry, so a resource Wynncraft adds later
  * needs no code change here.
+ * <p>
+ * The download handler runs off the render thread, while the filter is applied from the screen on
+ * the render thread, so all state is published by swapping an immutable snapshot rather than by
+ * mutating a shared collection.
  */
 public class GatheringNodeProvider extends BuiltInProvider {
     public static final String GATHERING_CATEGORY_ID = "wynntils:gathering";
-    public static final String UNKNOWN_GATHERING_CATEGORY_ID = GATHERING_CATEGORY_ID + ":unknown";
 
-    private static final List<MapFeature> ALL_FEATURES = new ArrayList<>();
-    private static final List<MapFeature> VISIBLE_FEATURES = new ArrayList<>();
-    private static final List<MapCategory> RESOURCE_CATEGORIES = new ArrayList<>();
-    private static final Map<String, GatheringNodeType> NODE_TYPES = new HashMap<>();
+    private volatile List<MapFeature> allFeatures = List.of();
+    private volatile List<MapFeature> visibleFeatures = List.of();
+    private volatile List<MapCategory> resourceCategories = List.of();
+    private volatile Map<String, GatheringNodeType> nodeTypes = Map.of();
 
     @Override
     public String getProviderId() {
@@ -51,12 +55,12 @@ public class GatheringNodeProvider extends BuiltInProvider {
 
     @Override
     public Stream<MapFeature> getFeatures() {
-        return VISIBLE_FEATURES.stream();
+        return visibleFeatures.stream();
     }
 
     @Override
     public Stream<MapCategory> getCategories() {
-        return RESOURCE_CATEGORIES.stream();
+        return resourceCategories.stream();
     }
 
     @Override
@@ -66,52 +70,62 @@ public class GatheringNodeProvider extends BuiltInProvider {
     }
 
     public void updateNodes(List<GatheringNodeLocation> nodes) {
-        ALL_FEATURES.forEach(this::notifyCallbacks);
-        ALL_FEATURES.clear();
-        ALL_FEATURES.addAll(nodes);
+        allFeatures.forEach(this::notifyCallbacks);
+        allFeatures = List.copyOf(nodes);
 
         rebuildNodeTypes();
         applyFilter();
     }
 
     public List<GatheringNodeType> getNodeTypes() {
-        return NODE_TYPES.values().stream().sorted().toList();
+        return nodeTypes.values().stream().sorted().toList();
     }
 
     /**
-     * Recomputes which nodes are shown on the map. Nodes of a resource that could not be resolved
-     * against the material registry are always shown, as they cannot be filtered.
+     * Recomputes which nodes are shown on the map. No callbacks are fired, as only the set of shown
+     * features changes, not the attributes of any of them, so there is nothing cached to invalidate.
      */
     public void applyFilter() {
-        // No callbacks here on purpose. Only the set of shown features changes, not the attributes
-        // of any of them, so there is nothing cached to invalidate.
-        VISIBLE_FEATURES.clear();
+        Map<String, GatheringNodeType> currentNodeTypes = nodeTypes;
 
-        for (MapFeature feature : ALL_FEATURES) {
-            GatheringNodeType nodeType = NODE_TYPES.get(feature.getCategoryId());
-            if (nodeType == null || Models.Profession.isGatheringNodeTypeVisible(nodeType)) {
-                VISIBLE_FEATURES.add(feature);
-            }
-        }
+        visibleFeatures = allFeatures.stream()
+                .filter(feature -> {
+                    GatheringNodeType nodeType = currentNodeTypes.get(feature.getCategoryId());
+                    return nodeType != null && Models.Profession.isGatheringNodeTypeVisible(nodeType);
+                })
+                .toList();
     }
 
     private void rebuildNodeTypes() {
-        RESOURCE_CATEGORIES.forEach(this::notifyCallbacks);
-        RESOURCE_CATEGORIES.clear();
-        NODE_TYPES.clear();
+        resourceCategories.forEach(this::notifyCallbacks);
+
+        Map<String, GatheringNodeType> newNodeTypes = new HashMap<>();
+        List<MapCategory> newCategories = new ArrayList<>();
+        List<String> unresolved = new ArrayList<>();
 
         for (String categoryId :
-                ALL_FEATURES.stream().map(MapFeature::getCategoryId).distinct().toList()) {
+                allFeatures.stream().map(MapFeature::getCategoryId).distinct().toList()) {
             Optional<Pair<MaterialType, SourceMaterial>> material =
                     Models.Profession.findMaterialBySourceName(getResourceName(categoryId));
-            if (material.isEmpty()) continue;
+            if (material.isEmpty()) {
+                unresolved.add(categoryId);
+                continue;
+            }
 
             GatheringNodeType nodeType = new GatheringNodeType(
                     categoryId, material.get().key(), material.get().value());
 
-            NODE_TYPES.put(categoryId, nodeType);
-            RESOURCE_CATEGORIES.add(new GatheringResourceCategory(nodeType));
+            newNodeTypes.put(categoryId, nodeType);
+            newCategories.add(new GatheringResourceCategory(nodeType));
         }
+
+        if (!unresolved.isEmpty()) {
+            // Nodes of these categories cannot be named or filtered, so they are not shown at all
+            WynntilsMod.warn("Unknown gathering node resources, they will not be shown on the map: " + unresolved);
+        }
+
+        nodeTypes = Map.copyOf(newNodeTypes);
+        resourceCategories = List.copyOf(newCategories);
     }
 
     public static String getProfessionCategoryId(MaterialType materialType) {

--- a/common/src/main/java/com/wynntils/models/profession/type/GatheringNodeType.java
+++ b/common/src/main/java/com/wynntils/models/profession/type/GatheringNodeType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.profession.type;
+
+import com.wynntils.utils.StringUtils;
+
+/**
+ * One kind of gathering node, as shown in the gathering node filter. The category id is the map data
+ * category all nodes of this kind belong to, and is what node visibility is keyed on.
+ */
+public record GatheringNodeType(String categoryId, MaterialType materialType, SourceMaterial sourceMaterial)
+        implements Comparable<GatheringNodeType> {
+    public String getDisplayName() {
+        return sourceMaterial.name() + " " + StringUtils.capitalized(materialType.name());
+    }
+
+    @Override
+    public int compareTo(GatheringNodeType other) {
+        int materialTypeCompare = Integer.compare(materialType.ordinal(), other.materialType.ordinal());
+        if (materialTypeCompare != 0) return materialTypeCompare;
+
+        int levelCompare = Integer.compare(sourceMaterial.level(), other.sourceMaterial.level());
+        if (levelCompare != 0) return levelCompare;
+
+        return sourceMaterial.name().compareToIgnoreCase(other.sourceMaterial.name());
+    }
+}

--- a/common/src/main/java/com/wynntils/screens/maps/GatheringNodeFilterScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GatheringNodeFilterScreen.java
@@ -5,8 +5,10 @@
 package com.wynntils.screens.maps;
 
 import com.mojang.blaze3d.platform.cursor.CursorTypes;
+import com.wynntils.core.components.Models;
 import com.wynntils.core.consumers.screens.WynntilsScreen;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.models.profession.type.GatheringNodeType;
 import com.wynntils.models.profession.type.MaterialType;
 import com.wynntils.screens.base.widgets.InfoButton;
 import com.wynntils.screens.base.widgets.TextInputBoxWidget;
@@ -42,8 +44,8 @@ public final class GatheringNodeFilterScreen extends WynntilsScreen {
     private final MainMapScreen oldMapScreen;
     private List<GatheringNodeFilterWidget> gatheringNodeFilterWidgets = new ArrayList<>();
     private List<GatheringProfessionFilterButton> professionFilterButtons = new ArrayList<>();
-    //    private List<PoiService.GatheringNodeType> gatheringNodeTypes = new ArrayList<>();
-    private Map<MaterialType, Boolean> filteredMaterialTypes = new EnumMap<>(MaterialType.class);
+    private List<GatheringNodeType> gatheringNodeTypes = new ArrayList<>();
+    private final Map<MaterialType, Boolean> filteredMaterialTypes = new EnumMap<>(MaterialType.class);
 
     private TextInputBoxWidget searchInput;
 
@@ -188,25 +190,24 @@ public final class GatheringNodeFilterScreen extends WynntilsScreen {
                         VerticalAlignment.TOP,
                         TextShadow.NORMAL);
 
-        //        if (gatheringNodeTypes.isEmpty()) {
-        //            FontRenderer.getInstance()
-        //                    .renderText(
-        //                            guiGraphics,
-        //                            StyledText.fromComponent(Component.translatable(
-        //                                    "screens.wynntils.gatheringNodeFilterGui.noGatheringNodeTypes")),
-        //                            getTranslationX() + Texture.WAYPOINT_MANAGER_BACKGROUND.width() / 2f,
-        //                            getTranslationY() + Texture.WAYPOINT_MANAGER_BACKGROUND.height() / 2f,
-        //                            CommonColors.WHITE,
-        //                            HorizontalAlignment.CENTER,
-        //                            VerticalAlignment.MIDDLE,
-        //                            TextShadow.NORMAL);
-        //        } else {
-        //            RenderUtils.enableScissor(
-        //                    guiGraphics, (int) (getTranslationX() + 10), (int) (getTranslationY() + 16), 322, 181);
-        //            gatheringNodeFilterWidgets.forEach(widget -> widget.render(guiGraphics, mouseX, mouseY,
-        // partialTick));
-        //            RenderUtils.disableScissor(guiGraphics);
-        //        }
+        if (gatheringNodeTypes.isEmpty()) {
+            FontRenderer.getInstance()
+                    .renderText(
+                            guiGraphics,
+                            StyledText.fromComponent(Component.translatable(
+                                    "screens.wynntils.gatheringNodeFilterGui.noGatheringNodeTypes")),
+                            getTranslationX() + Texture.WAYPOINT_MANAGER_BACKGROUND.width() / 2f,
+                            getTranslationY() + Texture.WAYPOINT_MANAGER_BACKGROUND.height() / 2f,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.CENTER,
+                            VerticalAlignment.MIDDLE,
+                            TextShadow.NORMAL);
+        } else {
+            RenderUtils.enableScissor(
+                    guiGraphics, (int) (getTranslationX() + 10), (int) (getTranslationY() + 16), 322, 181);
+            gatheringNodeFilterWidgets.forEach(widget -> widget.render(guiGraphics, mouseX, mouseY, partialTick));
+            RenderUtils.disableScissor(guiGraphics);
+        }
 
         professionFilterButtons.forEach(widget -> widget.render(guiGraphics, mouseX, mouseY, partialTick));
 
@@ -286,10 +287,10 @@ public final class GatheringNodeFilterScreen extends WynntilsScreen {
         return true;
     }
 
-    //    public void toggleGatheringNodeType(PoiService.GatheringNodeType gatheringNodeType) {
-    //        Services.Poi.setGatheringNodeTypeVisible(
-    //                gatheringNodeType, !Services.Poi.isGatheringNodeTypeVisible(gatheringNodeType));
-    //    }
+    public void toggleGatheringNodeType(GatheringNodeType gatheringNodeType) {
+        Models.Profession.setGatheringNodeTypeVisible(
+                gatheringNodeType, !Models.Profession.isGatheringNodeTypeVisible(gatheringNodeType));
+    }
 
     public void toggleMaterialType(MaterialType materialType, boolean selected, boolean excludeOthers) {
         if (excludeOthers) {
@@ -307,20 +308,18 @@ public final class GatheringNodeFilterScreen extends WynntilsScreen {
     }
 
     private void toggleAllGatheringNodeTypes(boolean visible) {
-        //        Services.Poi.setAllGatheringNodeTypesVisible(visible);
+        Models.Profession.setAllGatheringNodeTypesVisible(visible);
     }
 
     private void renderScroll(GuiGraphics guiGraphics) {
-        //        if (gatheringNodeTypes.size() <= MAX_WIDGETS_PER_PAGE) return;
-        //
-        //        scrollY = getTranslationY()
-        //                + 15
-        //                + MathUtils.map(
-        //                        gatheringNodesScrollOffset, 0, getMaxScrollOffset(), 0, 186 -
-        // Texture.SCROLL_BUTTON.height());
-        //
-        //        RenderUtils.drawTexturedRect(guiGraphics, Texture.SCROLL_BUTTON, getTranslationX() + SCROLL_RENDER_X,
-        // scrollY);
+        if (gatheringNodeTypes.size() <= MAX_WIDGETS_PER_PAGE) return;
+
+        scrollY = getTranslationY()
+                + 15
+                + MathUtils.map(
+                        gatheringNodesScrollOffset, 0, getMaxScrollOffset(), 0, 186 - Texture.SCROLL_BUTTON.height());
+
+        RenderUtils.drawTexturedRect(guiGraphics, Texture.SCROLL_BUTTON, getTranslationX() + SCROLL_RENDER_X, scrollY);
     }
 
     private void scroll(int newOffset) {
@@ -341,24 +340,23 @@ public final class GatheringNodeFilterScreen extends WynntilsScreen {
 
     private void populateGatheringNodeTypes() {
         gatheringNodeFilterWidgets = new ArrayList<>();
-        //        gatheringNodeTypes = Services.Poi.getGatheringNodeTypes().stream()
-        //                .filter(gatheringNodeType ->
-        // filteredMaterialTypes.getOrDefault(gatheringNodeType.materialType(), true))
-        //                .filter(gatheringNodeType ->
-        //                        searchMatches(gatheringNodeType.sourceMaterial().name()))
-        //                .toList();
+        gatheringNodeTypes = Models.Profession.getGatheringNodeTypes().stream()
+                .filter(gatheringNodeType -> filteredMaterialTypes.getOrDefault(gatheringNodeType.materialType(), true))
+                .filter(gatheringNodeType ->
+                        searchMatches(gatheringNodeType.sourceMaterial().name()))
+                .toList();
 
         int renderX = (int) (getTranslationX() + 12);
         int renderY = (int) (getTranslationY() + 16);
 
-        //        for (PoiService.GatheringNodeType gatheringNodeType : gatheringNodeTypes) {
-        //            GatheringNodeFilterWidget gatheringNodeFilterWidget =
-        //                    new GatheringNodeFilterWidget(renderX, renderY, 320, 20, this, gatheringNodeType);
-        //
-        //            gatheringNodeFilterWidget.visible = renderY <= getTranslationY() + 16 + 179;
-        //            gatheringNodeFilterWidgets.add(gatheringNodeFilterWidget);
-        //            renderY += 20;
-        //        }
+        for (GatheringNodeType gatheringNodeType : gatheringNodeTypes) {
+            GatheringNodeFilterWidget gatheringNodeFilterWidget =
+                    new GatheringNodeFilterWidget(renderX, renderY, 320, 20, this, gatheringNodeType);
+
+            gatheringNodeFilterWidget.visible = renderY <= getTranslationY() + 16 + 179;
+            gatheringNodeFilterWidgets.add(gatheringNodeFilterWidget);
+            renderY += 20;
+        }
 
         scroll(Math.min(gatheringNodesScrollOffset, getMaxScrollOffset()));
     }

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -310,7 +310,6 @@ public final class MainMapScreen extends AbstractMapScreen {
 
         // FIXME: Add back the pois that are still not converted to MapData
         //        - Provided custom pois
-        //        - Gathering Nodes
 
         return mapFeatures;
     }

--- a/common/src/main/java/com/wynntils/screens/maps/widgets/GatheringNodeFilterWidget.java
+++ b/common/src/main/java/com/wynntils/screens/maps/widgets/GatheringNodeFilterWidget.java
@@ -4,105 +4,126 @@
  */
 package com.wynntils.screens.maps.widgets;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
+import com.wynntils.core.components.Models;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.models.profession.type.GatheringNodeType;
 import com.wynntils.screens.maps.GatheringNodeFilterScreen;
+import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.render.RenderUtils;
+import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.type.HorizontalAlignment;
+import com.wynntils.utils.render.type.TextShadow;
+import com.wynntils.utils.render.type.VerticalAlignment;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 
 public class GatheringNodeFilterWidget extends AbstractWidget {
     private final GatheringNodeFilterScreen filterScreen;
-    //    private final PoiService.GatheringNodeType gatheringNodeType;
-    //    private final Texture icon;
-    //    private final Button toggleButton;
-    //    private final float iconWidth;
-    //    private final float iconHeight;
+    private final GatheringNodeType gatheringNodeType;
+    private final Texture icon;
+    private final Button toggleButton;
+    private final float iconWidth;
+    private final float iconHeight;
     private float iconRenderY;
 
-    public GatheringNodeFilterWidget(int x, int y, int width, int height, GatheringNodeFilterScreen filterScreen) {
-        //            PoiService.GatheringNodeType gatheringNodeType) {
-        super(x, y, width, height, Component.literal(""));
-        //                Component.literal(gatheringNodeType.sourceMaterial().name()));
+    public GatheringNodeFilterWidget(
+            int x,
+            int y,
+            int width,
+            int height,
+            GatheringNodeFilterScreen filterScreen,
+            GatheringNodeType gatheringNodeType) {
+        super(
+                x,
+                y,
+                width,
+                height,
+                Component.literal(gatheringNodeType.sourceMaterial().name()));
 
         this.filterScreen = filterScreen;
-        //        this.gatheringNodeType = gatheringNodeType;
-        //        this.icon = gatheringNodeType.materialType().getMaterialTexture();
+        this.gatheringNodeType = gatheringNodeType;
+        this.icon = gatheringNodeType.materialType().getMaterialTexture();
 
-        //        toggleButton = new Button.Builder(
-        //                        getToggleText(), (button) -> filterScreen.toggleGatheringNodeType(gatheringNodeType))
-        //                .pos(x + width - 60, y)
-        //                .size(55, 20)
-        //                .build();
+        toggleButton = new Button.Builder(
+                        getToggleText(), (button) -> filterScreen.toggleGatheringNodeType(gatheringNodeType))
+                .pos(x + width - 60, y)
+                .size(55, 20)
+                .build();
 
-        //        float scaleFactor = 0.8f * Math.min(width, height) / Math.max(icon.width(), icon.height());
-        //        iconWidth = icon.width() * scaleFactor;
-        //        iconHeight = icon.height() * scaleFactor;
+        float scaleFactor = 0.8f * Math.min(width, height) / Math.max(icon.width(), icon.height());
+        iconWidth = icon.width() * scaleFactor;
+        iconHeight = icon.height() * scaleFactor;
         updateRenderY(y);
     }
 
     @Override
     public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        //        RenderUtils.drawScalingTexturedRect(guiGraphics, icon, getX() + 2, iconRenderY, iconWidth,
-        // iconHeight);
-        //
-        //        CustomColor color =
-        //                Services.Poi.isGatheringNodeTypeVisible(gatheringNodeType) ? CommonColors.WHITE :
-        // CommonColors.GRAY;
-        //
-        //        FontRenderer.getInstance()
-        //                .renderScrollingText(
-        //                        guiGraphics,
-        //                        StyledText.fromString(gatheringNodeType.sourceMaterial().name()),
-        //                        getX() + 25,
-        //                        getY() + 10,
-        //                        140,
-        //                        color,
-        //                        HorizontalAlignment.LEFT,
-        //                        VerticalAlignment.MIDDLE,
-        //                        TextShadow.NORMAL);
-        //
-        //        FontRenderer.getInstance()
-        //                .renderText(
-        //                        guiGraphics,
-        //                        StyledText.fromString(
-        //                                "Level " + gatheringNodeType.sourceMaterial().level()),
-        //                        getX() + 210,
-        //                        getY() + 10,
-        //                        color,
-        //                        HorizontalAlignment.CENTER,
-        //                        VerticalAlignment.MIDDLE,
-        //                        TextShadow.NORMAL);
-        //
-        //        toggleButton.setMessage(getToggleText());
-        //        toggleButton.render(guiGraphics, mouseX, mouseY, partialTick);
-        //
-        //        if (this.isHovered) {
-        //            guiGraphics.requestCursor(CursorTypes.POINTING_HAND);
-        //        }
+        RenderUtils.drawScalingTexturedRect(guiGraphics, icon, getX() + 2, iconRenderY, iconWidth, iconHeight);
+
+        CustomColor color = Models.Profession.isGatheringNodeTypeVisible(gatheringNodeType)
+                ? CommonColors.WHITE
+                : CommonColors.GRAY;
+
+        FontRenderer.getInstance()
+                .renderScrollingText(
+                        guiGraphics,
+                        StyledText.fromString(gatheringNodeType.sourceMaterial().name()),
+                        getX() + 25,
+                        getY() + 10,
+                        140,
+                        color,
+                        HorizontalAlignment.LEFT,
+                        VerticalAlignment.MIDDLE,
+                        TextShadow.NORMAL);
+
+        FontRenderer.getInstance()
+                .renderText(
+                        guiGraphics,
+                        StyledText.fromString(
+                                "Level " + gatheringNodeType.sourceMaterial().level()),
+                        getX() + 210,
+                        getY() + 10,
+                        color,
+                        HorizontalAlignment.CENTER,
+                        VerticalAlignment.MIDDLE,
+                        TextShadow.NORMAL);
+
+        toggleButton.setMessage(getToggleText());
+        toggleButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+        if (this.isHovered) {
+            guiGraphics.requestCursor(CursorTypes.POINTING_HAND);
+        }
     }
 
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean isDoubleClick) {
         if (!isMouseOver(event.x(), event.y())) return false;
 
-        //        if (toggleButton.mouseClicked(event, isDoubleClick)) return true;
-        //
-        //        filterScreen.toggleGatheringNodeType(gatheringNodeType);
+        if (toggleButton.mouseClicked(event, isDoubleClick)) return true;
+
+        filterScreen.toggleGatheringNodeType(gatheringNodeType);
         return true;
     }
 
     public void updateRenderY(int y) {
         setY(y);
-        //        toggleButton.setY(y);
-        //        iconRenderY = (y + height / 2f) - iconHeight / 2f;
+        toggleButton.setY(y);
+        iconRenderY = (y + height / 2f) - iconHeight / 2f;
     }
 
-    //    private Component getToggleText() {
-    //        return Services.Poi.isGatheringNodeTypeVisible(gatheringNodeType)
-    //                ? Component.translatable("screens.wynntils.gatheringNodeFilterGui.hide")
-    //                : Component.translatable("screens.wynntils.gatheringNodeFilterGui.show");
-    //    }
+    private Component getToggleText() {
+        return Models.Profession.isGatheringNodeTypeVisible(gatheringNodeType)
+                ? Component.translatable("screens.wynntils.gatheringNodeFilterGui.hide")
+                : Component.translatable("screens.wynntils.gatheringNodeFilterGui.show");
+    }
 
     @Override
     protected void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {}

--- a/common/src/main/java/com/wynntils/screens/maps/widgets/GatheringProfessionFilterButton.java
+++ b/common/src/main/java/com/wynntils/screens/maps/widgets/GatheringProfessionFilterButton.java
@@ -5,6 +5,7 @@
 package com.wynntils.screens.maps.widgets;
 
 import com.mojang.blaze3d.platform.cursor.CursorTypes;
+import com.wynntils.core.components.Models;
 import com.wynntils.models.profession.type.MaterialType;
 import com.wynntils.screens.maps.GatheringNodeFilterScreen;
 import com.wynntils.utils.colors.CommonColors;
@@ -16,6 +17,7 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
+import org.lwjgl.glfw.GLFW;
 
 public class GatheringProfessionFilterButton extends AbstractWidget {
     private final GatheringNodeFilterScreen filterScreen;
@@ -83,8 +85,8 @@ public class GatheringProfessionFilterButton extends AbstractWidget {
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean isDoubleClick) {
         if (event.hasAltDown()) {
-            //            Services.Poi.setAllGatheringNodeTypesVisible(materialType, event.button() ==
-            // GLFW.GLFW_MOUSE_BUTTON_LEFT);
+            Models.Profession.setAllGatheringNodeTypesVisible(
+                    materialType, event.button() == GLFW.GLFW_MOUSE_BUTTON_LEFT);
             return true;
         }
         selected = !selected;

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
@@ -49,7 +49,6 @@ public class CategoriesProvider extends BuiltInProvider {
         for (MaterialType materialType : MaterialType.values()) {
             PROVIDED_CATEGORIES.add(new GatheringProfessionCategory(materialType));
         }
-        PROVIDED_CATEGORIES.add(new GatheringUnknownCategory());
         for (int tier = 1; tier <= LootChestTier.values().length; tier++) {
             PROVIDED_CATEGORIES.add(new FoundChestCategory(tier));
         }
@@ -396,33 +395,6 @@ public class CategoriesProvider extends BuiltInProvider {
                 @Override
                 public Optional<CustomColor> getLabelColor() {
                     return Optional.of(CustomColor.fromChatFormatting(materialType.getLabelColor()));
-                }
-
-                @Override
-                public Optional<MapVisibility> getIconVisibility() {
-                    return Optional.of(DefaultMapAttributes.ICON_ALWAYS);
-                }
-            });
-        }
-    }
-
-    private static final class GatheringUnknownCategory implements MapCategory {
-        @Override
-        public String getCategoryId() {
-            return GatheringNodeProvider.UNKNOWN_GATHERING_CATEGORY_ID;
-        }
-
-        @Override
-        public Optional<String> getName() {
-            return Optional.of("Unknown Gathering Nodes");
-        }
-
-        @Override
-        public Optional<MapAttributes> getAttributes() {
-            return Optional.of(new AbstractMapAttributes() {
-                @Override
-                public Optional<String> getIconId() {
-                    return Optional.of("wynntils:icon:symbols:question-mark");
                 }
 
                 @Override

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/CategoriesProvider.java
@@ -7,6 +7,8 @@ package com.wynntils.services.mapdata.providers.builtin;
 import com.google.common.base.CaseFormat;
 import com.wynntils.models.activities.type.ActivityType;
 import com.wynntils.models.containers.type.LootChestTier;
+import com.wynntils.models.profession.providers.GatheringNodeProvider;
+import com.wynntils.models.profession.type.MaterialType;
 import com.wynntils.services.hades.type.PlayerRelation;
 import com.wynntils.services.mapdata.attributes.DefaultMapAttributes;
 import com.wynntils.services.mapdata.attributes.MapMarkerOptionsBuilder;
@@ -43,6 +45,11 @@ public class CategoriesProvider extends BuiltInProvider {
         for (PlaceLocation.PlaceType layer : PlaceLocation.PlaceType.values()) {
             PROVIDED_CATEGORIES.add(new PlaceCategory(layer));
         }
+        PROVIDED_CATEGORIES.add(new GatheringCategory());
+        for (MaterialType materialType : MaterialType.values()) {
+            PROVIDED_CATEGORIES.add(new GatheringProfessionCategory(materialType));
+        }
+        PROVIDED_CATEGORIES.add(new GatheringUnknownCategory());
         for (int tier = 1; tier <= LootChestTier.values().length; tier++) {
             PROVIDED_CATEGORIES.add(new FoundChestCategory(tier));
         }
@@ -328,6 +335,99 @@ public class CategoriesProvider extends BuiltInProvider {
                 @Override
                 public Optional<MapVisibility> getLabelVisibility() {
                     return Optional.of(DefaultMapAttributes.LABEL_NEVER);
+                }
+            });
+        }
+    }
+
+    private static final class GatheringCategory implements MapCategory {
+        @Override
+        public String getCategoryId() {
+            return GatheringNodeProvider.GATHERING_CATEGORY_ID;
+        }
+
+        @Override
+        public Optional<String> getName() {
+            return Optional.of("Gathering Nodes");
+        }
+
+        @Override
+        public Optional<MapAttributes> getAttributes() {
+            return Optional.of(new AbstractMapAttributes() {
+                @Override
+                public Optional<Integer> getPriority() {
+                    return Optional.of(100);
+                }
+
+                @Override
+                public Optional<MapVisibility> getLabelVisibility() {
+                    return Optional.of(DefaultMapAttributes.LABEL_NEVER);
+                }
+            });
+        }
+    }
+
+    private static final class GatheringProfessionCategory implements MapCategory {
+        private final MaterialType materialType;
+
+        private GatheringProfessionCategory(MaterialType materialType) {
+            this.materialType = materialType;
+        }
+
+        @Override
+        public String getCategoryId() {
+            return GatheringNodeProvider.getProfessionCategoryId(materialType);
+        }
+
+        @Override
+        public Optional<String> getName() {
+            return Optional.of(materialType.getProfessionType().getDisplayName() + " Nodes");
+        }
+
+        @Override
+        public Optional<MapAttributes> getAttributes() {
+            return Optional.of(new AbstractMapAttributes() {
+                @Override
+                public Optional<String> getIconId() {
+                    return Optional.of("wynntils:icon:gathering:"
+                            + materialType.getProfessionType().name().toLowerCase(Locale.ROOT));
+                }
+
+                @Override
+                public Optional<CustomColor> getLabelColor() {
+                    return Optional.of(CustomColor.fromChatFormatting(materialType.getLabelColor()));
+                }
+
+                @Override
+                public Optional<MapVisibility> getIconVisibility() {
+                    return Optional.of(DefaultMapAttributes.ICON_ALWAYS);
+                }
+            });
+        }
+    }
+
+    private static final class GatheringUnknownCategory implements MapCategory {
+        @Override
+        public String getCategoryId() {
+            return GatheringNodeProvider.UNKNOWN_GATHERING_CATEGORY_ID;
+        }
+
+        @Override
+        public Optional<String> getName() {
+            return Optional.of("Unknown Gathering Nodes");
+        }
+
+        @Override
+        public Optional<MapAttributes> getAttributes() {
+            return Optional.of(new AbstractMapAttributes() {
+                @Override
+                public Optional<String> getIconId() {
+                    return Optional.of("wynntils:icon:symbols:question-mark");
+                }
+
+                @Override
+                public Optional<MapVisibility> getIconVisibility() {
+                    return Optional.of(DefaultMapAttributes.ICON_ALWAYS);
                 }
             });
         }

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/MapIconsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/MapIconsProvider.java
@@ -69,6 +69,7 @@ public class MapIconsProvider extends BuiltInProvider {
             new BuiltInIcon("wynntils:icon:symbols:fireball", Texture.FIREBALL),
             new BuiltInIcon("wynntils:icon:symbols:flag", Texture.FLAG),
             new BuiltInIcon("wynntils:icon:symbols:pointer", Texture.POINTER),
+            new BuiltInIcon("wynntils:icon:symbols:question-mark", Texture.QUESTION_MARK_ICON),
             new BuiltInIcon("wynntils:icon:symbols:sign", Texture.SIGN),
             new BuiltInIcon("wynntils:icon:symbols:star", Texture.STAR),
             new BuiltInIcon("wynntils:icon:symbols:wall", Texture.WALL),

--- a/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/MapIconsProvider.java
+++ b/common/src/main/java/com/wynntils/services/mapdata/providers/builtin/MapIconsProvider.java
@@ -69,7 +69,6 @@ public class MapIconsProvider extends BuiltInProvider {
             new BuiltInIcon("wynntils:icon:symbols:fireball", Texture.FIREBALL),
             new BuiltInIcon("wynntils:icon:symbols:flag", Texture.FLAG),
             new BuiltInIcon("wynntils:icon:symbols:pointer", Texture.POINTER),
-            new BuiltInIcon("wynntils:icon:symbols:question-mark", Texture.QUESTION_MARK_ICON),
             new BuiltInIcon("wynntils:icon:symbols:sign", Texture.SIGN),
             new BuiltInIcon("wynntils:icon:symbols:star", Texture.STAR),
             new BuiltInIcon("wynntils:icon:symbols:wall", Texture.WALL),

--- a/common/src/main/java/com/wynntils/utils/MapDataUtils.java
+++ b/common/src/main/java/com/wynntils/utils/MapDataUtils.java
@@ -8,6 +8,10 @@ import java.util.Locale;
 
 public final class MapDataUtils {
     public static String sanitizeFeatureId(String featureId) {
-        return featureId.replace(" ", "-").replaceAll("[^a-zA-Z\\-]", "").toLowerCase(Locale.ROOT);
+        return featureId
+                .replace(" ", "-")
+                .replaceAll("[^a-zA-Z0-9\\-]", "")
+                .replaceAll("^[0-9]+", "")
+                .toLowerCase(Locale.ROOT);
     }
 }

--- a/common/src/main/resources/assets/wynntils/urls.json
+++ b/common/src/main/resources/assets/wynntils/urls.json
@@ -156,6 +156,12 @@
     "url": "https://cdn.wynntils.com/static/Data-Storage/destinations.json"
   },
   {
+    "id": "dataStaticGatheringNodeMapFeatures",
+    "md5": "e8d7a686ff4b445d692599136147cf2b",
+    "path": "Reference/gathering_node_mapfeatures.json",
+    "url": "https://cdn.wynntils.com/static/Reference/gathering_node_mapfeatures.json"
+  },
+  {
     "id": "dataStaticGatheringNodes",
     "md5": "3edf9ef125979de9dc242253b16d1531",
     "path": "Reference/gathering_nodes.json",


### PR DESCRIPTION
The filter UI currently still depends on the enum - but the mapdata parts are fully compatible with new resource types without any new code change.

Relevant static storage PR: https://github.com/Wynntils/Static-Storage/pull/592

I've tested this in-game, what I know of this feature, it looks good, but please confirm.
<img width="3440" height="1371" alt="image" src="https://github.com/user-attachments/assets/ad52f468-e811-4e10-85d2-bc70de9ff66c" />
