### PR TITLE
fix: Default TM sort always left clicks

### DIFF
--- a/common/src/main/java/com/wynntils/features/trademarket/TradeMarketDefaultSortOrderFeature.java
+++ b/common/src/main/java/com/wynntils/features/trademarket/TradeMarketDefaultSortOrderFeature.java
@@ -56,7 +56,7 @@ public class TradeMarketDefaultSortOrderFeature extends Feature {
         // Find the shortest path from current sort order to the one we want to apply
         // Math.abs(path) is path's length, path < 0 -> right click else left click
         final int path1 = defaultSortOrder.get().ordinal() - currentSortOrder.ordinal();
-        final int path2 = path1 + TradeMarketSortOrder.LENGTH * (path1 > 0 ? 1 : -1);
+        final int path2 = path1 + TradeMarketSortOrder.LENGTH * (path1 > 0 ? -1 : 1);
         if (Math.abs(path1) < Math.abs(path2)) {
             clickCountdown = Math.abs(path1);
             shouldRightClick = path1 < 0;


### PR DESCRIPTION
Signs are reversed, currently if you set to Lowest Level Range it will left click like 6 times rather than right clicking once