### PR TITLE
fix: Restore volume when disabling silencer

### DIFF
--- a/common/src/main/java/com/wynntils/features/utilities/SilencerFeature.java
+++ b/common/src/main/java/com/wynntils/features/utilities/SilencerFeature.java
@@ -52,6 +52,14 @@ public class SilencerFeature extends Feature {
         super(ProfileDefault.onlyDefault());
     }
 
+    @Override
+    public void onDisable() {
+        if (isSilencerEnabled) {
+            restoreOriginalVolume();
+            isSilencerEnabled = false;
+        }
+    }
+
     @SubscribeEvent
     public void onDisconnect(WynncraftConnectionEvent.Disconnected event) {
         if (isSilencerEnabled) {


### PR DESCRIPTION
silencer can get stuck to permanent enabled when disabling the feature after enabling using keybind