### PR TITLE
fix: Illegal chat tab orderings deletes tab on save

### DIFF
--- a/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
@@ -21,7 +21,7 @@ import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -387,7 +387,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
     }
 
     private void saveChatTab() {
-        OptionalInt requestedOrder = getRequestedOrder();
+        Optional<Integer> requestedOrder = getRequestedOrder();
         if (requestedOrder.isEmpty()) return;
 
         ChatTab chatTab = new ChatTab(
@@ -404,7 +404,7 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
             Services.ChatTab.removeTab(edited);
         }
 
-        int insertIndex = Math.min(Services.ChatTab.getTabCount(), requestedOrder.getAsInt());
+        int insertIndex = Math.min(Services.ChatTab.getTabCount(), requestedOrder.get());
         Services.ChatTab.addTab(insertIndex, chatTab);
         McUtils.setScreen(ChatTabEditingScreen.create(chatTab, previousScreen));
     }
@@ -425,16 +425,16 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
         saveAndCloseButton.active = saveButton.active;
     }
 
-    private OptionalInt getRequestedOrder() {
+    private Optional<Integer> getRequestedOrder() {
         if (orderInput.getTextBoxInput().isEmpty()) {
-            return OptionalInt.of(Services.ChatTab.getTabCount());
+            return Optional.of(Services.ChatTab.getTabCount());
         }
 
         try {
             int requestedOrder = Integer.parseInt(orderInput.getTextBoxInput());
-            return requestedOrder >= 0 ? OptionalInt.of(requestedOrder) : OptionalInt.empty();
+            return requestedOrder >= 0 ? Optional.of(requestedOrder) : Optional.empty();
         } catch (NumberFormatException ignored) {
-            return OptionalInt.empty();
+            return Optional.empty();
         }
     }
 

--- a/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
@@ -21,6 +21,7 @@ import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -386,13 +387,8 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
     }
 
     private void saveChatTab() {
-        if (edited != null) {
-            Services.ChatTab.removeTab(edited);
-        }
-
-        int insertIndex = orderInput.getTextBoxInput().isEmpty()
-                ? Services.ChatTab.getTabCount()
-                : Math.min(Services.ChatTab.getTabCount(), Integer.parseInt(orderInput.getTextBoxInput()));
+        OptionalInt requestedOrder = getRequestedOrder();
+        if (requestedOrder.isEmpty()) return;
 
         ChatTab chatTab = new ChatTab(
                 nameInput.getTextBoxInput(),
@@ -403,28 +399,42 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
                         .map(box -> RecipientType.fromName(box.getMessage().getString()))
                         .collect(Collectors.toSet()),
                 filterRegexInput.getTextBoxInput().isBlank() ? null : filterRegexInput.getTextBoxInput());
+
+        if (edited != null) {
+            Services.ChatTab.removeTab(edited);
+        }
+
+        int insertIndex = Math.min(Services.ChatTab.getTabCount(), requestedOrder.getAsInt());
         Services.ChatTab.addTab(insertIndex, chatTab);
         McUtils.setScreen(ChatTabEditingScreen.create(chatTab, previousScreen));
     }
 
     private void updateSaveButtonActive() {
-        if (orderInput != null && !orderInput.getTextBoxInput().isBlank()) {
-            try {
-                Integer.parseInt(orderInput.getTextBoxInput());
-                orderInput.setRenderColor(CommonColors.GREEN);
-            } catch (NumberFormatException ignored) {
-                orderInput.setRenderColor(CommonColors.RED);
-                saveButton.active = false;
-                saveAndCloseButton.active = false;
-            }
-        }
-
         if (saveButton == null || saveAndCloseButton == null) return;
+
+        boolean orderValid = getRequestedOrder().isPresent();
+        orderInput.setRenderColor(orderInput.getTextBoxInput().isEmpty()
+                ? CommonColors.WHITE
+                : orderValid ? CommonColors.GREEN : CommonColors.RED);
 
         saveButton.active = !nameInput.getTextBoxInput().isEmpty()
                 && validatePattern()
-                && recipientTypeBoxes.stream().anyMatch(WynntilsCheckbox::isSelected);
+                && recipientTypeBoxes.stream().anyMatch(WynntilsCheckbox::isSelected)
+                && orderValid;
         saveAndCloseButton.active = saveButton.active;
+    }
+
+    private OptionalInt getRequestedOrder() {
+        if (orderInput.getTextBoxInput().isEmpty()) {
+            return OptionalInt.of(Services.ChatTab.getTabCount());
+        }
+
+        try {
+            int requestedOrder = Integer.parseInt(orderInput.getTextBoxInput());
+            return requestedOrder >= 0 ? OptionalInt.of(requestedOrder) : OptionalInt.empty();
+        } catch (NumberFormatException ignored) {
+            return OptionalInt.empty();
+        }
     }
 
     private boolean validatePattern() {

--- a/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
+++ b/common/src/main/java/com/wynntils/screens/chattabs/ChatTabEditingScreen.java
@@ -413,9 +413,10 @@ public final class ChatTabEditingScreen extends WynntilsGridLayoutScreen {
         if (saveButton == null || saveAndCloseButton == null) return;
 
         boolean orderValid = getRequestedOrder().isPresent();
-        orderInput.setRenderColor(orderInput.getTextBoxInput().isEmpty()
-                ? CommonColors.WHITE
-                : orderValid ? CommonColors.GREEN : CommonColors.RED);
+        orderInput.setRenderColor(
+                orderInput.getTextBoxInput().isEmpty()
+                        ? CommonColors.WHITE
+                        : orderValid ? CommonColors.GREEN : CommonColors.RED);
 
         saveButton.active = !nameInput.getTextBoxInput().isEmpty()
                 && validatePattern()


### PR DESCRIPTION
If you put -1 or asdf into chat tabs currently, then save, your tab will be deleted. This prevents saving with illegal values