### PR TITLE
fix: Fix map crashes when no player

### DIFF
--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -484,6 +484,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
 
     protected void renderCursor(
             GuiGraphics guiGraphics, float pointerScale, CustomColor pointerColor, PointerType pointerType) {
+        if (McUtils.player() == null) return;
+
         double pX = McUtils.player().getX();
         double pZ = McUtils.player().getZ();
 
@@ -548,6 +550,11 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
     }
 
     protected void centerMapAroundPlayer() {
+        if (McUtils.player() == null) {
+            centerMapOnWorld();
+            return;
+        }
+
         updateMapCenter(
                 (float) McUtils.player().getX(), (float) McUtils.player().getZ());
     }
@@ -560,6 +567,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
     }
 
     protected boolean isPlayerInsideMainArea() {
+        if (McUtils.player() == null) return false;
+
         return MathUtils.isInside(
                 (int) McUtils.player().getX(), (int) McUtils.player().getZ(), MIN_X, MAX_X, MIN_Z, MAX_Z);
     }

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -260,7 +260,9 @@ public final class MainMapScreen extends AbstractMapScreen {
 
         renderPois(guiGraphics, mouseX, mouseY);
 
-        if (Managers.Feature.getFeatureInstance(MappingProgressFeature.class).isEnabled()) {
+        if (Models.WorldState.onWorld()
+                && Managers.Feature.getFeatureInstance(MappingProgressFeature.class)
+                        .isEnabled()) {
             renderChunkBorders(guiGraphics);
         }
 


### PR DESCRIPTION
When accessing the map from the external config button using ModMenu to access settings from the title screen the player will not exist

https://athena.wynntils.com/crash/view/375f920ec62e012fb1287c62e89a7c67
https://athena.wynntils.com/crash/view/40b44ac4b12f691c475e4b52d6c37d95