### PR TITLE
feat: Reimplement territory management map mode on mapdata

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
@@ -117,7 +117,7 @@ public class CustomTerritoryManagementScreenFeature extends Feature {
         }
 
         if (event.getScreen() instanceof TerritoryManagementScreen territoryManagementScreen) {
-            //            territoryManagementScreen.setMapMode(useTerritoryMap.get());
+            territoryManagementScreen.setMapMode(useTerritoryMap.get());
         }
     }
 

--- a/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
+++ b/common/src/main/java/com/wynntils/models/territories/TerritoryModel.java
@@ -25,6 +25,7 @@ import com.wynntils.models.territories.profile.TerritoryProfile;
 import com.wynntils.models.territories.providers.TerritoryProvider;
 import com.wynntils.models.territories.type.TerritoryConnectionType;
 import com.wynntils.screens.territorymanagement.TerritoryManagementHolder;
+import com.wynntils.screens.territorymanagement.mapdata.ManageTerritoryProvider;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Deque;
@@ -56,6 +57,7 @@ public final class TerritoryModel extends Model {
             .create();
 
     private static final TerritoryProvider TERRITORY_PROVIDER = new TerritoryProvider();
+    private static final ManageTerritoryProvider MANAGE_TERRITORY_PROVIDER = new ManageTerritoryProvider();
 
     // This is the info gathered from the advancement from Wynncraft
     private final Map<String, TerritoryInfo> territoryInfoMap = new ConcurrentHashMap<>();
@@ -91,6 +93,7 @@ public final class TerritoryModel extends Model {
     @SubscribeEvent
     public void onModInitFinished(WynntilsInitEvent.ModInitFinished event) {
         Services.MapData.registerBuiltInProvider(TERRITORY_PROVIDER);
+        Services.MapData.registerBuiltInProvider(MANAGE_TERRITORY_PROVIDER);
     }
 
     public Collection<TerritoryProfile> getTerritoryProfiles() {

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -158,6 +158,8 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
 
         mapButtons = new ArrayList<>();
 
+        if (!shouldRenderMapControls()) return;
+
         // region Zoom slider & buttons
         this.addRenderableWidget(Button.builder(Component.literal("-"), (button -> {
                     int adjustment = KeyboardUtils.isShiftDown() ? 1 : 5;
@@ -179,6 +181,15 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
                 .tooltip(Tooltip.create(Component.translatable("screens.wynntils.map.zoomIncrement")))
                 .build());
         // endregion
+    }
+
+    /**
+     * Whether this screen currently shows the map, and with it the map controls.
+     * Subclasses that can hide the map return false in that state, so that the zoom buttons are not
+     * added as widgets: they would otherwise be rendered and clickable on top of the other content.
+     */
+    protected boolean shouldRenderMapControls() {
+        return true;
     }
 
     protected void renderTooltip(GuiGraphics guiGraphics, int mouseX, int mouseY) {

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -206,9 +206,6 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
         }
     }
 
-    // Drawn by the subclasses on top of the map itself, so this must not be hooked into the vanilla
-    // renderBackground call: that one runs before render(), and overriding it would both paint the
-    // border on screens that show no map and suppress the vanilla menu blur behind the screen.
     protected void renderMapBorder(GuiGraphics guiGraphics) {
         RenderUtils.drawScalingTexturedRect(
                 guiGraphics, Texture.FULLSCREEN_MAP_BORDER, renderX, renderY, renderWidth, renderHeight);

--- a/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/AbstractMapScreen.java
@@ -195,8 +195,10 @@ public abstract class AbstractMapScreen extends WynntilsScreen {
         }
     }
 
-    @Override
-    public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+    // Drawn by the subclasses on top of the map itself, so this must not be hooked into the vanilla
+    // renderBackground call: that one runs before render(), and overriding it would both paint the
+    // border on screens that show no map and suppress the vanilla menu blur behind the screen.
+    protected void renderMapBorder(GuiGraphics guiGraphics) {
         RenderUtils.drawScalingTexturedRect(
                 guiGraphics, Texture.FULLSCREEN_MAP_BORDER, renderX, renderY, renderWidth, renderHeight);
     }

--- a/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
@@ -418,15 +418,13 @@ public final class CustomSeaskipperScreen extends AbstractMapScreen {
         final int textureWidth = Texture.MAP_INFO_TOOLTIP_CENTER.width();
 
         RenderUtils.drawTexturedRect(guiGraphics, Texture.MAP_INFO_TOOLTIP_TOP, xOffset, yOffset);
-        RenderUtils.drawTexturedRect(
+        RenderUtils.drawScalingTexturedRect(
                 guiGraphics,
                 Texture.MAP_INFO_TOOLTIP_CENTER,
                 xOffset,
                 Texture.MAP_INFO_TOOLTIP_TOP.height() + yOffset,
                 textureWidth,
-                centerHeight,
-                textureWidth,
-                Texture.MAP_INFO_TOOLTIP_CENTER.height());
+                centerHeight);
         RenderUtils.drawTexturedRect(
                 guiGraphics,
                 Texture.MAP_INFO_NAME_BOX,

--- a/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/CustomSeaskipperScreen.java
@@ -203,7 +203,7 @@ public final class CustomSeaskipperScreen extends AbstractMapScreen {
 
         RenderUtils.disableScissor(guiGraphics);
 
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderMapBorder(guiGraphics);
 
         renderCoordinates(guiGraphics, mouseX, mouseY);
 

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -346,7 +346,7 @@ public final class GuildMapScreen extends AbstractMapScreen {
 
         RenderUtils.disableScissor(guiGraphics);
 
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderMapBorder(guiGraphics);
 
         renderCoordinates(guiGraphics, mouseX, mouseY);
 

--- a/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/GuildMapScreen.java
@@ -637,15 +637,13 @@ public final class GuildMapScreen extends AbstractMapScreen {
                 + (territoryInfo.isHeadquarters() ? 20 : 0);
 
         RenderUtils.drawTexturedRect(guiGraphics, Texture.MAP_INFO_TOOLTIP_TOP, xOffset, yOffset);
-        RenderUtils.drawTexturedRect(
+        RenderUtils.drawScalingTexturedRect(
                 guiGraphics,
                 Texture.MAP_INFO_TOOLTIP_CENTER,
                 xOffset,
                 Texture.MAP_INFO_TOOLTIP_TOP.height() + yOffset,
                 textureWidth,
-                centerHeight,
-                textureWidth,
-                Texture.MAP_INFO_TOOLTIP_CENTER.height());
+                centerHeight);
         RenderUtils.drawTexturedRect(
                 guiGraphics,
                 Texture.MAP_INFO_NAME_BOX,
@@ -797,15 +795,13 @@ public final class GuildMapScreen extends AbstractMapScreen {
         final float centerHeight = 35;
 
         RenderUtils.drawTexturedRect(guiGraphics, Texture.MAP_INFO_TOOLTIP_TOP, xOffset, yOffset);
-        RenderUtils.drawTexturedRect(
+        RenderUtils.drawScalingTexturedRect(
                 guiGraphics,
                 Texture.MAP_INFO_TOOLTIP_CENTER,
                 xOffset,
                 Texture.MAP_INFO_TOOLTIP_TOP.height() + yOffset,
                 textureWidth,
-                centerHeight,
-                textureWidth,
-                Texture.MAP_INFO_TOOLTIP_CENTER.height());
+                centerHeight);
         RenderUtils.drawTexturedRect(
                 guiGraphics,
                 Texture.MAP_INFO_NAME_BOX,

--- a/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/MainMapScreen.java
@@ -284,7 +284,7 @@ public final class MainMapScreen extends AbstractMapScreen {
 
         RenderUtils.disableScissor(guiGraphics);
 
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderMapBorder(guiGraphics);
 
         renderCoordinates(guiGraphics, mouseX, mouseY);
 

--- a/common/src/main/java/com/wynntils/screens/maps/WaypointCreationScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/WaypointCreationScreen.java
@@ -576,7 +576,7 @@ public final class WaypointCreationScreen extends AbstractMapScreen {
 
         RenderUtils.disableScissor(guiGraphics);
 
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderMapBorder(guiGraphics);
         super.doRender(guiGraphics, mouseX, mouseY, partialTick);
 
         FontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/screens/maps/WaypointVisibilityScreen.java
+++ b/common/src/main/java/com/wynntils/screens/maps/WaypointVisibilityScreen.java
@@ -211,7 +211,7 @@ public class WaypointVisibilityScreen extends AbstractMapScreen {
 
         RenderUtils.disableScissor(guiGraphics);
 
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderMapBorder(guiGraphics);
         super.doRender(guiGraphics, mouseX, mouseY, partialTick);
 
         FontRenderer.getInstance()

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -133,6 +133,11 @@ public class TerritoryManagementScreen extends AbstractMapScreen implements Wrap
         this.mapMode = mapMode;
     }
 
+    @Override
+    protected boolean shouldRenderMapControls() {
+        return mapMode;
+    }
+
     public void setMapPosition(float centerX, float centerZ, float zoomLevel) {
         this.setZoomLevel(zoomLevel);
         this.updateMapCenter(centerX, centerZ);

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -532,7 +532,7 @@ public class TerritoryManagementScreen extends AbstractMapScreen implements Wrap
 
         RenderUtils.disableScissor(guiGraphics);
 
-        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        renderMapBorder(guiGraphics);
 
         renderCoordinates(guiGraphics, mouseX, mouseY);
 

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/TerritoryManagementScreen.java
@@ -9,18 +9,26 @@ import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
-import com.wynntils.core.consumers.screens.WynntilsScreen;
 import com.wynntils.core.persisted.storage.Storage;
 import com.wynntils.core.text.StyledText;
+import com.wynntils.features.map.GuildMapFeature;
 import com.wynntils.features.ui.CustomTerritoryManagementScreenFeature;
 import com.wynntils.handlers.wrappedscreen.WrappedScreen;
 import com.wynntils.handlers.wrappedscreen.type.WrappedScreenInfo;
+import com.wynntils.models.emeralds.type.EmeraldUnits;
 import com.wynntils.models.items.items.gui.TerritoryItem;
+import com.wynntils.models.territories.TerritoryInfo;
+import com.wynntils.models.territories.profile.TerritoryProfile;
+import com.wynntils.models.territories.type.GuildResource;
 import com.wynntils.models.territories.type.TerritoryUpgrade;
 import com.wynntils.screens.base.TooltipProvider;
 import com.wynntils.screens.base.widgets.BasicTexturedButton;
 import com.wynntils.screens.base.widgets.ItemFilterUIButton;
 import com.wynntils.screens.base.widgets.ItemSearchWidget;
+import com.wynntils.screens.maps.AbstractMapScreen;
+import com.wynntils.screens.maps.widgets.MapButton;
+import com.wynntils.screens.territorymanagement.mapdata.ManageTerritoryArea;
+import com.wynntils.screens.territorymanagement.mapdata.ManageTerritoryProvider;
 import com.wynntils.screens.territorymanagement.widgets.GuildOverallProductionWidget;
 import com.wynntils.screens.territorymanagement.widgets.TerritoryApplyLoadoutButton;
 import com.wynntils.screens.territorymanagement.widgets.TerritoryHighlightLegendWidget;
@@ -34,18 +42,26 @@ import com.wynntils.screens.territorymanagement.widgets.quicksorts.TerritoryOver
 import com.wynntils.screens.territorymanagement.widgets.quicksorts.TerritoryQuickSortWidget;
 import com.wynntils.screens.territorymanagement.widgets.quicksorts.TerritoryTreasuryQuickSortWidget;
 import com.wynntils.services.itemfilter.type.ItemProviderType;
+import com.wynntils.services.map.type.TerritoryInfoType;
+import com.wynntils.services.mapdata.features.type.MapFeature;
 import com.wynntils.utils.MathUtils;
 import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.mc.type.PoiLocation;
 import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.render.MapRenderer;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.render.Texture;
+import com.wynntils.utils.render.state.ColoredLineBatchRenderState;
 import com.wynntils.utils.render.type.HorizontalAlignment;
 import com.wynntils.utils.render.type.TextShadow;
 import com.wynntils.utils.render.type.VerticalAlignment;
+import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.wynn.ContainerUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -53,13 +69,17 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.render.TextureSetup;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import org.joml.Matrix3x2f;
+import org.joml.Vector2f;
+import org.lwjgl.glfw.GLFW;
 
-// TODO: Reimplement map screen version
-// public class TerritoryManagementScreen extends AbstractMapScreen implements WrappedScreen {
-public class TerritoryManagementScreen extends WynntilsScreen implements WrappedScreen {
+public class TerritoryManagementScreen extends AbstractMapScreen implements WrappedScreen {
     // Constants
     // The render area is the area where the territories are rendered
     private static final Pair<Integer, Integer> RENDER_AREA_POSITION = new Pair<>(9, 16);
@@ -81,9 +101,9 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
             TerritoryUpgrade.TOWER_VOLLEY);
 
     // Map mode
-    //    private static TerritoryInfoType infoType = TerritoryInfoType.DEFENSE;
-    //    private boolean mapMode = false;
-    //    private MapButton infoTypeButton;
+    private static TerritoryInfoType infoType = TerritoryInfoType.DEFENSE;
+    private boolean mapMode = false;
+    private MapButton infoTypeButton;
 
     // Territory items
     private List<Pair<ItemStack, TerritoryItem>> territoryItems = new ArrayList<>();
@@ -104,20 +124,19 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
     private final TerritoryManagementHolder holder;
 
     public TerritoryManagementScreen(WrappedScreenInfo wrappedScreenInfo, TerritoryManagementHolder holder) {
-        //        super();
-        super(Component.literal("Territory Management"));
+        super();
         this.wrappedScreenInfo = wrappedScreenInfo;
         this.holder = holder;
     }
 
-    //    public void setMapMode(boolean mapMode) {
-    //        this.mapMode = mapMode;
-    //    }
-    //
-    //    public void setMapPosition(float centerX, float centerZ, float zoomLevel) {
-    //        this.setZoomLevel(zoomLevel);
-    //        this.updateMapCenter(centerX, centerZ);
-    //    }
+    public void setMapMode(boolean mapMode) {
+        this.mapMode = mapMode;
+    }
+
+    public void setMapPosition(float centerX, float centerZ, float zoomLevel) {
+        this.setZoomLevel(zoomLevel);
+        this.updateMapCenter(centerX, centerZ);
+    }
 
     @Override
     public WrappedScreenInfo getWrappedScreenInfo() {
@@ -128,25 +147,27 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
     protected void doInit() {
         super.doInit();
 
-        //        if (!mapMode) {
-        initListScreen();
-        //        } else {
-        //            initMapScreen();
-        //        }
+        if (!mapMode) {
+            initListScreen();
+        } else {
+            initMapScreen();
+        }
 
         this.addRenderableOnly(new GuildOverallProductionWidget(
-                //                mapMode ? (int) SCREEN_SIDE_OFFSET + 10 : getRenderX() - 190,
-                //                mapMode ? (int) SCREEN_SIDE_OFFSET + 35 : getRenderY() + 10,
-                getRenderX() - 190, getRenderY() + 10, 200, 150, holder));
+                mapMode ? (int) SCREEN_SIDE_OFFSET + 10 : getRenderX() - 190,
+                mapMode ? (int) SCREEN_SIDE_OFFSET + 35 : getRenderY() + 10,
+                200,
+                150,
+                holder));
 
-        //        if (firstInit) {
-        //            // When outside the main map, center to the middle of the map
-        //            if (!isPlayerInsideMainArea()) {
-        //                centerMapOnWorld();
-        //            }
-        //
-        //            firstInit = false;
-        //        }
+        if (firstInit) {
+            // When outside the main map, center to the middle of the map
+            if (!isPlayerInsideMainArea()) {
+                centerMapOnWorld();
+            }
+
+            firstInit = false;
+        }
 
         updateTerritoryItems();
     }
@@ -341,126 +362,116 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
     }
 
     private void initMapScreen() {
-        //        addMapButton(new MapButton(
-        //                Texture.ARROW_LEFT_ICON,
-        //                (button) -> ContainerUtils.clickOnSlot(
-        //                        BACK_BUTTON_SLOT,
-        //                        wrappedScreenInfo.containerId(),
-        //                        button,
-        //                        wrappedScreenInfo.containerMenu().getItems()),
-        //                List.of(Component.literal("[>] ")
-        //                        .withStyle(ChatFormatting.GRAY)
-        //                        .append(Component.translatable("gui.back")))));
-        //        addMapButton(new MapButton(
-        //                Texture.DEFENSE_FILTER_ICON,
-        //                (button) -> {
-        //                    Storage<Boolean> screenTerritoryProductionTooltip = Managers.Feature.getFeatureInstance(
-        //                            CustomTerritoryManagementScreenFeature.class)
-        //                            .screenTerritoryProductionTooltip;
-        //                    screenTerritoryProductionTooltip.store(!screenTerritoryProductionTooltip.get());
-        //                },
-        //                List.of(
-        //                        Component.literal("[>] ")
-        //                                .withStyle(ChatFormatting.BLUE)
-        //                                .append(
-        //                                        Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.disableTerritoryProductionTooltip")),
-        //                        Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.territoryProductionHelper1")
-        //                                .withStyle(ChatFormatting.GRAY),
-        //                        Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.territoryProductionHelper2")
-        //                                .withStyle(ChatFormatting.GRAY))));
-        //        infoTypeButton = new MapButton(
-        //                Texture.OVERLAY_EXTRA_ICON,
-        //                (b) -> {
-        //                    if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-        //                        setInfoType(infoType.getNext());
-        //                    } else if (b == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
-        //                        setInfoType(infoType.getPrevious());
-        //                    }
-        //                },
-        //                getCompleteInfoTypeTooltip());
-        //        addMapButton(infoTypeButton);
-        //
-        //        if (!holder.isSelectionMode()) {
-        //            addMapButton(new MapButton(
-        //                    Texture.TERRITORY_LOADOUT,
-        //                    (button) -> ContainerUtils.clickOnSlot(
-        //                            LOADOUT_BUTTON_SLOT,
-        //                            wrappedScreenInfo.containerId(),
-        //                            button,
-        //                            wrappedScreenInfo.containerMenu().getItems()),
-        //                    List.of(
-        //                            Component.literal("[>] ")
-        //                                    .withStyle(ChatFormatting.GOLD)
-        //                                    .append(Component.translatable(
-        //                                            "feature.wynntils.customTerritoryManagementScreen.loadouts")),
-        //                            Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.loadouts.description")
-        //                                    .withStyle(ChatFormatting.GRAY),
-        //                            Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.loadouts.clickToOpen")
-        //                                    .withStyle(ChatFormatting.GREEN))));
-        //        } else {
-        //            addMapButton(new MapButton(
-        //                    Texture.CHECKMARK_YELLOW,
-        //                    (button) -> {
-        //                        holder.saveMapPos();
-        //                        ContainerUtils.clickOnSlot(
-        //                                APPLY_BUTTON_SLOT,
-        //                                wrappedScreenInfo.containerId(),
-        //                                button,
-        //                                wrappedScreenInfo.containerMenu().getItems());
-        //                    },
-        //                    List.of(
-        //                            Component.literal("[>] ")
-        //                                    .withStyle(ChatFormatting.GOLD)
-        //                                    .append(Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.applySelection")),
-        //                            Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.applySelection.description")
-        //                                    .withStyle(ChatFormatting.GRAY),
-        //                            Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.applySelection.clickToConfirm")
-        //                                    .withStyle(ChatFormatting.GREEN))));
-        //        }
-        //
-        //        addMapButton(new MapButton(
-        //                Texture.HELP_ICON,
-        //                (b) -> {},
-        //                List.of(
-        //                        Component.literal("[>] ")
-        //                                .withStyle(ChatFormatting.YELLOW)
-        //                                .append(Component.translatable(
-        //                                        "feature.wynntils.customTerritoryManagementScreen.help.name")),
-        //                        Component.literal("- ")
-        //                                .withStyle(ChatFormatting.GRAY)
-        //                                .append(Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.help.description1")),
-        //                        Component.literal("- ")
-        //                                .withStyle(ChatFormatting.GRAY)
-        //                                .append(Component.translatable(
-        //
-        // "feature.wynntils.customTerritoryManagementScreen.help.description2")))));
+        addMapButton(new MapButton(
+                Texture.ARROW_LEFT_ICON,
+                (button) -> ContainerUtils.clickOnSlot(
+                        BACK_BUTTON_SLOT,
+                        wrappedScreenInfo.containerId(),
+                        button,
+                        wrappedScreenInfo.containerMenu().getItems()),
+                List.of(Component.literal("[>] ")
+                        .withStyle(ChatFormatting.GRAY)
+                        .append(Component.translatable("gui.back")))));
+        addMapButton(new MapButton(
+                Texture.DEFENSE_FILTER_ICON,
+                (button) -> {
+                    Storage<Boolean> screenTerritoryProductionTooltip = Managers.Feature.getFeatureInstance(
+                                    CustomTerritoryManagementScreenFeature.class)
+                            .screenTerritoryProductionTooltip;
+                    screenTerritoryProductionTooltip.store(!screenTerritoryProductionTooltip.get());
+                },
+                List.of(
+                        Component.literal("[>] ")
+                                .withStyle(ChatFormatting.BLUE)
+                                .append(
+                                        Component.translatable(
+                                                "feature.wynntils.customTerritoryManagementScreen.disableTerritoryProductionTooltip")),
+                        Component.translatable(
+                                        "feature.wynntils.customTerritoryManagementScreen.territoryProductionHelper1")
+                                .withStyle(ChatFormatting.GRAY),
+                        Component.translatable(
+                                        "feature.wynntils.customTerritoryManagementScreen.territoryProductionHelper2")
+                                .withStyle(ChatFormatting.GRAY))));
+        infoTypeButton = new MapButton(
+                Texture.OVERLAY_EXTRA_ICON,
+                (b) -> {
+                    if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                        setInfoType(infoType.getNext());
+                    } else if (b == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+                        setInfoType(infoType.getPrevious());
+                    }
+                },
+                getCompleteInfoTypeTooltip());
+        addMapButton(infoTypeButton);
+
+        if (!holder.isSelectionMode()) {
+            addMapButton(new MapButton(
+                    Texture.TERRITORY_LOADOUT,
+                    (button) -> ContainerUtils.clickOnSlot(
+                            LOADOUT_BUTTON_SLOT,
+                            wrappedScreenInfo.containerId(),
+                            button,
+                            wrappedScreenInfo.containerMenu().getItems()),
+                    List.of(
+                            Component.literal("[>] ")
+                                    .withStyle(ChatFormatting.GOLD)
+                                    .append(Component.translatable(
+                                            "feature.wynntils.customTerritoryManagementScreen.loadouts")),
+                            Component.translatable(
+                                            "feature.wynntils.customTerritoryManagementScreen.loadouts.description")
+                                    .withStyle(ChatFormatting.GRAY),
+                            Component.translatable(
+                                            "feature.wynntils.customTerritoryManagementScreen.loadouts.clickToOpen")
+                                    .withStyle(ChatFormatting.GREEN))));
+        } else {
+            addMapButton(new MapButton(
+                    Texture.CHECKMARK_YELLOW,
+                    (button) -> {
+                        holder.saveMapPos();
+                        ContainerUtils.clickOnSlot(
+                                APPLY_BUTTON_SLOT,
+                                wrappedScreenInfo.containerId(),
+                                button,
+                                wrappedScreenInfo.containerMenu().getItems());
+                    },
+                    List.of(
+                            Component.literal("[>] ")
+                                    .withStyle(ChatFormatting.GOLD)
+                                    .append(Component.translatable(
+                                            "feature.wynntils.customTerritoryManagementScreen.applySelection")),
+                            Component.translatable(
+                                            "feature.wynntils.customTerritoryManagementScreen.applySelection.description")
+                                    .withStyle(ChatFormatting.GRAY),
+                            Component.translatable(
+                                            "feature.wynntils.customTerritoryManagementScreen.applySelection.clickToConfirm")
+                                    .withStyle(ChatFormatting.GREEN))));
+        }
+
+        addMapButton(new MapButton(
+                Texture.HELP_ICON,
+                (b) -> {},
+                List.of(
+                        Component.literal("[>] ")
+                                .withStyle(ChatFormatting.YELLOW)
+                                .append(Component.translatable(
+                                        "feature.wynntils.customTerritoryManagementScreen.help.name")),
+                        Component.literal("- ")
+                                .withStyle(ChatFormatting.GRAY)
+                                .append(Component.translatable(
+                                        "feature.wynntils.customTerritoryManagementScreen.help.description1")),
+                        Component.literal("- ")
+                                .withStyle(ChatFormatting.GRAY)
+                                .append(Component.translatable(
+                                        "feature.wynntils.customTerritoryManagementScreen.help.description2")))));
     }
 
     @Override
     public void doRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        //        if (!this.mapMode) {
-        renderListScreen(guiGraphics, mouseX, mouseY, partialTick);
-        //        } else {
-        //            renderMapScreen(guiGraphics, mouseX, mouseY, partialTick);
-        //        }
+        if (!this.mapMode) {
+            renderListScreen(guiGraphics, mouseX, mouseY, partialTick);
+        } else {
+            renderMapScreen(guiGraphics, mouseX, mouseY, partialTick);
+        }
 
         // Render widget tooltip
         renderTooltip(guiGraphics, mouseX, mouseY);
@@ -494,47 +505,236 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
     }
 
     private void renderMapScreen(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        //        renderMap(guiGraphics);
-        //
-        //        RenderUtils.enableScissor(
-        //                guiGraphics,
-        //                (int) (renderX + renderedBorderXOffset),
-        //                (int) (renderY + renderedBorderYOffset),
-        //                (int) mapWidth,
-        //                (int) mapHeight);
-        //
-        //        renderPois(guiGraphics, mouseX, mouseY);
-        //
-        //        renderCursor(
-        //                guiGraphics,
-        //                1.5f,
-        //                Managers.Feature.getFeatureInstance(GuildMapFeature.class)
-        //                        .pointerColor
-        //                        .get(),
-        //                Managers.Feature.getFeatureInstance(GuildMapFeature.class)
-        //                        .pointerType
-        //                        .get());
-        //
-        //        RenderUtils.disableScissor(guiGraphics);
-        //
-        //        renderMapBorder(guiGraphics);
-        //
-        //        renderCoordinates(guiGraphics, mouseX, mouseY);
-        //
-        //        renderMapButtons(guiGraphics, mouseX, mouseY, partialTick);
-        //
-        //        renderZoomWidgets(guiGraphics, mouseX, mouseY, partialTick);
-        //
-        //        renderHoveredTerritoryInfo(guiGraphics);
-        //
-        //        if (isPanning) {
-        //            guiGraphics.requestCursor(CursorTypes.RESIZE_ALL);
-        //        } else if (holdingZoomHandle) {
-        //            guiGraphics.requestCursor(CursorTypes.RESIZE_NS);
-        //        } else if ((this.hovered != null && !(this.hovered instanceof TerritoryPoi))
-        //                || isMouseOverZoomHandle(mouseX, mouseY)) {
-        //            guiGraphics.requestCursor(CursorTypes.POINTING_HAND);
-        //        }
+        renderMap(guiGraphics);
+
+        RenderUtils.enableScissor(
+                guiGraphics,
+                (int) (renderX + renderedBorderXOffset),
+                (int) (renderY + renderedBorderYOffset),
+                (int) mapWidth,
+                (int) mapHeight);
+
+        renderTerritoryAreaPaths(guiGraphics);
+
+        renderMapFeatures(guiGraphics, mouseX, mouseY);
+
+        renderTerritoryDecorations(guiGraphics);
+
+        renderCursor(
+                guiGraphics,
+                1.5f,
+                Managers.Feature.getFeatureInstance(GuildMapFeature.class)
+                        .pointerColor
+                        .get(),
+                Managers.Feature.getFeatureInstance(GuildMapFeature.class)
+                        .pointerType
+                        .get());
+
+        RenderUtils.disableScissor(guiGraphics);
+
+        renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+
+        renderCoordinates(guiGraphics, mouseX, mouseY);
+
+        renderMapButtons(guiGraphics, mouseX, mouseY, partialTick);
+
+        renderZoomWidgets(guiGraphics, mouseX, mouseY, partialTick);
+
+        renderHoveredTerritoryInfo(guiGraphics);
+
+        if (isPanning) {
+            guiGraphics.requestCursor(CursorTypes.RESIZE_ALL);
+        } else if (holdingZoomHandle) {
+            guiGraphics.requestCursor(CursorTypes.RESIZE_NS);
+        } else if (hoveredFeature != null || isMouseOverZoomHandle(mouseX, mouseY)) {
+            guiGraphics.requestCursor(CursorTypes.POINTING_HAND);
+        }
+    }
+
+    private void renderTerritoryAreaPaths(GuiGraphics guiGraphics) {
+        List<ManageTerritoryArea> territoryAreas = getRenderedMapFeatures()
+                .filter(f -> f instanceof ManageTerritoryArea)
+                .map(f -> (ManageTerritoryArea) f)
+                .toList();
+
+        Map<String, ManageTerritoryArea> territoryAreasByName = territoryAreas.stream()
+                .collect(Collectors.toMap(
+                        area -> area.getTerritoryProfile().getName(), area -> area, (first, second) -> first));
+
+        // Accumulate every trading-route line into a single batch, submitted once below, instead of
+        // one GuiElementRenderState submission per route
+        List<ColoredLineBatchRenderState.Segment> segments = new ArrayList<>();
+
+        for (ManageTerritoryArea territoryArea : territoryAreas) {
+            TerritoryInfo territoryInfo = Models.Territory.getTerritoryInfo(
+                    territoryArea.getTerritoryProfile().getName());
+            if (territoryInfo == null) continue;
+
+            for (String tradingRoute : territoryInfo.getTradingRoutes()) {
+                ManageTerritoryArea destination = territoryAreasByName.get(tradingRoute);
+
+                if (destination == null) continue;
+
+                Vector2f firstCentroid = territoryArea.getBoundingPolygon().centroid();
+                Vector2f secondCentroid = destination.getBoundingPolygon().centroid();
+                float firstWorldX =
+                        MapRenderer.getRenderX((int) firstCentroid.x(), mapCenterX, centerX, zoomRenderScale);
+                float firstWorldZ =
+                        MapRenderer.getRenderZ((int) firstCentroid.y(), mapCenterZ, centerZ, zoomRenderScale);
+                float secondWorldX =
+                        MapRenderer.getRenderX((int) secondCentroid.x(), mapCenterX, centerX, zoomRenderScale);
+                float secondWorldZ =
+                        MapRenderer.getRenderZ((int) secondCentroid.y(), mapCenterZ, centerZ, zoomRenderScale);
+                segments.add(new ColoredLineBatchRenderState.Segment(
+                        firstWorldX,
+                        firstWorldZ,
+                        secondWorldX,
+                        secondWorldZ,
+                        1,
+                        CommonColors.DARK_GRAY.withAlpha(0.5f)));
+            }
+        }
+
+        if (segments.isEmpty()) return;
+
+        guiGraphics.guiRenderState.submitGuiElement(new ColoredLineBatchRenderState(
+                RenderPipelines.GUI,
+                TextureSetup.noTexture(),
+                new Matrix3x2f(guiGraphics.pose()),
+                segments,
+                guiGraphics.scissorStack.peek()));
+    }
+
+    private void renderTerritoryDecorations(GuiGraphics guiGraphics) {
+        List<ManageTerritoryArea> territoryAreas = getRenderedMapFeatures()
+                .filter(f -> f instanceof ManageTerritoryArea)
+                .map(f -> (ManageTerritoryArea) f)
+                .toList();
+
+        for (ManageTerritoryArea territoryArea : territoryAreas) {
+            TerritoryItem territoryItem = territoryArea.getTerritoryItem();
+            TerritoryProfile territoryProfile = territoryArea.getTerritoryProfile();
+
+            final int width = Math.abs(territoryProfile.getEndX() - territoryProfile.getStartX());
+            final int height = Math.abs(territoryProfile.getEndZ() - territoryProfile.getStartZ());
+            final float renderWidth = width * zoomRenderScale;
+            final float renderHeight = height * zoomRenderScale;
+
+            Vector2f centroid = territoryArea.getBoundingPolygon().centroid();
+            float centerScreenX = MapRenderer.getRenderX((int) centroid.x(), mapCenterX, centerX, zoomRenderScale);
+            float centerScreenZ = MapRenderer.getRenderZ((int) centroid.y(), mapCenterZ, centerZ, zoomRenderScale);
+
+            final float actualRenderX = centerScreenX - renderWidth / 2f;
+            final float actualRenderZ = centerScreenZ - renderHeight / 2f;
+
+            // Render the territory production type icons
+            Set<GuildResource> productionTypes = territoryItem.getProduction().keySet().stream()
+                    .filter(GuildResource::isMaterialResource)
+                    .collect(Collectors.toUnmodifiableSet());
+
+            if (!productionTypes.isEmpty() && zoomRenderScale >= 0.2f) {
+                int iconYOffset = 4;
+                if (territoryItem.isSelected() || territoryItem.isPending() || territoryItem.isHeadquarters()) {
+                    iconYOffset += 4;
+                }
+
+                if (productionTypes.size() <= 2) {
+                    GuildResource productionType = productionTypes.iterator().next();
+                    String symbol = productionType.getPrettySymbol().trim();
+                    symbol += productionTypes.size() == 2
+                            ? productionTypes
+                                    .iterator()
+                                    .next()
+                                    .getPrettySymbol()
+                                    .trim()
+                            : "";
+                    if (territoryItem.getDoubleResource()) {
+                        symbol += symbol;
+                    }
+
+                    FontRenderer.getInstance()
+                            .renderAlignedTextInBox(
+                                    guiGraphics,
+                                    StyledText.fromString(symbol),
+                                    actualRenderX,
+                                    actualRenderX + renderWidth + (territoryItem.getDoubleEmeralds() ? 8 : 0),
+                                    actualRenderZ + renderHeight / 2 + iconYOffset,
+                                    actualRenderZ + renderHeight,
+                                    0,
+                                    CommonColors.WHITE,
+                                    HorizontalAlignment.CENTER,
+                                    VerticalAlignment.TOP,
+                                    TextShadow.NORMAL);
+
+                    // Render E icon separately so we can shift it down to be aligned
+                    if (territoryItem.getDoubleEmeralds()) {
+                        FontRenderer.getInstance()
+                                .renderAlignedTextInBox(
+                                        guiGraphics,
+                                        StyledText.fromComponent(Component.literal(EmeraldUnits.EMERALD.getSymbol())
+                                                .withStyle(ChatFormatting.GREEN)),
+                                        actualRenderX,
+                                        actualRenderX + renderWidth - 8,
+                                        actualRenderZ + renderHeight / 2 + iconYOffset + 1,
+                                        actualRenderZ + renderHeight,
+                                        0,
+                                        CommonColors.WHITE,
+                                        HorizontalAlignment.CENTER,
+                                        VerticalAlignment.TOP,
+                                        TextShadow.NORMAL);
+                    }
+                } else {
+                    int i = 0;
+                    for (GuildResource productionType : productionTypes) {
+                        String symbol = productionType.getPrettySymbol().trim();
+                        FontRenderer.getInstance()
+                                .renderText(
+                                        guiGraphics,
+                                        StyledText.fromString(symbol),
+                                        actualRenderX + renderWidth / 2 + i * 8 - 12,
+                                        actualRenderZ + renderHeight / 2 + iconYOffset,
+                                        CommonColors.WHITE,
+                                        HorizontalAlignment.CENTER,
+                                        VerticalAlignment.TOP,
+                                        TextShadow.NORMAL);
+                        i++;
+                    }
+                }
+            }
+
+            if (territoryItem.isPending() && !territoryItem.isSelected()) {
+                RenderUtils.drawTexturedRect(
+                        guiGraphics,
+                        Texture.CHECKMARK_GRAY,
+                        actualRenderX + renderWidth / 2f - Texture.CHECKMARK_GRAY.width() / 2f,
+                        actualRenderZ + renderHeight / 2f - Texture.CHECKMARK_GRAY.height() / 2f);
+            } else if (!territoryItem.isPending() && territoryItem.isSelected()) {
+                RenderUtils.drawTexturedRect(
+                        guiGraphics,
+                        Texture.CHECKMARK_GREEN,
+                        actualRenderX + renderWidth / 2f - Texture.CHECKMARK_GREEN.width() / 2f,
+                        actualRenderZ + renderHeight / 2f - Texture.CHECKMARK_GREEN.height() / 2f);
+            } else if (territoryItem.isPending() && territoryItem.isSelected()) {
+                RenderUtils.drawTexturedRect(
+                        guiGraphics,
+                        Texture.CHECKMARK_YELLOW,
+                        actualRenderX + renderWidth / 2f - Texture.CHECKMARK_YELLOW.width() / 2f,
+                        actualRenderZ + renderHeight / 2f - Texture.CHECKMARK_YELLOW.height() / 2f);
+            } else if (territoryItem.isHeadquarters()) {
+                RenderUtils.drawTexturedRect(
+                        guiGraphics,
+                        Texture.GUILD_HEADQUARTERS,
+                        actualRenderX + renderWidth / 2f - Texture.GUILD_HEADQUARTERS.width() / 2f,
+                        actualRenderZ + renderHeight / 2f - Texture.GUILD_HEADQUARTERS.height() / 2f);
+            }
+        }
+    }
+
+    @Override
+    protected Stream<MapFeature> getRenderedMapFeatures() {
+        return Stream.concat(
+                Services.MapData.getFeaturesForCategory("wynntils:guild:managed-territory"),
+                Services.MapData.getFeaturesForCategory("wynntils:personal:user-marker"));
     }
 
     private void renderWidgets(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
@@ -643,7 +843,8 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
         }
     }
 
-    private void renderTooltip(GuiGraphics guiGraphics, int mouseX, int mouseY) {
+    @Override
+    protected void renderTooltip(GuiGraphics guiGraphics, int mouseX, int mouseY) {
         AbstractWidget hoveredWidget = getHoveredWidget(mouseX, mouseY);
         if (hoveredWidget == null) return;
         if (!(hoveredWidget instanceof TooltipProvider tooltipProvider)) return;
@@ -655,117 +856,69 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
                 Lists.transform(tooltipLines, Component::getVisualOrderText), mouseX, mouseY);
     }
 
-    //    @Override
-    //    protected void renderPois(
-    //            List<Poi> pois,
-    //            GuiGraphics guiGraphics,
-    //            BoundingBox textureBoundingBox,
-    //            float poiScale,
-    //            int mouseX,
-    //            int mouseY) {
-    //        hovered = null;
-    //
-    //        List<Poi> filteredPois = getRenderedPois(pois, textureBoundingBox, poiScale, mouseX, mouseY);
-    //
-    //        // Render trading routes
-    //        // We render them in both directions because optimizing it is not cheap either
-    //        for (Poi poi : filteredPois) {
-    //            if (!(poi instanceof ManageTerritoryPoi territoryPoi)) continue;
-    //
-    //            float poiRenderX = MapRenderer.getRenderX(poi, mapCenterX, centerX, zoomRenderScale);
-    //            float poiRenderZ = MapRenderer.getRenderZ(poi, mapCenterZ, centerZ, zoomRenderScale);
-    //
-    //            for (String tradingRoute : territoryPoi.getTerritoryInfo().getTradingRoutes()) {
-    //                Optional<Poi> routePoi = filteredPois.stream()
-    //                        .filter(filteredPoi -> filteredPoi.getName().equals(tradingRoute))
-    //                        .findFirst();
-    //
-    //                // Only render connection if the other poi is also in the filtered pois
-    //                if (routePoi.isPresent() && filteredPois.contains(routePoi.get())) {
-    //                    float x = MapRenderer.getRenderX(routePoi.get(), mapCenterX, centerX, zoomRenderScale);
-    //                    float z = MapRenderer.getRenderZ(routePoi.get(), mapCenterZ, centerZ, zoomRenderScale);
-    //
-    //                    RenderUtils.drawLine(guiGraphics, CommonColors.DARK_GRAY, poiRenderX, poiRenderZ, x, z, 1);
-    //                }
-    //            }
-    //        }
-    //
-    //        // Reverse and Render
-    //        for (int i = filteredPois.size() - 1; i >= 0; i--) {
-    //            Poi poi = filteredPois.get(i);
-    //
-    //            float poiRenderX = MapRenderer.getRenderX(poi, mapCenterX, centerX, zoomRenderScale);
-    //            float poiRenderZ = MapRenderer.getRenderZ(poi, mapCenterZ, centerZ, zoomRenderScale);
-    //
-    //            poi.renderAt(
-    //                    guiGraphics, poiRenderX, poiRenderZ, hovered == poi, poiScale, zoomRenderScale, zoomLevel,
-    // true);
-    //        }
-    //    }
-
     @Override
     public boolean doMouseClicked(MouseButtonEvent event, boolean isDoubleClick) {
-        //        if (!this.mapMode) {
-        // Render area widgets need to handle the scroll offset
-        // Check if mouse is over the render area
-        if (event.x() >= getRenderX() + RENDER_AREA_POSITION.a()
-                && event.x() <= getRenderX() + RENDER_AREA_POSITION.a() + RENDER_AREA_SIZE.a()
-                && event.y() >= getRenderY() + RENDER_AREA_POSITION.b()
-                && event.y() <= getRenderY() + RENDER_AREA_POSITION.b() + RENDER_AREA_SIZE.b()) {
-            for (AbstractWidget widget : renderAreaWidgets) {
-                if (widget.isMouseOver(event.x(), event.y())) {
-                    return widget.mouseClicked(
-                            new MouseButtonEvent(event.x(), event.y(), event.buttonInfo()), isDoubleClick);
+        if (!this.mapMode) {
+            // Render area widgets need to handle the scroll offset
+            // Check if mouse is over the render area
+            if (event.x() >= getRenderX() + RENDER_AREA_POSITION.a()
+                    && event.x() <= getRenderX() + RENDER_AREA_POSITION.a() + RENDER_AREA_SIZE.a()
+                    && event.y() >= getRenderY() + RENDER_AREA_POSITION.b()
+                    && event.y() <= getRenderY() + RENDER_AREA_POSITION.b() + RENDER_AREA_SIZE.b()) {
+                for (AbstractWidget widget : renderAreaWidgets) {
+                    if (widget.isMouseOver(event.x(), event.y())) {
+                        return widget.mouseClicked(
+                                new MouseButtonEvent(event.x(), event.y(), event.buttonInfo()), isDoubleClick);
+                    }
                 }
             }
-        }
 
-        for (TerritoryQuickFilterWidget quickFilter : quickFilters) {
-            if (quickFilter.isMouseOver(event.x(), event.y())) {
-                return quickFilter.mouseClicked(event, isDoubleClick);
+            for (TerritoryQuickFilterWidget quickFilter : quickFilters) {
+                if (quickFilter.isMouseOver(event.x(), event.y())) {
+                    return quickFilter.mouseClicked(event, isDoubleClick);
+                }
+            }
+
+            for (TerritoryQuickSortWidget quickSort : quickSorts) {
+                if (quickSort.isMouseOver(event.x(), event.y())) {
+                    return quickSort.mouseClicked(event, isDoubleClick);
+                }
+            }
+
+            // Check if the scroll button was clicked
+            float scrollX = getRenderX()
+                    + RENDER_AREA_POSITION.a()
+                    + RENDER_AREA_SIZE.a()
+                    + 10f
+                    - Texture.SCROLL_BUTTON.width() / 2f;
+            float scrollY = MathUtils.map(
+                    scrollOffset,
+                    0,
+                    getMaxScrollOffset(),
+                    getRenderY() + RENDER_AREA_POSITION.b(),
+                    getRenderY() + RENDER_AREA_POSITION.b() + RENDER_AREA_SIZE.b());
+            if (event.x() >= scrollX
+                    && event.x() <= scrollX + Texture.SCROLL_BUTTON.width()
+                    && event.y() >= scrollY - Texture.SCROLL_BUTTON.height() / 2f
+                    && event.y() <= scrollY + Texture.SCROLL_BUTTON.height() / 2f) {
+                draggingScroll = true;
+                return true;
+            }
+        } else {
+            for (GuiEventListener child :
+                    Stream.concat(children().stream(), mapButtons.stream()).toList()) {
+                if (child.isMouseOver(event.x(), event.y())) {
+                    child.mouseClicked(event, isDoubleClick);
+                    return true;
+                }
+            }
+
+            if (event.button() == GLFW.GLFW_MOUSE_BUTTON_RIGHT
+                    && hoveredFeature instanceof ManageTerritoryArea manageTerritoryArea) {
+                holder.saveMapPos();
+                manageTerritoryArea.onClick();
             }
         }
-
-        for (TerritoryQuickSortWidget quickSort : quickSorts) {
-            if (quickSort.isMouseOver(event.x(), event.y())) {
-                return quickSort.mouseClicked(event, isDoubleClick);
-            }
-        }
-
-        // Check if the scroll button was clicked
-        float scrollX = getRenderX()
-                + RENDER_AREA_POSITION.a()
-                + RENDER_AREA_SIZE.a()
-                + 10f
-                - Texture.SCROLL_BUTTON.width() / 2f;
-        float scrollY = MathUtils.map(
-                scrollOffset,
-                0,
-                getMaxScrollOffset(),
-                getRenderY() + RENDER_AREA_POSITION.b(),
-                getRenderY() + RENDER_AREA_POSITION.b() + RENDER_AREA_SIZE.b());
-        if (event.x() >= scrollX
-                && event.x() <= scrollX + Texture.SCROLL_BUTTON.width()
-                && event.y() >= scrollY - Texture.SCROLL_BUTTON.height() / 2f
-                && event.y() <= scrollY + Texture.SCROLL_BUTTON.height() / 2f) {
-            draggingScroll = true;
-            return true;
-        }
-        //        } else {
-        //            for (GuiEventListener child :
-        //                    Stream.concat(children().stream(), mapButtons.stream()).toList()) {
-        //                if (child.isMouseOver(event.x(), event.y())) {
-        //                    child.mouseClicked(event, isDoubleClick);
-        //                    return true;
-        //                }
-        //            }
-        //
-        //            if (event.button() == GLFW.GLFW_MOUSE_BUTTON_RIGHT
-        //                    && hovered instanceof ManageTerritoryPoi manageTerritoryPoi) {
-        //                holder.saveMapPos();
-        //                manageTerritoryPoi.onClick();
-        //            }
-        //        }
 
         return super.doMouseClicked(event, isDoubleClick);
     }
@@ -778,20 +931,19 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
-        //        if (!this.mapMode) {
-        // Scroll the render area
-        setScrollOffset((float) (scrollOffset - Math.signum(scrollY) * 10f));
-        scrollAreaWidgets(scrollOffset);
-        //        } else {
-        //            return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
-        //        }
+        if (!this.mapMode) {
+            // Scroll the render area
+            setScrollOffset((float) (scrollOffset - Math.signum(scrollY) * 10f));
+            scrollAreaWidgets(scrollOffset);
+        } else {
+            return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
+        }
         return true;
     }
 
     @Override
     public boolean mouseDragged(MouseButtonEvent event, double dragX, double dragY) {
-        //        if (!this.mapMode && draggingScroll) {
-        if (draggingScroll) {
+        if (!this.mapMode && draggingScroll) {
             // Calculate the new scroll offset
             float newScrollOffset = MathUtils.map(
                     (float) event.y(),
@@ -807,11 +959,36 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
         return super.mouseDragged(event, dragX, dragY);
     }
 
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        if (mapMode) {
+            switch (event.key()) {
+                case GLFW.GLFW_KEY_1 -> setInfoType(TerritoryInfoType.DEFENSE);
+                case GLFW.GLFW_KEY_2 -> setInfoType(TerritoryInfoType.PRODUCTION);
+                case GLFW.GLFW_KEY_3 -> setInfoType(TerritoryInfoType.TREASURY);
+                case GLFW.GLFW_KEY_4 -> setInfoType(TerritoryInfoType.SEEKING);
+                case GLFW.GLFW_KEY_H -> centerOnHeadquarters();
+            }
+        }
+
+        return keyPressedParent(event);
+    }
+
+    @Override
+    public void onClose() {
+        holder.resetMapPos();
+        super.onClose();
+    }
+
     public void updateTerritoryItems() {
         territoryItems = holder.territoryItems().stream().toList();
 
-        populateRenderAreaWidgets();
-        scrollOffset = Math.min(getMaxScrollOffset(), scrollOffset);
+        if (!this.mapMode) {
+            populateRenderAreaWidgets();
+            scrollOffset = Math.min(getMaxScrollOffset(), scrollOffset);
+        } else {
+            ManageTerritoryProvider.updateFeatures(holder);
+        }
     }
 
     public void updateSearchFromQuickFilters() {
@@ -821,6 +998,12 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
                 .collect(Collectors.joining(" "))
                 .trim()
                 .replaceAll("\\s+", " "));
+    }
+
+    private void setInfoType(TerritoryInfoType type) {
+        infoType = type;
+        infoTypeButton.setTooltip(getCompleteInfoTypeTooltip());
+        ManageTerritoryProvider.refreshColors();
     }
 
     private void populateRenderAreaWidgets() {
@@ -863,6 +1046,173 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
         scrollAreaWidgets(scrollOffset);
     }
 
+    private void renderHoveredTerritoryInfo(GuiGraphics guiGraphics) {
+        if (!(hoveredFeature instanceof ManageTerritoryArea territoryArea)) return;
+
+        int xOffset = (int) (width - SCREEN_SIDE_OFFSET - 250);
+        int yOffset = (int) (SCREEN_SIDE_OFFSET + 40);
+
+        renderTerritoryTooltip(guiGraphics, xOffset, yOffset, territoryArea);
+    }
+
+    private void renderTerritoryTooltip(
+            GuiGraphics guiGraphics, int xOffset, int yOffset, ManageTerritoryArea territoryArea) {
+        final TerritoryItem item = territoryArea.getTerritoryItem();
+
+        final List<Component> tooltipLines = new ArrayList<>();
+
+        for (GuildResource value : GuildResource.values()) {
+            int generation = item.getProduction().getOrDefault(value, 0);
+            CappedValue storage = item.getStorage().get(value);
+
+            if (generation != 0) {
+                StyledText formattedGenerated = StyledText.fromString(
+                        "%s+%d %s per Hour".formatted(value.getPrettySymbol(), generation, value.getName()));
+
+                tooltipLines.add(formattedGenerated.getComponent());
+            }
+
+            if (storage != null) {
+                StyledText formattedStored = StyledText.fromString("%s%d/%d %s stored"
+                        .formatted(value.getPrettySymbol(), storage.current(), storage.max(), value.getName()));
+
+                tooltipLines.add(formattedStored.getComponent());
+            }
+        }
+
+        tooltipLines.add(Component.literal(""));
+
+        StyledText defences = StyledText.fromString(ChatFormatting.GRAY
+                + "Territory Defences: %s"
+                        .formatted(item.getDefenseDifficulty().getDefenceColor()
+                                + item.getDefenseDifficulty().getAsString()));
+        tooltipLines.add(defences.getComponent());
+
+        TerritoryProfile territoryProfile = territoryArea.getTerritoryProfile();
+        TerritoryInfo territoryInfo = Models.Territory.getTerritoryInfo(item.getName());
+
+        String timeHeldString =
+                territoryInfo != null && territoryProfile.getGuild().equals(territoryInfo.getGuildName())
+                        ? territoryProfile.getTimeAcquiredColor() + territoryProfile.getReadableRelativeTimeAcquired()
+                        : "-";
+        tooltipLines.add(StyledText.fromString(ChatFormatting.GRAY + "Time Held: " + timeHeldString)
+                .getComponent());
+
+        if (territoryInfo != null && item.getTreasuryBonus() > 0) {
+            tooltipLines.add(Component.literal(""));
+
+            StyledText treasury = StyledText.fromString(ChatFormatting.LIGHT_PURPLE
+                    + "✦ Treasury Bonus: " + ChatFormatting.WHITE + "%.1f%%".formatted(item.getTreasuryBonus())
+                    + ChatFormatting.GRAY
+                    + " (%s)"
+                            .formatted(territoryInfo.getTreasury().getTreasuryColor()
+                                    + territoryInfo.getTreasury().getAsString()
+                                    + ChatFormatting.GRAY));
+            tooltipLines.add(treasury.getComponent());
+        }
+
+        List<Component> defenseLines = new ArrayList<>();
+        List<Component> bonusLines = new ArrayList<>();
+
+        Map<TerritoryUpgrade, Integer> territoryUpgrades = item.getUpgrades();
+
+        for (TerritoryUpgrade upgrade : TerritoryUpgrade.values()) {
+            if (territoryUpgrades.getOrDefault(upgrade, 0) == 0) continue;
+            Component upgradeLine = Component.literal("- ")
+                    .withStyle(ChatFormatting.LIGHT_PURPLE)
+                    .append(Component.literal(upgrade.getName()).withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(" [Lv. %s]".formatted(territoryUpgrades.get(upgrade)))
+                            .withStyle(ChatFormatting.DARK_GRAY));
+            if (DEFENSE_UPGRADES.contains(upgrade)) {
+                defenseLines.add(upgradeLine);
+            } else {
+                bonusLines.add(upgradeLine);
+            }
+        }
+
+        if (!defenseLines.isEmpty()) {
+            tooltipLines.add(Component.literal(""));
+            tooltipLines.add(Component.literal("Defenses:").withStyle(ChatFormatting.LIGHT_PURPLE));
+            tooltipLines.addAll(defenseLines);
+        }
+
+        if (!bonusLines.isEmpty()) {
+            tooltipLines.add(Component.literal(""));
+            tooltipLines.add(Component.literal("Bonuses:").withStyle(ChatFormatting.LIGHT_PURPLE));
+            tooltipLines.addAll(bonusLines);
+        }
+
+        final int textureWidth = Texture.MAP_INFO_TOOLTIP_CENTER.width();
+
+        final float centerHeight = (tooltipLines.size()) * 10 + 5;
+
+        RenderUtils.drawTexturedRect(guiGraphics, Texture.MAP_INFO_TOOLTIP_TOP, xOffset, yOffset);
+        RenderUtils.drawScalingTexturedRect(
+                guiGraphics,
+                Texture.MAP_INFO_TOOLTIP_CENTER.identifier(),
+                xOffset,
+                Texture.MAP_INFO_TOOLTIP_TOP.height() + yOffset,
+                textureWidth,
+                centerHeight,
+                textureWidth,
+                Texture.MAP_INFO_TOOLTIP_CENTER.height());
+        RenderUtils.drawTexturedRect(
+                guiGraphics,
+                Texture.MAP_INFO_NAME_BOX,
+                xOffset,
+                Texture.MAP_INFO_TOOLTIP_TOP.height() + centerHeight + yOffset);
+
+        float renderYOffset = 10 + yOffset;
+
+        for (Component line : tooltipLines) {
+            FontRenderer.getInstance()
+                    .renderText(
+                            guiGraphics,
+                            StyledText.fromComponent(line),
+                            10f + xOffset,
+                            renderYOffset,
+                            CommonColors.WHITE,
+                            HorizontalAlignment.LEFT,
+                            VerticalAlignment.TOP,
+                            TextShadow.OUTLINE,
+                            1.0f);
+            renderYOffset += 10;
+        }
+
+        // Territory name
+        FontRenderer.getInstance()
+                .renderAlignedTextInBox(
+                        guiGraphics,
+                        StyledText.fromString(item.getName()),
+                        7 + xOffset,
+                        textureWidth + xOffset,
+                        Texture.MAP_INFO_TOOLTIP_TOP.height() + centerHeight + yOffset,
+                        Texture.MAP_INFO_TOOLTIP_TOP.height()
+                                + centerHeight
+                                + Texture.MAP_INFO_NAME_BOX.height()
+                                + yOffset,
+                        0,
+                        CommonColors.WHITE,
+                        HorizontalAlignment.LEFT,
+                        VerticalAlignment.MIDDLE,
+                        TextShadow.OUTLINE);
+    }
+
+    private void centerOnHeadquarters() {
+        Optional<Pair<ItemStack, TerritoryItem>> hqItem = territoryItems.stream()
+                .filter((item) -> item.b().isHeadquarters())
+                .findFirst();
+        if (hqItem.isPresent()) {
+            TerritoryProfile territoryProfile =
+                    Models.Territory.getTerritoryProfile(hqItem.get().b().getName());
+            // The API territory list may not have loaded yet, or may not know this territory
+            if (territoryProfile == null) return;
+
+            PoiLocation location = territoryProfile.getCenterLocation();
+            updateMapCenter(location.getX(), location.getZ());
+        }
+    }
+
     private AbstractWidget getHoveredWidget(int mouseX, int mouseY) {
         for (AbstractWidget widget : renderAreaWidgets) {
             if (widget.isMouseOver(mouseX, mouseY)
@@ -878,6 +1228,12 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
                 if (widget.isMouseOver(mouseX, mouseY)) {
                     return widget;
                 }
+            }
+        }
+
+        for (AbstractWidget button : mapButtons) {
+            if (button.isMouseOver(mouseX, mouseY)) {
+                return button;
             }
         }
 
@@ -914,6 +1270,19 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
         return Math.max(0, totalHeight - RENDER_AREA_SIZE.b());
     }
 
+    private List<Component> getCompleteInfoTypeTooltip() {
+        return List.of(
+                Component.literal("[>] ")
+                        .withStyle(ChatFormatting.RED)
+                        .append(Component.translatable(
+                                "feature.wynntils.customTerritoryManagementScreen.cycleInfoType.name")),
+                Component.translatable("feature.wynntils.customTerritoryManagementScreen.cycleInfoType.description")
+                        .withStyle(ChatFormatting.GRAY),
+                Component.translatable("feature.wynntils.customTerritoryManagementScreen.cycleInfoType.description2")
+                        .withStyle(ChatFormatting.GRAY)
+                        .append(infoType.asComponent()));
+    }
+
     private int getRenderX() {
         return (this.width - Texture.TERRITORY_MANAGEMENT_BACKGROUND.width()) / 2;
     }
@@ -922,20 +1291,19 @@ public class TerritoryManagementScreen extends WynntilsScreen implements Wrapped
         return (this.height - Texture.TERRITORY_MANAGEMENT_BACKGROUND.height()) / 2;
     }
 
-    // Map position stubs - this screen doesn't have map mode
-    public void setMapPosition(float centerX, float centerZ, float zoomLevel) {
-        // No-op: map mode not supported in this version
-    }
-
     public float getMapCenterX() {
-        return 0;
+        return this.mapCenterX;
     }
 
     public float getMapCenterZ() {
-        return 0;
+        return this.mapCenterZ;
     }
 
     public float getZoomLevel() {
-        return 1;
+        return this.zoomLevel;
+    }
+
+    public TerritoryInfoType getInfoType() {
+        return this.infoType;
     }
 }

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/mapdata/ManageTerritoryArea.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/mapdata/ManageTerritoryArea.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.screens.territorymanagement.mapdata;
+
+import com.wynntils.models.items.items.gui.TerritoryItem;
+import com.wynntils.models.territories.profile.TerritoryProfile;
+import com.wynntils.models.territories.type.TerritoryConnectionType;
+import com.wynntils.models.territories.type.TerritoryUpgrade;
+import com.wynntils.screens.territorymanagement.TerritoryManagementHolder;
+import com.wynntils.screens.territorymanagement.TerritoryManagementScreen;
+import com.wynntils.services.mapdata.attributes.impl.AbstractMapAreaAttributes;
+import com.wynntils.services.mapdata.attributes.type.MapAreaAttributes;
+import com.wynntils.services.mapdata.features.type.MapArea;
+import com.wynntils.utils.MapDataUtils;
+import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.mc.type.Location;
+import com.wynntils.utils.type.BoundingPolygon;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A territory shown on {@link TerritoryManagementScreen}'s map mode, replacing the pre-Mapdata
+ * {@code ManageTerritoryPoi} that was deleted when the POI system was replaced by Mapdata.
+ * <p>
+ * The category id deliberately does not start with {@code wynntils:territory}, since
+ * {@link com.wynntils.services.mapdata.MapDataService#getFeaturesForCategory} does a prefix match on
+ * category id - if it did start with that prefix, {@code GuildMapScreen} would pick these features up
+ * alongside the real territory areas it renders.
+ */
+public final class ManageTerritoryArea implements MapArea {
+    private final TerritoryManagementHolder holder;
+    private final TerritoryProfile territoryProfile;
+
+    private final List<Location> polygonArea;
+    private final BoundingPolygon boundingPolygon;
+
+    private Supplier<TerritoryItem> territoryItemSupplier;
+    private TerritoryItem territoryItemCache;
+
+    public ManageTerritoryArea(
+            TerritoryManagementHolder holder,
+            TerritoryProfile territoryProfile,
+            Supplier<TerritoryItem> territoryItemSupplier) {
+        this.holder = holder;
+        this.territoryProfile = territoryProfile;
+        this.territoryItemSupplier = territoryItemSupplier;
+
+        // Polygon vertices, with the last vertex connecting to the first, in a counterclockwise
+        // orientation. Mirrors TerritoryArea: the provided coordinates are not trusted to already
+        // be in a specific order, so we must order them ourselves.
+        int startX = Math.max(territoryProfile.getStartX(), territoryProfile.getEndX());
+        int startZ = Math.max(territoryProfile.getStartZ(), territoryProfile.getEndZ());
+        int endX = Math.min(territoryProfile.getStartX(), territoryProfile.getEndX());
+        int endZ = Math.min(territoryProfile.getStartZ(), territoryProfile.getEndZ());
+
+        this.polygonArea = List.of(
+                new Location(startX, 0, startZ),
+                new Location(endX, 0, startZ),
+                new Location(endX, 0, endZ),
+                new Location(startX, 0, endZ));
+        this.boundingPolygon = BoundingPolygon.fromLocations(polygonArea);
+
+        // Prime the cache so getTerritoryItem() never returns null
+        getTerritoryItem();
+    }
+
+    @Override
+    public List<Location> getPolygonArea() {
+        return polygonArea;
+    }
+
+    @Override
+    public BoundingPolygon getBoundingPolygon() {
+        return boundingPolygon;
+    }
+
+    @Override
+    public String getFeatureId() {
+        return MapDataUtils.sanitizeFeatureId(territoryProfile.getName());
+    }
+
+    @Override
+    public String getCategoryId() {
+        return "wynntils:guild:managed-territory";
+    }
+
+    @Override
+    public Optional<MapAreaAttributes> getAttributes() {
+        return Optional.of(new AbstractMapAreaAttributes() {
+            @Override
+            public Optional<String> getLabel() {
+                TerritoryItem territoryItem = getTerritoryItem();
+
+                // A checkmark or the headquarters icon is drawn over the area's center instead,
+                // so the initials label would otherwise overlap it. See
+                // TerritoryManagementScreen#renderTerritoryDecorations.
+                if (territoryItem.isPending() || territoryItem.isSelected() || territoryItem.isHeadquarters()) {
+                    return Optional.of("");
+                }
+
+                return Optional.of(getShortName(territoryItem.getName()));
+            }
+
+            @Override
+            public Optional<String> getDescription() {
+                // MapFeatureRenderer draws the description under the label on hover, reproducing
+                // the old "full name on hover" behavior for free.
+                return Optional.of(territoryProfile.getName());
+            }
+
+            @Override
+            public Optional<CustomColor> getFillColor() {
+                // FIXME: This should render the component colors separately, but at the moment this serves as a
+                //        replacement for multiple area color support in mapdata. Revisit once MapAreaAttributes
+                //        can express more than one fill/border color (see also GuildMapScreen:996).
+                return Optional.of(CustomColor.blend(getInfoColors()).withAlpha(80));
+            }
+
+            @Override
+            public Optional<CustomColor> getBorderColor() {
+                // FIXME: This should render the component colors separately, but at the moment this serves as a
+                //        replacement for multiple area color support in mapdata. Revisit once MapAreaAttributes
+                //        can express more than one fill/border color (see also GuildMapScreen:996).
+                if (holder.territoryConnections().get(getTerritoryItem()) == TerritoryConnectionType.UNCONNECTED) {
+                    return Optional.of(CommonColors.RED);
+                }
+
+                return Optional.of(CustomColor.blend(getInfoColors()));
+            }
+
+            @Override
+            public Optional<CustomColor> getLabelColor() {
+                // FIXME: This should render the component colors separately, but at the moment this serves as a
+                //        replacement for multiple area color support in mapdata. Revisit once MapAreaAttributes
+                //        can express more than one fill/border color (see also GuildMapScreen:996).
+                return Optional.of(CustomColor.blend(getInfoColors()));
+            }
+        });
+    }
+
+    @Override
+    public List<String> getTags() {
+        return List.of();
+    }
+
+    public TerritoryProfile getTerritoryProfile() {
+        return territoryProfile;
+    }
+
+    public List<CustomColor> getInfoColors() {
+        TerritoryItem territoryItem = getTerritoryItem();
+
+        if (!(McUtils.screen() instanceof TerritoryManagementScreen territoryManagementScreen)) {
+            return List.of(CommonColors.WHITE);
+        }
+
+        List<CustomColor> colors = new ArrayList<>();
+
+        switch (territoryManagementScreen.getInfoType()) {
+            case DEFENSE -> {
+                colors.add(CustomColor.fromChatFormatting(
+                        territoryItem.getDefenseDifficulty().getDefenceColor()));
+                if (territoryItem.getUpgrades().getOrDefault(TerritoryUpgrade.TOWER_MULTI_ATTACKS, 0) > 0) {
+                    colors.add(CustomColor.fromHSV(1 / 2f, 0.8f, 0.9f, 1));
+                }
+            }
+            case PRODUCTION -> colors.addAll(territoryItem.getProductionColors());
+            case SEEKING -> colors.addAll(territoryItem.getSeekingColors());
+            case TREASURY -> colors.add(territoryItem.getTreasuryColor());
+        }
+
+        if (colors.isEmpty()) {
+            colors.add(CommonColors.WHITE);
+        }
+
+        return colors;
+    }
+
+    public void onClick() {
+        holder.territoryItemClicked(getTerritoryItem());
+    }
+
+    public TerritoryItem getTerritoryItem() {
+        return tryGetUpdatedTerritoryItem();
+    }
+
+    void setTerritoryItemSupplier(Supplier<TerritoryItem> territoryItemSupplier) {
+        this.territoryItemSupplier = territoryItemSupplier;
+    }
+
+    private TerritoryItem tryGetUpdatedTerritoryItem() {
+        TerritoryItem territoryItem = territoryItemSupplier.get();
+        if (territoryItem != null) {
+            territoryItemCache = territoryItem;
+        }
+        return territoryItemCache;
+    }
+
+    private static String getShortName(String fullName) {
+        return Arrays.stream(fullName.split(" ")).map(s -> s.substring(0, 1)).collect(Collectors.joining());
+    }
+}

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/mapdata/ManageTerritoryArea.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/mapdata/ManageTerritoryArea.java
@@ -26,15 +26,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-/**
- * A territory shown on {@link TerritoryManagementScreen}'s map mode, replacing the pre-Mapdata
- * {@code ManageTerritoryPoi} that was deleted when the POI system was replaced by Mapdata.
- * <p>
- * The category id deliberately does not start with {@code wynntils:territory}, since
- * {@link com.wynntils.services.mapdata.MapDataService#getFeaturesForCategory} does a prefix match on
- * category id - if it did start with that prefix, {@code GuildMapScreen} would pick these features up
- * alongside the real territory areas it renders.
- */
 public final class ManageTerritoryArea implements MapArea {
     private final TerritoryManagementHolder holder;
     private final TerritoryProfile territoryProfile;
@@ -87,6 +78,12 @@ public final class ManageTerritoryArea implements MapArea {
         return MapDataUtils.sanitizeFeatureId(territoryProfile.getName());
     }
 
+    /**
+     * The category id deliberately does not start with {@code wynntils:territory}, since
+     * {@link com.wynntils.services.mapdata.MapDataService#getFeaturesForCategory} does a prefix match on
+     * category id - if it did start with that prefix, {@code GuildMapScreen} would pick these features up
+     * alongside the real territory areas it renders.
+     */
     @Override
     public String getCategoryId() {
         return "wynntils:guild:managed-territory";

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/mapdata/ManageTerritoryProvider.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/mapdata/ManageTerritoryProvider.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.screens.territorymanagement.mapdata;
+
+import com.wynntils.core.components.Models;
+import com.wynntils.models.items.items.gui.TerritoryItem;
+import com.wynntils.models.territories.profile.TerritoryProfile;
+import com.wynntils.screens.territorymanagement.TerritoryManagementHolder;
+import com.wynntils.screens.territorymanagement.TerritoryManagementScreen;
+import com.wynntils.services.mapdata.features.type.MapFeature;
+import com.wynntils.services.mapdata.providers.builtin.BuiltInProvider;
+import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.type.Pair;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Provides {@link ManageTerritoryArea} features for {@link TerritoryManagementScreen}'s map mode.
+ * <p>
+ * This exists purely for cache invalidation: {@code MapDataService#resolveMapAttributes} memoizes
+ * resolved attributes per {@link MapFeature} instance, and the only way to evict a stale entry is
+ * {@code notifyCallbacks} from a registered provider - a screen-local feature list has no way to do
+ * that. The colors of a managed territory change on every container update (upgrades, selection,
+ * connections) and on every info type switch, so this provider reuses {@link ManageTerritoryArea}
+ * instances by territory name across updates and explicitly invalidates them instead of doing a full
+ * rebuild-and-notify every time, the way {@code TerritoryProvider} does for the real territories.
+ * <p>
+ * {@link #getFeatures()} returns an empty stream unless the territory management screen is currently
+ * open, since both {@code MainMapScreen} and {@code MinimapOverlay} consume the unfiltered
+ * {@code Services.MapData.getFeatures()} and must never see these.
+ */
+public class ManageTerritoryProvider extends BuiltInProvider {
+    private static final Map<String, ManageTerritoryArea> FEATURES_BY_NAME = new LinkedHashMap<>();
+
+    private static ManageTerritoryProvider instance;
+
+    public ManageTerritoryProvider() {
+        instance = this;
+    }
+
+    /**
+     * Rebuilds this provider's features from the holder's current territory items, reusing
+     * existing {@link ManageTerritoryArea} instances by territory name where possible, and
+     * invalidating the resolved-attribute cache for every territory whose backing item was
+     * refreshed.
+     */
+    public static void updateFeatures(TerritoryManagementHolder holder) {
+        if (instance == null) return;
+
+        Set<String> currentNames = new HashSet<>();
+
+        for (Pair<ItemStack, TerritoryItem> territoryItemPair : holder.territoryItems()) {
+            TerritoryItem territoryItem = territoryItemPair.b();
+            String name = territoryItem.getName();
+            currentNames.add(name);
+
+            ManageTerritoryArea existing = FEATURES_BY_NAME.get(name);
+            if (existing != null) {
+                existing.setTerritoryItemSupplier(() -> territoryItem);
+                instance.notifyCallbacks(existing);
+            } else {
+                TerritoryProfile territoryProfile = Models.Territory.getTerritoryProfile(name);
+                if (territoryProfile == null) continue;
+
+                FEATURES_BY_NAME.put(name, new ManageTerritoryArea(holder, territoryProfile, () -> territoryItem));
+            }
+        }
+
+        FEATURES_BY_NAME.keySet().removeIf(name -> {
+            if (currentNames.contains(name)) return false;
+
+            instance.notifyCallbacks(FEATURES_BY_NAME.get(name));
+            return true;
+        });
+    }
+
+    /**
+     * Forces every currently-provided feature's resolved attributes to be recomputed, without
+     * changing which territories are provided. Used when the info type (which colors are shown)
+     * is switched.
+     */
+    public static void refreshColors() {
+        if (instance == null) return;
+
+        FEATURES_BY_NAME.values().forEach(instance::notifyCallbacks);
+    }
+
+    @Override
+    public Stream<MapFeature> getFeatures() {
+        if (!(McUtils.screen() instanceof TerritoryManagementScreen)) {
+            return Stream.empty();
+        }
+
+        return FEATURES_BY_NAME.values().stream().map(area -> (MapFeature) area);
+    }
+
+    @Override
+    public String getProviderId() {
+        return "manage-territory";
+    }
+
+    @Override
+    public void reloadData() {
+        FEATURES_BY_NAME.values().forEach(this::notifyCallbacks);
+        FEATURES_BY_NAME.clear();
+    }
+}

--- a/common/src/main/java/com/wynntils/screens/territorymanagement/widgets/GuildOverallProductionWidget.java
+++ b/common/src/main/java/com/wynntils/screens/territorymanagement/widgets/GuildOverallProductionWidget.java
@@ -9,6 +9,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.features.ui.CustomTerritoryManagementScreenFeature;
 import com.wynntils.models.territories.type.GuildResource;
 import com.wynntils.screens.territorymanagement.TerritoryManagementHolder;
+import com.wynntils.utils.mc.KeyboardUtils;
 import com.wynntils.utils.render.RenderUtils;
 import com.wynntils.utils.type.CappedValue;
 import java.util.ArrayList;
@@ -19,8 +20,14 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 
 public class GuildOverallProductionWidget extends AbstractWidget {
+    // The screen re-creates this widget on every init, so the toggle state is kept static to
+    // survive a resize or a round trip through the territory container
+    private static boolean showDeltas = false;
+    private static boolean controlWasDown = false;
+
     private final TerritoryManagementHolder holder;
 
     public GuildOverallProductionWidget(int x, int y, int width, int height, TerritoryManagementHolder holder) {
@@ -88,40 +95,46 @@ public class GuildOverallProductionWidget extends AbstractWidget {
 
         lines.add(Component.literal(""));
 
-        long emeraldDelta = emeraldProduction - emeraldUsage;
-        long oreDelta = oreProduction - oreUsage;
-        long woodDelta = woodProduction - woodUsage;
-        long fishDelta = fishProduction - fishUsage;
-        long cropDelta = cropsProduction - cropsUsage;
+        // This widget receives no input events of its own, so the control key is polled here
+        if (!controlWasDown && KeyboardUtils.isControlDown()) {
+            showDeltas = !showDeltas;
+            controlWasDown = true;
+        } else if (!KeyboardUtils.isControlDown()) {
+            controlWasDown = false;
+        }
+
+        boolean showDelta = showDeltas || KeyboardUtils.isShiftDown();
+
         // Show overall cost
         lines.add(Component.literal("Overall Cost (per hour):").withStyle(ChatFormatting.GRAY));
-        lines.add(Component.literal("%.1fk Emeralds (%.1f%%)"
-                        .formatted(emeraldUsage / 1000d, (double) emeraldUsage / emeraldProduction * 100d))
-                .withStyle(ChatFormatting.GREEN)
-                .append(Component.literal(" [%s%.1fk]".formatted(emeraldDelta >= 0 ? "+" : "", emeraldDelta / 1000d))
-                        .withStyle(emeraldDelta >= 0 ? ChatFormatting.BLUE : ChatFormatting.RED)));
-        lines.add(Component.literal(
-                        "Ⓑ %.1fk Ore (%.1f%%)".formatted(oreUsage / 1000d, (double) oreUsage / oreProduction * 100d))
-                .withStyle(ChatFormatting.WHITE)
-                .append(Component.literal(" [%s%.1fk]".formatted(oreDelta >= 0 ? "+" : "", oreDelta / 1000d))
-                        .withStyle(oreDelta >= 0 ? ChatFormatting.BLUE : ChatFormatting.RED)));
-        lines.add(Component.literal("Ⓒ %.1fk Wood (%.1f%%)"
-                        .formatted(woodUsage / 1000d, (double) woodUsage / woodProduction * 100d))
-                .withStyle(ChatFormatting.GOLD)
-                .append(Component.literal(" [%s%.1fk]".formatted(woodDelta >= 0 ? "+" : "", woodDelta / 1000d))
-                        .withStyle(woodDelta >= 0 ? ChatFormatting.BLUE : ChatFormatting.RED)));
-        lines.add(Component.literal("Ⓚ %.1fk Fish (%.1f%%)"
-                        .formatted(fishUsage / 1000d, (double) fishUsage / fishProduction * 100d))
-                .withStyle(ChatFormatting.AQUA)
-                .append(Component.literal(" [%s%.1fk]".formatted(fishDelta >= 0 ? "+" : "", fishDelta / 1000d))
-                        .withStyle(fishDelta >= 0 ? ChatFormatting.BLUE : ChatFormatting.RED)));
-        lines.add(Component.literal("Ⓙ %.1fk Crops (%.1f%%)"
-                        .formatted(cropsUsage / 1000d, (double) cropsUsage / cropsProduction * 100d))
-                .withStyle(ChatFormatting.YELLOW)
-                .append(Component.literal(" [%s%.1fk]".formatted(cropDelta >= 0 ? "+" : "", cropDelta / 1000d))
-                        .withStyle(cropDelta >= 0 ? ChatFormatting.BLUE : ChatFormatting.RED)));
+        addOverallCostLine(lines, "", "Emeralds", emeraldUsage, emeraldProduction, ChatFormatting.GREEN, showDelta);
+        addOverallCostLine(lines, "Ⓑ ", "Ore", oreUsage, oreProduction, ChatFormatting.WHITE, showDelta);
+        addOverallCostLine(lines, "Ⓒ ", "Wood", woodUsage, woodProduction, ChatFormatting.GOLD, showDelta);
+        addOverallCostLine(lines, "Ⓚ ", "Fish", fishUsage, fishProduction, ChatFormatting.AQUA, showDelta);
+        addOverallCostLine(lines, "Ⓙ ", "Crops", cropsUsage, cropsProduction, ChatFormatting.YELLOW, showDelta);
 
         RenderUtils.renderTooltip(guiGraphics, lines, this.getX(), this.getY());
+    }
+
+    private static void addOverallCostLine(
+            List<Component> lines,
+            String symbol,
+            String name,
+            long usage,
+            int production,
+            ChatFormatting color,
+            boolean showDelta) {
+        MutableComponent line = Component.literal("%s%.1fk %s (%.1f%%)"
+                        .formatted(symbol, usage / 1000d, name, (double) usage / production * 100d))
+                .withStyle(color);
+
+        if (showDelta) {
+            long delta = production - usage;
+            line.append(Component.literal(" [%s%.1fk]".formatted(delta >= 0 ? "+" : "", delta / 1000d))
+                    .withStyle(delta >= 0 ? ChatFormatting.BLUE : ChatFormatting.RED));
+        }
+
+        lines.add(line);
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/utils/colors/CustomColor.java
+++ b/common/src/main/java/com/wynntils/utils/colors/CustomColor.java
@@ -15,6 +15,7 @@ import java.awt.Color;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.random.RandomGenerator;
@@ -209,6 +210,66 @@ public record CustomColor(int r, int g, int b, int a) {
         float[] hsb = this.asHSB();
         float brightness = hsb[2] + degree;
         return fromHSV(hsb[0], hsb[1], brightness, this.a);
+    }
+
+    /**
+     * Blends multiple colors into one, using a circular (hue-wheel) mean instead of a naive RGB
+     * average. An RGB average can wash out to grey for complementary inputs (e.g. dark red + teal),
+     * which is unacceptable when the blended color must stay visually distinct from an actual grey
+     * "no data" color. Saturation and value are averaged linearly; the hue is averaged by summing
+     * unit vectors around the hue wheel and taking the angle of the result, which is equivalent to
+     * picking the mean hue along the shortest arc between the inputs.
+     * <p>
+     * If the inputs are split exactly evenly around the wheel (e.g. two colors exactly 180 degrees
+     * apart), the summed vector has ~zero magnitude and the shortest arc is ambiguous in both
+     * directions. That tie is broken deterministically (independent of input order) by rotating 90
+     * degrees from the lowest input hue.
+     * <p>
+     * A single-element input is returned unchanged.
+     *
+     * FIXME: This exists only because MapAreaAttributes cannot express more than one fill/border
+     *        color, so it stands in for real multi-color area support. Revisit once MapAreaAttributes
+     *        can express more than one fill/border color (see also GuildMapScreen:996).
+     */
+    public static CustomColor blend(List<CustomColor> colors) {
+        if (colors.isEmpty()) {
+            return CommonColors.WHITE;
+        }
+
+        if (colors.size() == 1) {
+            return colors.getFirst();
+        }
+
+        double sinSum = 0;
+        double cosSum = 0;
+        float saturationSum = 0;
+        float valueSum = 0;
+        float alphaSum = 0;
+        float minHue = Float.MAX_VALUE;
+
+        for (CustomColor color : colors) {
+            float[] hsb = color.asHSB();
+            double angle = hsb[0] * 2 * Math.PI;
+            sinSum += Math.sin(angle);
+            cosSum += Math.cos(angle);
+            saturationSum += hsb[1];
+            valueSum += hsb[2];
+            alphaSum += color.a();
+            minHue = Math.min(minHue, hsb[0]);
+        }
+
+        int count = colors.size();
+        float hue;
+        if (Math.hypot(sinSum, cosSum) < 1.0e-4) {
+            // Degenerate case: the hues cancel out, so the shortest arc is ambiguous.
+            // Deterministically pick the point a quarter turn from the lowest input hue.
+            hue = (minHue + 0.25f) % 1f;
+        } else {
+            double angle = Math.atan2(sinSum, cosSum) / (2 * Math.PI);
+            hue = (float) (((angle % 1) + 1) % 1);
+        }
+
+        return CustomColor.fromHSV(hue, saturationSum / count, valueSum / count, (alphaSum / count) / 255f);
     }
 
     /** 0xAARRGGBB format */


### PR DESCRIPTION
Reimplement map mode on top of Mapdata at feature parity: info-type colouring, resource glyphs, checkmark/HQ icons, trading routes, unconnected borders, map buttons, 1/2/3/4 and H keybinds, the hovered info panel, and map-position save/restore across the manage -> back -> manage round trip.

ManageTerritoryArea uses the category id "wynntils:guild:managed-territory" so it cannot be picked up by GuildMapScreen, whose getFeaturesForCategory lookup is a startsWith prefix match. ManageTerritoryProvider exists for attribute-cache invalidation, since resolveMapAttributes memoizes per feature instance and only a registered provider can evict; it yields no features unless the screen is open, as MainMapScreen and MinimapOverlay both consume the unfiltered getFeatures().

MapAreaAttributes cannot express more than one fill or border colour, so the (at most two) info-type colours are collapsed into a single blended colour via CustomColor.blend, keeping the border free to carry connection state. The blend is an HSV circular mean rather than an RGB average, which would wash complementary inputs out to grey and collide with the "no upgrades" grey. Marked with a FIXME to revisit if mapdata gains real multi-colour area support.