### PR TITLE
fix: territory management hotkey

### DIFF
--- a/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
+++ b/common/src/main/java/com/wynntils/features/ui/CustomTerritoryManagementScreenFeature.java
@@ -43,7 +43,7 @@ public class CustomTerritoryManagementScreenFeature extends Feature {
     private static final Pattern TERRITORY_MANAGE_ITEM_PATTERN = Pattern.compile("§e§lTerritories \\[.+\\]");
     private static final Pattern MANAGE_TITLE_PATTERN = Pattern.compile(".+: Manage");
     private static final Pattern BACK_BUTTON_PATTERN = Pattern.compile("§7§lBack");
-    private static final int COMPASS_INVENTORY_SLOT = 42;
+    private static final int COMPASS_INVENTORY_SLOT = 43;
     private static final int GUILD_MANAGEMENT_SLOT = 26;
     private static final int TERRITORY_MANAGEMENT_SLOT = 14;
 


### PR DESCRIPTION
Fixes the territory management hotkey not working in wars. Slot was never updated post soul point removal.