### PR TITLE
fix: Tooltip fixes

### DIFF
--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
@@ -15,6 +15,7 @@ import com.wynntils.core.persisted.upfixers.Upfixer;
 import com.wynntils.models.character.type.SavableGear;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.items.encoding.type.EncodingSettings;
 import com.wynntils.models.items.encoding.type.ItemType;
 import com.wynntils.models.items.items.game.GearItem;
@@ -273,8 +274,8 @@ public class LoadoutMigrationUpfixer implements Upfixer {
             stats.add(new StatActualValue(statType, val.baseValue(), false, internalRoll, false));
         }
 
-        GearInstance gearInstance =
-                new GearInstance(stats, List.of(), 0, Optional.empty(), Optional.empty(), true, Optional.empty());
+        GearInstance gearInstance = new GearInstance(
+                stats, List.of(), 0, Optional.empty(), Optional.empty(), MetGearRequirements.UNKNOWN, Optional.empty());
         GearItem defaultGearItem = new GearItem(gearInfo, gearInstance);
 
         EncodingSettings encodingSettings = new EncodingSettings(true, true);

--- a/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
+++ b/common/src/main/java/com/wynntils/core/persisted/upfixers/storage/LoadoutMigrationUpfixer.java
@@ -15,7 +15,7 @@ import com.wynntils.core.persisted.upfixers.Upfixer;
 import com.wynntils.models.character.type.SavableGear;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
-import com.wynntils.models.gear.type.MetGearRequirements;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.items.encoding.type.EncodingSettings;
 import com.wynntils.models.items.encoding.type.ItemType;
 import com.wynntils.models.items.items.game.GearItem;
@@ -275,7 +275,13 @@ public class LoadoutMigrationUpfixer implements Upfixer {
         }
 
         GearInstance gearInstance = new GearInstance(
-                stats, List.of(), 0, Optional.empty(), Optional.empty(), MetGearRequirements.UNKNOWN, Optional.empty());
+                stats,
+                List.of(),
+                0,
+                Optional.empty(),
+                Optional.empty(),
+                GearInstanceRequirements.UNKNOWN,
+                Optional.empty());
         GearItem defaultGearItem = new GearItem(gearInfo, gearInstance);
 
         EncodingSettings encodingSettings = new EncodingSettings(true, true);

--- a/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
+++ b/common/src/main/java/com/wynntils/features/tooltips/ItemStatInfoFeature.java
@@ -76,6 +76,9 @@ public class ItemStatInfoFeature extends Feature {
     public final Config<Boolean> rainbowInternalRoll = new Config<>(true);
 
     @Persisted
+    public final Config<Boolean> craftedPercentages = new Config<>(true);
+
+    @Persisted
     public final Config<Boolean> showRollWheel = new Config<>(true);
 
     @Persisted
@@ -177,6 +180,7 @@ public class ItemStatInfoFeature extends Feature {
                         groupIdentifications.get(),
                         showBestValueLastAlways.get(),
                         rainbowInternalRoll.get(),
+                        craftedPercentages.get(),
                         showRollWheel.get()),
                 perfect.get(),
                 defective.get(),

--- a/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/TooltipBuilder.java
@@ -31,7 +31,7 @@ import net.minecraft.network.chat.Style;
 
 public abstract class TooltipBuilder {
     private static final TooltipStyle DEFAULT_TOOLTIP_STYLE =
-            new TooltipStyle(StatListOrdering.WYNNCRAFT, false, false, true, true);
+            new TooltipStyle(StatListOrdering.WYNNCRAFT, false, false, true, false, true);
 
     private final List<Component> header;
     private final List<Component> footer;

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipOptionDecorator.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipOptionDecorator.java
@@ -30,7 +30,9 @@ final class CraftedTooltipOptionDecorator implements TooltipIdentificationDecora
     @Override
     public MutableComponent getTitle(Component title) {
         MutableComponent decorated = title.copy();
-        if (options.overallPercentageInName() && overallPercentage.isPresent()) {
+        if (options.style().craftedPercentages()
+                && options.overallPercentageInName()
+                && overallPercentage.isPresent()) {
             decorated.append(ColorScaleUtils.getPercentageTextComponent(
                     options.colorMap(), overallPercentage.get(), options.colorLerp(), options.decimalPlaces(), true));
         }
@@ -49,11 +51,21 @@ final class CraftedTooltipOptionDecorator implements TooltipIdentificationDecora
         } else {
             percentage = 0;
         }
-        MutableComponent suffix = ColorScaleUtils.getPercentageTextComponent(
-                        options.colorMap(), percentage, options.colorLerp(), options.decimalPlaces(), true)
-                .withStyle(componentStyle -> componentStyle.withFont(CommonFonts.LANGUAGE_WYNNCRAFT_FONT));
-        if (style.rainbowInternalRoll() && actualValue.perfectInternalRoll()) {
-            suffix.withColor(WynncraftShaderColor.RAINBOW.color.asInt());
+        MutableComponent suffix;
+        boolean rainbowPerfect = style.rainbowInternalRoll() && actualValue.perfectInternalRoll();
+
+        if (style.craftedPercentages()) {
+            suffix = ColorScaleUtils.getPercentageTextComponent(
+                            options.colorMap(), percentage, options.colorLerp(), options.decimalPlaces(), true)
+                    .withStyle(componentStyle -> componentStyle.withFont(CommonFonts.LANGUAGE_WYNNCRAFT_FONT));
+
+            if (rainbowPerfect) {
+                suffix.withColor(WynncraftShaderColor.RAINBOW.color.asInt());
+            }
+        } else {
+            suffix = Component.literal(" ")
+                    .append(ColorScaleUtils.getWheelTextComponent(
+                            options.colorMap(), percentage, options.colorLerp(), rainbowPerfect));
         }
         return suffix;
     }

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipOptionDecorator.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipOptionDecorator.java
@@ -51,7 +51,7 @@ final class CraftedTooltipOptionDecorator implements TooltipIdentificationDecora
         } else {
             percentage = 0;
         }
-        MutableComponent suffix;
+        MutableComponent suffix = Component.empty();
         boolean rainbowPerfect = style.rainbowInternalRoll() && actualValue.perfectInternalRoll();
 
         if (style.craftedPercentages()) {
@@ -62,7 +62,7 @@ final class CraftedTooltipOptionDecorator implements TooltipIdentificationDecora
             if (rainbowPerfect) {
                 suffix.withColor(WynncraftShaderColor.RAINBOW.color.asInt());
             }
-        } else {
+        } else if (options.style().showRollWheel()) {
             suffix = Component.literal(" ")
                     .append(ColorScaleUtils.getWheelTextComponent(
                             options.colorMap(), percentage, options.colorLerp(), rainbowPerfect));

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipOptionDecorator.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/crafted/CraftedTooltipOptionDecorator.java
@@ -40,12 +40,15 @@ final class CraftedTooltipOptionDecorator implements TooltipIdentificationDecora
     @Override
     public MutableComponent getSuffix(
             StatActualValue actualValue, StatPossibleValues possibleValues, TooltipStyle style) {
-        if (!options.identificationDecorations() || actualValue.vanillaMeter().isEmpty()) {
-            return Component.empty();
-        }
+        if (!options.identificationDecorations()) return Component.empty();
 
-        float percentage = StatCalculator.getPercentageFromVanillaMeter(
-                actualValue.vanillaMeter().get());
+        float percentage;
+        if (actualValue.vanillaMeter().isPresent()) {
+            percentage = StatCalculator.getPercentageFromVanillaMeter(
+                    actualValue.vanillaMeter().get());
+        } else {
+            percentage = 0;
+        }
         MutableComponent suffix = ColorScaleUtils.getPercentageTextComponent(
                         options.colorMap(), percentage, options.colorLerp(), options.decimalPlaces(), true)
                 .withStyle(componentStyle -> componentStyle.withFont(CommonFonts.LANGUAGE_WYNNCRAFT_FONT));

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -381,18 +381,18 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                 .ifPresent(quest -> requirements.add(requirementLine(
                         " Quest",
                         StringUtils.shorten(quest, 10),
-                        item.getMetGearRequirements().questReqMet())));
+                        item.getGearInstanceRequirements().questReqMet())));
         info.requirements()
                 .classType()
                 .ifPresent(classType -> requirements.add(requirementLine(
                         " Class Type",
                         classType.getFullName(),
-                        item.getMetGearRequirements().classReqMet())));
+                        item.getGearInstanceRequirements().classReqMet())));
         if (info.requirements().level() > 0) {
             requirements.add(requirementLine(
                     " Combat Level",
                     String.valueOf(info.requirements().level()),
-                    item.getMetGearRequirements().levelReqMet()));
+                    item.getGearInstanceRequirements().levelReqMet()));
         }
         return requirements;
     }
@@ -429,7 +429,9 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
             int count = skillRequirement(info, skill);
             boolean fulfilled = count == 0
                     || instance != null
-                            && instance.metGearRequirements().skillReqsMet().getOrDefault(skill, false);
+                            && instance.gearInstanceRequirements()
+                                    .skillReqsMet()
+                                    .getOrDefault(skill, false);
             String icon = count == 0 ? "\uE005" : fulfilled ? "\uE006" : "\uE007";
 
             Component skillValue = Component.empty()

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -376,17 +376,21 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
 
         info.requirements()
                 .quest()
-                .ifPresent(quest -> requirements.add(
-                        requirementLine(" Quest", StringUtils.shorten(quest, 10), item.meetsActualRequirements())));
+                .ifPresent(quest -> requirements.add(requirementLine(
+                        " Quest",
+                        StringUtils.shorten(quest, 10),
+                        item.getMetGearRequirements().questReqMet())));
         info.requirements()
                 .classType()
                 .ifPresent(classType -> requirements.add(requirementLine(
-                        " Class Type", classType.getFullName(), Models.Character.getClassType() == classType)));
+                        " Class Type",
+                        classType.getFullName(),
+                        item.getMetGearRequirements().classReqMet())));
         if (info.requirements().level() > 0) {
             requirements.add(requirementLine(
                     " Combat Level",
                     String.valueOf(info.requirements().level()),
-                    Models.CharacterStats.getLevel() >= info.requirements().level()));
+                    item.getMetGearRequirements().levelReqMet()));
         }
         return requirements;
     }
@@ -422,8 +426,8 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
         for (Skill skill : Skill.values()) {
             int count = skillRequirement(info, skill);
             boolean fulfilled = count == 0
-                    || instance != null && instance.meetsRequirements()
-                    || Models.SkillPoint.getTotalSkillPoints(skill) >= count;
+                    || instance != null
+                            && instance.metGearRequirements().skillReqsMet().getOrDefault(skill, false);
             String icon = count == 0 ? "\uE005" : fulfilled ? "\uE006" : "\uE007";
             line.append(withWhiteShadow(Component.literal(icon + "\uDAFF\uDFFF")
                     .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_REQUIREMENT_SPRITE_FONT))));

--- a/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/impl/identifiable/IdentifiableTooltipBuilder.java
@@ -4,6 +4,7 @@
  */
 package com.wynntils.handlers.tooltip.impl.identifiable;
 
+import com.wynntils.core.components.Managers;
 import com.wynntils.core.components.Models;
 import com.wynntils.core.components.Services;
 import com.wynntils.core.text.CommonStyles;
@@ -46,6 +47,7 @@ import com.wynntils.utils.colors.CommonColors;
 import com.wynntils.utils.colors.CustomColor;
 import com.wynntils.utils.mc.ComponentUtils;
 import com.wynntils.utils.mc.LoreUtils;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.TooltipUtils;
 import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.type.RangedValue;
@@ -429,16 +431,33 @@ public final class IdentifiableTooltipBuilder<T, U> extends TooltipBuilder {
                     || instance != null
                             && instance.metGearRequirements().skillReqsMet().getOrDefault(skill, false);
             String icon = count == 0 ? "\uE005" : fulfilled ? "\uE006" : "\uE007";
-            line.append(withWhiteShadow(Component.literal(icon + "\uDAFF\uDFFF")
-                    .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_REQUIREMENT_SPRITE_FONT))));
-            line.append(Component.literal("\uDB00\uDC03").withStyle(CommonStyles.SPACE));
-            line.append(Component.literal(String.valueOf(count))
-                    .withStyle(Style.EMPTY
-                            .withFont(CommonFonts.LANGUAGE_WYNNCRAFT_FONT)
-                            .withColor(count == 0 ? 0x555555 : fulfilled ? 0xacfac6 : 0xfaacac)));
-            line.append(Component.literal("\uDB00\uDC04").withStyle(CommonStyles.SPACE));
+
+            Component skillValue = Component.empty()
+                    .append(withWhiteShadow(Component.literal(icon + "\uDAFF\uDFFF")
+                            .withStyle(Style.EMPTY.withFont(CommonFonts.TOOLTIP_REQUIREMENT_SPRITE_FONT))))
+                    .append(Component.literal("\uDB00\uDC03").withStyle(CommonStyles.SPACE))
+                    .append(Component.literal(String.valueOf(count))
+                            .withStyle(Style.EMPTY
+                                    .withFont(CommonFonts.LANGUAGE_WYNNCRAFT_FONT)
+                                    .withColor(count == 0 ? 0x555555 : fulfilled ? 0xacfac6 : 0xfaacac)));
+
+            line.append(centerInSkillCell(skillValue));
         }
         return line;
+    }
+
+    private Component centerInSkillCell(Component component) {
+        int contentWidth = McUtils.mc().font.width(component);
+
+        int left = Math.max(0, (27 - contentWidth) / 2);
+        int right = Math.max(0, 27 - contentWidth - left);
+
+        return Component.empty()
+                .append(Component.literal(Managers.Font.calculateOffset(0, left))
+                        .withStyle(CommonStyles.SPACE))
+                .append(component)
+                .append(Component.literal(Managers.Font.calculateOffset(0, right))
+                        .withStyle(CommonStyles.SPACE));
     }
 
     private List<TooltipLine> buildShiny(IdentifiableItemProperty<?, ?> item, GearTier tier) {

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipOptions.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipOptions.java
@@ -24,7 +24,7 @@ public record TooltipOptions(
         boolean colorLerp,
         int decimalPlaces) {
     public static final TooltipOptions DEFAULT = new TooltipOptions(
-            new TooltipStyle(StatListOrdering.WYNNCRAFT, false, false, true, true),
+            new TooltipStyle(StatListOrdering.WYNNCRAFT, false, false, true, false, true),
             false,
             false,
             false,

--- a/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipStyle.java
+++ b/common/src/main/java/com/wynntils/handlers/tooltip/type/TooltipStyle.java
@@ -11,4 +11,5 @@ public record TooltipStyle(
         boolean groupIdentifications,
         boolean showBestValueLastAlways,
         boolean rainbowInternalRoll,
+        boolean craftedPercentages,
         boolean showRollWheel) {}

--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -114,7 +114,7 @@ public final class GearModel extends Model {
                     result.powders(),
                     result.rerolls(),
                     result.shinyStat(),
-                    result.allRequirementsMet(),
+                    result.metGearRequirements(),
                     result.setInstance());
         }
 
@@ -156,7 +156,7 @@ public final class GearModel extends Model {
                 result.identifications(),
                 result.powders(),
                 result.powderSlots(),
-                result.allRequirementsMet(),
+                result.metGearRequirements(),
                 result.durability(),
                 result.currentPage());
     }
@@ -184,7 +184,7 @@ public final class GearModel extends Model {
                 result.damages(),
                 result.defences(),
                 result.requirements(),
-                result.allRequirementsMet(),
+                result.metGearRequirements(),
                 result.identifications(),
                 result.powders(),
                 result.powderSlots(),

--- a/common/src/main/java/com/wynntils/models/gear/GearModel.java
+++ b/common/src/main/java/com/wynntils/models/gear/GearModel.java
@@ -114,7 +114,7 @@ public final class GearModel extends Model {
                     result.powders(),
                     result.rerolls(),
                     result.shinyStat(),
-                    result.metGearRequirements(),
+                    result.gearInstanceRequirements(),
                     result.setInstance());
         }
 
@@ -156,7 +156,7 @@ public final class GearModel extends Model {
                 result.identifications(),
                 result.powders(),
                 result.powderSlots(),
-                result.metGearRequirements(),
+                result.gearInstanceRequirements(),
                 result.durability(),
                 result.currentPage());
     }
@@ -184,7 +184,7 @@ public final class GearModel extends Model {
                 result.damages(),
                 result.defences(),
                 result.requirements(),
-                result.metGearRequirements(),
+                result.gearInstanceRequirements(),
                 result.identifications(),
                 result.powders(),
                 result.powderSlots(),

--- a/common/src/main/java/com/wynntils/models/gear/type/GearInstance.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.gear.type;
@@ -19,7 +19,7 @@ public record GearInstance(
         int rerolls,
         Optional<Float> overallQuality,
         Optional<ShinyStat> shinyStat,
-        boolean meetsRequirements,
+        MetGearRequirements metGearRequirements,
         Optional<SetInstance> setInstance) {
     public static GearInstance create(
             GearInfo gearInfo,
@@ -27,7 +27,7 @@ public record GearInstance(
             List<Powder> powders,
             int rerolls,
             Optional<ShinyStat> shinyStat,
-            boolean meetsRequirements,
+            MetGearRequirements metGearRequirements,
             Optional<SetInstance> setInstance) {
         return new GearInstance(
                 identifications,
@@ -36,7 +36,7 @@ public record GearInstance(
                 StatCalculator.calculateOverallQuality(
                         gearInfo.name(), gearInfo.getPossibleValueList(), identifications),
                 shinyStat,
-                meetsRequirements,
+                metGearRequirements,
                 setInstance);
     }
 

--- a/common/src/main/java/com/wynntils/models/gear/type/GearInstance.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearInstance.java
@@ -19,7 +19,7 @@ public record GearInstance(
         int rerolls,
         Optional<Float> overallQuality,
         Optional<ShinyStat> shinyStat,
-        MetGearRequirements metGearRequirements,
+        GearInstanceRequirements gearInstanceRequirements,
         Optional<SetInstance> setInstance) {
     public static GearInstance create(
             GearInfo gearInfo,
@@ -27,7 +27,7 @@ public record GearInstance(
             List<Powder> powders,
             int rerolls,
             Optional<ShinyStat> shinyStat,
-            MetGearRequirements metGearRequirements,
+            GearInstanceRequirements gearInstanceRequirements,
             Optional<SetInstance> setInstance) {
         return new GearInstance(
                 identifications,
@@ -36,7 +36,7 @@ public record GearInstance(
                 StatCalculator.calculateOverallQuality(
                         gearInfo.name(), gearInfo.getPossibleValueList(), identifications),
                 shinyStat,
-                metGearRequirements,
+                gearInstanceRequirements,
                 setInstance);
     }
 

--- a/common/src/main/java/com/wynntils/models/gear/type/GearInstanceRequirements.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/GearInstanceRequirements.java
@@ -7,9 +7,9 @@ package com.wynntils.models.gear.type;
 import com.wynntils.models.elements.type.Skill;
 import java.util.Map;
 
-public record MetGearRequirements(
+public record GearInstanceRequirements(
         boolean levelReqMet, boolean classReqMet, Map<Skill, Boolean> skillReqsMet, boolean questReqMet) {
-    public static final MetGearRequirements UNKNOWN = new MetGearRequirements(false, false, Map.of(), false);
+    public static final GearInstanceRequirements UNKNOWN = new GearInstanceRequirements(false, false, Map.of(), false);
 
     public boolean meetsAllRequirements() {
         return levelReqMet

--- a/common/src/main/java/com/wynntils/models/gear/type/MetGearRequirements.java
+++ b/common/src/main/java/com/wynntils/models/gear/type/MetGearRequirements.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.models.gear.type;
+
+import com.wynntils.models.elements.type.Skill;
+import java.util.Map;
+
+public record MetGearRequirements(
+        boolean levelReqMet, boolean classReqMet, Map<Skill, Boolean> skillReqsMet, boolean questReqMet) {
+    public static final MetGearRequirements UNKNOWN = new MetGearRequirements(false, false, Map.of(), false);
+
+    public boolean meetsAllRequirements() {
+        return levelReqMet
+                && classReqMet
+                && skillReqsMet.values().stream().allMatch(Boolean::booleanValue)
+                && questReqMet;
+    }
+}

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -9,6 +9,7 @@ import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearType;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.items.encoding.data.CustomGearTypeData;
 import com.wynntils.models.items.encoding.data.CustomIdentificationsData;
 import com.wynntils.models.items.encoding.data.DamageData;
@@ -130,7 +131,7 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
                 identifications,
                 powders,
                 powderSlots,
-                false,
+                MetGearRequirements.UNKNOWN,
                 durability,
                 0));
     }

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/CraftedGearItemTransformer.java
@@ -7,9 +7,9 @@ package com.wynntils.models.items.encoding.impl.item;
 import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearType;
-import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.items.encoding.data.CustomGearTypeData;
 import com.wynntils.models.items.encoding.data.CustomIdentificationsData;
 import com.wynntils.models.items.encoding.data.DamageData;
@@ -131,7 +131,7 @@ public class CraftedGearItemTransformer extends ItemTransformer<CraftedGearItem>
                 identifications,
                 powders,
                 powderSlots,
-                MetGearRequirements.UNKNOWN,
+                GearInstanceRequirements.UNKNOWN,
                 durability,
                 0));
     }

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/GearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/GearItemTransformer.java
@@ -8,7 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
-import com.wynntils.models.gear.type.MetGearRequirements;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.items.encoding.data.IdentificationData;
 import com.wynntils.models.items.encoding.data.NameData;
 import com.wynntils.models.items.encoding.data.PowderData;
@@ -75,7 +75,13 @@ public class GearItemTransformer extends ItemTransformer<GearItem> {
         return ErrorOr.of(new GearItem(
                 gearInfo,
                 GearInstance.create(
-                        gearInfo, idList, powders, rerolls, shinyStat, MetGearRequirements.UNKNOWN, Optional.empty())));
+                        gearInfo,
+                        idList,
+                        powders,
+                        rerolls,
+                        shinyStat,
+                        GearInstanceRequirements.UNKNOWN,
+                        Optional.empty())));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/encoding/impl/item/GearItemTransformer.java
+++ b/common/src/main/java/com/wynntils/models/items/encoding/impl/item/GearItemTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2024.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.encoding.impl.item;
@@ -8,6 +8,7 @@ import com.wynntils.core.components.Models;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.items.encoding.data.IdentificationData;
 import com.wynntils.models.items.encoding.data.NameData;
 import com.wynntils.models.items.encoding.data.PowderData;
@@ -72,7 +73,9 @@ public class GearItemTransformer extends ItemTransformer<GearItem> {
         List<StatActualValue> idList = identifications.values().stream().toList();
 
         return ErrorOr.of(new GearItem(
-                gearInfo, GearInstance.create(gearInfo, idList, powders, rerolls, shinyStat, false, Optional.empty())));
+                gearInfo,
+                GearInstance.create(
+                        gearInfo, idList, powders, rerolls, shinyStat, MetGearRequirements.UNKNOWN, Optional.empty())));
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
@@ -8,10 +8,10 @@ import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
-import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.items.properties.ClassableItemProperty;
 import com.wynntils.models.items.properties.CraftedItemProperty;
 import com.wynntils.models.items.properties.DurableItemProperty;
@@ -53,7 +53,7 @@ public class CraftedGearItem extends GameItem
     private final List<StatActualValue> identifications;
     private final List<Powder> powders;
     private final int powderSlots;
-    private final MetGearRequirements metGearRequirements;
+    private final GearInstanceRequirements gearInstanceRequirements;
     private final CappedValue durability;
     private int currentPage;
 
@@ -70,7 +70,7 @@ public class CraftedGearItem extends GameItem
             List<StatActualValue> identifications,
             List<Powder> powders,
             int powderSlots,
-            MetGearRequirements metGearRequirements,
+            GearInstanceRequirements gearInstanceRequirements,
             CappedValue durability,
             int currentPage) {
         this.name = name;
@@ -85,7 +85,7 @@ public class CraftedGearItem extends GameItem
         this.identifications = identifications;
         this.powders = powders;
         this.powderSlots = powderSlots;
-        this.metGearRequirements = metGearRequirements;
+        this.gearInstanceRequirements = gearInstanceRequirements;
         this.durability = durability;
         this.currentPage = currentPage;
     }
@@ -171,12 +171,12 @@ public class CraftedGearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return metGearRequirements.meetsAllRequirements();
+        return gearInstanceRequirements.meetsAllRequirements();
     }
 
     @Override
-    public MetGearRequirements getMetGearRequirements() {
-        return metGearRequirements;
+    public GearInstanceRequirements getGearInstanceRequirements() {
+        return gearInstanceRequirements;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/CraftedGearItem.java
@@ -11,6 +11,7 @@ import com.wynntils.models.gear.type.GearAttackSpeed;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.items.properties.ClassableItemProperty;
 import com.wynntils.models.items.properties.CraftedItemProperty;
 import com.wynntils.models.items.properties.DurableItemProperty;
@@ -52,7 +53,7 @@ public class CraftedGearItem extends GameItem
     private final List<StatActualValue> identifications;
     private final List<Powder> powders;
     private final int powderSlots;
-    private final boolean requirementsMet;
+    private final MetGearRequirements metGearRequirements;
     private final CappedValue durability;
     private int currentPage;
 
@@ -69,7 +70,7 @@ public class CraftedGearItem extends GameItem
             List<StatActualValue> identifications,
             List<Powder> powders,
             int powderSlots,
-            boolean requirementsMet,
+            MetGearRequirements metGearRequirements,
             CappedValue durability,
             int currentPage) {
         this.name = name;
@@ -84,7 +85,7 @@ public class CraftedGearItem extends GameItem
         this.identifications = identifications;
         this.powders = powders;
         this.powderSlots = powderSlots;
-        this.requirementsMet = requirementsMet;
+        this.metGearRequirements = metGearRequirements;
         this.durability = durability;
         this.currentPage = currentPage;
     }
@@ -170,7 +171,12 @@ public class CraftedGearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return requirementsMet;
+        return metGearRequirements.meetsAllRequirements();
+    }
+
+    @Override
+    public MetGearRequirements getMetGearRequirements() {
+        return metGearRequirements;
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
@@ -8,9 +8,9 @@ import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
-import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInfo;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.items.properties.ClassableItemProperty;
@@ -184,12 +184,12 @@ public class GearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return gearInstance != null && gearInstance.metGearRequirements().meetsAllRequirements();
+        return gearInstance != null && gearInstance.gearInstanceRequirements().meetsAllRequirements();
     }
 
     @Override
-    public MetGearRequirements getMetGearRequirements() {
-        return gearInstance == null ? MetGearRequirements.UNKNOWN : gearInstance.metGearRequirements();
+    public GearInstanceRequirements getGearInstanceRequirements() {
+        return gearInstance == null ? GearInstanceRequirements.UNKNOWN : gearInstance.gearInstanceRequirements();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/GearItem.java
@@ -10,6 +10,7 @@ import com.wynntils.models.gear.type.GearInfo;
 import com.wynntils.models.gear.type.GearInstance;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInfo;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.items.properties.ClassableItemProperty;
@@ -183,7 +184,12 @@ public class GearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return gearInstance != null && gearInstance.meetsRequirements();
+        return gearInstance != null && gearInstance.metGearRequirements().meetsAllRequirements();
+    }
+
+    @Override
+    public MetGearRequirements getMetGearRequirements() {
+        return gearInstance == null ? MetGearRequirements.UNKNOWN : gearInstance.metGearRequirements();
     }
 
     @Override

--- a/common/src/main/java/com/wynntils/models/items/items/game/UnknownGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/UnknownGearItem.java
@@ -8,10 +8,10 @@ import com.wynntils.models.character.type.ClassType;
 import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
-import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInfo;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.items.properties.ClassableItemProperty;
@@ -51,7 +51,7 @@ public class UnknownGearItem extends GameItem
     private final List<Pair<DamageType, RangedValue>> damages;
     private final List<Pair<Element, Integer>> defences;
     private final GearRequirements requirements;
-    private final MetGearRequirements metGearRequirements;
+    private final GearInstanceRequirements gearInstanceRequirements;
     private final List<StatActualValue> identifications;
     private final List<Powder> powders;
     private final int powderSlots;
@@ -70,7 +70,7 @@ public class UnknownGearItem extends GameItem
             List<Pair<DamageType, RangedValue>> damages,
             List<Pair<Element, Integer>> defences,
             GearRequirements requirements,
-            MetGearRequirements metGearRequirements,
+            GearInstanceRequirements gearInstanceRequirements,
             List<StatActualValue> identifications,
             List<Powder> powders,
             int powderSlots,
@@ -87,7 +87,7 @@ public class UnknownGearItem extends GameItem
         this.damages = damages;
         this.defences = defences;
         this.requirements = requirements;
-        this.metGearRequirements = metGearRequirements;
+        this.gearInstanceRequirements = gearInstanceRequirements;
         this.identifications = identifications;
         this.powders = powders;
         this.powderSlots = powderSlots;
@@ -160,12 +160,12 @@ public class UnknownGearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return metGearRequirements.meetsAllRequirements();
+        return gearInstanceRequirements.meetsAllRequirements();
     }
 
     @Override
-    public MetGearRequirements getMetGearRequirements() {
-        return metGearRequirements;
+    public GearInstanceRequirements getGearInstanceRequirements() {
+        return gearInstanceRequirements;
     }
 
     @Override
@@ -199,8 +199,8 @@ public class UnknownGearItem extends GameItem
                 + health + ", damages="
                 + damages + ", defences="
                 + defences + ", requirements="
-                + requirements + ", metGearRequirements="
-                + metGearRequirements + ", identifications="
+                + requirements + ", gearInstanceRequirements="
+                + gearInstanceRequirements + ", identifications="
                 + identifications + ", powders="
                 + powders + ", powderSlots="
                 + powderSlots + ", rerolls="

--- a/common/src/main/java/com/wynntils/models/items/items/game/UnknownGearItem.java
+++ b/common/src/main/java/com/wynntils/models/items/items/game/UnknownGearItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © Wynntils 2023-2025.
+ * Copyright © Wynntils 2023-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.items.game;
@@ -11,6 +11,7 @@ import com.wynntils.models.gear.type.GearAttackSpeed;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
 import com.wynntils.models.gear.type.GearType;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInfo;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.items.properties.ClassableItemProperty;
@@ -50,7 +51,7 @@ public class UnknownGearItem extends GameItem
     private final List<Pair<DamageType, RangedValue>> damages;
     private final List<Pair<Element, Integer>> defences;
     private final GearRequirements requirements;
-    private final boolean allRequirementsMet;
+    private final MetGearRequirements metGearRequirements;
     private final List<StatActualValue> identifications;
     private final List<Powder> powders;
     private final int powderSlots;
@@ -69,7 +70,7 @@ public class UnknownGearItem extends GameItem
             List<Pair<DamageType, RangedValue>> damages,
             List<Pair<Element, Integer>> defences,
             GearRequirements requirements,
-            boolean allRequirementsMet,
+            MetGearRequirements metGearRequirements,
             List<StatActualValue> identifications,
             List<Powder> powders,
             int powderSlots,
@@ -86,7 +87,7 @@ public class UnknownGearItem extends GameItem
         this.damages = damages;
         this.defences = defences;
         this.requirements = requirements;
-        this.allRequirementsMet = allRequirementsMet;
+        this.metGearRequirements = metGearRequirements;
         this.identifications = identifications;
         this.powders = powders;
         this.powderSlots = powderSlots;
@@ -159,7 +160,12 @@ public class UnknownGearItem extends GameItem
 
     @Override
     public boolean meetsActualRequirements() {
-        return allRequirementsMet;
+        return metGearRequirements.meetsAllRequirements();
+    }
+
+    @Override
+    public MetGearRequirements getMetGearRequirements() {
+        return metGearRequirements;
     }
 
     @Override
@@ -193,8 +199,8 @@ public class UnknownGearItem extends GameItem
                 + health + ", damages="
                 + damages + ", defences="
                 + defences + ", requirements="
-                + requirements + ", allRequirementsMet="
-                + allRequirementsMet + ", identifications="
+                + requirements + ", metGearRequirements="
+                + metGearRequirements + ", identifications="
                 + identifications + ", powders="
                 + powders + ", powderSlots="
                 + powderSlots + ", rerolls="

--- a/common/src/main/java/com/wynntils/models/items/properties/RequirementItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/RequirementItemProperty.java
@@ -4,7 +4,7 @@
  */
 package com.wynntils.models.items.properties;
 
-import com.wynntils.models.gear.type.MetGearRequirements;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 
 public interface RequirementItemProperty {
     /**
@@ -15,5 +15,5 @@ public interface RequirementItemProperty {
     /**
      * @return the met gear requirements info for the item
      */
-    MetGearRequirements getMetGearRequirements();
+    GearInstanceRequirements getGearInstanceRequirements();
 }

--- a/common/src/main/java/com/wynntils/models/items/properties/RequirementItemProperty.java
+++ b/common/src/main/java/com/wynntils/models/items/properties/RequirementItemProperty.java
@@ -1,12 +1,19 @@
 /*
- * Copyright © Wynntils 2024.
+ * Copyright © Wynntils 2024-2026.
  * This file is released under LGPLv3. See LICENSE for full license details.
  */
 package com.wynntils.models.items.properties;
+
+import com.wynntils.models.gear.type.MetGearRequirements;
 
 public interface RequirementItemProperty {
     /**
      * @return true if the item is usable by the player
      */
     boolean meetsActualRequirements();
+
+    /**
+     * @return the met gear requirements info for the item
+     */
+    MetGearRequirements getMetGearRequirements();
 }

--- a/common/src/main/java/com/wynntils/models/stats/StatCalculator.java
+++ b/common/src/main/java/com/wynntils/models/stats/StatCalculator.java
@@ -294,8 +294,10 @@ public final class StatCalculator {
 
     public static Optional<Float> calculateOverallQualityFromVanillaMeters(List<StatActualValue> identifications) {
         DoubleSummaryStatistics percents = identifications.stream()
-                .flatMap(actualValue -> actualValue.vanillaMeter().stream())
-                .mapToDouble(StatCalculator::getPercentageFromVanillaMeter)
+                .mapToDouble(actualValue -> actualValue
+                        .vanillaMeter()
+                        .map(StatCalculator::getPercentageFromVanillaMeter)
+                        .orElse(0f))
                 .summaryStatistics();
         if (percents.getCount() == 0) return Optional.empty();
 

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
@@ -7,9 +7,9 @@ package com.wynntils.models.wynnitem.parsing;
 import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
-import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.models.stats.type.ShinyStat;
@@ -44,6 +44,6 @@ public record WynnItemParseResult(
         CappedValue uses,
         int durationSeconds,
         Optional<ShinyStat> shinyStat,
-        MetGearRequirements metGearRequirements,
+        GearInstanceRequirements gearInstanceRequirements,
         Optional<SetInstance> setInstance,
         int currentPage) {}

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParseResult.java
@@ -9,6 +9,7 @@ import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.gear.type.GearAttackSpeed;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.stats.type.DamageType;
 import com.wynntils.models.stats.type.ShinyStat;
@@ -43,33 +44,6 @@ public record WynnItemParseResult(
         CappedValue uses,
         int durationSeconds,
         Optional<ShinyStat> shinyStat,
-        boolean allRequirementsMet,
+        MetGearRequirements metGearRequirements,
         Optional<SetInstance> setInstance,
-        int currentPage) {
-    public static WynnItemParseResult fromInternalRoll(
-            List<StatActualValue> identifications, List<Powder> powders, int rerolls) {
-        return new WynnItemParseResult(
-                null,
-                null,
-                0,
-                0,
-                0,
-                null,
-                List.of(),
-                List.of(),
-                null,
-                identifications,
-                List.of(),
-                List.of(),
-                powders,
-                0,
-                rerolls,
-                CappedValue.EMPTY,
-                CappedValue.EMPTY,
-                0,
-                Optional.empty(),
-                true,
-                Optional.empty(),
-                0);
-    }
-}
+        int currentPage) {}

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -16,6 +16,7 @@ import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearAttackSpeed;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
+import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInfo;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.stats.type.DamageType;
@@ -35,12 +36,15 @@ import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.type.Pair;
 import com.wynntils.utils.type.RangedValue;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FontDescription;
@@ -163,7 +167,12 @@ public final class WynnItemParser {
         GearTier tier = null;
         String itemType = extractFrameSpriteCode(itemStack);
         Optional<ShinyStat> shinyStat = Optional.empty();
-        boolean allRequirementsMet = true;
+        boolean levelReqMet = true;
+        boolean classReqMet = true;
+        boolean questReqMet = true;
+        Map<Skill, Boolean> skillReqsMet = Arrays.stream(Skill.values())
+                .collect(
+                        Collectors.toMap(skill -> skill, skill -> true, (a, b) -> a, () -> new EnumMap<>(Skill.class)));
         SetInfo setInfo = null;
         Map<String, Boolean> activeItems = new HashMap<>();
         int setWynnCount = 0;
@@ -315,7 +324,7 @@ public final class WynnItemParser {
 
                     String mark = levelMatcher.group(1);
                     if (mark.contains("\uE007")) {
-                        allRequirementsMet = false;
+                        levelReqMet = false;
                     }
 
                     continue;
@@ -327,12 +336,12 @@ public final class WynnItemParser {
                     Matcher partMatcher = normalizedCoded.getMatcher(SKILL_REQ_PART_PATTERN);
                     int index = 0;
                     while (partMatcher.find()) {
-                        if (partMatcher.group(1).equals("\uE007")) {
-                            allRequirementsMet = false;
-                        }
-
                         Skill skill = Skill.values()[index];
                         skillReqs.add(Pair.of(skill, Integer.parseInt(partMatcher.group(2))));
+
+                        if (partMatcher.group(1).equals("\uE007")) {
+                            skillReqsMet.put(skill, false);
+                        }
 
                         index++;
                     }
@@ -353,7 +362,7 @@ public final class WynnItemParser {
 
                     String mark = classMatcher.group(1);
                     if (mark.contains("\uE007")) {
-                        allRequirementsMet = false;
+                        classReqMet = false;
                     }
 
                     continue;
@@ -366,7 +375,7 @@ public final class WynnItemParser {
 
                     String mark = questMatcher.group(1);
                     if (mark.contains("\uE007")) {
-                        allRequirementsMet = false;
+                        questReqMet = false;
                     }
 
                     continue;
@@ -457,7 +466,7 @@ public final class WynnItemParser {
                 uses,
                 durationSeconds,
                 shinyStat,
-                allRequirementsMet,
+                new MetGearRequirements(levelReqMet, classReqMet, skillReqsMet, questReqMet),
                 Optional.of(new SetInstance(setInfo, activeItems, setWynnCount, wynnBonuses)),
                 currentPage);
     }

--- a/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
+++ b/common/src/main/java/com/wynntils/models/wynnitem/parsing/WynnItemParser.java
@@ -14,9 +14,9 @@ import com.wynntils.models.elements.type.Element;
 import com.wynntils.models.elements.type.Powder;
 import com.wynntils.models.elements.type.Skill;
 import com.wynntils.models.gear.type.GearAttackSpeed;
+import com.wynntils.models.gear.type.GearInstanceRequirements;
 import com.wynntils.models.gear.type.GearRequirements;
 import com.wynntils.models.gear.type.GearTier;
-import com.wynntils.models.gear.type.MetGearRequirements;
 import com.wynntils.models.gear.type.SetInfo;
 import com.wynntils.models.gear.type.SetInstance;
 import com.wynntils.models.stats.type.DamageType;
@@ -466,7 +466,7 @@ public final class WynnItemParser {
                 uses,
                 durationSeconds,
                 shinyStat,
-                new MetGearRequirements(levelReqMet, classReqMet, skillReqsMet, questReqMet),
+                new GearInstanceRequirements(levelReqMet, classReqMet, skillReqsMet, questReqMet),
                 Optional.of(new SetInstance(setInfo, activeItems, setWynnCount, wynnBonuses)),
                 currentPage);
     }

--- a/common/src/main/java/com/wynntils/utils/colors/CustomColor.java
+++ b/common/src/main/java/com/wynntils/utils/colors/CustomColor.java
@@ -22,6 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.CRC32;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.TextColor;
 
 public record CustomColor(int r, int g, int b, int a) {
     public static final CustomColor NONE = new CustomColor(-1, -1, -1, -1);
@@ -76,6 +77,10 @@ public record CustomColor(int r, int g, int b, int a) {
 
     public static CustomColor fromChatFormatting(ChatFormatting cf) {
         return fromInt(cf.getColor() | 0xFF000000);
+    }
+
+    public static CustomColor fromTextColor(TextColor tc) {
+        return fromInt(tc.getValue() | 0xFF000000);
     }
 
     /**

--- a/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
+++ b/common/src/main/java/com/wynntils/utils/wynn/ColorScaleUtils.java
@@ -4,12 +4,17 @@
  */
 package com.wynntils.utils.wynn;
 
+import com.wynntils.core.text.fonts.wynnfonts.TooltipIdentificationMeterFont;
 import com.wynntils.utils.MathUtils;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.colors.WynncraftShaderColor;
+import com.wynntils.utils.type.CappedValue;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
@@ -48,6 +53,19 @@ public final class ColorScaleUtils {
                 .toPlainString();
         return Component.literal(" [" + (estimated ? "~" : "") + percentString + "%]")
                 .withStyle(color);
+    }
+
+    public static MutableComponent getWheelTextComponent(
+            NavigableMap<Float, TextColor> colorMap, float percentage, boolean colorLerp, boolean rainbowPerfect) {
+        CustomColor fillColor = CustomColor.fromTextColor(
+                colorLerp ? getPercentageColor(colorMap, percentage) : getFlatPercentageColor(colorMap, percentage));
+        CappedValue value = CappedValue.fromProgress(percentage / 100, 100);
+        return TooltipIdentificationMeterFont.buildCounterSingleLayerMeter(
+                        value,
+                        rainbowPerfect && value.isAtCap() ? WynncraftShaderColor.RAINBOW.color : fillColor,
+                        CustomColor.fromChatFormatting(ChatFormatting.DARK_GRAY),
+                        "")
+                .copy();
     }
 
     private static TextColor getPercentageColor(NavigableMap<Float, TextColor> colorMap, float percentage) {

--- a/common/src/main/resources/assets/wynntils/lang/en_us.json
+++ b/common/src/main/resources/assets/wynntils/lang/en_us.json
@@ -1028,6 +1028,8 @@
   "feature.wynntils.itemScreenshot.saveToDisk.name": "Save Item Screenshots to Disk",
   "feature.wynntils.itemStatInfo.colorLerp.description": "Should the colored percentage for item ID vary smoothly instead of between fixed levels?",
   "feature.wynntils.itemStatInfo.colorLerp.name": "Color Lerp",
+  "feature.wynntils.itemStatInfo.craftedPercentages.description": "Replace the roll wheel with a percentage for crafted items?",
+  "feature.wynntils.itemStatInfo.craftedPercentages.name": "Crafted Percentages",
   "feature.wynntils.itemStatInfo.decimalPlaces.description": "How many decimal places should item stats display?",
   "feature.wynntils.itemStatInfo.decimalPlaces.name": "Stat Decimal Places",
   "feature.wynntils.itemStatInfo.defective.description": "Should the names of defective (0%%) items look garbled?",


### PR DESCRIPTION
Requirements are now properly parsed from the tooltip for each requirement type so no longer are the requirement lines built from solely whether all requirements are met or not.

Fixes the skill point value line not being spaced out to sit under the icon, it's not perfect but it's better than it was.

Makes crafted items handle 0% rolls in both the suffix decoration and the overall roll

Adds a config option to disable showing percentages instead of the wheel on crafted items

And makes the show roll wheel config work again