### PR TITLE
fix: Prevent chat input from triggering keybinds

### DIFF
--- a/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/KeyBindManager.java
@@ -12,6 +12,8 @@ import com.wynntils.core.consumers.features.properties.RegisterKeyBind;
 import com.wynntils.core.mod.type.CrashType;
 import com.wynntils.mc.event.InventoryKeyPressEvent;
 import com.wynntils.mc.event.InventoryMouseClickedEvent;
+import com.wynntils.mc.event.KeyInputEvent;
+import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.mc.mixin.accessors.OptionsAccessor;
 import com.wynntils.utils.mc.McUtils;
@@ -27,8 +29,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
+import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.inventory.Slot;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
@@ -60,7 +64,7 @@ public final class KeyBindManager extends Manager {
 
     private final Set<KeyBind> enabledKeyBinds = ConcurrentHashMap.newKeySet();
     private final Map<Feature, List<KeyBind>> keyBinds = new ConcurrentHashMap<>();
-    private final Map<String, KeyMapping> mappingsById = new ConcurrentHashMap<>();
+    private final Map<String, WynntilsKeyMapping> mappingsById = new ConcurrentHashMap<>();
 
     private boolean registeredKeybinds = false;
 
@@ -75,7 +79,7 @@ public final class KeyBindManager extends Manager {
         List<KeyMapping> list = new ArrayList<>(Arrays.asList(options.keyMappings));
 
         for (KeyBindDefinition def : KeyBindDefinition.definitions()) {
-            KeyMapping mapping = new KeyMapping(def.translationKey(), def.type(), def.defaultKey(), def.category());
+            WynntilsKeyMapping mapping = new WynntilsKeyMapping(def);
 
             list.add(mapping);
             mappingsById.put(def.id(), mapping);
@@ -99,7 +103,7 @@ public final class KeyBindManager extends Manager {
     }
 
     KeyMapping findActiveKeyMapping(
-            String keybindName, KeyMapping[] activeMappings, Map<String, KeyMapping> mappingsById) {
+            String keybindName, KeyMapping[] activeMappings, Map<String, ? extends KeyMapping> mappingsById) {
         KeyBindDefinition definition = getKeyBindDefinition(keybindName);
         if (definition != null) {
             KeyMapping registeredMapping = mappingsById.get(definition.id());
@@ -157,6 +161,23 @@ public final class KeyBindManager extends Manager {
     @SubscribeEvent
     public void onTick(TickEvent e) {
         triggerKeybinds();
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST, receiveCanceled = true)
+    public void onKeyInput(KeyInputEvent e) {
+        boolean inChat = McUtils.screen() instanceof ChatScreen;
+        for (WynntilsKeyMapping mapping : mappingsById.values()) {
+            if (mapping.matches(e.getKeyEvent())) {
+                mapping.onInput(e.getAction(), inChat);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onScreenInit(ScreenInitEvent.Post e) {
+        if (!(e.getScreen() instanceof ChatScreen)) return;
+
+        mappingsById.values().forEach(WynntilsKeyMapping::suppressChatInput);
     }
 
     @SubscribeEvent

--- a/common/src/main/java/com/wynntils/core/keybinds/WynntilsKeyMapping.java
+++ b/common/src/main/java/com/wynntils/core/keybinds/WynntilsKeyMapping.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.keybinds;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import org.lwjgl.glfw.GLFW;
+
+public final class WynntilsKeyMapping extends KeyMapping {
+    private boolean blockedByChat;
+
+    public WynntilsKeyMapping(KeyBindDefinition definition) {
+        super(definition.translationKey(), definition.type(), definition.defaultKey(), definition.category());
+    }
+
+    public void onInput(int action, boolean inChat) {
+        if (action == GLFW.GLFW_RELEASE) {
+            blockedByChat = false;
+        } else if (inChat) {
+            suppressChatInput();
+        } else if (action == GLFW.GLFW_PRESS) {
+            blockedByChat = false;
+        }
+    }
+
+    public void suppressChatInput() {
+        if (key.getType() == InputConstants.Type.MOUSE) return;
+
+        blockedByChat = true;
+        super.setDown(false);
+    }
+
+    @Override
+    public void setDown(boolean down) {
+        super.setDown(down && !blockedByChat);
+    }
+
+    @Override
+    public void setKey(InputConstants.Key key) {
+        if (!this.key.equals(key)) blockedByChat = false;
+        super.setKey(key);
+    }
+}

--- a/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
+++ b/common/src/main/java/com/wynntils/features/combat/QuickCastFeature.java
@@ -20,6 +20,7 @@ import com.wynntils.mc.event.ChangeCarriedItemEvent;
 import com.wynntils.mc.event.DestroyBlockEvent;
 import com.wynntils.mc.event.PlayerAttackEvent;
 import com.wynntils.mc.event.PlayerInteractEvent;
+import com.wynntils.mc.event.ScreenInitEvent;
 import com.wynntils.mc.event.TickEvent;
 import com.wynntils.mc.event.UseItemEvent;
 import com.wynntils.models.character.type.ClassType;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.InteractionHand;
@@ -123,6 +125,13 @@ public class QuickCastFeature extends Feature {
     public void onWorldChange(WorldStateEvent event) {
         clearInputSelectionState();
         Models.SpellCaster.clear();
+    }
+
+    @SubscribeEvent
+    public void onScreenInit(ScreenInitEvent.Post event) {
+        if (!(event.getScreen() instanceof ChatScreen)) return;
+
+        clearInputSelectionState();
     }
 
     @SubscribeEvent

--- a/fabric/src/test/java/com/wynntils/core/keybinds/TestChatKeybindSuppression.java
+++ b/fabric/src/test/java/com/wynntils/core/keybinds/TestChatKeybindSuppression.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © Wynntils 2026.
+ * This file is released under LGPLv3. See LICENSE for full license details.
+ */
+package com.wynntils.core.keybinds;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.wynntils.core.WynntilsMod;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.input.KeyEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lwjgl.glfw.GLFW;
+
+public class TestChatKeybindSuppression {
+    private WynntilsKeyMapping mapping;
+
+    @BeforeAll
+    public static void setup() {
+        WynntilsMod.setupTestEnv();
+    }
+
+    @BeforeEach
+    public void createMapping() {
+        mapping = new WynntilsKeyMapping(new KeyBindDefinition(
+                "testChatInput",
+                "Test chat input",
+                KeyBindManager.COMMANDS_CATEGORY,
+                InputConstants.Type.KEYSYM,
+                GLFW.GLFW_KEY_L,
+                true));
+    }
+
+    @Test
+    public void blocksKeysHeldBeforeChatUntilReleaseAndFreshPress() {
+        mapping.setDown(true);
+        mapping.suppressChatInput();
+        Assertions.assertFalse(mapping.isDown());
+
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+        mapping.onInput(GLFW.GLFW_REPEAT, false);
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+
+        mapping.onInput(GLFW.GLFW_RELEASE, false);
+        mapping.setDown(false);
+        mapping.onInput(GLFW.GLFW_PRESS, false);
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+    }
+
+    @Test
+    public void typingAndRepeatingInChatCannotActivateMapping() {
+        mapping.onInput(GLFW.GLFW_PRESS, true);
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+        mapping.onInput(GLFW.GLFW_REPEAT, true);
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+    }
+
+    @Test
+    public void screenResetsDoNotClearChatSuppression() {
+        mapping.suppressChatInput();
+        KeyMapping.releaseAll();
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+    }
+
+    @Test
+    public void freshPressRecoversWhenReleaseWasNotObserved() {
+        mapping.suppressChatInput();
+        mapping.onInput(GLFW.GLFW_PRESS, false);
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+    }
+
+    @Test
+    public void vanillaMappingsAreNotSuppressedByChat() {
+        KeyMapping vanillaMapping = new KeyMapping(
+                "testVanillaInput", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_L, KeyBindManager.COMMANDS_CATEGORY);
+        mapping.suppressChatInput();
+        vanillaMapping.setDown(true);
+        mapping.setDown(true);
+        Assertions.assertTrue(vanillaMapping.isDown());
+        Assertions.assertFalse(mapping.isDown());
+    }
+
+    @Test
+    public void mouseMappingsRemainUsableInAndAfterChat() {
+        mapping.setKey(InputConstants.Type.MOUSE.getOrCreate(GLFW.GLFW_MOUSE_BUTTON_4));
+        mapping.suppressChatInput();
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+        mapping.setDown(false);
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+    }
+
+    @Test
+    public void rebindingDoesNotCarrySuppressionToAnotherKeyOrMouseButton() {
+        mapping.suppressChatInput();
+        mapping.setKey(InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_K));
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+
+        mapping.suppressChatInput();
+        mapping.setKey(InputConstants.Type.MOUSE.getOrCreate(GLFW.GLFW_MOUSE_BUTTON_4));
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+    }
+
+    @Test
+    public void reapplyingTheSameBindingDoesNotLetAHeldChatKeyThrough() {
+        mapping.suppressChatInput();
+        mapping.setKey(InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_L));
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+    }
+
+    @Test
+    public void scanCodeMappingsAlsoRespectSuppressionAndRelease() {
+        mapping.setKey(InputConstants.Type.SCANCODE.getOrCreate(42));
+        Assertions.assertTrue(mapping.matches(new KeyEvent(GLFW.GLFW_KEY_UNKNOWN, 42, 0)));
+        mapping.suppressChatInput();
+        mapping.onInput(GLFW.GLFW_REPEAT, false);
+        mapping.setDown(true);
+        Assertions.assertFalse(mapping.isDown());
+        mapping.onInput(GLFW.GLFW_RELEASE, false);
+        mapping.onInput(GLFW.GLFW_PRESS, false);
+        mapping.setDown(true);
+        Assertions.assertTrue(mapping.isDown());
+    }
+}


### PR DESCRIPTION
Prevents keys held after chat enter is sent from triggering additional keybinds

For example, if we are in TM and we chat search something like "soul" for soul essence, that last L may be interpreted as a keybind if we press enter too quickly without fully releasing the L key

https://discord.com/channels/394189072635133952/1257255311589511189/1546645210656940152

Normally in chat this is just annoying, but in TM it can cause you to lose pages and searches since keys like L and M will bring up full screen maps or custom /lobby binds or whatever else

gpt assisted tests but it looks fine i think, and of course works in game